### PR TITLE
Remove model annotations in specs

### DIFF
--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -16,7 +16,7 @@ if Rails.env.development?
       'model_dir'            => "app/models",
       'include_version'      => "false",
       'require'              => "",
-      'exclude_tests'        => "false",
+      'exclude_tests'        => "true",
       'exclude_fixtures'     => "false",
       'exclude_factories'    => "false",
       'ignore_model_sub_dir' => "false",

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,17 +1,3 @@
-# == Schema Information
-#
-# Table name: lists
-#
-#  id       :integer          not null, primary key
-#  name     :string(255)
-#  index    :integer          default(0), not null
-#  topic_id :integer          not null
-#
-# Indexes
-#
-#  index_lists_on_topic_id  (topic_id)
-#
-
 require "rails_helper"
 
 RSpec.describe List do

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -1,27 +1,3 @@
-# == Schema Information
-#
-# Table name: tags
-#
-#  id          :integer          not null, primary key
-#  type        :string(255)
-#  slug        :string(255)      not null
-#  title       :string(255)      not null
-#  description :string(255)
-#  parent_id   :integer
-#  created_at  :datetime
-#  updated_at  :datetime
-#  content_id  :string(255)      not null
-#  state       :string(255)      not null
-#  dirty       :boolean          default(FALSE), not null
-#  beta        :boolean          default(FALSE)
-#
-# Indexes
-#
-#  index_tags_on_content_id          (content_id) UNIQUE
-#  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
-#  tags_parent_id_fk                 (parent_id)
-#
-
 require 'rails_helper'
 
 RSpec.describe MainstreamBrowsePage do

--- a/spec/models/tag_association_spec.rb
+++ b/spec/models/tag_association_spec.rb
@@ -1,19 +1,3 @@
-# == Schema Information
-#
-# Table name: tag_associations
-#
-#  id          :integer          not null, primary key
-#  from_tag_id :integer          not null
-#  to_tag_id   :integer          not null
-#  created_at  :datetime
-#  updated_at  :datetime
-#
-# Indexes
-#
-#  index_tag_associations_on_from_tag_id_and_to_tag_id  (from_tag_id,to_tag_id) UNIQUE
-#  index_tag_associations_on_to_tag_id                  (to_tag_id)
-#
-
 require 'rails_helper'
 
 RSpec.describe TagAssociation do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,27 +1,3 @@
-# == Schema Information
-#
-# Table name: tags
-#
-#  id          :integer          not null, primary key
-#  type        :string(255)
-#  slug        :string(255)      not null
-#  title       :string(255)      not null
-#  description :string(255)
-#  parent_id   :integer
-#  created_at  :datetime
-#  updated_at  :datetime
-#  content_id  :string(255)      not null
-#  state       :string(255)      not null
-#  dirty       :boolean          default(FALSE), not null
-#  beta        :boolean          default(FALSE)
-#
-# Indexes
-#
-#  index_tags_on_content_id          (content_id) UNIQUE
-#  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
-#  tags_parent_id_fk                 (parent_id)
-#
-
 require 'rails_helper'
 
 RSpec.describe Tag do

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,27 +1,3 @@
-# == Schema Information
-#
-# Table name: tags
-#
-#  id          :integer          not null, primary key
-#  type        :string(255)
-#  slug        :string(255)      not null
-#  title       :string(255)      not null
-#  description :string(255)
-#  parent_id   :integer
-#  created_at  :datetime
-#  updated_at  :datetime
-#  content_id  :string(255)      not null
-#  state       :string(255)      not null
-#  dirty       :boolean          default(FALSE), not null
-#  beta        :boolean          default(FALSE)
-#
-# Indexes
-#
-#  index_tags_on_content_id          (content_id) UNIQUE
-#  index_tags_on_slug_and_parent_id  (slug,parent_id) UNIQUE
-#  tags_parent_id_fk                 (parent_id)
-#
-
 require 'rails_helper'
 
 RSpec.describe Topic do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,21 +1,3 @@
-# == Schema Information
-#
-# Table name: users
-#
-#  id                  :integer          not null, primary key
-#  name                :string(255)
-#  email               :string(255)
-#  uid                 :string(255)      not null
-#  organisation_slug   :string(255)
-#  permissions         :string(255)
-#  remotely_signed_out :boolean          default(FALSE)
-#  disabled            :boolean          default(FALSE)
-#
-# Indexes
-#
-#  index_users_on_uid  (uid) UNIQUE
-#
-
 require 'rails_helper'
 
 require 'gds-sso/lint/user_spec'


### PR DESCRIPTION
Currently the `annotate` gem helpfully adds annotations to both the models in `app/models` and the specs in `spec/models`.

This is duplicate and makes for noisy commits.