### PR TITLE
Show previews and sort mode for tags

### DIFF
--- a/app/assets/stylesheets/views/mainstream_browse_pages.scss
+++ b/app/assets/stylesheets/views/mainstream_browse_pages.scss
@@ -98,4 +98,17 @@ h1 .type {
   border-top: 1px solid #eee;
   padding: 10px 0 0;
   position: relative;
+
+  small i {
+    color: #2A2A2A;
+    margin-right: 3px;
+  }
+
+  ul {
+    padding-left: 0;
+
+    li {
+      list-style: none;
+    }
+  }
 }

--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -20,7 +20,7 @@ module HeaderHelper
   def tag_header(tag, mode = nil)
     breadcrumbs = [active_navigation_item, tag.parent, tag, mode]
 
-    title = tag.title_including_parent
+    title = "#{icon tag.sort_mode} #{tag.title_including_parent}"
     title = "#{title}: #{mode}" if mode
     title = "#{title} #{beta_tag}" if tag.beta?
     title = "#{title} #{draft_tag}" if tag.draft?

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,0 +1,15 @@
+module IconHelper
+  ALIASES = {
+    curated: 'list-alt',
+    a_to_z: 'sort-by-alphabet',
+  }
+
+  def icon(name)
+    return unless name
+    class_name = ALIASES[name.to_sym] || name
+    content_tag :i, '',
+      class: "glyphicon glyphicon-#{class_name}",
+      data: { toggle: 'tooltip' },
+      title: name.to_s.humanize
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -73,7 +73,7 @@ class Tag < ActiveRecord::Base
   alias child? has_parent?
 
   def self.sorted_parents
-    only_parents.includes(:children).order(:title)
+    only_parents.includes(children: [:lists]).order(:title)
   end
 
   def sorted_children
@@ -131,6 +131,19 @@ class Tag < ActiveRecord::Base
 
   def legacy_tag_type
     nil
+  end
+
+  def sort_mode
+    return nil unless parent_id
+    display_curated_links? ? :curated : :a_to_z
+  end
+
+  def display_curated_links?
+    if @_display_curated_links.nil?
+      @_display_curated_links = lists.any?
+    else
+      @_display_curated_links
+    end
   end
 
 private

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -1,14 +1,11 @@
 <%= tag_header @browse_page do %>
-  <%= link_to 'Edit', edit_mainstream_browse_page_path(@browse_page) %>
+  <%= link_to "Edit page",
+    edit_mainstream_browse_page_path(@browse_page) %>
 
   <% if @browse_page.may_publish? %>
     <%= link_to "Publish mainstream browse page",
                publish_mainstream_browse_page_path(@browse_page),
                method: :post %>
-  <% end %>
-
-  <% if @browse_page.has_parent? %>
-    <%= link_to 'Edit list', tag_lists_path(@browse_page) %>
   <% end %>
 <% end %>
 
@@ -26,4 +23,8 @@
           include_children_column: false,
           empty_message: "No topics exist yet." %>
   </section>
+<% end %>
+
+<% if @browse_page.child? %>
+  <%= render 'shared/tags/lists_of_links_preview', tag: @browse_page %>
 <% end %>

