### PR TITLE
Send root `browse` page data to content store

### DIFF
--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -1,0 +1,30 @@
+class RootBrowsePagePresenter
+
+  def render_for_publishing_api
+    {
+      content_id: "8413047e-570a-448b-b8cb-d288a12807dd",
+      format: "mainstream_browse_page",
+      title: "Browse",
+      locale: 'en',
+      public_updated_at: Time.now.iso8601,
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+      routes: routes,
+      update_type: "major",
+      links: links,
+    }
+  end
+
+private
+
+  def routes
+    [ {path: "/browse", type: "exact"} ]
+  end
+
+  def links
+    {
+      "top_level_browse_pages" => MainstreamBrowsePage.sorted_parents.map(&:content_id)
+    }
+  end
+
+end

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -6,7 +6,7 @@ class RootBrowsePagePresenter
       format: "mainstream_browse_page",
       title: "Browse",
       locale: 'en',
-      public_updated_at: Time.now.iso8601,
+      public_updated_at: public_updated_at,
       publishing_app: "collections-publisher",
       rendering_app: "collections",
       routes: routes,
@@ -17,13 +17,28 @@ class RootBrowsePagePresenter
 
 private
 
+  def top_level_browse_pages
+    MainstreamBrowsePage.sorted_parents
+  end
+
+  def public_updated_at
+    if links["top_level_browse_pages"].empty?
+      raise "Top-level pages Array can't be empty"
+    else
+      top_level_browse_pages
+        .map(&:updated_at)
+        .max
+        .iso8601
+    end
+  end
+
   def routes
     [ {path: "/browse", type: "exact"} ]
   end
 
   def links
     {
-      "top_level_browse_pages" => MainstreamBrowsePage.sorted_parents.map(&:content_id)
+      "top_level_browse_pages" => top_level_browse_pages.map(&:content_id)
     }
   end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -3,6 +3,8 @@ namespace :publishing_api do
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
   task :republish_all_tags => :environment do
 
+    CollectionsPublisher.services(:publishing_api).put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
+
     puts "Sending #{Tag.count} tags to the publishing-api"
     done = 0
     Tag.find_each do |tag|

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
     it "sets public_updated_at based on the browse page update time" do
       Timecop.travel 3.hours.ago do
-        browse_page.save!
+        browse_page.touch
       end
 
       expect(presented_data[:public_updated_at]).to eq(browse_page.updated_at.iso8601)

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -108,12 +108,30 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
     describe "linking to related pages" do
 
-      let!(:top_level_page_1) { create(:mainstream_browse_page) }
-      let!(:top_level_page_2) { create(:mainstream_browse_page) }
+      let!(:top_level_page_1) { create(
+        :mainstream_browse_page,
+        :title => "Top-level page 1",
+      )}
+      let!(:top_level_page_2) { create(
+        :mainstream_browse_page,
+        :title => "Top-level page 2",
+      )}
 
-      let!(:second_level_page_1) { create(:mainstream_browse_page, :parent => top_level_page_1) }
-      let!(:second_level_page_2) { create(:mainstream_browse_page, :parent => top_level_page_1) }
-      let!(:second_level_page_3) { create(:mainstream_browse_page, :parent => top_level_page_2) }
+      let!(:second_level_page_1) { create(
+        :mainstream_browse_page,
+        :title => "Second-level page 1",
+        :parent => top_level_page_1,
+      )}
+      let!(:second_level_page_2) { create(
+        :mainstream_browse_page,
+        :title => "Second-level page 2",
+        :parent => top_level_page_1,
+      )}
+      let!(:second_level_page_3) { create(
+        :mainstream_browse_page,
+        :title => "Second-level page 3",
+        :parent => top_level_page_2,
+      )}
 
       context "for a top-level browse page" do
 

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe RootBrowsePagePresenter do
           top_level_page_2.content_id,
         ])
       end
+
+      context "top_level_page_1 updated before top_level_page_2" do
+        setup do
+          Timecop.travel 3.hours.ago do
+            top_level_page_1.save!
+          end
+          top_level_page_2.save!
+        end
+        it "#public_updated_at should equal most recent #updated_time" do
+          expect(rendered[:public_updated_at]).to eq(
+            top_level_page_2.updated_at.iso8601
+          )
+        end
+      end
     end
   end
 end

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -9,17 +9,23 @@ RSpec.describe RootBrowsePagePresenter do
       expect(rendered).to be_valid_against_schema('mainstream_browse_page')
     end
 
-    it "renders valid top level browse pages" do
-      top_level_page_1 = create(:mainstream_browse_page)
-      top_level_page_2 = create(:mainstream_browse_page)
+    context "with top level browse pages" do
 
