### PR TITLE
Use content_id in URLs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
     authorise_user!("GDS Editor")
   end
 
-  def find_topic_for_sector_id
+  def find_topic
     @topic = Topic.find_by!(content_id: params[:sector_id])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,14 +12,7 @@ class ApplicationController < ActionController::Base
     authorise_user!("GDS Editor")
   end
 
-  # FIXME: clean this up when we're using content_ids in the URL.
   def find_topic_for_sector_id
-    if params[:sector_id].include?('/')
-      parent_slug, child_slug = params[:sector_id].split('/', 2)
-      parent = Topic.find_by!(:slug => parent_slug)
-      @topic = parent.children.find_by!(:slug => child_slug)
-    else
-      @topic = Topic.only_parents.find_by!(:slug => params[:sector_id])
-    end
+    @topic = Topic.find_by!(content_id: params[:sector_id])
   end
 end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -16,11 +16,11 @@ class ListItemsController < ApplicationController
           flash[:error] = 'Could not add that list item to your list'
         end
 
-        redirect_to sector_lists_path(@topic.panopticon_slug)
+        redirect_to sector_lists_path(@topic)
       }
       format.js {
         if saved
-          render json: {errors: [], updateURL: sector_list_list_item_path(@topic.panopticon_slug, @list, list_item)}
+          render json: {errors: [], updateURL: sector_list_list_item_path(@topic, @list, list_item)}
         else
           render json: {errors: list_item.errors.to_json}, status: 422
         end
@@ -44,7 +44,7 @@ class ListItemsController < ApplicationController
           flash[:alert] = "Could not remove the list item from this list"
         end
 
-        redirect_to sector_lists_path(@topic.panopticon_slug)
+        redirect_to sector_lists_path(@topic)
       }
       format.js {
         if destroyed

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,5 +1,5 @@
 class ListItemsController < ApplicationController
-  before_filter :find_topic_for_sector_id
+  before_filter :find_topic
   before_filter :find_list
 
   def create

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,5 +1,5 @@
 class ListsController < ApplicationController
-  before_filter :find_topic_for_sector_id
+  before_filter :find_topic
 
   def index
     @lists = @topic.lists.ordered

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -20,7 +20,7 @@ class ListsController < ApplicationController
       flash[:error] = 'Could not create your list'
     end
 
-    redirect_to sector_lists_path(@topic.panopticon_slug)
+    redirect_to sector_lists_path(@topic)
   end
 
   def destroy
@@ -34,7 +34,7 @@ class ListsController < ApplicationController
       flash[:alert] = "Could not delete the list"
     end
 
-    redirect_to sector_lists_path(@topic.panopticon_slug)
+    redirect_to sector_lists_path(@topic)
   end
 
   def update
@@ -51,7 +51,7 @@ class ListsController < ApplicationController
           flash[:error] = 'Could not save your list'
         end
 
-        redirect_to sector_lists_path(@topic.panopticon_slug)
+        redirect_to sector_lists_path(@topic)
       }
       format.js {
         if saved

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -1,5 +1,5 @@
 class SectorsController < ApplicationController
-  before_filter :find_topic_for_sector_id, :only => [:publish]
+  before_filter :find_topic, :only => [:publish]
 
   def index
     subtopics = Topic.only_children.includes(:parent).order(:title)

--- a/app/controllers/sectors_controller.rb
+++ b/app/controllers/sectors_controller.rb
@@ -10,6 +10,6 @@ class SectorsController < ApplicationController
     PublishingAPINotifier.send_to_publishing_api(@topic)
 
     flash[:success] = "Topic published"
-    redirect_to sector_lists_path(@topic.panopticon_slug)
+    redirect_to sector_lists_path(@topic)
   end
 end

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @list, :url => sector_list_path(@topic.panopticon_slug, @list) do |f| %>
+<%= form_for @list, :url => sector_list_path(@topic, @list) do |f| %>
   <h2>Edit list</h2>
   <%= f.text_field :name %>
 

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -18,7 +18,7 @@
         <% @topic.untagged_list_items.each do |list_item| %>
           <tr>
             <td class='title'><%= list_item.title %></td>
-            <td class='remove'><%= button_to 'Remove', sector_list_list_item_path(@topic.panopticon_slug, list_item.list, list_item), method: :delete %></td>
+            <td class='remove'><%= button_to 'Remove', sector_list_list_item_path(@topic, list_item.list, list_item), method: :delete %></td>
           </tr>
         <% end %>
       </tbody>
@@ -28,7 +28,7 @@
 
 <% unless @topic.draft? %>
   <p>
-    <%= button_to 'Publish', sector_publish_path(@topic.panopticon_slug),
+    <%= button_to 'Publish', sector_publish_path(@topic),
           method: :put,
           class: "btn btn-success publish js-confirm",
           :'data-confirm-text' => "Are you sure you want to publish this immediately to GOV.UK?",
@@ -37,7 +37,7 @@
   </p>
 <% end %>
 
-<%= form_for(List.new, url: sector_lists_path(@topic.panopticon_slug), html: {id: 'new-list'}) do |f| %>
+<%= form_for(List.new, url: sector_lists_path(@topic), html: {id: 'new-list'}) do |f| %>
   <h2>New list</h2>
   <%= f.text_field :name %>
 
@@ -51,13 +51,13 @@
       aria-labelledby='list-<%= list.id %>-header'
       id='list-<%= list.id %>-section'
       data-index='<%= list.index %>'
-      data-update-url='<%= sector_list_path(@topic.panopticon_slug, list) %>'
+      data-update-url='<%= sector_list_path(@topic, list) %>'
     >
       <h2 id='list-<%= list.id %>-header'><%= list.name %></h2>
       <ul>
-        <li><%= link_to 'Edit name', edit_sector_list_path(@topic.panopticon_slug, list) %></li>
+        <li><%= link_to 'Edit name', edit_sector_list_path(@topic, list) %></li>
         <li>
-          <%= button_to 'Delete list', sector_list_path(@topic.panopticon_slug, list),
+          <%= button_to 'Delete list', sector_list_path(@topic, list),
                 method: :delete,
                 class: 'js-confirm',
                 :'data-confirm-text' => 'Are you sure you want to delete this list and all its content?'
@@ -78,20 +78,20 @@
           <tr class='empty-list'><td>Empty</td></tr>
           <% list.tagged_list_items.each do |list_item| %>
             <tr
-              data-update-url='<%= sector_list_list_item_path(@topic.panopticon_slug, list, list_item) %>'
+              data-update-url='<%= sector_list_list_item_path(@topic, list, list_item) %>'
               data-index='<%= list_item.index %>'
               data-list-id='<%= list.id %>'
             >
               <td class='index'><%= list_item.index %></td>
               <td class='title'><%= list_item.title %></td>
               <td class='api-url'><%= list_item.api_url %></td>
-              <td class='remove'><%= button_to 'Remove', sector_list_list_item_path(@topic.panopticon_slug, list, list_item), method: :delete %></td>
+              <td class='remove'><%= button_to 'Remove', sector_list_list_item_path(@topic, list, list_item), method: :delete %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
 
-      <%= form_for(ListItem.new, url: sector_list_list_items_path(@topic.panopticon_slug, list), html: {id: nil}) do |f| %>
+      <%= form_for(ListItem.new, url: sector_list_list_items_path(@topic, list), html: {id: nil}) do |f| %>
         <%= f.text_field :api_url, label: 'API URL' %>
         <%= f.number_field :index %>
 

--- a/app/views/sectors/index.html.erb
+++ b/app/views/sectors/index.html.erb
@@ -15,9 +15,9 @@
     </tr>
     <% subtopics.each do |subtopic| %>
       <tr>
-        <td><%= link_to subtopic.title, sector_lists_path(subtopic.panopticon_slug) %></td>
+        <td><%= link_to subtopic.title, sector_lists_path(subtopic) %></td>
         <td><%= 'draft' if subtopic.draft? %></td>
-        <td class="edit"><%= link_to "Edit", sector_lists_path(subtopic.panopticon_slug) %></td>
+        <td class="edit"><%= link_to "Edit", sector_lists_path(subtopic) %></td>
       </tr>
     <% end %>
   <% end %>

--- a/spec/controllers/sectors_controller_spec.rb
+++ b/spec/controllers/sectors_controller_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe SectorsController do
     it "notifies the publishing API" do
       expect(PublishingAPINotifier).to receive(:send_to_publishing_api).with(subtopic)
 
-      put :publish, sector_id: subtopic.panopticon_slug
+      put :publish, sector_id: subtopic
     end
 
     it "marks the sector as clean" do
-      put :publish, sector_id: subtopic.panopticon_slug
+      put :publish, sector_id: subtopic
 
       subtopic.reload
       expect(subtopic).not_to be_dirty


### PR DESCRIPTION
Previously, `panopticon_slug` was used in URLs. 

The only code that now uses `Topic#panopticon_slug` is https://github.com/alphagov/collections-publisher/blob/4c078e0259ea1d5742f23149e925b966ba28000b/app/models/topic.rb#L43, but that appears to be correct. @rboulton ?

In preparation for https://trello.com/c/u7tOFFXk/109-merge-sectors-and-topics-interfaces-in-collections-publisher

from :train: