### PR TITLE
Prevent changing the slug for all tags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -41,7 +41,7 @@ class Tag < ActiveRecord::Base
   validates :slug, :title, :content_id, presence: true
   validates :slug, uniqueness: { scope: ["parent_id"] }, format: { with: /\A[a-z0-9-]*\z/ }
   validate :parent_is_not_a_child
-  validate :slug_change_once_published
+  validate :cannot_change_slug
 
   before_validation :generate_content_id, on: :create
 
@@ -150,9 +150,9 @@ private
     self.content_id ||= SecureRandom.uuid
   end
 
-  def slug_change_once_published
-    if slug_changed? && state == 'published'
-      errors.add(:slug, 'cannot change a slug once published')
+  def cannot_change_slug
+    if slug_changed? && !new_record?
+      errors.add(:slug, 'cannot change a slug once saved')
     end
   end
 end

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -1,5 +1,5 @@
 <%= form_for @browse_page do |f| %>
-  <%= f.text_field :slug %>
+  <%= f.text_field :slug, :disabled => true %>
   <%= f.text_field :title %>
   <%= f.text_field :description %>
 

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -11,7 +11,7 @@
 </h1>
 
 <%= form_for @topic, html: { class: 'topic' } do |f| %>
-  <%= f.text_field :slug %>
+  <%= f.text_field :slug, :disabled => true %>
   <%= f.text_field :title %>
   <%= f.text_field :description %>
   <%= f.check_box :beta %>

--- a/spec/controllers/mainstream_browse_pages_controller_spec.rb
+++ b/spec/controllers/mainstream_browse_pages_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe MainstreamBrowsePagesController do
     it 'notifies panopticon' do
       expect(PanopticonNotifier).to receive(:update_tag).with(presenter)
 
-      put :update, id: mainstream_browse_page.content_id, mainstream_browse_page: attributes
+      put :update, id: mainstream_browse_page.content_id, mainstream_browse_page: attributes.merge(:slug => mainstream_browse_page.slug)
     end
   end
 

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -137,10 +137,10 @@ RSpec.describe "creating and editing topics" do
     click_on 'Working at sea'
     click_on 'Edit'
 
-    fill_in 'Slug', with: ''
+    fill_in 'Title', with: ''
     click_on 'Save'
 
-    expect(page).to have_content("Slug can't be blank")
+    expect(page).to have_content("Title can't be blank")
   end
 
   it "creating a child topic" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -176,9 +176,8 @@ RSpec.describe Tag do
     end
   end
 
-  it 'does not allow changing the slug for a published tag' do
+  it 'does not allow changing the slug for an existing tag' do
     tag = create(:tag, slug: 'example')
-    tag.publish
     tag.slug = 'a-different-slug'
 
     expect(tag).not_to be_valid


### PR DESCRIPTION
We previously allowed changing the slug for draft tags.  This doesn't
work properly because it's not possible to propogate the change to
Panopticon in this way (Panopticon returns a 404 when trying to update
the tag because it can't find a tag with the new slug - obviously).

Additionally, it's not really possible to support this because the
tag_id (containing the slug) is used as the foreign key when tagging
content, and therefore updating the tag's slug would break anything
tagged with it.

We therefore can't allow editing the slugs for tags until everything has
moved over to the 'new world', and is using content_ids to link
everything.