### PR TITLE
Make tag links in collections publisher clickable

### DIFF
--- a/app/views/shared/tags/_metadata.html.erb
+++ b/app/views/shared/tags/_metadata.html.erb
@@ -1,7 +1,7 @@
 <section class="attributes">
   <dl>
     <dt>URL</dt>
-    <dd><%= resource.base_path %></dd>
+    <dd><%= link_to resource.base_path, Plek.new.website_root + resource.base_path %></dd>
 
     <% if resource.has_parent? %>
     <dt>Parent</dt>

--- a/app/views/shared/tags/_table.html.erb
+++ b/app/views/shared/tags/_table.html.erb
@@ -15,7 +15,7 @@
       <% resources.each do |resource| %>
       <tr>
         <td><%= link_to resource.title, polymorphic_path(resource) %></td>
-        <td><%= resource.base_path %></td>
+        <td><%= link_to resource.base_path, Plek.new.website_root + resource.base_path %></td>
         <td><%= resource.state %></td>
         <% unless local_assigns[:include_children_column] == false %>
           <td>


### PR DESCRIPTION
Where "urls" are displayed for topics or mainstream browse pages, they
are now clickable and open the corresponding URL on the live site when
clicked.

https://trello.com/c/4xrXljxX/61-make-tag-links-in-collections-publisher-clickable