### PR TITLE
Remove decent exposure from tags

### DIFF
--- a/app/controllers/concerns/tag_create_update_publish.rb
+++ b/app/controllers/concerns/tag_create_update_publish.rb
@@ -26,61 +26,61 @@ module TagCreateUpdatePublish
   end
 
   def index
+    @resource = resource
     render 'shared/tags/index'
   end
 
   def new
+    @resource = resource
     render 'shared/tags/new'
   end
 
   def show
+    @resource = resource
     render 'shared/tags/show'
   end
 
   def edit
+    @resource = resource
     render 'shared/tags/edit'
   end
 
   def create
-    # Assigning the attributes directly, rather than using the 'attributes' key
-    # in the `expose` method above, means that we can use the `mainstream_browse_page`
-    # helper in other member actions.
-    #
-    # This is described in greater detail in this GitHub issue:
-    # https://github.com/hashrocket/decent_exposure/issues/99#issuecomment-32115500
-    #
-    resource.attributes = tag_params
+    @resource = resource
+    @resource.attributes = tag_params
 
-    if resource.save
+    if @resource.save
       PanopticonNotifier.create_tag(
-        presenter_klass.new(resource)
+        presenter_klass.new(@resource)
       )
 
-      redirect_to polymorphic_path(resource)
+      redirect_to polymorphic_path(@resource)
     else
       render 'shared/tags/new'
     end
   end
 
   def update
-    if resource.update_attributes(tag_params)
+    @resource = resource
+    if @resource.update_attributes(tag_params)
       PanopticonNotifier.update_tag(
-        presenter_klass.new(resource)
+        presenter_klass.new(@resource)
       )
 
-      redirect_to polymorphic_path(resource)
+      redirect_to polymorphic_path(@resource)
     else
       render 'shared/tags/edit'
     end
   end
 
   def publish
-    resource.publish!
+    @resource = resource
+    @resource.publish!
     PanopticonNotifier.publish_tag(
-      presenter_klass.new(resource)
+      presenter_klass.new(@resource)
     )
 
-    redirect_to polymorphic_path(resource)
+    redirect_to polymorphic_path(@resource)
   end
 
 private

--- a/app/controllers/concerns/tag_create_update_publish.rb
+++ b/app/controllers/concerns/tag_create_update_publish.rb
@@ -3,7 +3,7 @@ module TagCreateUpdatePublish
 
   included do
     before_filter :find_resource, only: [:edit, :publish, :show, :update]
-    before_filter :new_resource, only: [:create, :index, :new]
+    before_filter :new_resource, only: [:create, :new]
 
     helper_method :parent, :parent_tags, :tag_type_label
   end
@@ -27,6 +27,7 @@ module TagCreateUpdatePublish
   end
 
   def index
+    @model_class = self.class.tag_model
     render 'shared/tags/index'
   end
 

--- a/app/controllers/concerns/tag_create_update_publish.rb
+++ b/app/controllers/concerns/tag_create_update_publish.rb
@@ -3,6 +3,7 @@ module TagCreateUpdatePublish
 
   included do
     before_filter :find_resource, only: [:edit, :publish, :show, :update]
+    before_filter :new_resource, only: [:create, :index, :new]
 
     helper_method :parent, :parent_tags, :tag_type_label
   end
@@ -10,8 +11,6 @@ module TagCreateUpdatePublish
   module ClassMethods
     def tag_create_update_publish_for(klass)
       @tag_model = klass
-      expose(:resource, model: symbolized_tag_model_name,
-                        finder: :find_by_content_id)
     end
 
     def tag_model
@@ -28,12 +27,10 @@ module TagCreateUpdatePublish
   end
 
   def index
-    @resource = resource
     render 'shared/tags/index'
   end
 
   def new
-    @resource = resource
     render 'shared/tags/new'
   end
 
@@ -46,7 +43,6 @@ module TagCreateUpdatePublish
   end
 
   def create
-    @resource = resource
     @resource.attributes = tag_params
 
     if @resource.save
