### PR TITLE
Fix layout of list delete-buttons

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -5,7 +5,7 @@
   margin-bottom: 20px;
 }
 
-input[type=submit] {
+.btn-submit {
   @extend .btn;
   @extend .btn-lg;
   @extend .btn-success;

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -2,5 +2,5 @@
   <h2>Edit list</h2>
   <%= f.text_field :name %>
 
-  <button>Save</button>
+  <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -18,7 +18,10 @@
         <% @topic.untagged_list_items.each do |list_item| %>
           <tr>
             <td class='title'><%= list_item.title %></td>
-            <td class='remove'><%= button_to 'Remove', topic_list_list_item_path(@topic, list_item.list, list_item), method: :delete %></td>
+            <td class='remove'>
+              <%= button_to 'Remove', topic_list_list_item_path(@topic, list_item.list, list_item),
+                method: :delete, class: 'btn btn-sm btn-danger' %>
+            </td>
           </tr>
         <% end %>
       </tbody>
@@ -41,7 +44,7 @@
   <h2>New list</h2>
   <%= f.text_field :name %>
 
-  <button class='btn btn-primary'>Create</button>
+  <button class='btn-submit'>Create</button>
 <% end %>
 
 <div class="curated-lists">
@@ -58,7 +61,7 @@
         <li>
           <%= button_to 'Delete list', topic_list_path(@topic, list),
                 method: :delete,
-                class: 'js-confirm',
+                class: 'js-confirm btn btn-sm btn-danger',
                 :'data-confirm-text' => 'Are you sure you want to delete this list and all its content?'
           %>
         </li>

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -12,5 +12,5 @@
           data: { placeholder: "Choose additional topics..." } } %>
   <% end %>
 
-  <%= f.submit 'Save' %>
+  <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>

--- a/app/views/mainstream_browse_pages/new.html.erb
+++ b/app/views/mainstream_browse_pages/new.html.erb
@@ -13,5 +13,5 @@
   <%= f.text_field :title %>
   <%= f.text_field :description %>
 
-  <%= f.submit 'Create' %>
+  <%= f.submit 'Create', class: 'btn-submit' %>
 <% end %>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -22,5 +22,5 @@
     </div>
   <% end %>
 
-  <%= f.submit 'Save' %>
+  <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -13,5 +13,5 @@
   <%= f.text_field :title %>
   <%= f.text_field :description %>
 
-  <%= f.submit 'Create' %>
+  <%= f.submit 'Create', class: 'btn-submit' %>
 <% end %>


### PR DESCRIPTION
Over-eager added CSS in 78ec9cc styled every button in the application as a submit-button. This is inappropriate for delete buttons. By using a explicit `btn-submit` class we stop inadvertent styling.

## Before

![screen shot 2015-05-27 at 12 10 02](https://cloud.githubusercontent.com/assets/233676/7834655/57f22654-0469-11e5-8398-1450b55a13ca.png)

## After

![screen shot 2015-05-27 at 12 09 43](https://cloud.githubusercontent.com/assets/233676/7834654/57f01986-0469-11e5-837e-52f2b7c600ed.png)


