### PR TITLE
Fix test failure github reporting.

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -49,16 +49,13 @@ git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-sc
 )
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
+export RAILS_ENV=test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
-RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load
-RAILS_ENV=test bundle exec rake ${TEST_TASK:-"default"}
+bundle exec rake db:drop db:create db:schema:load
 
-EXIT_STATUS=$?
-
-if [ "$EXIT_STATUS" == "0" ]; then
+if bundle exec rake ${TEST_TASK:-"default"}; then
   github_status "$REPO_NAME" success "succeeded on Jenkins"
 else
   github_status "$REPO_NAME" failure "failed on Jenkins"
+  exit 1
 fi
-
-exit $EXIT_STATUS


### PR DESCRIPTION
This was reporting that the run errored instead of failed.  This is
because the error handler was being invoked any time a command exited
non-zero.

Changing this to run the tests as part of an if statement prevents the
error handler being triggered, and allows us to handle the outcome
apropriately.