### PR TITLE
Don't load test tasks in production.

### DIFF
--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,8 +1,11 @@
-require 'rspec/core/rake_task'
+if Rails.env.development? or Rails.env.test?
 
-namespace :spec do
-  desc "Run all schema specs"
-  RSpec::Core::RakeTask.new(:schema => "spec:prepare") do |t|
-    t.rspec_opts = '-t schema_test'
+  require 'rspec/core/rake_task'
+
+  namespace :spec do
+    desc "Run all schema specs"
+    RSpec::Core::RakeTask.new(:schema => "spec:prepare") do |t|
+      t.rspec_opts = '-t schema_test'
+    end
   end
 end


### PR DESCRIPTION
This was causing errors on deploy because the rspec require errored
because rspec isn't installed.

Best viewed with `?w=1`