### PR TITLE
Move topics to /topic namespace

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,7 @@ module ApplicationHelper
     classes + key
   end
 
+  def website_url(base_path)
+    Plek.new.website_root + base_path
+  end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -29,7 +29,7 @@ class MainstreamBrowsePage < Tag
   validate :parents_cannot_have_topics_associated
 
   def base_path
-    "/browse#{super}"
+    "/browse/#{full_slug}"
   end
 
   def legacy_tag_type

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: redirects
+#
+#  id                       :integer          not null, primary key
+#  tag_id                   :integer
+#  original_topic_base_path :string(255)      not null
+#  from_base_path           :string(255)      not null
+#  to_base_path             :string(255)      not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#
+# Indexes
+#
+#  index_redirects_on_tag_id  (tag_id)
+#
+
+class Redirect < ActiveRecord::Base
+  belongs_to :tag
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -26,7 +26,13 @@
 class Topic < Tag
   has_many :mainstream_browse_pages, through: :reverse_tag_associations, source: :from_tag
 
+  alias subtopic? has_parent?
+
   def legacy_tag_type
     'specialist_sector'
+  end
+
+  def base_path
+    "/topic/#{full_slug}"
   end
 end

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -1,12 +1,39 @@
 class PublishingAPINotifier
   def self.send_to_publishing_api(tag)
-    presenter = TagPresenter.presenter_for(tag)
-    publishing_api = CollectionsPublisher.services(:publishing_api)
+    new(tag).send_to_publishing_api
+  end
 
+  attr_reader :tag
+
+  def initialize(tag)
+    @tag = tag
+  end
+
+  def send_to_publishing_api
     if tag.published?
       publishing_api.put_content_item(presenter.base_path, presenter.render_for_publishing_api)
+      add_redirects
     else
       publishing_api.put_draft_content_item(presenter.base_path, presenter.render_for_publishing_api)
     end
+  end
+
+private
+
+  def add_redirects
+    redirects = tag.redirects.group_by(&:original_topic_base_path)
+
+    redirects.each do |old_path, redirects|
+      presenter = RedirectPresenter.new(redirects)
+      publishing_api.put_content_item(old_path, presenter.render_for_publishing_api)
+    end
+  end
+
+  def presenter
+    @presenter ||= TagPresenter.presenter_for(tag)
+  end
+
+  def publishing_api
+    @publishing_api ||= CollectionsPublisher.services(:publishing_api)
   end
 end

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,0 +1,28 @@
+class RedirectPresenter
+  attr_reader :redirects
+
+  def initialize(redirects)
+    @redirects = redirects
+  end
+
+  def render_for_publishing_api
+    {
+      format: 'redirect',
+      publishing_app: 'collections-publisher',
+      update_type: 'major',
+      redirects: redirect_routes,
+    }
+  end
+
+private
+
+  def redirect_routes
+    redirects.map do |redirect|
+      {
+        path: redirect.from_base_path,
+        destination: redirect.to_base_path,
+        type: 'exact',
+      }
+    end
+  end
+end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -1,5 +1,5 @@
 class TagPresenter
-  delegate :legacy_tag_type, to: :tag
+  delegate :legacy_tag_type, :base_path, to: :tag
 
   def self.presenter_for(tag)
     case tag
@@ -14,10 +14,6 @@ class TagPresenter
 
   def initialize(tag)
     @tag = tag
-  end
-
-  def base_path
-    @tag.base_path
   end
 
   def render_for_publishing_api

--- a/app/views/topics/_redirects.html.erb
+++ b/app/views/topics/_redirects.html.erb
@@ -1,0 +1,14 @@
+<h3>Redirects</h3>
+
+<table class='table'>
+  <tr>
+    <th>From</th>
+    <th>To</th>
+  </tr>
+  <% redirects.each do |redirect| %>
+    <tr>
+      <td><%= link_to website_url(redirect.from_base_path) %></td>
+      <td><%= link_to website_url(redirect.to_base_path) %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -15,3 +15,7 @@
 <% if @topic.child? %>
   <%= render 'shared/tags/lists_of_links_preview', tag: @topic %>
 <% end %>
+
+<% if @topic.redirects.any? %>
+  <%= render 'redirects', redirects: @topic.redirects %>
+<% end %>

