### PR TITLE
Only publish tags that aren't already published

### DIFF
--- a/lib/tasks/load_tags_from_content_api.rake
+++ b/lib/tasks/load_tags_from_content_api.rake
@@ -47,7 +47,7 @@ task :load_tags_from_content_api => :environment do
   tags.each do |api_tag|
     existing_tag = Tag.where(slug: api_tag.slug).first
 
-    if api_tag.state == "live"
+    if api_tag.state == "live" && !existing_tag.published?
       existing_tag.publish
       existing_tag.save!
     end


### PR DESCRIPTION
This makes the task easier to run again in the future and won't blow up
should someone attempt to migrate data again.