### PR TITLE
Report build errors differently from failures.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -22,7 +22,7 @@ function error_handler {
   else
     echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
   fi
-  github_status "$REPO_NAME" failure "failed on Jenkins"
+  github_status "$REPO_NAME" error "errored on Jenkins"
   exit "${code}"
 }
 


### PR DESCRIPTION
The gh-status API has an error result as well as a failure state.
Update jenkins.sh to set this when the script errors to be able to
distinguish errors from actual test failures.