### PR TITLE
Send top and second-level pages to content-store

### DIFF
--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -9,6 +9,28 @@ private
   def links
     super.merge(
       "related_topics" => @tag.topics.order(:title).map(&:content_id),
+      "top_level_browse_page" => top_level_browse_page_id,
+      "top_level_browse_pages" => @tag.class.sorted_parents.map(&:content_id),
+      "second_level_browse_pages" => second_level_browse_pages,
     )
   end
+
+private
+
+  def top_level_browse_page_id
+    if @tag.has_parent?
+      [@tag.parent.content_id]
+    else
+      []
+    end
+  end
+
+  def second_level_browse_pages
+    if @tag.child?
+      @tag.parent.sorted_children.map(&:content_id)
+    else
+      @tag.sorted_children.map(&:content_id)
+    end
+  end
+
 end

--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -9,7 +9,7 @@ private
   def links
     super.merge(
       "related_topics" => @tag.topics.order(:title).map(&:content_id),
-      "top_level_browse_page" => top_level_browse_page_id,
+      "active_top_level_browse_page" => top_level_browse_page_id,
       "top_level_browse_pages" => @tag.class.sorted_parents.map(&:content_id),
       "second_level_browse_pages" => second_level_browse_pages,
     )


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/D2vjglFv/110-store-full-information-needed-to-render-first-two-columns-of-a-mainstream-browse-page-in-content-store)

## This PR is for working towards:

 - removing use of `contentapi` by collections frontend.
 - Making collections frontend simpler so we can more easily experiment with putting childcare content into it in a new way.

## Details

When collections-publisher sends a mainstream browse page document to the content store, it should include the full details needed to render the first two columns of the page, so that the collections frontend doesn't need to make a call to content-api to render these columns of a mainstream browse page.

This information consists of:

 - For `/browse`, the titles, descriptions and base_paths of all the top level mainstream browse pages.

 - For `/browse/foo`, the same as for `/browse`, and also the titles, descriptions and base_paths of all the 2nd level mainstream browse pages under `foo`.

 - For `/browse/foo/bar`, the same information as for `/browse/foo`. (Also the links to topics, if any, which we're already putting in the content store.)
