### PR TITLE
Register .json route for mainstream browse pages.

### DIFF
--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -17,6 +17,12 @@ private
 
 private
 
+  def routes
+    super + [
+      {path: "#{base_path}.json", type: "exact"},
+    ]
+  end
+
   def active_top_level_browse_page_id
     if @tag.has_parent?
       [@tag.parent.content_id]

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -2,9 +2,6 @@ namespace :publishing_api do
 
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
   task :republish_all_tags => :environment do
-
-    CollectionsPublisher.services(:publishing_api).put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
-
     puts "Sending #{Tag.count} tags to the publishing-api"
     done = 0
     Tag.find_each do |tag|
@@ -19,6 +16,11 @@ namespace :publishing_api do
         puts "#{done} completed..."
       end
     end
-    puts "All done, #{done} tags sent to publishing-api."
+    puts "Done: #{done} tags sent to publishing-api."
+
+    puts "Sending root browse page to publishing-api"
+    CollectionsPublisher.services(:publishing_api).put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
+
+    puts "All done"
   end
 end

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
     it "includes the necessary routes" do
       expect(presented_data[:routes]).to eq([
         {:path => "/browse/benefits", :type => "exact"},
+        {:path => "/browse/benefits.json", :type => "exact"},
       ])
     end
 


### PR DESCRIPTION
Now that /browse is being registered as an exact route, these routes
started returning 404s because they weren't registered here.  This adds
them back to allow the AJAX version of /browse to work again