### PR TITLE
Only show uncategorized warning when it applies.

### DIFF
--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -103,7 +103,9 @@
 
 <section class="list" aria-labelledby='list-uncategorized-header' id='list-uncategorized-section'>
   <h2 id='list-uncategorized-header'>Uncategorized (A to Z)</h2>
-  <p><b>Note:</b> These will not be displayed to users</p>
+  <%- if @lists.any? -%>
+    <p><b>Note:</b> These will not be displayed to users</p>
+  <%- end -%>
 
   <table class='table table-hover'>
     <thead>

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -29,11 +29,19 @@ RSpec.describe "Curating the contents of topics" do
       visit sectors_path
       click_on 'Offshore'
 
+      within '#list-uncategorized-section' do
+        expect(page).not_to have_content('These will not be displayed to users')
+      end
+
       within '#new-list' do
         fill_in 'Name', :with => 'Oil rigs'
         click_on 'Create'
       end
       expect(page).to have_selector('.list h2', :text => 'Oil rigs')
+
+      within '#list-uncategorized-section' do
+        expect(page).to have_content('These will not be displayed to users')
+      end
 
       target = page.find(:xpath, "//section[contains(@class, 'list')][.//h2 = 'Oil rigs']//tbody[contains(@class, 'curated-list')]")
       within '#list-uncategorized-section' do
@@ -117,10 +125,19 @@ RSpec.describe "Curating the contents of topics" do
       visit sectors_path
       click_on 'Offshore'
 
+      within '#list-uncategorized-section' do
+        expect(page).not_to have_content('These will not be displayed to users')
+      end
+
       within '#new-list' do
         fill_in 'Name', :with => 'Oil rigs'
         click_on 'Create'
       end
+
+      within '#list-uncategorized-section' do
+        expect(page).to have_content('These will not be displayed to users')
+      end
+
       within :xpath, "//section[@class='list'][.//h2 = 'Oil rigs']" do
         fill_in 'API URL', :with => contentapi_url_for_slug('oil-rig-safety-requirements')
         fill_in 'Index', :with => 0


### PR DESCRIPTION
The 'These will not be displayed to users' warning is only true for a
subtopic that has curated groups, so this hides it when there are no
groups.

Trello: https://trello.com/c/FyRu03Ux/96