### PR TITLE
Include parent title in topics dropdown and sort by both

### DIFF
--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -5,7 +5,7 @@ class MainstreamBrowsePagesController < ApplicationController
   before_filter :require_gds_editor_permissions!
 
   def edit
-    @topics = Topic.all
+    set_topics_for_select
   end
 
   def show; end
@@ -30,7 +30,7 @@ class MainstreamBrowsePagesController < ApplicationController
 
       redirect_to mainstream_browse_page_path(@resource)
     else
-      @topics = Topic.all
+      set_topics_for_select
       render :edit
     end
   end
@@ -38,5 +38,9 @@ class MainstreamBrowsePagesController < ApplicationController
 private
   def presenter_klass
     MainstreamBrowsePagePresenter
+  end
+
+  def set_topics_for_select
+    @topics_for_select = Topic.includes(:parent).sort_by(&:title_including_parent)
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -66,6 +66,14 @@ class Tag < ActiveRecord::Base
     parent.present?
   end
 
+  def title_including_parent
+    if has_parent?
+      "#{parent.title}: #{title}"
+    else
+      title
+    end
+  end
+
   def base_path
     base = has_parent? ? "/#{parent.slug}" : ''
     "#{base}/#{slug}"

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -13,7 +13,7 @@
 
   <% if !@resource.parent.blank? %>
   <%= f.select :topics,
-      options_from_collection_for_select(@topics, :id, :title, @resource.topics.map { |t| t.id }),
+      options_from_collection_for_select(@topics_for_select, :id, :title_including_parent, @resource.topics.map(&:id)),
       {},
       { multiple: true,
         class: "select2",

--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "associating topics to mainstream browse pages" do
   context "existing mainstream browse pages" do
     let!(:mainstream_browse_page_parent) { create(:mainstream_browse_page) }
     let!(:mainstream_browse_page)        { create(:mainstream_browse_page, parent: mainstream_browse_page_parent) }
-    let!(:topic)                         { create(:topic) }
-    let!(:topic_two)                     { create(:topic) }
+    let!(:topic)                         { create(:topic, title: "Bravo") }
+    let!(:topic_two)                     { create(:topic, title: "Alpha") }
 
     it "should show any topics that are associated" do
       mainstream_browse_page.topics = [topic, topic_two]
@@ -33,6 +33,27 @@ RSpec.describe "associating topics to mainstream browse pages" do
       expect(page.status_code).to eq(200)
       expect(page).to have_content(topic.title)
       expect(page).to have_content(topic_two.title)
+    end
+
+    it "should sort topic dropdown and include parent topic title" do
+      create(:topic, parent: topic, title: "Bravo")
+      create(:topic, parent: topic, title: "Alpha")
+      create(:topic, parent: topic, title: "Charlie")
+      create(:topic, parent: topic_two, title: "Bravo")
+      create(:topic, parent: topic_two, title: "Alpha")
+
+      visit edit_mainstream_browse_page_path(mainstream_browse_page)
+
+      topic_titles = page.all(:css, "#mainstream_browse_page_topics option").map(&:text)
+      expect(topic_titles).to eq([
+        "Alpha",
+        "Alpha: Alpha",
+        "Alpha: Bravo",
+        "Bravo",
+        "Bravo: Alpha",
+        "Bravo: Bravo",
+        "Bravo: Charlie",
+      ])
     end
 
     it "should allow associating topics" do


### PR DESCRIPTION
To make it easier to find topics to select.

Trello: https://trello.com/c/tUXtPH7a/91