### PR TITLE
Remove base_path from Publishing API request body

### DIFF
--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -3,6 +3,6 @@ class PublishingAPINotifier
     sector_hash = sector_presenter.render_for_publishing_api
 
     publishing_api = CollectionsPublisher.services(:publishing_api)
-    publishing_api.put_content_item(sector_hash[:base_path], sector_hash)
+    publishing_api.put_content_item(sector_presenter.base_path, sector_hash)
   end
 end

--- a/app/presenters/sector_presenter.rb
+++ b/app/presenters/sector_presenter.rb
@@ -12,7 +12,6 @@ class SectorPresenter
   def render_for_publishing_api
     {
       title: @sector.title,
-      base_path: base_path,
       description: @sector.details.description,
       format: "specialist_sector",
       need_ids: [],
@@ -30,11 +29,11 @@ class SectorPresenter
     }
   end
 
-private
-
   def base_path
     web_url.path
   end
+
+private
 
   def web_url
     @web_url ||= URI.parse(@sector.web_url)

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -10,11 +10,7 @@ RSpec.describe PublishingAPINotifier do
   describe "#publish(sector_presenter)" do
     let(:sector_hash) { double(:sector_hash) }
     let(:base_path) { double(:base_path) }
-    let(:presenter) { double(:sector_presenter, render_for_publishing_api: sector_hash) }
-
-    before do
-      allow(sector_hash).to receive(:[]).with(:base_path).and_return(base_path)
-    end
+    let(:presenter) { double(:sector_presenter, base_path: base_path, render_for_publishing_api: sector_hash) }
 
     it "sends a formatted version of the sector groupings to the publishing API" do
       PublishingAPINotifier.publish(presenter)

--- a/spec/presenters/sector_presenter_spec.rb
+++ b/spec/presenters/sector_presenter_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe SectorPresenter do
 
         expect(sector_hash).to include(
           title: "Offshore",
-          base_path: "/oil-and-gas/offshore",
           description: "Important information about offshore drilling",
           format: "specialist_sector",
           need_ids: [],


### PR DESCRIPTION
Publishing API currently ignores this field and is about to start rejecting it.
It uses the version in the request URL instead.

For more context: alphagov/content-store#104