### PR TITLE
Highlight the correct navigation item

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,15 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?
+  helper_method :gds_editor?, :active_navigation_item
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
+  end
+
+  # Can be overridden to allow controllers to choose the active menu item.
+  def active_navigation_item
+    controller_name
   end
 
   def require_gds_editor_permissions!

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -70,4 +70,7 @@ private
     params.require(:list).permit(:name, :index)
   end
 
+  def active_navigation_item
+    @tag.is_a?(MainstreamBrowsePage) ? 'mainstream_browse_pages' : 'topics'
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,12 +8,12 @@
 
 <% content_for :navbar_items do %>
   <% if gds_editor? %>
-    <li class='<%= controller_name == 'mainstream_browse_pages' ? 'active' : nil %>'>
+    <li class='<%= active_navigation_item == 'mainstream_browse_pages' ? 'active' : nil %>'>
       <%= link_to 'Mainstream browse pages', mainstream_browse_pages_path %>
     </li>
   <% end %>
 
-  <li class='<%= controller_name.in?(%w[topics lists]) ? 'active' : nil %>'>
+  <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
     <%= link_to 'Topics', topics_path %>
   </li>
 <% end %>


### PR DESCRIPTION
Lists used to only belong to Topics, so whenever we were on a page rendered by `ListsController` we highlighted the Topics entry in the navigation.

We now support lists for mainstream browse pages too (#71), so we need another way to determine in which section we currently are. By adding a helper method we can let the controllers decide which navigation item to highlight.

Trello: https://trello.com/c/iy1tB6gU/124-add-curation-of-mainstream-browse-pages-to-collections-publisher
