### PR TITLE
Do not send Uncategorized groups to Publishing API

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -25,7 +25,7 @@ class SectorPresenter
       redirects: [],
       update_type: "major", # All changes in this app are de facto major for now.
       details: {
-        groups: categorized_groups + uncategorized_groups
+        groups: categorized_groups
       }
     }
   end
@@ -46,19 +46,6 @@ private
         name: list.name,
         contents: list.tagged_contents.map(&:api_url)
       }
-    end
-  end
-
-  def uncategorized_groups
-    if uncategorized_contents.any?
-      [
-        {
-          name: "Other",
-          contents: uncategorized_contents
-        }
-      ]
-    else
-      []
     end
   end
 

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -102,6 +102,7 @@
 
 <section aria-labelledby='list-uncategorized-header' id='list-uncategorized-section'>
   <h2 id='list-uncategorized-header'>Uncategorized (A to Z)</h2>
+  <p><b>Note:</b> These will not be displayed to users</p>
 
   <table class='table table-hover'>
     <thead>

--- a/features/step_definitions/curated_list_steps.rb
+++ b/features/step_definitions/curated_list_steps.rb
@@ -95,12 +95,6 @@ Then(/^the curated lists should have been sent to the publishing API$/) do
         content: [
           'undersea-piping-restrictions'
         ]
-      },
-      {
-        name: 'Other',
-        content: [
-          'north-sea-shipping-lanes'
-        ]
       }
     ]
   )

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -85,29 +85,10 @@ RSpec.describe SectorPresenter do
                 "http://example.com/api/oil-rig-safety-requirements.json",
                 "http://example.com/api/oil-rig-staffing.json"
               ]
-            },
-            # Uncurated content
-            {
-              name: "Other",
-              contents: [
-                "http://example.com/api/north-sea-shipping-lanes.json"
-              ]
             }
           ]
         }
       )
-    end
-
-    context "with no uncategorized contents" do
-      let(:uncategorized_contents) { [] }
-
-      it "does not include the 'other' block" do
-        sector_hash = SectorPresenter.render_for_publishing_api(sector)
-
-        sector_hash[:details][:groups].each do |group|
-          expect(group[:name]).not_to eq("Other")
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/82281760

As we are adding the latest feed, we no longer need to display the "Other" section at the bottom of a sub-topic.

This PR stops uncategorized groups, which power the "Other" section, being sent to the Publishing API. It also adds a note to the user on the frontend warning about this behaviour.
