### PR TITLE
Reset the database on each CI run.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -35,6 +35,7 @@ github_status "$REPO_NAME" pending "is running on Jenkins"
 git merge --no-commit origin/master || git merge --abort
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
+RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load
 RAILS_ENV=test bundle exec rake
 
 export EXIT_STATUS=$?


### PR DESCRIPTION
Rails' automatic schema maintenance doesn't cope 100% with switching
between branches with different schemas.  Specifically, it doesn't
handle changes to a column's null state.

Explicitly dropping and re-creating the test database on each run
ensures that we're running with a clean state.

This should prevent test failures like https://ci-new.alphagov.co.uk/job/govuk_collections_publisher_branches/174/console