### PR TITLE
Remove `before` test blocks by assigning parents directly

### DIFF
--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -20,14 +20,9 @@ RSpec.describe "associating topics to mainstream browse pages" do
 
   context "existing mainstream browse pages" do
     let!(:mainstream_browse_page_parent) { create(:mainstream_browse_page) }
-    let!(:mainstream_browse_page)        { create(:mainstream_browse_page) }
+    let!(:mainstream_browse_page)        { create(:mainstream_browse_page, parent: mainstream_browse_page_parent) }
     let!(:topic)                         { create(:topic) }
     let!(:topic_two)                     { create(:topic) }
-
-    before do
-      mainstream_browse_page_parent.children << mainstream_browse_page
-      expect(mainstream_browse_page_parent.save).to eql true
-    end
 
     it "should show any topics that are associated" do
       mainstream_browse_page.topics = [topic, topic_two]

--- a/spec/models/tag_association_spec.rb
+++ b/spec/models/tag_association_spec.rb
@@ -18,13 +18,8 @@ require 'rails_helper'
 
 RSpec.describe TagAssociation do
   let!(:mainstream_browse_page_parent) { create(:mainstream_browse_page) }
-  let!(:mainstream_browse_page)        { create(:mainstream_browse_page) }
+  let!(:mainstream_browse_page)        { create(:mainstream_browse_page, parent: mainstream_browse_page_parent) }
   let!(:topic)                         { create(:topic) }
-
-  before do
-    mainstream_browse_page_parent.children << mainstream_browse_page
-    expect(mainstream_browse_page_parent.save).to eql true
-  end
 
   it "should not allow associating topics on parent mainstream browse pages" do
     mainstream_browse_page_parent.topics << topic


### PR DESCRIPTION
These two `before` test blocks are no longer needed because we can do
the parent assignment as part of the `let!(..) {}` calls.