### PR TITLE
Add Sidekiq monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'select2-rails', '~> 3.5.9'
 
 gem 'unicorn', '~> 4.9.0'
 
+# sidekiq-web depends on sinatra
+gem 'sinatra', require: nil
 gem 'sidekiq', '~> 2.17.2'
 
 gem 'byebug', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
       rack (>= 0.4)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.2)
@@ -233,6 +235,10 @@ GEM
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sprockets (3.2.0)
       rack (~> 1.0)
     sprockets-rails (2.3.1)
@@ -295,6 +301,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   select2-rails (~> 3.5.9)
   sidekiq (~> 2.17.2)
+  sinatra
   timecop (~> 0.7.1)
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,16 @@ Rails.application.routes.draw do
   }
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
+
+  class SidekiqAccessContraint
+    def matches?(request)
+      user = request.env['warden'].user
+      user && user.has_permission?("Sidekiq Monitoring")
+    end
+  end
+
+  require 'sidekiq/web'
+  mount Sidekiq::Web,
+    at: '/sidekiq',
+    constraints: SidekiqAccessContraint.new
 end

--- a/spec/features/sidekiq_monitoring_spec.rb
+++ b/spec/features/sidekiq_monitoring_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "Sidekiq monitoring" do
+  it "allows users with the correct permissions to monitor Sidekiq" do
+    user = create(:user, permissions: ["signin", "Sidekiq Monitoring"])
+    allow_any_instance_of(Warden::Proxy).to receive(:user).and_return(user)
+
+    visit '/sidekiq'
+
+    expect(page).to have_content 'Sidekiq'
+  end
+
+  it "does not allow unauthenticated users to monitor Sidekiq" do
+    allow_any_instance_of(Warden::Proxy).to receive(:user).and_return(nil)
+
+    expect {
+      visit '/sidekiq'
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+  it "does not allow users without permissions to monitor Sidekiq" do
+    user = create(:user, permissions: ["signin"])
+    allow_any_instance_of(Warden::Proxy).to receive(:user).and_return(user)
+
+    expect {
+      visit '/sidekiq'
+    }.to raise_error(ActionController::RoutingError)
+  end
+end


### PR DESCRIPTION
This commit exposes the sidekiq-web monitoring app on `/sidekiq`.

Sidekiq was added in https://github.com/alphagov/collections-publisher/pull/96. Users are authenticated via the normal GDS::SSO mechanism. They need the `Sidekiq Monitoring` permission to see the app.

Related to Trello: https://trello.com/c/v1B0aJxW/185

Note that `/sidekiq` is currently blocked by nginx.