### PR TITLE
Curate lists for Mainstream Browse Pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,10 @@ private
     authorise_user!("GDS Editor")
   end
 
+  def require_gds_editor_permissions_to_edit_browse_pages!
+    require_gds_editor_permissions! if @tag.is_a?(MainstreamBrowsePage)
+  end
+
   def find_tag
     @tag = Tag.find_by!(content_id: params[:tag_id])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ private
     authorise_user!("GDS Editor")
   end
 
-  def find_topic
-    @topic = Topic.find_by!(content_id: params[:topic_id])
+  def find_tag
+    @tag = Tag.find_by!(content_id: params[:tag_id])
   end
 end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,8 +1,7 @@
 class ListItemsController < ApplicationController
   before_filter :find_tag
   before_filter :find_list
-  before_filter :require_gds_editor_permissions!,
-    if: :editing_lists_for_mainstream_browse_page?
+  before_filter :require_gds_editor_permissions_to_edit_browse_pages!
 
   def create
     list_item = @list.list_items.build(list_item_params)
@@ -84,9 +83,5 @@ private
 
   def list_item_params
     params.require(:list_item).permit(:title, :api_url, :index)
-  end
-
-  def editing_lists_for_mainstream_browse_page?
-    @tag.is_a?(MainstreamBrowsePage)
   end
 end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,12 +1,12 @@
 class ListItemsController < ApplicationController
-  before_filter :find_topic
+  before_filter :find_tag
   before_filter :find_list
 
   def create
     list_item = @list.list_items.build(list_item_params)
     saved = list_item.save
 
