### PR TITLE
Send single tags to content store in rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -16,7 +16,7 @@ namespace :publishing_api do
     tags.find_each do |tag|
       retries = 0
       begin
-        PublishingAPINotifier.send_to_publishing_api(tag)
+        PublishingAPINotifier.new(tag).send_single_tag_to_publishing_api
       rescue GdsApi::TimedOutException, Timeout::Error => e
         retries += 1
         if retries <= 3


### PR DESCRIPTION
The rake task currently publishes all tags, *and* their dependent tags, doing a lot of duplicate work. This commit restricts the rake task to only publish a single tag.