### PR TITLE
Make headings consistent across pages

### DIFF
--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -1,0 +1,42 @@
+module HeaderHelper
+  # Generates a header with `title` and `breadcrumbs`. Last item in the
+  # breadcrumbs array should be a string for the "active" entry.
+  def header(title, breadcrumbs:, page_title: nil)
+    breadcrumbs = breadcrumbs.compact
+    active_item = breadcrumbs.pop
+
+    locals = {
+      title: title,
+      breadcrumbs: breadcrumbs,
+      page_title: page_title || title,
+      active_item: active_item.try(:title) || active_item
+    }
+
+    render layout: 'shared/header', locals: locals do
+      yield if block_given?
+    end
+  end
+
+  def tag_header(tag, mode = nil)
+    breadcrumbs = [active_navigation_item, tag.parent, tag, mode]
+
+    title = tag.title_including_parent
+    title = "#{title}: #{mode}" if mode
+    title = "#{title} #{beta_tag}" if tag.beta?
+    title = "#{title} #{draft_tag}" if tag.draft?
+
+    header title, breadcrumbs: breadcrumbs, page_title: tag.title_including_parent do
+      yield if block_given?
+    end
+  end
+
+  def auto_link(object)
+    if object.is_a?(ActiveRecord::Base)
+      link_to object.title, object
+    elsif object.to_s.starts_with?('<a href')
+      raw object
+    else
+      link_to object.to_s.humanize, object.to_sym
+    end
+  end
+end

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -11,4 +11,8 @@ module StatusHelper
   def beta_tag
     status 'In Beta', :warning
   end
+
+  def draft_tag
+    status 'draft', :draft
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -82,7 +82,7 @@ class Tag < ActiveRecord::Base
 
   def title_including_parent
     if has_parent?
-      "#{parent.title}: #{title}"
+      "#{parent.title} / #{title}"
     else
       title
     end

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -1,6 +1,8 @@
-<%= form_for @list, :url => tag_list_path(@tag, @list) do |f| %>
-  <h2>Edit list</h2>
-  <%= f.text_field :name %>
+<%= header "Edit '#{@list.name}'",
+  breadcrumbs: [active_navigation_item, @tag.parent, @tag,
+    link_to('Links', tag_lists_path(@tag)), @list.name] %>
 
+<%= form_for @list, :url => tag_list_path(@tag, @list) do |f| %>
+  <%= f.text_field :name %>
   <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Curated lists for "<%= @tag.title %>"<%= " (draft)" if @tag.draft? %></h1>
+<%= tag_header @tag, 'Lists' %>
 
 <% if @tag.untagged_list_items.any? %>
   <%= render 'untagged_list_items', tag: @tag %>

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -1,14 +1,4 @@
-<%= content_for :page_title, "Edit mainstream browse page" %>
-
-<h1>
-  <span class="type">Mainstream browse page</span>
-
-  Editing
-  <% if @browse_page.has_parent? %>
-    <%= @browse_page.parent.title %>:
-  <% end %>
-  <%= @browse_page.title %>
-</h1>
+<%= tag_header @browse_page, 'Edit' %>
 
 <%= form_for @browse_page do |f| %>
   <%= f.text_field :slug, :disabled => true %>

--- a/app/views/mainstream_browse_pages/index.html.erb
+++ b/app/views/mainstream_browse_pages/index.html.erb
@@ -1,14 +1,8 @@
-<%= content_for :page_title, "Mainstream browse page" %>
-
-<header class="heading-with-actions">
-  <h1>Mainstream browse page</h1>
-
-  <nav class="actions">
-    <%= link_to new_mainstream_browse_page_path, class: 'new' do %>
-      <span class="icon"></span> Add a mainstream browse page
-    <% end %>
-  </nav>
-</header>
+<%= header "Mainstream browse pages", breadcrumbs: ["Mainstream browse pages"] do %>
+  <%= link_to new_mainstream_browse_page_path, class: 'new' do %>
+    <span class="icon"></span> Add a mainstream browse page
+  <% end %>
+<% end %>
 
 <%= render 'shared/tags/table',
       resources: @browse_pages,

--- a/app/views/mainstream_browse_pages/new.html.erb
+++ b/app/views/mainstream_browse_pages/new.html.erb
@@ -1,6 +1,5 @@
-<%= content_for :page_title, 'New mainstream browse page' %>
-
-<h1>New mainstream browse page</h1>
+<%= header "New mainstream browse page",
+  breadcrumbs: [:mainstream_browse_pages, @browse_page.parent, "New"] %>
 
 <%= form_for @browse_page do |f| %>
   <%= f.select :parent_id,

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -1,30 +1,16 @@
-<%= content_for :page_title, @browse_page.title %>
+<%= tag_header @browse_page do %>
+  <%= link_to 'Edit', edit_mainstream_browse_page_path(@browse_page) %>
 
-<header class="heading-with-actions">
-  <h1>
-    <span class="type">Mainstream browse page</span>
+  <% if @browse_page.may_publish? %>
+    <%= link_to "Publish mainstream browse page",
+               publish_mainstream_browse_page_path(@browse_page),
+               method: :post %>
+  <% end %>
 
