### PR TITLE
Send subtopic parents when creating subtopic

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -35,4 +35,12 @@ class Topic < Tag
   def base_path
     "/topic/#{full_slug}"
   end
+
+  def dependent_tags
+    if has_parent?
+      [parent]
+    else
+      []
+    end
+  end
 end

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -175,6 +175,8 @@ RSpec.describe "creating and editing topics" do
       "description" => 'Remember your cheese...',
       "format" => 'topic',
     })
+    # And its parent should have been sent to publishing-api
+    assert_publishing_api_put_draft_item('/topic/working-at-sea')
 
     # And the child topic should have been created in Panopticon
     assert_tag_created_in_panopticon(


### PR DESCRIPTION
The parent now includes a list of its children, so it's necessary to
re-send the parent when a child is created.

This data will then be used to render the top-level topic pages.