### PR TITLE
Send root level browse page to content store

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -44,6 +44,10 @@ class MainstreamBrowsePage < Tag
     end
   end
 
+  def top_level_mainstream_browse_page?
+    !child?
+  end
+
 private
 
   def parents_cannot_have_topics_associated

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -156,6 +156,10 @@ class Tag < ActiveRecord::Base
     [] # should be overridden in subclasses
   end
 
+  def top_level_mainstream_browse_page?
+    false # should be overridden in subclasses
+  end
+
 private
 
   def parent_is_not_a_child

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -55,6 +55,14 @@ RSpec.describe PublishingAPINotifier do
   end
 
   describe "#send_to_publishing_api" do
+    it "sends /browse for top level mainstream browse pages" do
+      tag = create(:mainstream_browse_page, :published, slug: 'foo')
+
+      PublishingAPINotifier.send_to_publishing_api(tag)
+
+      expect(stubbed_content_store).to have_content_item_slug('/browse')
+    end
+
     context "for a draft tag" do
       it "sends the presented details to the publishing-api", schema_test: true do
         tag = create(:topic, :draft, slug: 'foo')


### PR DESCRIPTION
When a top level mainstream browse page is added/published the root level browse page also needs to be updated.

https://trello.com/c/v1B0aJxW/185-update-content-store-when-list-of-browse-pages-change