### PR TITLE
Add missing foreign key constraints for schema

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 class MainstreamBrowsePage < Tag

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'securerandom'

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 class Topic < Tag

--- a/db/migrate/20150424150725_add_foreign_key_constraints.rb
+++ b/db/migrate/20150424150725_add_foreign_key_constraints.rb
@@ -1,0 +1,16 @@
+class AddForeignKeyConstraints < ActiveRecord::Migration
+  def change
+    add_foreign_key "list_items", "lists", name: "list_items_list_id_fk"
+    add_foreign_key "lists", "tags", column: "topic_id", name: "lists_topic_id_fk"
+    add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"
+
+    add_foreign_key "tag_associations", "tags",
+                    column: "from_tag_id",
+                    name: "tag_associations_from_tag_id_fk",
+                    dependent: :delete
+    add_foreign_key "tag_associations", "tags",
+                    column: "to_tag_id",
+                    name: "tag_associations_to_tag_id_fk",
+                    dependent: :delete
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,31 +11,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150423134118) do
+ActiveRecord::Schema.define(version: 20150424150725) do
 
-  create_table "list_items", force: true do |t|
-    t.string   "api_url"
-    t.integer  "index",      default: 0, null: false
-    t.integer  "list_id"
+  create_table "list_items", force: :cascade do |t|
+    t.string   "api_url",    limit: 255
+    t.integer  "index",      limit: 4,   default: 0, null: false
+    t.integer  "list_id",    limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title"
+    t.string   "title",      limit: 255
   end
 
   add_index "list_items", ["list_id", "index"], name: "index_list_items_on_list_id_and_index", using: :btree
 
-  create_table "lists", force: true do |t|
-    t.string  "name"
-    t.integer "index",    default: 0,    null: false
-    t.boolean "dirty",    default: true, null: false
-    t.integer "topic_id",                null: false
+  create_table "lists", force: :cascade do |t|
+    t.string  "name",     limit: 255
+    t.integer "index",    limit: 4,   default: 0,    null: false
+    t.boolean "dirty",    limit: 1,   default: true, null: false
+    t.integer "topic_id", limit: 4,                  null: false
   end
 
   add_index "lists", ["topic_id"], name: "index_lists_on_topic_id", using: :btree
 
-  create_table "tag_associations", force: true do |t|
-    t.integer  "from_tag_id", null: false
-    t.integer  "to_tag_id",   null: false
+  create_table "tag_associations", force: :cascade do |t|
+    t.integer  "from_tag_id", limit: 4, null: false
+    t.integer  "to_tag_id",   limit: 4, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -43,30 +43,36 @@ ActiveRecord::Schema.define(version: 20150423134118) do
   add_index "tag_associations", ["from_tag_id", "to_tag_id"], name: "index_tag_associations_on_from_tag_id_and_to_tag_id", unique: true, using: :btree
   add_index "tag_associations", ["to_tag_id"], name: "index_tag_associations_on_to_tag_id", using: :btree
 
-  create_table "tags", force: true do |t|
-    t.string   "type"
-    t.string   "slug",        null: false
-    t.string   "title",       null: false
-    t.string   "description"
-    t.integer  "parent_id"
+  create_table "tags", force: :cascade do |t|
+    t.string   "type",        limit: 255
+    t.string   "slug",        limit: 255, null: false
+    t.string   "title",       limit: 255, null: false
+    t.string   "description", limit: 255
+    t.integer  "parent_id",   limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "content_id",  null: false
-    t.string   "state",       null: false
+    t.string   "content_id",  limit: 255, null: false
+    t.string   "state",       limit: 255, null: false
   end
 
+  add_index "tags", ["parent_id"], name: "tags_parent_id_fk", using: :btree
   add_index "tags", ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true, using: :btree
 
-  create_table "users", force: true do |t|
-    t.string  "name"
-    t.string  "email"
-    t.string  "uid",                                 null: false
-    t.string  "organisation_slug"
-    t.string  "permissions"
-    t.boolean "remotely_signed_out", default: false
-    t.boolean "disabled",            default: false
+  create_table "users", force: :cascade do |t|
+    t.string  "name",                limit: 255
+    t.string  "email",               limit: 255
+    t.string  "uid",                 limit: 255,                 null: false
+    t.string  "organisation_slug",   limit: 255
+    t.string  "permissions",         limit: 255
+    t.boolean "remotely_signed_out", limit: 1,   default: false
+    t.boolean "disabled",            limit: 1,   default: false
   end
 
   add_index "users", ["uid"], name: "index_users_on_uid", unique: true, using: :btree
 
+  add_foreign_key "list_items", "lists", name: "list_items_list_id_fk"
+  add_foreign_key "lists", "tags", column: "topic_id", name: "lists_topic_id_fk"
+  add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk"
+  add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk"
+  add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"
 end

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'spec_helper'

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'spec_helper'

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Where possible, we should get the database to enforce the schema in
addition to our models.

This change applies a migration `AddForeignKeyConstraints`, which adds
foreign key constraints to our tables. This was done using the
`immigrant`[1] gem.

The only effective change here is in the file called
`db/migrate/20150424150725_add_foreign_key_constraints.rb`. The rest of
the diff is adding annotations for our schema structure as comments.

[1] https://github.com/jenseng/immigrant