--- a/app/views/shared/tags/_children.html.erb
+++ b/app/views/shared/tags/_children.html.erb
@@ -14,7 +14,7 @@
 
     <%=
       render partial: 'shared/tags/table', locals: {
-        resources: resource.children.order(:title),
+        resources: resource.children.includes(:lists).order(:title),
         include_children_column: false,
         empty_message: "No children exist yet.
           #{link_to('Add one', new_polymorphic_path(resource, parent_id: resource.id))}".html_safe

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -1,0 +1,26 @@
+<%= link_to 'Edit list', tag_lists_path(tag),
+      class: 'btn btn-md btn-default pull-right',
+      id: 'edit-list' %>
+
+<h2>Links</h2>
+
+<p>Links for this tag have been curated into lists.</p>
+
+<% tag.lists.each do |list| %>
+  <h4><%= list.name %></h4>
+  <% if list.list_items.empty? %>
+    <em>No items in list</em>
+  <% end %>
+  <ul>
+  <% list.list_items.each do |item| %>
+    <li><%= item.title %></li>
+  <% end %>
+  </ul>
+<% end %>
+
+<h4>Uncurated items <em>(not shown to user)</em></h4>
+<ul>
+<% tag.uncategorized_list_items.each do |item| %>
+  <li><%= item.title %></li>
+<% end %>
+</ul>

--- a/app/views/shared/tags/_lists_of_links_preview.html.erb
+++ b/app/views/shared/tags/_lists_of_links_preview.html.erb
@@ -1,0 +1,5 @@
+<% if tag.display_curated_links? %>
+  <%= render 'shared/tags/curated_links_preview', tag: tag %>
+<% else %>
+  <%= render 'shared/tags/uncurated_links_preview', tag: tag %>
+<% end %>

--- a/app/views/shared/tags/_table.html.erb
+++ b/app/views/shared/tags/_table.html.erb
@@ -14,7 +14,10 @@
     <% if resources.any? %>
       <% resources.each do |resource| %>
       <tr>
-        <td><%= link_to resource.title, polymorphic_path(resource) %></td>
+        <td>
+          <small><%= icon resource.sort_mode %></small>
+          <%= link_to resource.title, polymorphic_path(resource) %>
+        </td>
         <td><%= link_to resource.base_path, Plek.new.website_root + resource.base_path %></td>
         <td><%= status(resource.state, resource.state) %> <%= beta_tag if resource.beta? %></td>
 
@@ -23,6 +26,7 @@
             <ul>
             <% resource.sorted_children.each do |child_tag| %>
               <li>
+                <small><%= icon child_tag.sort_mode %></small>
                 <%= link_to child_tag.title, polymorphic_path(child_tag) %>
                 <%= draft_tag if child_tag.draft? %>
                 <%= beta_tag if child_tag.beta? %>

--- a/app/views/shared/tags/_uncurated_links_preview.html.erb
+++ b/app/views/shared/tags/_uncurated_links_preview.html.erb
@@ -1,0 +1,13 @@
+<%= link_to 'Start curating links', tag_lists_path(tag),
+      class: 'btn btn-md btn-default pull-right',
+      id: 'edit-list' %>
+
+<h2>Links</h2>
+
+<p>Links for this tag have not been curated into lists.</p>
+
+<ul>
+<% tag.list_items_from_contentapi.each do |link| %>
+  <li><%= link.title %></li>
+<% end %>
+</ul>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,16 +1,17 @@
 <%= tag_header @topic do %>
   <% if gds_editor? %>
-    <%= link_to 'Edit', edit_topic_path(@topic) %>
+    <%= link_to 'Edit topic', 
+      edit_topic_path(@topic) %>
 
     <% if @topic.may_publish? %>
       <%= link_to 'Publish topic', publish_topic_path(@topic), method: :post %>
     <% end %>
   <% end %>
-
-  <% if @topic.has_parent? %>
-    <%= link_to 'Edit list', tag_lists_path(@topic) %>
-  <% end %>
 <% end %>
 
 <%= render 'shared/tags/metadata', resource: @topic %>
 <%= render 'shared/tags/children', resource: @topic %>
+
+<% if @topic.child? %>
+  <%= render 'shared/tags/lists_of_links_preview', tag: @topic %>
+<% end %>

--- a/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
+++ b/spec/features/associating_topics_to_mainstream_browse_pages_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe "associating topics to mainstream browse pages" do
   before do
     stub_user.permissions << "GDS Editor"
     stub_all_panopticon_tag_calls
+
+    # Stub the content-api with empty because the `show` pages are trying to
+    # fetch the links to show as preview. 
+    stub_content_api(grouped_results: [])
   end
 
   context "parent mainstream browse pages" do

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -344,6 +344,6 @@ RSpec.describe "Curating the contents of topics" do
   def visit_topic_list_curation_page
     visit topics_path
     click_on 'Offshore'
-    click_on 'Edit list'
+    find('#edit-list').click
   end
 end

--- a/spec/features/listing_browse_pages_spec.rb
+++ b/spec/features/listing_browse_pages_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe 'listing mainstream browse pages' do
     end
 
     it 'does not show the link given a child page' do
+      # Stub the content-api with empty because the `show` pages are trying to
+      # fetch the links to show as preview.
+      stub_content_api(grouped_results: [])
+
       # When I visit a child browse page
       visit mainstream_browse_page_path(child_browse_page)
 

--- a/spec/features/mainstream_browse_pages_spec.rb
+++ b/spec/features/mainstream_browse_pages_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe "managing mainstream browse pages" do
   before :each do
     stub_user.permissions << "GDS Editor"
     stub_all_panopticon_tag_calls
+
+    # Stub the content-api with empty because the `show` pages are trying to
+    # fetch the links to show as preview.
+    stub_content_api(grouped_results: [])
   end
 
   it "viewing the browse page index" do

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe "creating and editing topics" do
   before :each do
     stub_user.permissions << "GDS Editor"
     stub_all_panopticon_tag_calls
+
+    # Stub the content-api with empty because the `show` pages are trying to
+    # fetch the links to show as preview.
+    stub_content_api(grouped_results: [])
   end
 
   it "Creating a topic" do

--- a/spec/features/viewing_topics_spec.rb
+++ b/spec/features/viewing_topics_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Viewing topics" do
     # Given some parent topics with various number of children
     create(:topic, :published, :title => "Oil and Gas")
     business_tax = create(:topic, :published, :title => "Business Tax")
-    create(:topic, :parent => business_tax, :title => "VAT")
+    vat_topic = create(:topic, :parent => business_tax, :title => "VAT")
     create(:topic, :parent => business_tax, :title => "PAYE")
 
     # When I visit the topics index
@@ -33,5 +33,34 @@ RSpec.describe "Viewing topics" do
       'PAYE',
       'VAT',
     ])