@@ -106,5 +102,9 @@ private
 
   def find_resource
     @resource = self.class.tag_model.find_by_content_id(params[:id])
+  end
+
+  def new_resource
+    @resource = self.class.tag_model.new
   end
 end

--- a/app/controllers/concerns/tag_create_update_publish.rb
+++ b/app/controllers/concerns/tag_create_update_publish.rb
@@ -2,6 +2,8 @@ module TagCreateUpdatePublish
   extend ActiveSupport::Concern
 
   included do
+    before_filter :find_resource, only: [:edit, :publish, :show, :update]
+
     helper_method :parent, :parent_tags, :tag_type_label
   end
 
@@ -36,12 +38,10 @@ module TagCreateUpdatePublish
   end
 
   def show
-    @resource = resource
     render 'shared/tags/show'
   end
 
   def edit
-    @resource = resource
     render 'shared/tags/edit'
   end
 
@@ -61,7 +61,6 @@ module TagCreateUpdatePublish
   end
 
   def update
-    @resource = resource
     if @resource.update_attributes(tag_params)
       PanopticonNotifier.update_tag(
         presenter_klass.new(@resource)
@@ -74,7 +73,6 @@ module TagCreateUpdatePublish
   end
 
   def publish
-    @resource = resource
     @resource.publish!
     PanopticonNotifier.publish_tag(
       presenter_klass.new(@resource)
@@ -106,4 +104,7 @@ private
     params[:parent_id] || params.fetch(self.class.symbolized_tag_model_name, {})[:parent_id]
   end
 
+  def find_resource
+    @resource = self.class.tag_model.find_by_content_id(params[:id])
+  end
 end

--- a/app/views/shared/tags/edit.html.erb
+++ b/app/views/shared/tags/edit.html.erb
@@ -4,14 +4,14 @@
   <span class="type"><%= tag_type_label %></span>
 
   Editing
-  <% if resource.has_parent? %>
-    <%= resource.parent.title %>:
+  <% if @resource.has_parent? %>
+    <%= @resource.parent.title %>:
   <% end %>
-    <%= resource.title %>
+    <%= @resource.title %>
 </h1>
 
 <%=
 render partial: 'shared/tags/form', locals: {
-  resource: resource
+  resource: @resource
 }
 %>

--- a/app/views/shared/tags/index.html.erb
+++ b/app/views/shared/tags/index.html.erb
@@ -4,7 +4,7 @@
   <h1><%= tag_type_label.pluralize %></h1>
 
   <nav class="actions">
-    <%= link_to new_polymorphic_path(@resource), class: 'new' do %>
+    <%= link_to new_polymorphic_path(@model_class), class: 'new' do %>
       <span class="icon"></span> Add a <%= tag_type_label.downcase %>
     <% end %>
   </nav>
@@ -14,6 +14,6 @@
   render partial: 'shared/tags/table', locals: {
     resources: parent_tags,
     empty_message: "No #{tag_type_label.downcase.pluralize} exist yet.
-      #{link_to('Add one', new_polymorphic_path(@resource))}".html_safe
+      #{link_to('Add one', new_polymorphic_path(@model_class))}".html_safe
   }
 %>

--- a/app/views/shared/tags/index.html.erb
+++ b/app/views/shared/tags/index.html.erb
@@ -4,7 +4,7 @@
   <h1><%= tag_type_label.pluralize %></h1>
 
   <nav class="actions">
-    <%= link_to new_polymorphic_path(resource), class: 'new' do %>
+    <%= link_to new_polymorphic_path(@resource), class: 'new' do %>
       <span class="icon"></span> Add a <%= tag_type_label.downcase %>
     <% end %>
   </nav>
@@ -14,6 +14,6 @@
   render partial: 'shared/tags/table', locals: {
     resources: parent_tags,
     empty_message: "No #{tag_type_label.downcase.pluralize} exist yet.
-      #{link_to('Add one', new_polymorphic_path(resource))}".html_safe
+      #{link_to('Add one', new_polymorphic_path(@resource))}".html_safe
   }
 %>

--- a/app/views/shared/tags/new.html.erb
+++ b/app/views/shared/tags/new.html.erb
@@ -6,7 +6,7 @@
 
 <%=
   render partial: 'shared/tags/form', locals: {
-    resource: resource,
+    resource: @resource,
     parent: parent,
   }
 %>

--- a/app/views/shared/tags/show.html.erb
+++ b/app/views/shared/tags/show.html.erb
@@ -1,30 +1,30 @@
-<%= content_for :page_title, resource.title %>
+<%= content_for :page_title, @resource.title %>
 
 <header class="heading-with-actions">
   <h1>
     <span class="type"><%= tag_type_label %></span>
-    <% if resource.has_parent? %>
-      <%= link_to "#{resource.parent.title}:", polymorphic_path(resource.parent) %>
+    <% if @resource.has_parent? %>
+      <%= link_to "#{@resource.parent.title}:", polymorphic_path(@resource.parent) %>
     <% end %>
-    <%= resource.title %>
+    <%= @resource.title %>
   </h1>
 
   <nav class="actions">
-    <%= link_to 'Edit', edit_polymorphic_path(resource) %>
-    <% if resource.may_publish? %>
-      <%= link_to "Publish #{tag_type_label.downcase}", polymorphic_path(resource, action: 'publish'), method: :post %>
+    <%= link_to 'Edit', edit_polymorphic_path(@resource) %>
+    <% if @resource.may_publish? %>
+      <%= link_to "Publish #{tag_type_label.downcase}", polymorphic_path(@resource, action: 'publish'), method: :post %>
     <% end %>
   </nav>
 </header>
 
 <%=
   render partial: 'shared/tags/metadata', locals: {
-    resource: resource
+    resource: @resource
   }
 %>
 
 <%=
   render partial: 'shared/tags/children', locals: {
-    resource: resource
+    resource: @resource
   }
 %>

--- a/spec/controllers/mainstream_browse_pages_controller_spec.rb
+++ b/spec/controllers/mainstream_browse_pages_controller_spec.rb
@@ -76,7 +76,7 @@ describe MainstreamBrowsePagesController do
     it 'notifies panopticon' do
       expect(PanopticonNotifier).to receive(:update_tag).with(presenter)
 
-      put :update, id: 'abc', mainstream_browse_page: attributes
+      put :update, id: mainstream_browse_page.content_id, mainstream_browse_page: attributes
     end
   end
 

--- a/spec/controllers/mainstream_browse_pages_controller_spec.rb
+++ b/spec/controllers/mainstream_browse_pages_controller_spec.rb
@@ -44,15 +44,9 @@ describe MainstreamBrowsePagesController do
 
   describe 'POST create' do
     before do
-      allow(controller).to receive(:resource)
-        .and_return(mainstream_browse_page) # defined in `describe` blocks below
       allow(MainstreamBrowsePagePresenter).to receive(:new)
-        .with(mainstream_browse_page).and_return(presenter)
+        .and_return(presenter)
     end
-
-    let(:mainstream_browse_page) {
-      MainstreamBrowsePage.new
-    }
 
     it 'notifies panopticon' do
       expect(PanopticonNotifier).to receive(:create_tag).with(presenter)
@@ -63,8 +57,6 @@ describe MainstreamBrowsePagesController do
 
   describe 'PUT update' do
     before do
-      allow(controller).to receive(:resource)
-        .and_return(mainstream_browse_page) # defined in `describe` blocks below
       allow(MainstreamBrowsePagePresenter).to receive(:new)
         .with(mainstream_browse_page).and_return(presenter)
     end


### PR DESCRIPTION
This pull request removes the use of the `decent_exposure` gem for the `Tag`-like objects in this application.

The reason for doing this is because upcoming features in the application require some feature diversion between `Topic` and `MainstreamBrowsePage` objects and will result in changes being made to the views.

**NOTE:** `decent_exposure` is still being used for the `ListItem` and `Sector` objects and they will be cleaned up in the near future.