### PR TITLE
Topics can be in beta

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -63,7 +63,7 @@ class TopicsController < ApplicationController
 private
 
   def topic_params
-    params.require(:topic).permit(:slug, :title, :description, :parent_id)
+    params.require(:topic).permit(:slug, :title, :description, :parent_id, :beta)
   end
 
   def find_topic

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -7,4 +7,8 @@ module StatusHelper
 
     content_tag :span, text, class: "label label-#{class_name}"
   end
+
+  def beta_tag
+    status 'In Beta', :warning
+  end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -13,6 +13,7 @@
 #  content_id  :string(255)      not null
 #  state       :string(255)      not null
 #  dirty       :boolean          default(FALSE), not null
+#  beta        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,6 +13,7 @@
 #  content_id  :string(255)      not null
 #  state       :string(255)      not null
 #  dirty       :boolean          default(FALSE), not null
+#  beta        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -13,6 +13,7 @@
 #  content_id  :string(255)      not null
 #  state       :string(255)      not null
 #  dirty       :boolean          default(FALSE), not null
+#  beta        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -18,6 +18,7 @@ private
   def details
     super.merge({
       :groups => categorized_groups,
+      :beta => @tag.beta,
     })
   end
 

--- a/app/views/shared/tags/_table.html.erb
+++ b/app/views/shared/tags/_table.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <td><%= link_to resource.title, polymorphic_path(resource) %></td>
         <td><%= link_to resource.base_path, Plek.new.website_root + resource.base_path %></td>
-        <td><%= status(resource.state, resource.state) %></td>
+        <td><%= status(resource.state, resource.state) %> <%= beta_tag if resource.beta? %></td>
 
         <% unless local_assigns[:include_children_column] == false %>
           <td class='children'>
@@ -25,6 +25,7 @@
               <li>
                 <%= link_to child_tag.title, polymorphic_path(child_tag) %>
                 <%= status('draft', :draft) if child_tag.draft? %>
+                <%= beta_tag if child_tag.beta? %>
               </li>
             <% end %>
             </ul>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -7,7 +7,7 @@
   <% if @topic.has_parent? %>
     <%= @topic.parent.title %>:
   <% end %>
-    <%= @topic.title %>
+    <%= @topic.title %> <%= beta_tag if @topic.beta? %>
 </h1>
 
 <%= form_for @topic, html: { class: 'topic' } do |f| %>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -14,6 +14,7 @@
   <%= f.text_field :slug %>
   <%= f.text_field :title %>
   <%= f.text_field :description %>
+  <%= f.check_box :beta %>
 
   <% if @topic.published? && @topic.dirty? %>
     <div class="callout callout-warning">

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -12,6 +12,7 @@
   <%= f.text_field :slug %>
   <%= f.text_field :title %>
   <%= f.text_field :description %>
+  <%= f.check_box :beta %>
 
   <%= f.submit 'Create', class: 'btn-submit' %>
 <% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -8,7 +8,7 @@
       <%= link_to "#{@topic.parent.title}:", @topic.parent %>
     <% end %>
 
-    <%= @topic.title %>
+    <%= @topic.title %> <%= beta_tag if @topic.beta? %>
   </h1>
 
   <nav class="actions">

--- a/db/migrate/20150527125401_add_beta_to_tags.rb
+++ b/db/migrate/20150527125401_add_beta_to_tags.rb
@@ -1,0 +1,5 @@
+class AddBetaToTags < ActiveRecord::Migration
+  def change
+    add_column :tags, :beta, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150427135925) do
+ActiveRecord::Schema.define(version: 20150527125401) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20150427135925) do
     t.string   "content_id",  limit: 255,                 null: false
     t.string   "state",       limit: 255,                 null: false
     t.boolean  "dirty",       limit: 1,   default: false, null: false
