### PR TITLE
Update schema for rails 4.2

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,29 +13,29 @@
 
 ActiveRecord::Schema.define(version: 20150423134118) do
 
-  create_table "list_items", force: true do |t|
-    t.string   "api_url"
-    t.integer  "index",      default: 0, null: false
-    t.integer  "list_id"
+  create_table "list_items", force: :cascade do |t|
+    t.string   "api_url",    limit: 255
+    t.integer  "index",      limit: 4,   default: 0, null: false
+    t.integer  "list_id",    limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title"
+    t.string   "title",      limit: 255
   end
 
   add_index "list_items", ["list_id", "index"], name: "index_list_items_on_list_id_and_index", using: :btree
 
-  create_table "lists", force: true do |t|
-    t.string  "name"
-    t.integer "index",    default: 0,    null: false
-    t.boolean "dirty",    default: true, null: false
-    t.integer "topic_id",                null: false
+  create_table "lists", force: :cascade do |t|
+    t.string  "name",     limit: 255
+    t.integer "index",    limit: 4,   default: 0,    null: false
+    t.boolean "dirty",    limit: 1,   default: true, null: false
+    t.integer "topic_id", limit: 4,                  null: false
   end
 
   add_index "lists", ["topic_id"], name: "index_lists_on_topic_id", using: :btree
 
-  create_table "tag_associations", force: true do |t|
-    t.integer  "from_tag_id", null: false
-    t.integer  "to_tag_id",   null: false
+  create_table "tag_associations", force: :cascade do |t|
+    t.integer  "from_tag_id", limit: 4, null: false
+    t.integer  "to_tag_id",   limit: 4, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -43,28 +43,28 @@ ActiveRecord::Schema.define(version: 20150423134118) do
   add_index "tag_associations", ["from_tag_id", "to_tag_id"], name: "index_tag_associations_on_from_tag_id_and_to_tag_id", unique: true, using: :btree
   add_index "tag_associations", ["to_tag_id"], name: "index_tag_associations_on_to_tag_id", using: :btree
 
-  create_table "tags", force: true do |t|
-    t.string   "type"
-    t.string   "slug",        null: false
-    t.string   "title",       null: false
-    t.string   "description"
-    t.integer  "parent_id"
+  create_table "tags", force: :cascade do |t|
+    t.string   "type",        limit: 255
+    t.string   "slug",        limit: 255, null: false
+    t.string   "title",       limit: 255, null: false
+    t.string   "description", limit: 255
+    t.integer  "parent_id",   limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "content_id",  null: false
-    t.string   "state",       null: false
+    t.string   "content_id",  limit: 255, null: false
+    t.string   "state",       limit: 255, null: false
   end
 
   add_index "tags", ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true, using: :btree
 
-  create_table "users", force: true do |t|
-    t.string  "name"
-    t.string  "email"
-    t.string  "uid",                                 null: false
-    t.string  "organisation_slug"
-    t.string  "permissions"
-    t.boolean "remotely_signed_out", default: false
-    t.boolean "disabled",            default: false
+  create_table "users", force: :cascade do |t|
+    t.string  "name",                limit: 255
+    t.string  "email",               limit: 255
+    t.string  "uid",                 limit: 255,                 null: false
+    t.string  "organisation_slug",   limit: 255
+    t.string  "permissions",         limit: 255
+    t.boolean "remotely_signed_out", limit: 1,   default: false
+    t.boolean "disabled",            limit: 1,   default: false
   end
 
   add_index "users", ["uid"], name: "index_users_on_uid", unique: true, using: :btree


### PR DESCRIPTION
This update is the results of running `rake db:migrate` and it causes a
change to the schema now that we've upgrade from 4.1.2 to 4.2.1.