### PR TITLE
Edit #active_top_level_browse_page_id

### DIFF
--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -21,7 +21,7 @@ private
     if @tag.has_parent?
       [@tag.parent.content_id]
     else
-      []
+      [@tag.content_id]
     end
   end
 

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe MainstreamBrowsePagePresenter do
         let(:presenter) { MainstreamBrowsePagePresenter.new(top_level_page_1) }
         let(:presented_data) { presenter.render_for_publishing_api }
 
-        it "it does not have a parent browse pages" do
+        it "it has self as active browse page" do
           expect(presented_data[:links]["active_top_level_browse_page"]).to eq(
-            []
+            [top_level_page_1.content_id]
           )
         end
 


### PR DESCRIPTION
The method should never return an empty array. When @tag
is the active_top_level_browse_page, it should return its
own id.