+
+    # Given the subtopic pages have links
+    stub_content_api(grouped_results: [
+      { title: 'A link that only exists in the Content API'}
+    ])
+
+    # When I visit a subtopic page that has no lists
+    click_on 'PAYE'
+
+    # Then I should see the items are not curated
+    expect(page).to have_content 'Links for this tag have not been curated into lists'
+
+    # And I should see the link
+    expect(page).to have_content 'A link that only exists in the Content API'
+
+    # When I go back a level
+    within '.breadcrumb' do
+      click_on 'Business Tax'
+    end
+
+    # And I visit the subtopic page that does have lists
+    vat_topic.lists.create!
+    click_on 'VAT'
+
+    # Then I should see the items are curated
+    expect(page).to have_content 'Links for this tag have been curated into lists'
+
+    # And I should see the link
+    expect(page).to have_content 'A link that only exists in the Content API'
   end
 end

--- a/spec/helpers/icon_helper_spec.rb
+++ b/spec/helpers/icon_helper_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe IconHelper do
+  describe '#icon' do
+    it 'returns nothing for nil name' do
+      expect(helper.icon(nil)).to eql(nil)
+    end
+
+    it 'returns a tag for an icon name' do
+      expect(helper.icon(:some_name)).to eql '<i class="glyphicon glyphicon-some_name" data-toggle="tooltip" title="Some name"></i>'
+    end
+
+    it 'can use aliases' do
+      expect(helper.icon(:curated)).to eql '<i class="glyphicon glyphicon-list-alt" data-toggle="tooltip" title="Curated"></i>'
+    end
+  end
+end

--- a/spec/support/content_api_helpers.rb
+++ b/spec/support/content_api_helpers.rb
@@ -6,6 +6,10 @@ module ContentApiHelpers
   def contentapi_url_for_slug(slug)
     "#{Plek.new.find('contentapi')}/#{slug}.json"
   end
+
+  def stub_content_api(result)
+    stub_request(:get, %r[.contentapi]).to_return(body: JSON.dump(result))
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR:

- Adds previews for lists on the show pages of `MainstreamBrowsePage` and `Topic`.
- Adds a little icon to all relevant pages to show wether the tag is alphabetical or curated.

Hopefully this will it easier to grasp the different "sort modes" for a tag.

Needs some wordsmithery.

## Before

![screen shot 2015-06-10 at 13 20 58](https://cloud.githubusercontent.com/assets/233676/8082241/aa853d56-0f73-11e5-8e1a-bf0822b91604.png)
![screen shot 2015-06-10 at 13 21 00](https://cloud.githubusercontent.com/assets/233676/8082237/aa8366b6-0f73-11e5-9594-a3b1a5dc3fd1.png)
![screen shot 2015-06-10 at 13 21 02](https://cloud.githubusercontent.com/assets/233676/8082239/aa83d0ce-0f73-11e5-86c8-365f9528a6c2.png)

## After

![screen shot 2015-06-10 at 13 21 13](https://cloud.githubusercontent.com/assets/233676/8082238/aa837da4-0f73-11e5-994d-15b73bfdcd80.png)
![screen shot 2015-06-10 at 13 21 18](https://cloud.githubusercontent.com/assets/233676/8082236/aa831d28-0f73-11e5-94eb-80b8e0506fc0.png)

![screen shot 2015-06-10 at 13 21 23](https://cloud.githubusercontent.com/assets/233676/8082240/aa83f9b4-0f73-11e5-9575-7c0068717a0a.png)
(curated)

![screen shot 2015-06-10 at 13 22 58](https://cloud.githubusercontent.com/assets/233676/8082260/d9c5786a-0f73-11e5-8110-a0889f94cc02.png)
(alphabetized)
