### PR TITLE
Existing topics appear when editing mainstream browse pages

### DIFF
--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -12,7 +12,7 @@
   <%= f.text_field :description %>
 
   <%= f.select :topics,
-      options_from_collection_for_select(@topics, "id", "title", @resource.topics),
+      options_from_collection_for_select(@topics, :id, :title, @resource.topics.map { |t| t.id }),
       {},
       { multiple: true,
         class: "select2",

--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -54,5 +54,15 @@ describe "associating topics to mainstream browse pages" do
       expect(page).to_not have_content(topic.title)
       expect(page).to_not have_content(topic_two.title)
     end
+
+    it "should show the already assigned topics when editing" do
+      mainstream_browse_page.topics = [topic, topic_two]
+      expect(mainstream_browse_page.save).to be_true
+
+      visit edit_mainstream_browse_page_path(mainstream_browse_page)
+
+      expect(page.status_code).to eq(200)
+      expect(page).to have_select("mainstream_browse_page_topics", selected: [topic.title, topic_two.title])
+    end
   end
 end


### PR DESCRIPTION
When editing `MainstreamBrowsePage` items, show the already assigned
`Topic` values.

The response to this involved updating the use of
`options_from_collection_for_select` to provide the existing topics as
the fourth parameter (`selected`) in the form of an array of ids.

Also switched out the fields we're using to be symbols instead of
strings as that's what they're being converted to behind the scenes
anyway.