### PR TITLE
Register prefix routes for curated content.

### DIFF
--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -20,7 +20,7 @@ class SectorPresenter
       publishing_app: "collections-publisher",
       rendering_app: "collections", # This will soon change to `collections-frontend`.
       routes: [
-        {path: base_path, type: "exact"}
+        {path: base_path, type: "prefix"}
       ],
       redirects: [],
       update_type: "major", # All changes in this app are de facto major for now.

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SectorPresenter do
           publishing_app: "collections-publisher",
           rendering_app: "collections", # This will soon change to `collections-frontend`.
           routes: [
-            {path: "/oil-and-gas/offshore", type: "exact"}
+            {path: "/oil-and-gas/offshore", type: "prefix"}
           ],
           redirects: [],
           update_type: "major" # All changes in this app are de facto major for now.


### PR DESCRIPTION
This change was already made in Panopticon to
support the /latest and /email-signup pages, but
not updated here.  Since Panopticon doesn't use
the URL arbiter for this, that means that
Collections Publisher can sometimes overwrite the
prefix route with an exact route, taking the sub-
pages offline (see https://govuk.zendesk.com/agent/tickets/936651).

The intention is for these to change to multiple
exact routes when topic creation is moved from
Panopticon into Collections Publisher.