-    <% if @browse_page.has_parent? %>
-      <%= link_to "#{@browse_page.parent.title}:", @browse_page.parent %>
-    <% end %>
-
-    <%= @browse_page.title %>
-  </h1>
-
-  <nav class="actions">
-    <%= link_to 'Edit', edit_mainstream_browse_page_path(@browse_page) %>
-
-    <% if @browse_page.may_publish? %>
-      <%= link_to "Publish mainstream browse page",
-                  publish_mainstream_browse_page_path(@browse_page),
-                  method: :post %>
-    <% end %>
-
-    <% if @browse_page.has_parent? %>
-      <%= link_to 'Edit list', tag_lists_path(@browse_page) %>
-    <% end %>
-  </nav>
-</header>
+  <% if @browse_page.has_parent? %>
+    <%= link_to 'Edit list', tag_lists_path(@browse_page) %>
+  <% end %>
+<% end %>
 
 <%= render 'shared/tags/metadata', resource: @browse_page %>
 <%= render 'shared/tags/children', resource: @browse_page %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, page_title %>
+
+<header class="heading-with-actions">
+  <ol class="breadcrumb">
+    <% breadcrumbs.each do |crumb| %>
+      <li><%= auto_link crumb %></li>
+    <% end %>
+
+    <li class="active"><%= active_item %></li>
+  </ol>
+
+  <h1><%= raw title %></h1>
+
+  <% if block_given? %>
+    <nav class="actions">
+      <%= yield %>
+    </nav>
+  <% end %>
+</header>

--- a/app/views/shared/tags/_table.html.erb
+++ b/app/views/shared/tags/_table.html.erb
@@ -24,7 +24,7 @@
             <% resource.sorted_children.each do |child_tag| %>
               <li>
                 <%= link_to child_tag.title, polymorphic_path(child_tag) %>
-                <%= status('draft', :draft) if child_tag.draft? %>
+                <%= draft_tag if child_tag.draft? %>
                 <%= beta_tag if child_tag.beta? %>
               </li>
             <% end %>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -1,14 +1,4 @@
-<%= content_for :page_title, "Edit topic" %>
-
-<h1>
-  <span class="type">Topic</span>
-
-  Editing
-  <% if @topic.has_parent? %>
-    <%= @topic.parent.title %>:
-  <% end %>
-    <%= @topic.title %> <%= beta_tag if @topic.beta? %>
-</h1>
+<%= tag_header @topic, 'Edit' %>
 
 <%= form_for @topic, html: { class: 'topic' } do |f| %>
   <%= f.text_field :slug, :disabled => true %>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,16 +1,10 @@
-<%= content_for :page_title, "Topics" %>
-
-<header class="heading-with-actions">
-  <h1>Topics</h1>
-
+<%= header 'Topics', breadcrumbs: ['Topics'] do %>
   <% if gds_editor? %>
-    <nav class="actions">
-      <%= link_to new_topic_path, class: 'new' do %>
-        <span class="icon"></span> Add a topic
-      <% end %>
-    </nav>
+    <%= link_to new_topic_path, class: 'new' do %>
+      <span class="icon"></span> Add a topic
+    <% end %>
   <% end %>
-</header>
+<% end %>
 
 <%= render 'shared/tags/table',
       resources: @topics,

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,6 +1,5 @@
-<%= content_for :page_title, 'New topic' %>
-
-<h1>New topic</h1>
+<%= header "New topic",
+  breadcrumbs: [:topics, @topic.parent, "New"] %>
 
 <%= form_for @topic, html: { class: 'topic' } do |f| %>
   <%= f.select :parent_id,

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,30 +1,16 @@
-<%= content_for :page_title, @topic.title %>
+<%= tag_header @topic do %>
+  <% if gds_editor? %>
+    <%= link_to 'Edit', edit_topic_path(@topic) %>
 
-<header class="heading-with-actions">
-  <h1>
-    <span class="type">Topics</span>
-
-    <% if @topic.has_parent? %>
-      <%= link_to "#{@topic.parent.title}:", @topic.parent %>
+    <% if @topic.may_publish? %>
+      <%= link_to 'Publish topic', publish_topic_path(@topic), method: :post %>
     <% end %>
+  <% end %>
 
-    <%= @topic.title %> <%= beta_tag if @topic.beta? %>
-  </h1>
-
-  <nav class="actions">
-    <% if gds_editor? %>
-      <%= link_to 'Edit', edit_topic_path(@topic) %>
-
-      <% if @topic.may_publish? %>
-        <%= link_to 'Publish topic', publish_topic_path(@topic), method: :post %>
-      <% end %>
-    <% end %>
-
-    <% if @topic.has_parent? %>
-      <%= link_to 'Edit list', tag_lists_path(@topic) %>
-    <% end %>
-  </nav>
-</header>
+  <% if @topic.has_parent? %>
+    <%= link_to 'Edit list', tag_lists_path(@topic) %>
+  <% end %>
+<% end %>
 
 <%= render 'shared/tags/metadata', resource: @topic %>
 <%= render 'shared/tags/children', resource: @topic %>

