### PR TITLE
Add missing foreign key constraints

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 class MainstreamBrowsePage < Tag

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,10 +27,9 @@ class Tag < ActiveRecord::Base
   belongs_to :parent, class_name: 'Tag'
   has_many :children, class_name: 'Tag', foreign_key: :parent_id
 
-  has_many :tag_associations, foreign_key: :from_tag_id,
-           dependent: :destroy
+  has_many :tag_associations, foreign_key: :from_tag_id
   has_many :reverse_tag_associations, foreign_key: :to_tag_id,
-           class_name: "TagAssociation", dependent: :destroy
+           class_name: "TagAssociation"
 
   validates :slug, :title, :content_id, presence: true
   validates :slug, uniqueness: { scope: ["parent_id"] }, format: { with: /\A[a-z0-9-]*\z/ }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'securerandom'

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 class Topic < Tag

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -20,7 +20,7 @@
 
 class Topic < Tag
   has_many :mainstream_browse_pages, through: :reverse_tag_associations, source: :from_tag
-  has_many :lists, :dependent => :destroy
+  has_many :lists
   has_many :list_items, :through => :lists
 
   # returns unsaved ListItems for content tagged to this topic, but not in a

--- a/db/migrate/20150427094415_add_foreign_keys_for_lists_and_list_items.rb
+++ b/db/migrate/20150427094415_add_foreign_keys_for_lists_and_list_items.rb
@@ -1,0 +1,14 @@
+class AddForeignKeysForListsAndListItems < ActiveRecord::Migration
+  def change
+    # When a `List` is deleted, this :cascade causes the respective
+    # `ListItem` records to be deleted.
+    add_foreign_key "list_items", "lists",
+                    name: "list_items_list_id_fk",
+                    on_delete: :cascade
+
+    add_foreign_key "lists", "tags",
+                    column: "topic_id",
+                    name: "lists_topic_id_fk",
+                    on_delete: :cascade
+  end
+end

--- a/db/migrate/20150427095118_add_foreign_keys_for_tags_and_tag_associations.rb
+++ b/db/migrate/20150427095118_add_foreign_keys_for_tags_and_tag_associations.rb
@@ -1,0 +1,18 @@
+class AddForeignKeysForTagsAndTagAssociations < ActiveRecord::Migration
+  def change
+    add_foreign_key "tag_associations", "tags",
+                    column: "from_tag_id",
+                    name: "tag_associations_from_tag_id_fk",
+                    on_delete: :cascade
+
+    add_foreign_key "tag_associations", "tags",
+                    column: "to_tag_id",
+                    name: "tag_associations_to_tag_id_fk",
+                    on_delete: :cascade
+
+    add_foreign_key "tags", "tags",
+                    column: "parent_id",
+                    name: "tags_parent_id_fk",
+                    on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150423134118) do
+ActiveRecord::Schema.define(version: 20150427094415) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255
@@ -69,4 +69,6 @@ ActiveRecord::Schema.define(version: 20150423134118) do
 
   add_index "users", ["uid"], name: "index_users_on_uid", unique: true, using: :btree
 
+  add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
+  add_foreign_key "lists", "tags", column: "topic_id", name: "lists_topic_id_fk", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150427094415) do
+ActiveRecord::Schema.define(version: 20150427095118) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20150427094415) do
     t.string   "state",       limit: 255, null: false
   end
 
+  add_index "tags", ["parent_id"], name: "tags_parent_id_fk", using: :btree
   add_index "tags", ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
@@ -71,4 +72,7 @@ ActiveRecord::Schema.define(version: 20150427094415) do
 
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
   add_foreign_key "lists", "tags", column: "topic_id", name: "lists_topic_id_fk", on_delete: :cascade
+  add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
+  add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade
+  add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -50,5 +50,16 @@ RSpec.describe List do
         expect(list).not_to be_dirty
       end
     end
+
+    describe "#delete" do
+      it "deletes list items" do
+        list = create(:list)
+        item = create(:list_item, list: list)
+
+        list.delete
+
+        expect { item.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'spec_helper'

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'spec_helper'

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,6 +16,7 @@
 # Indexes
 #
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
+#  tags_parent_id_fk                 (parent_id)
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Where possible, we should get the database to enforce the schema in addition to our models.

This change add two migrations `AddForeignKeysForListsAndListItems` and `AddForeignKeysForTagsAndTagAssociations` as well as removing the equivalent `dependent` actions that exist on the respective models.

The initial work for this was done using the immigrant[1] gem, but it was pulled apart into separate commits and migrations to make it easier to understand. The `on_delete` actions were added to allow removal of the `dependent` actions on the models.

[1] https://github.com/jenseng/immigrant