### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'plek', '~> 1.10.0'
 gem 'airbrake', '~> 4.2.0'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 18.10.0'
+gem 'gds-api-adapters', '20.1.1'
 
 gem 'govuk_admin_template', '~> 2.3.1'
 gem 'generic_form_builder', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (18.10.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -292,7 +292,7 @@ DEPENDENCIES
   capybara (~> 2.4.1)
   database_cleaner (~> 1.3.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (~> 18.10.0)
+  gds-api-adapters (= 20.1.1)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.9.0)
   govuk-content-schema-test-helpers (~> 1.3)


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information