-      rendered = RootBrowsePagePresenter.new.render_for_publishing_api
+      let!(:top_level_page_1) { create(:mainstream_browse_page)}
+      let!(:top_level_page_2) { create(:mainstream_browse_page)}
 
-      expect(rendered).to be_valid_against_schema('mainstream_browse_page')
-      expect(rendered[:links]["top_level_browse_pages"]).to eq([
-        top_level_page_1.content_id,
-        top_level_page_2.content_id,
-      ])
+      let(:rendered) { RootBrowsePagePresenter.new.render_for_publishing_api}
+
+      it "is valid against the schema" do
+        expect(rendered).to be_valid_against_schema('mainstream_browse_page')
+      end
+
+      it "includes all the top-level browse pages" do
+        expect(rendered[:links]["top_level_browse_pages"]).to eq([
+          top_level_page_1.content_id,
+          top_level_page_2.content_id,
+        ])
+      end
     end
   end
 end

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe RootBrowsePagePresenter do
 
   describe "#render_for_publishing_api" do
-    it "is valid against the schema without browse pages", :schema_test => true do
-      rendered = RootBrowsePagePresenter.new.render_for_publishing_api
-
-      expect(rendered).to be_valid_against_schema('mainstream_browse_page')
+    it "raises a RunTimeError if top-level browse pages are not present" do
+      expect {
+        RootBrowsePagePresenter.new.render_for_publishing_api
+      }.to raise_error(RuntimeError)
     end
 
     context "with top level browse pages" do

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe RootBrowsePagePresenter do
 
     context "with top level browse pages" do
 
-      let!(:top_level_page_1) { create(:mainstream_browse_page)}
-      let!(:top_level_page_2) { create(:mainstream_browse_page)}
+      let!(:top_level_page_1) { create(
+        :mainstream_browse_page,
+        :title => "Top-Level Page 1",
+      )}
+      let!(:top_level_page_2) { create(
+        :mainstream_browse_page,
+        :title => "Top-Level Page 2",
+      )}
 
       let(:rendered) { RootBrowsePagePresenter.new.render_for_publishing_api}
 

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe RootBrowsePagePresenter do
+
+  describe "#render_for_publishing_api" do
+    it "is valid against the schema without browse pages", :schema_test => true do
+      rendered = RootBrowsePagePresenter.new.render_for_publishing_api
+
+      expect(rendered).to be_valid_against_schema('mainstream_browse_page')
+    end
+
+    it "renders valid top level browse pages" do
+      top_level_page_1 = create(:mainstream_browse_page)
+      top_level_page_2 = create(:mainstream_browse_page)
+
+      rendered = RootBrowsePagePresenter.new.render_for_publishing_api
+
+      expect(rendered).to be_valid_against_schema('mainstream_browse_page')
+      expect(rendered[:links]["top_level_browse_pages"]).to eq([
+        top_level_page_1.content_id,
+        top_level_page_2.content_id,
+      ])
+    end
+  end
+end

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -34,13 +34,12 @@ RSpec.describe RootBrowsePagePresenter do
       end
 
       context "top_level_page_1 updated before top_level_page_2" do
-        setup do
-          Timecop.travel 3.hours.ago do
-            top_level_page_1.save!
-          end
-          top_level_page_2.save!
-        end
         it "#public_updated_at should equal most recent #updated_time" do
+          Timecop.travel 3.hours.ago do
+            top_level_page_1.touch
+          end
+          top_level_page_2.touch
+
           expect(rendered[:public_updated_at]).to eq(
             top_level_page_2.updated_at.iso8601
           )


### PR DESCRIPTION
## This PR completes: 
- the work started in this PR: https://github.com/alphagov/collections-publisher/pull/86
- this [ticket](https://trello.com/c/D2vjglFv/110-store-full-information-needed-to-render-first-two-columns-of-a-mainstream-browse-page-in-content-store)

# Working towards:

 - removing use of `contentapi` by collections frontend.

 - Making collections frontend simpler so we can more easily experiment with putting childcare content into it in a new way.

# Details

When collections-publisher sends a mainstream browse page document to the content store, it should include the full details needed to render the first two columns of the page, so that the collections frontend doesn't need to make a call to content-api to render these columns of a mainstream browse page.

This information is stored in entries in the "links" field, and consists of:

 - For `/browse`: the list of all the top level mainstream browse pages.

## Browse page available in dev:

![screen shot 2015-06-16 at 15 12 52](https://cloud.githubusercontent.com/assets/5038475/8185204/c98b183a-143a-11e5-9a37-f19725011035.png)

