### PR TITLE
Include topic children in links

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -21,10 +21,14 @@ private
   end
 
   def links
-    return super unless @tag.has_parent?
-
-    super.merge({
-      "parent" => [@tag.parent.content_id],
-    })
+    if @tag.has_parent?
+      super.merge({
+        "parent" => [@tag.parent.content_id],
+      })
+    else
+      super.merge({
+        "children" => @tag.children.order(:title).map(&:content_id),
+      })
+    end
   end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -50,8 +50,17 @@ RSpec.describe TopicPresenter do
         ])
       end
 
-      it "has no links" do
-        expect(presented_data[:links]).to eq({})
+      describe "links" do
+        it "does not include a parent link" do
+          expect(presented_data[:links]).not_to have_key("parent")
+        end
+
+        it "includes links to all its child topics in title order" do
+          bravo = create(:topic, :parent => topic, :title => "Bravo")
+          alpha = create(:topic, :parent => topic, :title => "Alpha")
+          expect(presented_data[:links]).to have_key("children")
+          expect(presented_data[:links]["children"]).to eq([alpha, bravo].map(&:content_id))
+        end
       end
     end
 


### PR DESCRIPTION
So that we can render the topic pages entirely from the content-store.