### PR TITLE
Add unique index on tag content_id.

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -16,6 +16,7 @@
 #
 # Indexes
 #
+#  index_tags_on_content_id          (content_id) UNIQUE
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
 #  tags_parent_id_fk                 (parent_id)
 #

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,7 @@
 #
 # Indexes
 #
+#  index_tags_on_content_id          (content_id) UNIQUE
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
 #  tags_parent_id_fk                 (parent_id)
 #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -16,6 +16,7 @@
 #
 # Indexes
 #
+#  index_tags_on_content_id          (content_id) UNIQUE
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
 #  tags_parent_id_fk                 (parent_id)
 #

--- a/db/migrate/20150427135925_add_index_to_tag_content_id.rb
+++ b/db/migrate/20150427135925_add_index_to_tag_content_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToTagContentId < ActiveRecord::Migration
+  def change
+    add_index :tags, :content_id, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150427095118) do
+ActiveRecord::Schema.define(version: 20150427135925) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20150427095118) do
     t.boolean  "dirty",       limit: 1,   default: false, null: false
   end
 
+  add_index "tags", ["content_id"], name: "index_tags_on_content_id", unique: true, using: :btree
   add_index "tags", ["parent_id"], name: "tags_parent_id_fk", using: :btree
   add_index "tags", ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true, using: :btree
 

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -16,6 +16,7 @@
 #
 # Indexes
 #
+#  index_tags_on_content_id          (content_id) UNIQUE
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
 #  tags_parent_id_fk                 (parent_id)
 #

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -16,6 +16,7 @@
 #
 # Indexes
 #
+#  index_tags_on_content_id          (content_id) UNIQUE
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
 #  tags_parent_id_fk                 (parent_id)
 #
@@ -32,6 +33,15 @@ describe Tag do
       expect(tag).to be_valid
       expect(tag.save).to eql true
       expect(tag).to be_persisted
+    end
+
+    it 'requires a unique content_id at db level' do
+      duplicate = create(:tag)
+      tag.content_id = duplicate.content_id
+
+      expect {
+        tag.save :validate => false
+      }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "requires a title" do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,6 +16,7 @@
 #
 # Indexes
 #
+#  index_tags_on_content_id          (content_id) UNIQUE
 #  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
 #  tags_parent_id_fk                 (parent_id)
 #


### PR DESCRIPTION
Only enforced at DB level because we're unlikely to have collisions.

Most of the controllers look up tags by their content_id, so having an
index on this column is a good thing.