### PR TITLE
Don't raise when tag is missing in content-api

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -40,11 +40,15 @@ class Topic < Tag
   end
 
   def list_items_from_contentapi
-    @_list_items_from_contentapi ||= CollectionsPublisher.services(:content_api)
-      .with_tag(panopticon_slug, 'specialist_sector', draft: true)
-      .map { |content_blob|
-        ListItem.new(title: content_blob.title, api_url: content_blob.id)
-      }
+    @_list_items_from_contentapi ||= begin
+      CollectionsPublisher.services(:content_api)
+        .with_tag(panopticon_slug, 'specialist_sector', draft: true)
+        .map { |content_blob|
+          ListItem.new(title: content_blob.title, api_url: content_blob.id)
+        }
+    rescue GdsApi::HTTPNotFound
+      []
+    end
   end
 
   # FIXME: remove this once we're using content_id's in URLs everywhere.

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -139,5 +139,11 @@ RSpec.describe Topic do
 
       expect(subtopic.list_items_from_contentapi).to eq([])
     end
+
+    it "returns empty array when no topic exists in content api" do
+      stub_request(:get, %r[.]).to_return(status: 404)
+
+      expect(subtopic.list_items_from_contentapi).to eq([])
+    end
   end
 end


### PR DESCRIPTION
`Topic#list_items_from_contentapi ` currently crashes on `GdsApi::HTTPNotFound` when the tag doesn't exist in the content api. We should return an empty array instead.

Trello: https://trello.com/c/C2ODigO4/142-collections-publisher-don-t-crash-when-tag-is-missing-in-content-api