### PR TITLE
MainstreamBrowsePage: only children can have topics associated

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -23,7 +23,16 @@
 class MainstreamBrowsePage < Tag
   has_many :topics, through: :tag_associations, source: :to_tag
 
+  validate :parents_cannot_have_topics_associated
+
   def base_path
     "/browse#{super}"
+  end
+
+private
+  def parents_cannot_have_topics_associated
+    if !parent.present? and topics.any?
+      errors.add(:topics, "top-level mainstream browse pages cannot have topics assigned to them")
+    end
   end
 end

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -11,12 +11,14 @@
   <%= f.text_field :title %>
   <%= f.text_field :description %>
 
+  <% if !@resource.parent.blank? %>
   <%= f.select :topics,
       options_from_collection_for_select(@topics, :id, :title, @resource.topics.map { |t| t.id }),
       {},
       { multiple: true,
         class: "select2",
         data: {placeholder: "Choose additional topics..."}} %>
+  <% end %>
 
   <div class="form-actions">
     <button type="submit">

--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -6,6 +6,18 @@ describe "associating topics to mainstream browse pages" do
     stub_all_panopticon_tag_calls
   end
 
+  context "parent mainstream browse pages" do
+    let!(:mainstream_browse_page) { create(:mainstream_browse_page) }
+
+    it "should not allow adding any topics" do
+      visit edit_mainstream_browse_page_path(mainstream_browse_page)
+
+      within "form.resource" do
+        expect(page).to_not have_selector("#mainstream_browse_page_topics")
+      end
+    end
+  end
+
   context "existing mainstream browse pages" do
     let!(:mainstream_browse_page_parent) { create(:mainstream_browse_page) }
     let!(:mainstream_browse_page)        { create(:mainstream_browse_page) }

--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -7,9 +7,15 @@ describe "associating topics to mainstream browse pages" do
   end
 
   context "existing mainstream browse pages" do
-    let!(:mainstream_browse_page) { create(:mainstream_browse_page) }
-    let!(:topic)                  { create(:topic) }
-    let!(:topic_two)              { create(:topic) }
+    let!(:mainstream_browse_page_parent) { create(:mainstream_browse_page) }
+    let!(:mainstream_browse_page)        { create(:mainstream_browse_page) }
+    let!(:topic)                         { create(:topic) }
+    let!(:topic_two)                     { create(:topic) }
+
+    before do
+      mainstream_browse_page_parent.children << mainstream_browse_page
+      expect(mainstream_browse_page_parent.save).to eql true
+    end
 
     it "should show any topics that are associated" do
       mainstream_browse_page.topics = [topic, topic_two]

--- a/spec/models/tag_association_spec.rb
+++ b/spec/models/tag_association_spec.rb
@@ -17,8 +17,19 @@
 require 'spec_helper'
 
 describe TagAssociation do
-  let!(:mainstream_browse_page) { create(:mainstream_browse_page) }
-  let!(:topic)                  { create(:topic) }
+  let!(:mainstream_browse_page_parent) { create(:mainstream_browse_page) }
+  let!(:mainstream_browse_page)        { create(:mainstream_browse_page) }
+  let!(:topic)                         { create(:topic) }
+
+  before do
+    mainstream_browse_page_parent.children << mainstream_browse_page
+    expect(mainstream_browse_page_parent.save).to eql true
+  end
+
+  it "should not allow associating topics on parent mainstream browse pages" do
+    mainstream_browse_page_parent.topics << topic
+    expect(mainstream_browse_page_parent.valid?).to eql false
+  end
 
   it "is created by associating mainstream browse pages and topics" do
     expect(TagAssociation.where(from_tag: mainstream_browse_page,

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -67,8 +67,12 @@ describe MainstreamBrowsePagePresenter do
     end
 
     context "linking to related topics" do
+      let!(:parent_browse_page) { create(:mainstream_browse_page) }
+
       before :each do
         browse_page.save!
+        parent_browse_page.children << browse_page
+        parent_browse_page.save!
       end
 
       it "sends empty array without any" do


### PR DESCRIPTION
Top-level (parent) mainstream browse page records such as `/browse/driving` shouldn't have topics assigned to them. Only allow child `MainstreamBrowsePage` records to have topics assigned to them. Parents shouldn't have topics assigned to them.