--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -47,12 +47,12 @@ RSpec.describe "associating topics to mainstream browse pages" do
       topic_titles = page.all(:css, "#mainstream_browse_page_topics option").map(&:text)
       expect(topic_titles).to eq([
         "Alpha",
-        "Alpha: Alpha",
-        "Alpha: Bravo",
+        "Alpha / Alpha",
+        "Alpha / Bravo",
         "Bravo",
-        "Bravo: Alpha",
-        "Bravo: Bravo",
-        "Bravo: Charlie",
+        "Bravo / Alpha",
+        "Bravo / Bravo",
+        "Bravo / Charlie",
       ])
     end
 

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe "Curating the contents of topics" do
         click_on 'Create'
       end
 
+      # We need to scroll down first to see all the lists.
+      page.driver.scroll_to 0, 100
+
       expect(page).to have_selector('.list h2', :text => 'Oil rigs')
 
       within '#list-uncategorized-section' do
@@ -71,6 +74,7 @@ RSpec.describe "Curating the contents of topics" do
         page.find(:xpath, ".//*[contains(@class,'ui-sortable-handle')][.//td[@class='title'] = 'Undersea piping restrictions']")
           .drag_to(target)
       end
+
       within :xpath, "//section[contains(@class, 'list')][.//h2 = 'Piping']" do
         expect(page).to have_content('Undersea piping restrictions')
         expect(page).not_to have_selector(".working") # Wait until the AJAX call has completed
@@ -87,6 +91,7 @@ RSpec.describe "Curating the contents of topics" do
           'Oil rig safety requirements',
         ])
       end
+
       within :xpath, "//section[contains(@class,'list')][.//h2 = 'Piping']" do
         titles = page.all('td.title').map(&:text)
         expect(titles).to eq([


### PR DESCRIPTION
Currently page headers are defined per page and differ. This PR:

- Adds a consistent `<h1>` header
- Adds a breadcrumb to let the user see the structure and navigate back
- Uses the page title as browser `<title>`

Part of an effort to improve the curated links editor. Trello: https://trello.com/c/VXdUyg2g/149-collections-publisher-improve-the-curated-links-editor

## Before
![screen shot 2015-06-08 at 11 42 43](https://cloud.githubusercontent.com/assets/233676/8033145/06319ca4-0dd4-11e5-8e25-829959aa2fb3.png)
![screen shot 2015-06-08 at 11 42 45](https://cloud.githubusercontent.com/assets/233676/8033142/06308aa8-0dd4-11e5-8031-a55e0a5a8563.png)
![screen shot 2015-06-08 at 11 42 47](https://cloud.githubusercontent.com/assets/233676/8033144/0631830e-0dd4-11e5-9e70-f31e0fa458cd.png)
![screen shot 2015-06-08 at 11 42 48](https://cloud.githubusercontent.com/assets/233676/8033143/06312850-0dd4-11e5-8da7-5da7ead6f3a7.png)
![screen shot 2015-06-08 at 11 42 50](https://cloud.githubusercontent.com/assets/233676/8033146/06327818-0dd4-11e5-81db-1ce535b683fc.png)
![screen shot 2015-06-08 at 11 42 52](https://cloud.githubusercontent.com/assets/233676/8033147/0634faca-0dd4-11e5-8c42-587e1b6ad2af.png)
![screen shot 2015-06-08 at 11 42 54](https://cloud.githubusercontent.com/assets/233676/8033148/0641ac8e-0dd4-11e5-8aca-241b2247a6f3.png)

## After

![screen shot 2015-06-08 at 11 41 32](https://cloud.githubusercontent.com/assets/233676/8033165/15e4d490-0dd4-11e5-995d-26ca822beef6.png)
![screen shot 2015-06-08 at 11 42 01](https://cloud.githubusercontent.com/assets/233676/8033166/15e58c00-0dd4-11e5-9026-d99052029079.png)
![screen shot 2015-06-08 at 11 42 02](https://cloud.githubusercontent.com/assets/233676/8033167/15e8c014-0dd4-11e5-84b8-e2f97f1e2992.png)
![screen shot 2015-06-08 at 11 42 04](https://cloud.githubusercontent.com/assets/233676/8033168/15e8e38c-0dd4-11e5-81e3-20ab2034526b.png)
![screen shot 2015-06-08 at 11 42 05](https://cloud.githubusercontent.com/assets/233676/8033170/15ea44fc-0dd4-11e5-9449-9b4b97b971c1.png)
![screen shot 2015-06-08 at 11 42 07](https://cloud.githubusercontent.com/assets/233676/8033169/15e98b16-0dd4-11e5-8a39-ee7d30f4bc21.png)
![screen shot 2015-06-08 at 11 42 10](https://cloud.githubusercontent.com/assets/233676/8033171/15f6242a-0dd4-11e5-810c-c391bbab2d7a.png)

Best reviewed in Split view.