-    @topic.mark_as_dirty! if saved
+    @tag.mark_as_dirty! if saved
 
     respond_to do |format|
       format.html {
@@ -16,11 +16,11 @@ class ListItemsController < ApplicationController
           flash[:error] = 'Could not add that list item to your list'
         end
 
-        redirect_to topic_lists_path(@topic)
+        redirect_to tag_lists_path(@tag)
       }
       format.js {
         if saved
-          render json: {errors: [], updateURL: topic_list_list_item_path(@topic, @list, list_item)}
+          render json: {errors: [], updateURL: tag_list_list_item_path(@tag, @list, list_item)}
         else
           render json: {errors: list_item.errors.to_json}, status: 422
         end
@@ -34,7 +34,7 @@ class ListItemsController < ApplicationController
 
     destroyed = list_item.destroyed?
 
-    @topic.mark_as_dirty! if destroyed
+    @tag.mark_as_dirty! if destroyed
 
     respond_to do |format|
       format.html {
@@ -44,7 +44,7 @@ class ListItemsController < ApplicationController
           flash[:alert] = "Could not remove the list item from this list"
         end
 
-        redirect_to topic_lists_path(@topic)
+        redirect_to tag_lists_path(@tag)
       }
       format.js {
         if destroyed
@@ -64,7 +64,7 @@ class ListItemsController < ApplicationController
     respond_to do |format|
       format.js {
         if list_item.save
-          @topic.mark_as_dirty!
+          @tag.mark_as_dirty!
 
           render json: {errors: []}
         else
@@ -77,7 +77,7 @@ class ListItemsController < ApplicationController
 private
 
   def find_list
-    @list = @topic.lists.find(params[:list_id])
+    @list = @tag.lists.find(params[:list_id])
   end
 
   def list_item_params

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,6 +1,8 @@
 class ListItemsController < ApplicationController
   before_filter :find_tag
   before_filter :find_list
+  before_filter :require_gds_editor_permissions!,
+    if: :editing_lists_for_mainstream_browse_page?
 
   def create
     list_item = @list.list_items.build(list_item_params)
@@ -82,5 +84,9 @@ private
 
   def list_item_params
     params.require(:list_item).permit(:title, :api_url, :index)
+  end
+
+  def editing_lists_for_mainstream_browse_page?
+    @tag.is_a?(MainstreamBrowsePage)
   end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,5 +1,7 @@
 class ListsController < ApplicationController
   before_filter :find_tag
+  before_filter :require_gds_editor_permissions!,
+    if: :editing_lists_for_mainstream_browse_page?
 
   def index
     @lists = @tag.lists.ordered
@@ -67,5 +69,9 @@ private
 
   def list_params
     params.require(:list).permit(:name, :index)
+  end
+
+  def editing_lists_for_mainstream_browse_page?
+    @tag.is_a?(MainstreamBrowsePage)
   end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,7 +1,6 @@
 class ListsController < ApplicationController
   before_filter :find_tag
-  before_filter :require_gds_editor_permissions!,
-    if: :editing_lists_for_mainstream_browse_page?
+  before_filter :require_gds_editor_permissions_to_edit_browse_pages!
 
   def index
     @lists = @tag.lists.ordered
@@ -71,7 +70,4 @@ private
     params.require(:list).permit(:name, :index)
   end
 
-  def editing_lists_for_mainstream_browse_page?
-    @tag.is_a?(MainstreamBrowsePage)
-  end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,47 +1,47 @@
 class ListsController < ApplicationController
-  before_filter :find_topic
+  before_filter :find_tag
 
   def index
-    @lists = @topic.lists.ordered
+    @lists = @tag.lists.ordered
   end
 
   def edit
-    @list = @topic.lists.find(params[:id])
+    @list = @tag.lists.find(params[:id])
   end
 
   def create
-    list = @topic.lists.build(list_params)
-    list.index = (@topic.lists.maximum(:index) || 0) + 1
+    list = @tag.lists.build(list_params)
+    list.index = (@tag.lists.maximum(:index) || 0) + 1
 
     if list.save
-      @topic.mark_as_dirty!
+      @tag.mark_as_dirty!
       flash[:success] = 'List created'
     else
       flash[:error] = 'Could not create your list'
     end
 
-    redirect_to topic_lists_path(@topic)
+    redirect_to tag_lists_path(@tag)
   end
 
   def destroy
-    list = @topic.lists.find(params[:id])
+    list = @tag.lists.find(params[:id])
     list.destroy
 
     if list.destroyed?
-      @topic.mark_as_dirty!
+      @tag.mark_as_dirty!
       flash[:success] = "List deleted"
     else
       flash[:alert] = "Could not delete the list"
     end
 
-    redirect_to topic_lists_path(@topic)
+    redirect_to tag_lists_path(@tag)
   end
 
   def update
-    list = @topic.lists.find(params[:id])
+    list = @tag.lists.find(params[:id])
     saved = list.update_attributes(list_params)
 
-    @topic.mark_as_dirty! if saved
+    @tag.mark_as_dirty! if saved
 
     respond_to do |format|
       format.html {
@@ -51,7 +51,7 @@ class ListsController < ApplicationController
           flash[:error] = 'Could not save your list'
         end
 
-        redirect_to topic_lists_path(@topic)
+        redirect_to tag_lists_path(@tag)
       }
       format.js {
         if saved

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,8 +1,9 @@
 class TagsController < ApplicationController
+  before_filter :find_tag
+  before_filter :require_gds_editor_permissions_to_edit_browse_pages!
+
   def republish
-    tag = Tag.find_by!(content_id: params[:tag_id])
-    authorise_user!("GDS Editor") if tag.is_a?(MainstreamBrowsePage)
-    PublishingAPINotifier.send_to_publishing_api(tag)
+    PublishingAPINotifier.send_to_publishing_api(@tag)
     redirect_to :back
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,8 @@
+class TagsController < ApplicationController
+  def republish
+    tag = Tag.find_by!(content_id: params[:tag_id])
+    authorise_user!("GDS Editor") if tag.is_a?(MainstreamBrowsePage)
+    PublishingAPINotifier.send_to_publishing_api(tag)
+    redirect_to :back
+  end
+end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -57,7 +57,7 @@ class TopicsController < ApplicationController
     topic = find_topic
 
     PublishingAPINotifier.send_to_publishing_api(topic)
-    redirect_to topic_lists_path(topic)
+    redirect_to tag_lists_path(topic)
   end
 
 private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -53,13 +53,6 @@ class TopicsController < ApplicationController
     redirect_to topic
   end
 
-  def republish
-    topic = find_topic
-
-    PublishingAPINotifier.send_to_publishing_api(topic)
-    redirect_to tag_lists_path(topic)
-  end
-
 private
 
   def topic_params

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -31,7 +31,12 @@ class MainstreamBrowsePage < Tag
     "/browse#{super}"
   end
 
+  def tag_type
+    'section'
+  end
+
 private
+
   def parents_cannot_have_topics_associated
     if !parent.present? and topics.any?
       errors.add(:topics, "top-level mainstream browse pages cannot have topics assigned to them")

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -31,7 +31,7 @@ class MainstreamBrowsePage < Tag
     "/browse#{super}"
   end
 
-  def tag_type
+  def legacy_tag_type
     'section'
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -120,7 +120,7 @@ class Tag < ActiveRecord::Base
   def list_items_from_contentapi
     @_list_items_from_contentapi ||= begin
       CollectionsPublisher.services(:content_api)
-        .with_tag(panopticon_slug, 'specialist_sector', draft: true)
+        .with_tag(panopticon_slug, tag_type, draft: true)
         .map { |content_blob|
           ListItem.new(title: content_blob.title, api_url: content_blob.id)
         }
@@ -131,7 +131,11 @@ class Tag < ActiveRecord::Base
 
   # FIXME: remove this once we're using content_id's in URLs everywhere.
   def panopticon_slug
-    self.base_path[1..-1]
+    self.base_path.gsub('/browse', '')[1..-1]
+  end
+
+  def tag_type
+    nil
   end
 
 private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -120,7 +120,7 @@ class Tag < ActiveRecord::Base
   def list_items_from_contentapi
     @_list_items_from_contentapi ||= begin
       CollectionsPublisher.services(:content_api)
-        .with_tag(panopticon_slug, tag_type, draft: true)
+        .with_tag(panopticon_slug, legacy_tag_type, draft: true)
         .map { |content_blob|
           ListItem.new(title: content_blob.title, api_url: content_blob.id)
         }
@@ -134,7 +134,7 @@ class Tag < ActiveRecord::Base
     self.base_path.gsub('/browse', '')[1..-1]
   end
 
-  def tag_type
+  def legacy_tag_type
     nil
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -25,7 +25,7 @@
 class Topic < Tag
   has_many :mainstream_browse_pages, through: :reverse_tag_associations, source: :from_tag
 
-  def tag_type
+  def legacy_tag_type
     'specialist_sector'
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -24,4 +24,8 @@
 
 class Topic < Tag
   has_many :mainstream_browse_pages, through: :reverse_tag_associations, source: :from_tag
+
+  def tag_type
+    'specialist_sector'
+  end
 end

--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -11,8 +11,4 @@ private
       "related_topics" => @tag.topics.order(:title).map(&:content_id),
     )
   end
-
-  def tag_type
-    'section'
-  end
 end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -1,4 +1,6 @@
 class TagPresenter
+  delegate :legacy_tag_type, to: :tag
+
   def self.presenter_for(tag)
     case tag
     when MainstreamBrowsePage
@@ -42,7 +44,7 @@ class TagPresenter
       tag_id: tag_id,
       title: tag.title,
       description: tag.description,
-      tag_type: tag_type,
+      tag_type: legacy_tag_type,
       parent_id: parent.slug,
     }
   end
@@ -80,8 +82,6 @@ private
   end
 
   attr_reader :tag
-
-  delegate :tag_type, to: :tag
 
   def parent
     tag.parent || NullParent.new

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -60,7 +60,18 @@ private
 
   # potentially extended in subclasses
   def details
-    {}
+    {
+      :groups => categorized_groups,
+    }
+  end
+
+  def categorized_groups
+    @tag.lists.ordered.map do |list|
+      {
+        name: list.name,
+        contents: list.tagged_list_items.map(&:api_url)
+      }
+    end
   end
 
   # potentially extended in subclasses

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -70,9 +70,7 @@ private
 
   attr_reader :tag
 
-  def tag_type
-    nil
-  end
+  delegate :tag_type, to: :tag
 
   def parent
     tag.parent || NullParent.new

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -17,18 +17,7 @@ private
 
   def details
     super.merge({
-      :groups => categorized_groups,
       :beta => @tag.beta,
     })
   end
-
-  def categorized_groups
-    @tag.lists.ordered.map do |list|
-      {
-        name: list.name,
-        contents: list.tagged_list_items.map(&:api_url)
-      }
-    end
-  end
-
 end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -31,8 +31,4 @@ private
     end
   end
 
-  def tag_type
-    'specialist_sector'
-  end
-
 end

--- a/app/views/lists/_list_editor.html.erb
+++ b/app/views/lists/_list_editor.html.erb
@@ -5,12 +5,12 @@
       aria-labelledby='list-<%= list.id %>-header'
       id='list-<%= list.id %>-section'
       data-index='<%= list.index %>'
-      data-update-url='<%= topic_list_path(topic, list) %>'>
+      data-update-url='<%= tag_list_path(tag, list) %>'>
       <h2 id='list-<%= list.id %>-header'><%= list.name %></h2>
       <ul>
-        <li><%= link_to 'Edit name', edit_topic_list_path(topic, list) %></li>
+        <li><%= link_to 'Edit name', edit_tag_list_path(tag, list) %></li>
         <li>
-          <%= button_to 'Delete list', topic_list_path(topic, list),
+          <%= button_to 'Delete list', tag_list_path(tag, list),
                 method: :delete,
                 class: 'js-confirm btn btn-sm btn-danger',
                 :'data-confirm-text' => 'Are you sure you want to delete this list and all its content?'
@@ -31,20 +31,20 @@
           <tr class='empty-list'><td>Empty</td></tr>
           <% list.tagged_list_items.each do |list_item| %>
             <tr
-              data-update-url='<%= topic_list_list_item_path(topic, list, list_item) %>'
+              data-update-url='<%= tag_list_list_item_path(tag, list, list_item) %>'
               data-index='<%= list_item.index %>'
               data-list-id='<%= list.id %>'
             >
               <td class='index'><%= list_item.index %></td>
               <td class='title'><%= list_item.title %></td>
               <td class='api-url'><%= list_item.api_url %></td>
-              <td class='remove'><%= button_to 'Remove', topic_list_list_item_path(topic, list, list_item), method: :delete %></td>
+              <td class='remove'><%= button_to 'Remove', tag_list_list_item_path(tag, list, list_item), method: :delete %></td>
             </tr>
           <% end %>
         </tbody>
       </table>
 
-      <%= form_for(ListItem.new, url: topic_list_list_items_path(topic, list), html: {id: nil}) do |f| %>
+      <%= form_for(ListItem.new, url: tag_list_list_items_path(tag, list), html: {id: nil}) do |f| %>
         <%= f.text_field :api_url, label: 'API URL' %>
         <%= f.number_field :index %>
 

--- a/app/views/lists/_list_editor.html.erb
+++ b/app/views/lists/_list_editor.html.erb
@@ -1,0 +1,55 @@
+<div class="curated-lists">
+  <% lists.each do |list| %>
+    <section
+      class="list"
+      aria-labelledby='list-<%= list.id %>-header'
+      id='list-<%= list.id %>-section'
+      data-index='<%= list.index %>'
+      data-update-url='<%= topic_list_path(topic, list) %>'>
+      <h2 id='list-<%= list.id %>-header'><%= list.name %></h2>
+      <ul>
+        <li><%= link_to 'Edit name', edit_topic_list_path(topic, list) %></li>
+        <li>
+          <%= button_to 'Delete list', topic_list_path(topic, list),
+                method: :delete,
+                class: 'js-confirm btn btn-sm btn-danger',
+                :'data-confirm-text' => 'Are you sure you want to delete this list and all its content?'
+          %>
+        </li>
+      </ul>
+
+      <table class='table table-hover'>
+        <thead>
+          <tr>
+            <th class='index'>Index</th>
+            <th class='title'>Title</th>
+            <th class='api-url' colspan='2'>API URL</th>
+          </tr>
+        </thead>
+
+        <tbody class='curated-list' data-list-id='<%= list.id %>'>
+          <tr class='empty-list'><td>Empty</td></tr>
+          <% list.tagged_list_items.each do |list_item| %>
+            <tr
+              data-update-url='<%= topic_list_list_item_path(topic, list, list_item) %>'
+              data-index='<%= list_item.index %>'
+              data-list-id='<%= list.id %>'
+            >
+              <td class='index'><%= list_item.index %></td>
+              <td class='title'><%= list_item.title %></td>
+              <td class='api-url'><%= list_item.api_url %></td>
+              <td class='remove'><%= button_to 'Remove', topic_list_list_item_path(topic, list, list_item), method: :delete %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%= form_for(ListItem.new, url: topic_list_list_items_path(topic, list), html: {id: nil}) do |f| %>
+        <%= f.text_field :api_url, label: 'API URL' %>
+        <%= f.number_field :index %>
+
+        <button class='btn btn-primary'>Add</button>
+      <% end %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/lists/_new_list.html.erb
+++ b/app/views/lists/_new_list.html.erb
@@ -1,4 +1,4 @@
-<%= form_for List.new, url: topic_lists_path(topic), html: { id: 'new-list' } do |f| %>
+<%= form_for List.new, url: tag_lists_path(tag), html: { id: 'new-list' } do |f| %>
   <h2>New list</h2>
   <%= f.text_field :name %>
 

--- a/app/views/lists/_new_list.html.erb
+++ b/app/views/lists/_new_list.html.erb
@@ -1,0 +1,6 @@
+<%= form_for List.new, url: topic_lists_path(topic), html: { id: 'new-list' } do |f| %>
+  <h2>New list</h2>
+  <%= f.text_field :name %>
+
+  <button class='btn-submit'>Create</button>
+<% end %>

--- a/app/views/lists/_publish_button.html.erb
+++ b/app/views/lists/_publish_button.html.erb
@@ -1,0 +1,8 @@
+<p>
+  <%= button_to 'Publish changes to GOV.UK', republish_topic_path(topic),
+        method: :post,
+        class: "btn btn-success publish btn-lg js-confirm",
+        :'data-confirm-text' => "Are you sure you want to publish this immediately to GOV.UK?",
+        disabled: !topic.dirty?
+  %>
+</p>

--- a/app/views/lists/_publish_button.html.erb
+++ b/app/views/lists/_publish_button.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= button_to 'Publish changes to GOV.UK', republish_topic_path(tag),
+  <%= button_to 'Publish changes to GOV.UK', tag_republish_path(tag),
         method: :post,
         class: "btn btn-success publish btn-lg js-confirm",
         :'data-confirm-text' => "Are you sure you want to publish this immediately to GOV.UK?",

--- a/app/views/lists/_publish_button.html.erb
+++ b/app/views/lists/_publish_button.html.erb
@@ -1,8 +1,8 @@
 <p>
-  <%= button_to 'Publish changes to GOV.UK', republish_topic_path(topic),
+  <%= button_to 'Publish changes to GOV.UK', republish_topic_path(tag),
         method: :post,
         class: "btn btn-success publish btn-lg js-confirm",
         :'data-confirm-text' => "Are you sure you want to publish this immediately to GOV.UK?",
-        disabled: !topic.dirty?
+        disabled: !tag.dirty?
   %>
 </p>

--- a/app/views/lists/_uncategorized_list_items.html.erb
+++ b/app/views/lists/_uncategorized_list_items.html.erb
@@ -1,0 +1,25 @@
+<section class="list" aria-labelledby='list-uncategorized-header' id='list-uncategorized-section'>
+  <h2 id='list-uncategorized-header'>Uncategorized (A to Z)</h2>
+  <% if lists.any? %>
+    <p><b>Note:</b> These will not be displayed to users</p>
+  <% end %>
+
+  <table class='table table-hover'>
+    <thead>
+      <tr>
+        <td class='title'>Title</th>
+        <th class='api-url'>API URL</th>
+      </tr>
+    </thead>
+
+    <tbody class='curated-list'>
+      <tr class='empty-list'><td colspan='2'>Empty</td></tr>
+      <% topic.uncategorized_list_items.each do |list_item| %>
+        <tr>
+          <td class='title'><%= list_item.title %></td>
+          <td class='api-url'><%= list_item.api_url %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</section>

--- a/app/views/lists/_uncategorized_list_items.html.erb
+++ b/app/views/lists/_uncategorized_list_items.html.erb
@@ -14,7 +14,7 @@
 
     <tbody class='curated-list'>
       <tr class='empty-list'><td colspan='2'>Empty</td></tr>
-      <% topic.uncategorized_list_items.each do |list_item| %>
+      <% tag.uncategorized_list_items.each do |list_item| %>
         <tr>
           <td class='title'><%= list_item.title %></td>
           <td class='api-url'><%= list_item.api_url %></td>

--- a/app/views/lists/_untagged_list_items.html.erb
+++ b/app/views/lists/_untagged_list_items.html.erb
@@ -1,7 +1,7 @@
 <div class='untagged-list-items subtle-highlight'>
   <p>
-    <strong>Warning</strong>: this content has been curated but is not tagged to this topic.
-    Please either remove it or re-tag it to the topic.
+    <strong>Warning</strong>: this content has been curated but is not tagged.
+    Please either remove it or re-tag it.
   </p>
 
   <table class='table table-hover'>
@@ -12,11 +12,11 @@
     </thead>
 
     <tbody>
-      <% topic.untagged_list_items.each do |list_item| %>
+      <% tag.untagged_list_items.each do |list_item| %>
         <tr>
           <td class='title'><%= list_item.title %></td>
           <td class='remove'>
-            <%= button_to 'Remove', topic_list_list_item_path(topic, list_item.list, list_item),
+            <%= button_to 'Remove', tag_list_list_item_path(tag, list_item.list, list_item),
               method: :delete, class: 'btn btn-sm btn-danger' %>
           </td>
         </tr>

--- a/app/views/lists/_untagged_list_items.html.erb
+++ b/app/views/lists/_untagged_list_items.html.erb
@@ -1,0 +1,26 @@
+<div class='untagged-list-items subtle-highlight'>
+  <p>
+    <strong>Warning</strong>: this content has been curated but is not tagged to this topic.
+    Please either remove it or re-tag it to the topic.
+  </p>
+
+  <table class='table table-hover'>
+    <thead>
+      <tr>
+        <th class='title'>Title</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% topic.untagged_list_items.each do |list_item| %>
+        <tr>
+          <td class='title'><%= list_item.title %></td>
+          <td class='remove'>
+            <%= button_to 'Remove', topic_list_list_item_path(topic, list_item.list, list_item),
+              method: :delete, class: 'btn btn-sm btn-danger' %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @list, :url => topic_list_path(@topic, @list) do |f| %>
+<%= form_for @list, :url => tag_list_path(@tag, @list) do |f| %>
   <h2>Edit list</h2>
   <%= f.text_field :name %>
 

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,130 +1,13 @@
 <h1>Curated lists for "<%= @topic.title %>"<%= " (draft)" if @topic.draft? %></h1>
 
 <% if @topic.untagged_list_items.any? %>
-  <div class='untagged-list-items subtle-highlight'>
-    <p>
-      <strong>Warning</strong>: this content has been curated but is not tagged to this topic.
-      Please either remove it or re-tag it to the topic.
-    </p>
-
-    <table class='table table-hover'>
-      <thead>
-        <tr>
-          <th class='title'>Title</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @topic.untagged_list_items.each do |list_item| %>
-          <tr>
-            <td class='title'><%= list_item.title %></td>
-            <td class='remove'>
-              <%= button_to 'Remove', topic_list_list_item_path(@topic, list_item.list, list_item),
-                method: :delete, class: 'btn btn-sm btn-danger' %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
+  <%= render 'untagged_list_items', topic: @topic %>
 <% end %>
 
 <% unless @topic.draft? %>
-  <p>
-    <%= button_to 'Publish changes to GOV.UK', republish_topic_path(@topic),
-          method: :post,
-          class: "btn btn-success publish btn-lg js-confirm",
-          :'data-confirm-text' => "Are you sure you want to publish this immediately to GOV.UK?",
-          disabled: !@topic.dirty?
-    %>
-  </p>
+  <%= render 'publish_button', topic: @topic %>
 <% end %>
 
-<%= form_for(List.new, url: topic_lists_path(@topic), html: {id: 'new-list'}) do |f| %>
-  <h2>New list</h2>
-  <%= f.text_field :name %>
-
-  <button class='btn-submit'>Create</button>
-<% end %>
-
-<div class="curated-lists">
-  <% @lists.each do |list| %>
-    <section
-      class="list"
-      aria-labelledby='list-<%= list.id %>-header'
-      id='list-<%= list.id %>-section'
-      data-index='<%= list.index %>'
-      data-update-url='<%= topic_list_path(@topic, list) %>'>
-      <h2 id='list-<%= list.id %>-header'><%= list.name %></h2>
-      <ul>
-        <li><%= link_to 'Edit name', edit_topic_list_path(@topic, list) %></li>
-        <li>
-          <%= button_to 'Delete list', topic_list_path(@topic, list),
-                method: :delete,
-                class: 'js-confirm btn btn-sm btn-danger',
-                :'data-confirm-text' => 'Are you sure you want to delete this list and all its content?'
-          %>
-        </li>
-      </ul>
-
-      <table class='table table-hover'>
-        <thead>
-          <tr>
-            <th class='index'>Index</th>
-            <th class='title'>Title</th>
-            <th class='api-url' colspan='2'>API URL</th>
-          </tr>
-        </thead>
-
-        <tbody class='curated-list' data-list-id='<%= list.id %>'>
-          <tr class='empty-list'><td>Empty</td></tr>
-          <% list.tagged_list_items.each do |list_item| %>
-            <tr
-              data-update-url='<%= topic_list_list_item_path(@topic, list, list_item) %>'
-              data-index='<%= list_item.index %>'
-              data-list-id='<%= list.id %>'
-            >
-              <td class='index'><%= list_item.index %></td>
-              <td class='title'><%= list_item.title %></td>
-              <td class='api-url'><%= list_item.api_url %></td>
-              <td class='remove'><%= button_to 'Remove', topic_list_list_item_path(@topic, list, list_item), method: :delete %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-
-      <%= form_for(ListItem.new, url: topic_list_list_items_path(@topic, list), html: {id: nil}) do |f| %>
-        <%= f.text_field :api_url, label: 'API URL' %>
-        <%= f.number_field :index %>
-
-        <button class='btn btn-primary'>Add</button>
-      <% end %>
-    </section>
-  <% end %>
-</div>
-
-<section class="list" aria-labelledby='list-uncategorized-header' id='list-uncategorized-section'>
-  <h2 id='list-uncategorized-header'>Uncategorized (A to Z)</h2>
-  <%- if @lists.any? -%>
-    <p><b>Note:</b> These will not be displayed to users</p>
-  <%- end -%>
-
-  <table class='table table-hover'>
-    <thead>
-      <tr>
-        <td class='title'>Title</th>
-        <th class='api-url'>API URL</th>
-      </tr>
-    </thead>
-
-    <tbody class='curated-list'>
-      <tr class='empty-list'><td colspan='2'>Empty</td></tr>
-      <% @topic.uncategorized_list_items.each do |list_item| %>
-        <tr>
-          <td class='title'><%= list_item.title %></td>
-          <td class='api-url'><%= list_item.api_url %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-</section>
+<%= render 'new_list', topic: @topic %>
+<%= render 'list_editor', lists: @lists, topic: @topic %>
+<%= render 'uncategorized_list_items', lists: @lists, topic: @topic %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,13 +1,13 @@
-<h1>Curated lists for "<%= @topic.title %>"<%= " (draft)" if @topic.draft? %></h1>
+<h1>Curated lists for "<%= @tag.title %>"<%= " (draft)" if @tag.draft? %></h1>
 
-<% if @topic.untagged_list_items.any? %>
-  <%= render 'untagged_list_items', topic: @topic %>
+<% if @tag.untagged_list_items.any? %>
+  <%= render 'untagged_list_items', tag: @tag %>
 <% end %>
 
-<% unless @topic.draft? %>
-  <%= render 'publish_button', topic: @topic %>
+<% unless @tag.draft? %>
+  <%= render 'publish_button', tag: @tag %>
 <% end %>
 
-<%= render 'new_list', topic: @topic %>
-<%= render 'list_editor', lists: @lists, topic: @topic %>
-<%= render 'uncategorized_list_items', lists: @lists, topic: @topic %>
+<%= render 'new_list', tag: @tag %>
+<%= render 'list_editor', lists: @lists, tag: @tag %>
+<%= render 'uncategorized_list_items', lists: @lists, tag: @tag %>

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -19,6 +19,10 @@
                   publish_mainstream_browse_page_path(@browse_page),
                   method: :post %>
     <% end %>
+
+    <% if @browse_page.has_parent? %>
+      <%= link_to 'Edit list', tag_lists_path(@browse_page) %>
+    <% end %>
   </nav>
 </header>
 

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -21,7 +21,7 @@
     <% end %>
 
     <% if @topic.has_parent? %>
-      <%= link_to 'Edit list', topic_lists_path(@topic) %>
+      <%= link_to 'Edit list', tag_lists_path(@topic) %>
     <% end %>
   </nav>
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,11 +13,18 @@ Rails.application.routes.draw do
       post :publish
       post :republish
     end
+  end
 
+  resources :tags, only: [] do
     resources :lists, only: [:index, :edit, :create, :update, :destroy] do
       resources :list_items, only: [:create, :update, :destroy]
     end
   end
+
+  # Legacy route, may have been bookmarked by user.
+  get '/topics/:tag_id/lists', to: redirect { |params, _request|
+    "/tags/#{params[:tag_id]}/lists"
+  }
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,12 @@ Rails.application.routes.draw do
   resources :topics, except: :destroy do
     member do
       post :publish
-      post :republish
     end
   end
 
   resources :tags, only: [] do
+    post :republish
+
     resources :lists, only: [:index, :edit, :create, :update, :destroy] do
       resources :list_items, only: [:create, :update, :destroy]
     end

--- a/spec/controllers/tags_controller.rb
+++ b/spec/controllers/tags_controller.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe TagsController do
+  describe 'POST #republish' do
+    it "disallows normal users to republish mainstream browse pages" do
+      mainstream_browse_page = create(:mainstream_browse_page)
+
+      post :republish, tag_id: mainstream_browse_page.content_id
+
+      expect(response.code).to eq('403')
+    end
+
+    it "allows only GDS Editors to republish mainstream browse pages" do
+      stub_user.permissions << "GDS Editor"
+      mainstream_browse_page = create(:mainstream_browse_page)
+      allow(PublishingAPINotifier).to receive(:send_to_publishing_api)
+
+      post :republish, tag_id: mainstream_browse_page.content_id
+
+      expect(response.code).to eq('302')
+    end
+
+    it "allows non-GDS Editors to republish topic pages" do
+      topic = create(:topic)
+      allow(PublishingAPINotifier).to receive(:send_to_publishing_api)
+
+      post :republish, tag_id: topic.content_id
+
+      expect(response.code).to eq('302')
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Tag do
       list2 = create(:list, :tag => subtag)
       create(:list_item, :list => list2, :api_url => contentapi_url_for_slug('content-3'))
 
-      content_api_has_artefacts_with_a_tag('specialist_sector', 'tag/subtag', [
+      content_api_has_artefacts_with_a_tag('tag', 'tag/subtag', [
         'content-1',
         'content-2',
         'content-3',
@@ -289,7 +289,7 @@ RSpec.describe Tag do
     end
 
     it "returns all list items for content that's no longer tagged to the tag" do
-      content_api_has_artefacts_with_a_tag('specialist_sector', 'tag/subtag', [
+      content_api_has_artefacts_with_a_tag('tag', 'tag/subtag', [
         'content-1',
         'content-3',
       ])
@@ -300,7 +300,7 @@ RSpec.describe Tag do
     end
 
     it "returns empty array if all list items' content is tagged to the tag" do
-      content_api_has_artefacts_with_a_tag('specialist_sector', 'tag/subtag', [
+      content_api_has_artefacts_with_a_tag('tag', 'tag/subtag', [
         'content-1',
         'content-2',
         'content-3',
@@ -315,7 +315,7 @@ RSpec.describe Tag do
     let(:subtag) { create(:tag, :parent => tag, :slug => 'subtag') }
 
     it "returns the ListItem instances for all content tagged to the tag" do
-      content_api_has_artefacts_with_a_tag('specialist_sector', 'tag/subtag', [
+      content_api_has_artefacts_with_a_tag('tag', 'tag/subtag', [
         'example-content-1',
         'example-content-2'
       ])
@@ -334,7 +334,7 @@ RSpec.describe Tag do
     end
 
     it "returns empty array when no items are tagged to the tag" do
-      content_api_has_artefacts_with_a_tag('specialist_sector', 'tag/subtag', [])
+      content_api_has_artefacts_with_a_tag('tag', 'tag/subtag', [])
 
       expect(subtag.list_items_from_contentapi).to eq([])
     end
@@ -343,6 +343,22 @@ RSpec.describe Tag do
       stub_request(:get, %r[.]).to_return(status: 404)
 
       expect(subtag.list_items_from_contentapi).to eq([])
+    end
+
+    it "returns the correct info for a browse page" do
+      parent = create(:mainstream_browse_page, slug: 'benefits')
+      browse_page = create(:mainstream_browse_page, parent: parent, slug: 'entitlement')
+      content_api_has_artefacts_with_a_tag('section', 'benefits/entitlement', [
+        'example-content-1',
+        'example-content-2'
+      ])
+
+      items = browse_page.list_items_from_contentapi
+
+      expect(items.map(&:title)).to eq([
+        "Example content 1",
+        "Example content 2"
+      ])
     end
   end
 end

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
       title: 'Citizenship',
       description: 'Living in the UK, passports',
       parent: nil,
-      tag_type: 'section',
+      legacy_tag_type: 'section',
     ) }
 
     let(:presenter) { MainstreamBrowsePagePresenter.new(mainstream_browse_page) }

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         :rendering_app => 'collections',
         :redirects => [],
         :update_type => "major",
-        :details => {},
+        :details => { :groups=>[] },
       })
     end
 

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TagPresenter do
       title: 'Citizenship',
       description: 'Living in the UK, passports',
       parent: nil,
-      tag_type: nil,
+      legacy_tag_type: nil,
     }}
 
     it 'returns a hash of tag attributes' do

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe TagPresenter do
       title: 'Citizenship',
       description: 'Living in the UK, passports',
       parent: nil,
+      tag_type: nil,
     }}
 
     it 'returns a hash of tag attributes' do

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -52,4 +52,68 @@ RSpec.describe TagPresenter do
     end
   end
 
+  describe "details hash" do
+    let(:tag) do
+      create(:tag, {
+        :parent => create(:tag, :slug => 'oil-and-gas'),
+        :slug => 'offshore',
+        :title => 'Offshore',
+        :description => 'Oil rigs, pipelines etc.',
+      })
+    end
+
+    let(:presented_data) do
+      TopicPresenter.new(tag).render_for_publishing_api
+    end
+
+    it "should contain an empty groups array with no curated lists" do
+      expect(presented_data[:details]).to eq({
+        :groups => [],
+        :beta => false,
+      })
+    end
+
+    context "with some curated lists" do
+      let(:oil_rigs) { create(:list, :tag => tag, :index => 1, :name => 'Oil rigs') }
+      let(:piping) { create(:list, :tag => tag, :index => 0, :name => 'Piping') }
+
+      before :each do
+        allow(oil_rigs).to receive(:tagged_list_items).and_return([
+          OpenStruct.new(:api_url => "http://api.example.com/oil-rig-safety-requirements"),
+          OpenStruct.new(:api_url => "http://api.example.com/oil-rig-staffing"),
+        ])
+
+        allow(piping).to receive(:tagged_list_items).and_return([
+          OpenStruct.new(:api_url => "http://api.example.com/undersea-piping-restrictions"),
+        ])
+
+        allow(tag).to receive(:lists).and_return(double(:ordered => [piping, oil_rigs]))
+      end
+
+      it "provides the curated lists ordered by their index" do
+        expect(presented_data[:details]).to eq({
+          :groups => [
+            {
+              :name => "Piping",
+              :contents => [
+                "http://api.example.com/undersea-piping-restrictions",
+              ]
+            },
+            {
+              :name => "Oil rigs",
+              :contents => [
+                "http://api.example.com/oil-rig-safety-requirements",
+                "http://api.example.com/oil-rig-staffing",
+              ]
+            }
+          ],
+          :beta => false,
+        })
+      end
+
+      it "is valid against the schema", :schema_test => true do
+        expect(presented_data).to be_valid_against_schema('topic')
+      end
+    end
+  end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -50,56 +50,6 @@ RSpec.describe TopicPresenter do
       expect(presented_data[:public_updated_at]).to eq(topic.updated_at.iso8601)
     end
 
-    describe "details hash" do
-      it "should contain an empty groups array with no curated lists" do
-        expect(presented_data[:details]).to eq({
-          :groups => [],
-          :beta => false,
-        })
-      end
-
-      context "with some curated lists" do
-        let(:oil_rigs) { create(:list, :tag => topic, :index => 1, :name => 'Oil rigs') }
-        let(:piping) { create(:list, :tag => topic, :index => 0, :name => 'Piping') }
-
-        before :each do
-          allow(oil_rigs).to receive(:tagged_list_items).and_return([
-            OpenStruct.new(:api_url => "http://api.example.com/oil-rig-safety-requirements"),
-            OpenStruct.new(:api_url => "http://api.example.com/oil-rig-staffing"),
-          ])
-          allow(piping).to receive(:tagged_list_items).and_return([
-            OpenStruct.new(:api_url => "http://api.example.com/undersea-piping-restrictions"),
-          ])
-          allow(topic).to receive(:lists).and_return(double(:ordered => [piping, oil_rigs]))
-        end
-
-        it "provides the curated lists ordered by their index" do
-          expect(presented_data[:details]).to eq({
-            :groups => [
-              {
-                :name => "Piping",
-                :contents => [
-                  "http://api.example.com/undersea-piping-restrictions",
-                ]
-              },
-              {
-                :name => "Oil rigs",
-                :contents => [
-                  "http://api.example.com/oil-rig-safety-requirements",
-                  "http://api.example.com/oil-rig-staffing",
-                ]
-              }
-            ],
-            :beta => false,
-          })
-        end
-
-        it "is valid against the schema", :schema_test => true do
-          expect(presented_data).to be_valid_against_schema('topic')
-        end
-      end
-    end
-
     describe "routing" do
       it "includes routes for latest, and email_signups in addition to base route" do
         expect(presented_data[:routes]).to eq([

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,4 +80,9 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
+
+  config.before :each, type: :controller do
+    # Set a referer header so `redirect_to :back` works in tests. 
+    request.env["HTTP_REFERER"] = ''
+  end
 end


### PR DESCRIPTION
This PR adds the ability to group the links on mainstream browse pages into "curated lists".

This works identical to the current functionality for curating the list contents of a Topic:

![screen shot 2015-05-29 at 14 55 26](https://cloud.githubusercontent.com/assets/233676/7884010/c5f8e11a-0612-11e5-8898-03707591fb82.png)

https://www.gov.uk/browse/benefits/tax-credits

### Trello

> Allow the content shown in 2nd level mainstream browse pages to be curated, in a similar way to that in which sub-topic page content can be curated. This curation should be limited to GDS editors (but viewing of mainstream browse pages is currently restricted in this way already, so this shouldn't be hard). Curated content should be able to be put into groups, with named headings, and have its order controlled. Content should be able to appear in more than one group.

https://trello.com/c/iy1tB6gU/124-add-curation-of-mainstream-browse-pages-to-collections-publisher

### Related PRs

- https://github.com/alphagov/collections-publisher/pull/70 (Make Lists belong to Tag)
- https://github.com/alphagov/govuk-content-schemas/pull/76 (Add curated links to mainstream browse pages)

Best reviewed per-commit.