### PR TITLE
Generate CSV for router-data redirects

### DIFF
--- a/lib/tasks/topic_redirects.rake
+++ b/lib/tasks/topic_redirects.rake
@@ -1,0 +1,16 @@
+desc "Generate a CSV for router-data redirects"
+task :topic_redirects => [:environment] do
+  topic_base_paths = Topic.published.only_parents.map(&:base_path).sort
+
+  topic_base_paths.each do |base_path|
+    puts "#{base_path},/topic#{base_path},exact"
+  end
+
+  subtopic_base_paths = Topic.published.only_children.map(&:base_path).sort
+
+  subtopic_base_paths.each do |base_path|
+    puts "#{base_path},/topic#{base_path},exact"
+    puts "#{base_path}/email-signup,/topic#{base_path}/email-signup,exact"
+    puts "#{base_path}/latest,/topic#{base_path}/latest,exact"
+  end
+end


### PR DESCRIPTION
Adds a rake task to output a CSV with redirect instructions, to feed to the `router-data` repo. It will redirect all topic pages to their new location at `/topic`.

For example:

```
/business-tax to /business-tax
```

And subtopics:

```
/business-tax/air-passenger-duty to /topic/business-tax/air-passenger-duty
/business-tax/air-passenger-duty/email-signup to /topic/business-tax/air-passenger-duty/email-signup
/business-tax/air-passenger-duty/latest to /topic/business-tax/air-passenger-duty/latest
```

Part of Trello: https://trello.com/c/EoWPp4qZ/187