### PR TITLE
Restore page heading when editing browse page.

### DIFF
--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -1,3 +1,15 @@
+<%= content_for :page_title, "Edit mainstream browse page" %>
+
+<h1>
+  <span class="type">Mainstream browse page</span>
+
+  Editing
+  <% if @browse_page.has_parent? %>
+    <%= @browse_page.parent.title %>:
+  <% end %>
+  <%= @browse_page.title %>
+</h1>
+
 <%= form_for @browse_page do |f| %>
   <%= f.text_field :slug %>
   <%= f.text_field :title %>


### PR DESCRIPTION
This got lost in the refactoring somehow.