--- a/db/migrate/20150622073111_create_redirects.rb
+++ b/db/migrate/20150622073111_create_redirects.rb
@@ -1,0 +1,13 @@
+class CreateRedirects < ActiveRecord::Migration
+  def change
+    create_table :redirects do |t|
+      t.integer :tag_id, index: true
+      t.string :original_topic_base_path, null: false
+      t.string :from_base_path, null: false
+      t.string :to_base_path, null: false
+      t.timestamps null: false
+    end
+
+    add_foreign_key :redirects, :tags, on_delete: :cascade
+  end
+end

--- a/db/migrate/20150622073727_add_redirects_for_topics_namespace.rb
+++ b/db/migrate/20150622073727_add_redirects_for_topics_namespace.rb
@@ -1,0 +1,42 @@
+class AddRedirectsForTopicsNamespace < ActiveRecord::Migration
+  def up
+    Topic.published.only_parents.each do |topic|
+      original_topic_base_path = '/' + topic.full_slug
+
+      Redirect.create!(
+        tag: topic,
+        original_topic_base_path: original_topic_base_path,
+        from_base_path: original_topic_base_path,
+        to_base_path: '/topic' + original_topic_base_path
+      )
+    end
+
+    Topic.published.only_children.each do |topic|
+      original_topic_base_path = '/' + topic.full_slug
+
+      Redirect.create!(
+        tag: topic,
+        original_topic_base_path: original_topic_base_path,
+        from_base_path: original_topic_base_path,
+        to_base_path: '/topic' + original_topic_base_path
+      )
+
+      Redirect.create!(
+        tag: topic,
+        original_topic_base_path: original_topic_base_path,
+        from_base_path: original_topic_base_path + '/email-signup',
+        to_base_path: '/topic' + original_topic_base_path + '/email-signup'
+      )
+
+      Redirect.create!(
+        tag: topic,
+        original_topic_base_path: original_topic_base_path,
+        from_base_path: original_topic_base_path + '/latest',
+        to_base_path: '/topic' + original_topic_base_path + '/latest'
+      )
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,17 @@ ActiveRecord::Schema.define(version: 20150623122832) do
 
   add_index "lists", ["tag_id"], name: "index_lists_on_tag_id", using: :btree
 
+  create_table "redirects", force: :cascade do |t|
+    t.integer  "tag_id",                   limit: 4
+    t.string   "original_topic_base_path", limit: 255, null: false
+    t.string   "from_base_path",           limit: 255, null: false
+    t.string   "to_base_path",             limit: 255, null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+  end
+
+  add_index "redirects", ["tag_id"], name: "index_redirects_on_tag_id", using: :btree
+
   create_table "tag_associations", force: :cascade do |t|
     t.integer  "from_tag_id", limit: 4, null: false
     t.integer  "to_tag_id",   limit: 4, null: false
@@ -76,6 +87,7 @@ ActiveRecord::Schema.define(version: 20150623122832) do
 
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
   add_foreign_key "lists", "tags", name: "lists_tag_id_fk", on_delete: :cascade
+  add_foreign_key "redirects", "tags", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade
   add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