+    t.boolean  "beta",        limit: 1,   default: false
   end
 
   add_index "tags", ["content_id"], name: "index_tags_on_content_id", unique: true, using: :btree

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe "Curating the contents of topics" do
                   contentapi_url_for_slug('undersea-piping-restrictions'),
               ]},
             ],
+            "beta" => false,
           }
         },
       )
@@ -189,6 +190,7 @@ RSpec.describe "Curating the contents of topics" do
                   contentapi_url_for_slug('undersea-piping-restrictions'),
               ]},
             ],
+            "beta" => false,
           }
         },
       )

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "creating and editing topics" do
     # Then the topic should be updated
     visit topics_path
     expect(page).to have_content('Working on the ocean')
+    expect(page).to have_content('In Beta')
 
     # And a live item should have been sent to publishing-api
     assert_publishing_api_put_item('/working-at-sea', {

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe "creating and editing topics" do
 
     fill_in 'Title', :with => 'Working on the ocean'
     fill_in 'Description', :with => 'I woke up one morning, The sea was still there.'
+    check 'Beta'
     click_on 'Save'
 
     # Then the topic should be updated
@@ -111,6 +112,10 @@ RSpec.describe "creating and editing topics" do
       "title" => 'Working on the ocean',
       "description" => "I woke up one morning, The sea was still there.",
       "format" => "topic",
+      "details" => {
+        "groups" => [],
+        "beta" => true,
+      }
     })
 
     # And the topic should have been updated in Panopticon

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -13,6 +13,7 @@
 #  content_id  :string(255)      not null
 #  state       :string(255)      not null
 #  dirty       :boolean          default(FALSE), not null
+#  beta        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -13,6 +13,7 @@
 #  content_id  :string(255)      not null
 #  state       :string(255)      not null
 #  dirty       :boolean          default(FALSE), not null
+#  beta        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -13,6 +13,7 @@
 #  content_id  :string(255)      not null
 #  state       :string(255)      not null
 #  dirty       :boolean          default(FALSE), not null
+#  beta        :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe TopicPresenter do
       it "should contain an empty groups array with no curated lists" do
         expect(presented_data[:details]).to eq({
           :groups => [],
+          :beta => false,
         })
       end
 
@@ -88,7 +89,8 @@ RSpec.describe TopicPresenter do
                   "http://api.example.com/oil-rig-staffing",
                 ]
               }
-            ]
+            ],
+            :beta => false,
           })
         end
 


### PR DESCRIPTION
This PR adds a "Beta" checkbox to Topics. Users can check this box to add a beta-banner to the topic or subtopic page. This will be added to `collections` in a later PR.

Depends on a schema change in https://github.com/alphagov/govuk-content-schemas/pull/77. Be sure to pull `govuk-content-schemas` before running the tests. 

Trello: https://trello.com/c/H9UMp051/139

### Before

![screen shot 2015-05-27 at 15 57 59](https://cloud.githubusercontent.com/assets/233676/7839240/45f7139a-0489-11e5-99c3-482765f42d37.png)
![screen shot 2015-05-27 at 15 57 57](https://cloud.githubusercontent.com/assets/233676/7839248/4c50d3fc-0489-11e5-96ed-fcfefb371483.png)
![screen shot 2015-05-27 at 16 02 06](https://cloud.githubusercontent.com/assets/233676/7839327/c0c846fc-0489-11e5-9292-a79ebdce02a6.png)


### After

![screen shot 2015-05-27 at 15 58 33](https://cloud.githubusercontent.com/assets/233676/7839287/7cb13ed8-0489-11e5-99c3-3564def33aa6.png)
![screen shot 2015-05-27 at 15 58 42](https://cloud.githubusercontent.com/assets/233676/7839288/7f93c526-0489-11e5-8b87-cc1cf2f733d4.png)
![screen shot 2015-05-27 at 16 02 00](https://cloud.githubusercontent.com/assets/233676/7839332/c5c58a16-0489-11e5-97b4-296fd707850c.png)
