### PR TITLE
Send topics to rummager after update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This is a Ruby on Rails application for internal use, with no public facing aspe
 - [alphagov/content-store](https://github.com/alphagov/content-store) -
   (write request only) to store information about the topic
   groupings for Collections API and other apps to use.
+- [alphagov/rummager](https://github.com/alphagov/rummager) -
+  (write request only) to index topics.
 
 
 ### Running the application

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -19,6 +19,7 @@ class TopicsController < ApplicationController
     if topic.update_attributes(topic_params)
       PanopticonNotifier.update_tag(TopicPresenter.new(topic))
       PublishingAPINotifier.send_to_publishing_api(topic)
+      RummagerNotifier.new(topic).notify
       redirect_to topic
     else
       @topic = topic
@@ -51,6 +52,7 @@ class TopicsController < ApplicationController
     topic.publish!
     PanopticonNotifier.publish_tag(TopicPresenter.new(topic))
     PublishingAPINotifier.send_to_publishing_api(topic)
+    RummagerNotifier.new(topic).notify
     redirect_to topic
   end
 

--- a/app/notifiers/rummager_notifier.rb
+++ b/app/notifiers/rummager_notifier.rb
@@ -1,0 +1,29 @@
+class RummagerNotifier
+  attr_reader :topic
+
+  def initialize(topic)
+    @topic = topic
+  end
+
+  def notify
+    return if topic.draft?
+
+    # Will add it to mainstream index with type 'edition'.
+    CollectionsPublisher.services(:rummager).add_document(
+      'edition',
+      topic.base_path,
+      payload
+    )
+  end
+
+  private
+
+  def payload
+    {
+      format: 'specialist_sector',
+      title: topic.title,
+      description: topic.description,
+      link: topic.base_path,
+    }
+  end
+end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -17,7 +17,7 @@ module CollectionsPublisher
   class ServiceNotRegisteredException < Exception; end
 end
 
-# Only used by rake task `populate_published_groups` 
+# Only used by rake task `populate_published_groups`
 require 'gds_api/content_store'
 CollectionsPublisher.services(:content_store, GdsApi::ContentStore.new(Plek.new.find('content-store')))
 
@@ -32,3 +32,6 @@ CollectionsPublisher.services(
   :panopticon,
   GdsApi::Panopticon.new(Plek.new.find('panopticon'),
                          bearer_token: ENV['PANOPTICON_BEARER_TOKEN'] || 'example'))
+
+require 'gds_api/rummager'
+CollectionsPublisher.services(:rummager, GdsApi::Rummager.new(Plek.new.find('rummager')))

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,8 @@
+namespace :rummager do
+  desc 'Send all topics to Rummager'
+  task index_topics: [:environment] do
+    Topic.published.find_each do |topic|
+      RummagerNotifier.new(topic).notify
+    end
+  end
+end

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe TopicsController do
       topic = create(:topic)
       allow(PanopticonNotifier).to receive(:publish_tag)
       allow(PublishingAPINotifier).to receive(:send_to_publishing_api)
+      allow_any_instance_of(RummagerNotifier).to receive(:notify)
 
       post :publish, id: topic.content_id
 

--- a/spec/notifiers/rummager_notifier_spec.rb
+++ b/spec/notifiers/rummager_notifier_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe RummagerNotifier do
+  before do
+    allow(rummager).to receive(:add_document)
+  end
+
+  describe '#notify' do
+    it 'does not send draft topics to rummager' do
+      topic = create(:topic, :draft)
+
+      RummagerNotifier.new(topic).notify
+
+      expect(rummager).not_to have_received(:add_document)
+    end
+
+    it 'sends published topics to rummager' do
+      topic = create(:topic, :published)
+
+      RummagerNotifier.new(topic).notify
+
+      expect(rummager).to have_received(:add_document)
+    end
+
+    it 'sends published topics to rummager' do
+      topic = create(:topic, :published,
+        title: 'A Topic',
+        slug: 'a-test-topic',
+        description: 'A description.')
+
+      RummagerNotifier.new(topic).notify
+
+      expect(rummager).to have_received(:add_document)
+        .with("edition", "/topic/a-test-topic", {
+          format: 'specialist_sector',
+          title: 'A Topic',
+          description: 'A description.',
+          link: '/topic/a-test-topic',
+        })
+    end
+  end
+
+  def rummager
+    CollectionsPublisher.services(:rummager)
+  end
+end


### PR DESCRIPTION
Send topics to rummager after update. Currently, the panopticon app sends data to Rummager for indexing.

Collections publisher owns the documents, so is the natural place to do this.

_This is a re-commit of 6dc69bc, which was reverted in 28c4d08 because it was committed straight to master._