### PR TITLE
Add "Unpublished changes" label for tags

### DIFF
--- a/app/assets/stylesheets/topics.scss
+++ b/app/assets/stylesheets/topics.scss
@@ -26,3 +26,8 @@ table.topics {
     padding: 3px;
   }
 }
+
+h1 .label {
+  font-size: 60%;
+  vertical-align: middle;
+}

--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -22,8 +22,7 @@ module HeaderHelper
 
     title = tag.title_including_parent
     title = "#{title}: #{mode}" if mode
-    title = "#{title} #{beta_tag}" if tag.beta?
-    title = "#{title} #{draft_tag}" if tag.draft?
+    title = title + ' ' + labels_for_tag(tag)
 
     header title, breadcrumbs: breadcrumbs, page_title: tag.title_including_parent do
       yield if block_given?

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -8,8 +8,20 @@ module StatusHelper
     content_tag :span, text, class: "label label-#{class_name}"
   end
 
+  def labels_for_tag(tag)
+    labels = []
+    labels << draft_tag if tag.draft?
+    labels << beta_tag if tag.beta?
+    labels << dirty_tag if tag.dirty?
+    labels.join(' ')
+  end
+
   def beta_tag
     status 'In Beta', :warning
+  end
+
+  def dirty_tag
+    status 'Unpublished changes', :danger
   end
 
   def draft_tag

--- a/app/views/shared/tags/_table.html.erb
+++ b/app/views/shared/tags/_table.html.erb
@@ -16,7 +16,11 @@
       <tr>
         <td><%= link_to resource.title, polymorphic_path(resource) %></td>
         <td><%= link_to resource.base_path, Plek.new.website_root + resource.base_path %></td>
-        <td><%= status(resource.state, resource.state) %> <%= beta_tag if resource.beta? %></td>
+        <td>
+          <%= status(resource.state, resource.state) %>
+          <%= beta_tag if resource.beta? %>
+          <%= dirty_tag if resource.dirty? %>
+        </td>
 
         <% unless local_assigns[:include_children_column] == false %>
           <td class='children'>
@@ -24,8 +28,7 @@
             <% resource.sorted_children.each do |child_tag| %>
               <li>
                 <%= link_to child_tag.title, polymorphic_path(child_tag) %>
-                <%= draft_tag if child_tag.draft? %>
-                <%= beta_tag if child_tag.beta? %>
+                <%= labels_for_tag(child_tag) %>
               </li>
             <% end %>
             </ul>

--- a/spec/features/viewing_topics_spec.rb
+++ b/spec/features/viewing_topics_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe "Viewing topics" do
     ])
 
     child_titles = page.all('td.children li').map(&:text)
-    expect(child_titles).to eq([
-      'PAYE draft',
-      'VAT draft',
+    first_words_of_titles = child_titles.map(&:split).map(&:first)
+    expect(first_words_of_titles).to eq([
+      'PAYE',
+      'VAT',
     ])
 
     # When I visit a topic page


### PR DESCRIPTION
When a list is updated the tag is marked as "dirty", which means it has changes that have not been published to the content store and aren't shown on the site.

Adding a label will help users to see which tags have unpublished changes - currently only the appearance of the "Publish" button would indicate the published state.

## Before

![screen shot 2015-06-11 at 13 44 54](https://cloud.githubusercontent.com/assets/233676/8107324/5710995e-1040-11e5-9f7a-7079e5d2d33a.png)
![screen shot 2015-06-11 at 13 45 58](https://cloud.githubusercontent.com/assets/233676/8107332/6690aeaa-1040-11e5-8291-f199fbaeb351.png)

## After

![screen shot 2015-06-11 at 13 41 45](https://cloud.githubusercontent.com/assets/233676/8107323/570ed31c-1040-11e5-8240-8a913a449c55.png)
![screen shot 2015-06-11 at 13 45 52](https://cloud.githubusercontent.com/assets/233676/8107331/66902728-1040-11e5-9141-bcc45e9a7ffb.png)