+  factory :redirect do
+    original_topic_base_path "/some/route"
+    from_base_path "/some/route"
+    to_base_path "/to/some/route"
+  end
+
   factory :user do
     uid { SecureRandom.hex }
     permissions { ["signin"] }

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Curating the contents of topics" do
 
       #Then the curated lists should have been sent to the publishing API
       assert_publishing_api_put_item(
-        "/oil-and-gas/offshore",
+        "/topic/oil-and-gas/offshore",
         {
           "details" => {
             "groups" => [
@@ -163,7 +163,7 @@ RSpec.describe "Curating the contents of topics" do
 
       #Then the curated lists should have been sent to the publishing API
       assert_publishing_api_put_item(
-        "/oil-and-gas/offshore",
+        "/topic/oil-and-gas/offshore",
         {
           "details" => {
             "groups" => [

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "creating and editing topics" do
     end
 
     # And a draft should have been sent to publishing-api
-    assert_publishing_api_put_draft_item('/working-at-sea', {
+    assert_publishing_api_put_draft_item('/topic/working-at-sea', {
       "title" => "Working at sea",
       "description" => 'The sea, the sky, the sea, the sky...',
       "format" => "topic",
@@ -78,7 +78,7 @@ RSpec.describe "creating and editing topics" do
     expect(page).to have_content('I woke up one morning, The sea was still there.')
 
     # And a draft should have been sent to publishing-api
-    assert_publishing_api_put_draft_item('/working-at-sea', {
+    assert_publishing_api_put_draft_item('/topic/working-at-sea', {
       "title" => "Working on the ocean",
       "description" => "I woke up one morning, The sea was still there.",
       "format" => "topic",
@@ -113,7 +113,7 @@ RSpec.describe "creating and editing topics" do
     expect(page).to have_content('In Beta')
 
     # And a live item should have been sent to publishing-api
-    assert_publishing_api_put_item('/working-at-sea', {
+    assert_publishing_api_put_item('/topic/working-at-sea', {
       "title" => 'Working on the ocean',
       "description" => "I woke up one morning, The sea was still there.",
       "format" => "topic",
@@ -149,7 +149,8 @@ RSpec.describe "creating and editing topics" do
 
   it "creating a child topic" do
     # Given a draft topic exists
-    create(:topic, :draft, :slug => 'working-at-sea', :title => 'Working at sea')
+    topic = create(:topic, :draft, :slug => 'working-at-sea', :title => 'Working at sea')
+    create(:redirect, tag: topic)
 
     # When I fill out the details for a new child topic
     visit topics_path
@@ -169,7 +170,7 @@ RSpec.describe "creating and editing topics" do
     expect(page).to have_content('Remember your cheese...')
 
     # And a draft should have been sent to publishing-api
-    assert_publishing_api_put_draft_item('/working-at-sea/desert-islands', {
+    assert_publishing_api_put_draft_item('/topic/working-at-sea/desert-islands', {
       "title" => 'Desert Islands',
       "description" => 'Remember your cheese...',
       "format" => 'topic',
@@ -202,7 +203,7 @@ RSpec.describe "creating and editing topics" do
     end
 
     # And a live item should have been sent to publishing-api
-    assert_publishing_api_put_item('/working-at-sea', {
+    assert_publishing_api_put_item('/topic/working-at-sea', {
       "title" => "Working at sea",
       "format" => "topic",
     })
@@ -223,7 +224,7 @@ RSpec.describe "creating and editing topics" do
     click_on 'Save'
 
     # And a live item should have been sent to publishing-api
-    assert_publishing_api_put_item('/working-at-sea', {
+    assert_publishing_api_put_item('/topic/working-at-sea', {
       "details" => {
         "groups" => [],
         "beta" => false,

--- a/spec/migrations/add_redirects_for_topics_spec.rb
+++ b/spec/migrations/add_redirects_for_topics_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+require "#{Rails.root}/db/migrate/20150622073727_add_redirects_for_topics_namespace"
+
+RSpec.describe AddRedirectsForTopicsNamespace do
+  describe '#up' do
+    it 'creates redirects for published parent topics' do
+      create(:topic, :draft, slug: 'foo')
+      create(:topic, :published, slug: 'draft-foo')
+
+      AddRedirectsForTopicsNamespace.new.up
+
+      expect(Redirect.count).to eql(1)
+    end
+
+    it 'creates the correct parent redirects' do
+      topic = create(:topic, :published, slug: 'foo')
+
+      AddRedirectsForTopicsNamespace.new.up
+      redirect = Redirect.last
+
+      expect(redirect.tag).to eql(topic)
+      expect(redirect.original_topic_base_path).to eql('/foo')
+      expect(redirect.from_base_path).to eql('/foo')
+      expect(redirect.to_base_path).to eql('/topic/foo')
+    end
+
+    it 'creates redirects for parent topics' do
+      parent = create(:topic, :published, slug: 'foo')
+      child = create(:topic, :published, parent: parent, slug: 'bar')
+      child = create(:topic, :draft, parent: parent, slug: 'draft-bar')
+
+      AddRedirectsForTopicsNamespace.new.up
+
+      expect(Redirect.count).to eql(4)
+    end
+
+    it 'creates the child topic redirects' do
+      parent = create(:topic, :published, slug: 'foo')
+      child = create(:topic, :published, parent: parent, slug: 'bar')
+
+      AddRedirectsForTopicsNamespace.new.up
+
+      expect(child.redirects.map(&:from_base_path)).to eql(
+        [ "/foo/bar",
+          "/foo/bar/email-signup",
+          "/foo/bar/latest"]
+      )
+
+      expect(child.redirects.map(&:to_base_path)).to eql(
+        [ "/topic/foo/bar",
+          "/topic/foo/bar/email-signup",
+          "/topic/foo/bar/latest"]
+      )
+    end
+  end
+end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Redirect do
+  describe '#tag' do
+    it 'deletes itself if the parent tag is deleted' do
+      topic = create(:topic)
+      redirect = create(:redirect, tag: topic)
+
+      topic.destroy
+
+      expect { redirect.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -169,18 +169,18 @@ RSpec.describe Tag do
 
   end
 
-  describe '#base_path' do
+  describe '#full_slug' do
     it 'returns the slug for a parent tag' do
       tag = build(:tag, slug: 'example')
 
-      expect(tag.base_path).to eq('/example')
+      expect(tag.full_slug).to eq('example')
     end
 
     it 'joins the parent slug for a child tag' do
       parent = create(:tag)
       tag = build(:tag, slug: 'example', parent: parent)
 
-      expect(tag.base_path).to eq("/#{parent.slug}/example")
+      expect(tag.full_slug).to eq("#{parent.slug}/example")
     end
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,4 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Topic do
+  describe '#base_path' do
+    it 'includes the /topic namespace for parents' do
+      topic = create(:topic, slug: 'foo')
+
+      base_path = topic.base_path
+
+      expect(base_path).to eql('/topic/foo')
+    end
+
+    it 'includes the /topic namespace for subtopics' do
+      topic = create(:topic, slug: 'bar', parent: create(:topic, slug: 'foo'))
+
+      base_path = topic.base_path
+
+      expect(base_path).to eql('/topic/foo/bar')
+    end
+  end
 end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -1,45 +1,47 @@
 require "rails_helper"
 
 RSpec.describe PublishingAPINotifier do
-  let(:publishing_api) { instance_double("GdsApi::PublishingApi", :put_content_item => nil, :put_draft_content_item => nil) }
+  include ContentStoreHelpers
+  before { stub_content_store! }
 
-  before do
-    allow(CollectionsPublisher).to receive(:services).with(:publishing_api).and_return(publishing_api)
-  end
-
-  describe "send_to_publishing_api" do
-    let(:presenter) { instance_double("TagPresenter", :base_path => "/foo", :render_for_publishing_api => :presented_details) }
-    before :each do
-      allow(TagPresenter).to receive(:presenter_for).and_return(presenter)
-    end
-
+  describe "#send_to_publishing_api" do
     context "for a draft tag" do
-      let(:tag) { create(:topic, :draft) }
-
-      it "constructs a presenter for the given tag" do
-        expect(TagPresenter).to receive(:presenter_for).with(tag).and_return(presenter)
-        PublishingAPINotifier.send_to_publishing_api(tag)
-      end
-
-      it "sends the presented details as a draft to the publishing-api" do
-        expect(publishing_api).to receive(:put_draft_content_item).with("/foo", :presented_details)
-        expect(publishing_api).not_to receive(:put_content_item)
+      it "sends the presented details to the publishing-api", schema_test: true do
+        tag = create(:topic, :draft, slug: 'foo')
 
         PublishingAPINotifier.send_to_publishing_api(tag)
+
+        expect(stubbed_content_store).to have_draft_content_item_slug('/topic/foo')
+        expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('topic')
       end
     end
 
     context "for a published tag" do
-      let(:tag) { create(:topic, :published) }
+      it "sends the presented details to the publishing-api", schema_test: true do
+        tag = create(:topic, :published, slug: 'foo')
 
-      it "constructs a presenter for the given tag" do
-        expect(TagPresenter).to receive(:presenter_for).with(tag).and_return(presenter)
         PublishingAPINotifier.send_to_publishing_api(tag)
+
+        expect(stubbed_content_store).to have_content_item_slug('/topic/foo')
+        expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('topic')
       end
 
-      it "sends the presented details to the publishing-api" do
-        expect(publishing_api).to receive(:put_content_item).with("/foo", :presented_details)
+      it "sends topic redirects to the publishing-api", schema_test: true do
+        tag = create(:topic, :published, slug: 'foo')
+
+        create(:redirect, tag: tag,
+          original_topic_base_path: '/foo',
+          from_base_path: '/foo',
+          to_base_path: '/topic/foo',
+        )
+
         PublishingAPINotifier.send_to_publishing_api(tag)
+
+        expect(stubbed_content_store).to have_content_item_slug('/foo')
+        expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('redirect')
+        expect(stubbed_content_store.last_updated_item[:redirects]).to eql([
+          { path: "/foo", type: "exact", destination: "/topic/foo" },
+        ])
       end
     end
   end

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe TagPresenter do
 
   describe '#render_for_publishing_api' do
     let(:tag) do
-      create(:tag, {
+      create(:topic, {
         :parent => create(:tag, :slug => 'oil-and-gas'),
         :slug => 'offshore',
         :title => 'Offshore',

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe TopicPresenter do
       end
 
       it "returns the base_path for the topic" do
-        expect(presenter.base_path).to eq("/working-at-sea")
+        expect(presenter.base_path).to eq("/topic/working-at-sea")
       end
 
       it "sets public_updated_at based on the topic update time" do
@@ -46,7 +46,7 @@ RSpec.describe TopicPresenter do
 
       it "includes the base route" do
         expect(presented_data[:routes]).to eq([
-          {:path => "/working-at-sea", :type => "exact"},
+          {:path => "/topic/working-at-sea", :type => "exact"},
         ])
       end
 
@@ -78,7 +78,7 @@ RSpec.describe TopicPresenter do
       let(:presented_data) { presenter.render_for_publishing_api }
 
       it "returns the base_path for the subtopic" do
-        expect(presenter.base_path).to eq("/oil-and-gas/offshore")
+        expect(presenter.base_path).to eq("/topic/oil-and-gas/offshore")
       end
 
       it "includes the base fields" do
@@ -110,9 +110,9 @@ RSpec.describe TopicPresenter do
 
       it "includes routes for latest, and email_signups in addition to base route" do
         expect(presented_data[:routes]).to eq([
-          {:path => "/oil-and-gas/offshore", :type => "exact"},
-          {:path => "/oil-and-gas/offshore/latest", :type => "exact"},
-          {:path => "/oil-and-gas/offshore/email-signup", :type => "exact"},
+          {:path => "/topic/oil-and-gas/offshore", :type => "exact"},
+          {:path => "/topic/oil-and-gas/offshore/latest", :type => "exact"},
+          {:path => "/topic/oil-and-gas/offshore/email-signup", :type => "exact"},
         ])
       end
 

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -1,0 +1,45 @@
+module ContentStoreHelpers
+  RSpec::Matchers.define :have_content_item_slug do |expected_slug|
+    match do |stubbed_content_store|
+      stubbed_content_store.stored_slugs.include?(expected_slug)
+    end
+  end
+
+  RSpec::Matchers.define :have_draft_content_item_slug do |expected_slug|
+    match do |stubbed_content_store|
+      stubbed_content_store.stored_draft_slugs.include?(expected_slug)
+    end
+  end
+
+  def stub_content_store!
+    @stubbed_content_store = FakeContentStore.new
+    allow(CollectionsPublisher).to receive(:services)
+      .with(:publishing_api)
+      .and_return(@stubbed_content_store)
+  end
+
+  def stubbed_content_store
+    @stubbed_content_store
+  end
+
+  class FakeContentStore
+    attr_reader :stored_slugs,
+                :stored_draft_slugs,
+                :last_updated_item
+
+    def initialize
+      @stored_slugs = []
+      @stored_draft_slugs = []
+    end
+
+    def put_content_item(slug, item)
+      @stored_slugs << slug
+      @last_updated_item = item
+    end
+
+    def put_draft_content_item(slug, item)
+      @stored_draft_slugs << slug
+      @last_updated_item = item
+    end
+  end
+end


### PR DESCRIPTION
This PR makes collections-publisher publish Topics to the `/topic` namespace.

- Publish Topics under `/topic`. Done by prepending `/topic` to the base path of Topics.
- Sets up redirects for the old URLs. This is done by publishing "redirect" content items for the version without `/topic`.

Best reviewed per-commit and in split view.

Trello: https://trello.com/c/EoWPp4qZ/187-move-topics-to-topic

After this is deployed, we need to republish all the items.

### Screenshots

To help understand what is going on, we show the redirects for a topic if it has any:

![screen shot 2015-06-18 at 14 37 47](https://cloud.githubusercontent.com/assets/233676/8232464/eab34b5c-15c7-11e5-9b44-cd61e74f0e22.png)
![screen shot 2015-06-18 at 14 37 53](https://cloud.githubusercontent.com/assets/233676/8232465/eab3b66e-15c7-11e5-9aee-1067cf6be6da.png)

