### PR TITLE
Remove deprecated route from topics

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -11,7 +11,6 @@ private
     super + [
       {path: "#{base_path}/latest", type: "exact"},
       {path: "#{base_path}/email-signup", type: "exact"},
-      {path: "#{base_path}/email-signups", type: "exact"},
     ]
   end
 

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe TopicPresenter do
           {:path => "/oil-and-gas/offshore", :type => "exact"},
           {:path => "/oil-and-gas/offshore/latest", :type => "exact"},
           {:path => "/oil-and-gas/offshore/email-signup", :type => "exact"},
-          {:path => "/oil-and-gas/offshore/email-signups", :type => "exact"},
         ])
       end
 


### PR DESCRIPTION
The `/topic/emails-signups` (plural) route has been deprecated in `collections` and [currently returns a 404](https://www.gov.uk/oil-and-gas/environment-reporting-and-regulation/email-signups).

Removing the route here will make cause the router to return 404, saving a request to collections app.