### PR TITLE
Allow publishers to reorder mainstream pages

### DIFF
--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -55,6 +55,10 @@ class MainstreamBrowsePagesController < ApplicationController
     redirect_to browse_page
   end
 
+  def manage_child_ordering
+    @browse_page = find_browse_page
+  end
+
 private
 
   def topics_for_select
@@ -80,6 +84,6 @@ private
 
   def tag_params
     params.require(:mainstream_browse_page)
-      .permit(:slug, :title, :description, :parent_id)
+      .permit(:slug, :title, :description, :parent_id, :child_ordering, children_attributes: [:index, :id])
   end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -15,6 +15,8 @@
 #  dirty            :boolean          default(FALSE), not null
 #  beta             :boolean          default(FALSE)
 #  published_groups :text(16777215)
+#  child_ordering   :string(255)      default("alphabetical"), not null
+#  index            :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -30,6 +30,8 @@ class MainstreamBrowsePage < Tag
 
   validate :parents_cannot_have_topics_associated
 
+  accepts_nested_attributes_for :children
+
   def base_path
     "/browse/#{full_slug}"
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,6 +15,8 @@
 #  dirty            :boolean          default(FALSE), not null
 #  beta             :boolean          default(FALSE)
 #  published_groups :text(16777215)
+#  child_ordering   :string(255)      default("alphabetical"), not null
+#  index            :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -52,7 +52,8 @@ class Tag < ActiveRecord::Base
 
   scope :only_parents, -> { where('parent_id IS NULL') }
   scope :only_children, -> { where('parent_id IS NOT NULL') }
-  scope :in_alphabetical_order, -> { order('title ASC') }
+  scope :in_alphabetical_order, -> { order(:title) }
+  scope :in_curated_order, -> { order(:index) }
 
   # The links last sent to the content-store.
   serialize :published_groups, JSON

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -92,7 +92,11 @@ class Tag < ActiveRecord::Base
   end
 
   def sorted_children
-    children.sort_by(&:title)
+    if self.child_ordering == "alphabetical"
+      children.in_alphabetical_order
+    else
+      children.in_curated_order
+    end
   end
 
   def title_including_parent

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -59,7 +59,7 @@ class Tag < ActiveRecord::Base
   serialize :published_groups, JSON
 
   # after_initialize is expensive, but MySQL doesn't support default values
-  # on text columns. When we've moved to PG, move this to the database.  
+  # on text columns. When we've moved to PG, move this to the database.
   after_initialize do
     self.published_groups ||= []
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -30,6 +30,7 @@ require 'securerandom'
 class Tag < ActiveRecord::Base
   include AASM
   include ActiveModel::Dirty
+  ORDERING_TYPES = ["alphabetical", "curated"]
 
   belongs_to :parent, class_name: 'Tag'
   has_many :children, class_name: 'Tag', foreign_key: :parent_id
@@ -45,6 +46,7 @@ class Tag < ActiveRecord::Base
 
   validates :slug, :title, :content_id, presence: true
   validates :slug, uniqueness: { scope: ["parent_id"] }, format: { with: /\A[a-z0-9-]*\z/ }
+  validates :child_ordering, inclusion: {in: ORDERING_TYPES}
   validate :parent_is_not_a_child
   validate :cannot_change_slug
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -15,6 +15,8 @@
 #  dirty            :boolean          default(FALSE), not null
 #  beta             :boolean          default(FALSE)
 #  published_groups :text(16777215)
+#  child_ordering   :string(255)      default("alphabetical"), not null
+#  index            :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
+++ b/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
@@ -1,0 +1,9 @@
+<%= tag_header @browse_page, 'Manage child ordering' %>
+
+<%= form_for @browse_page do |f| %>
+  <%= f.select :child_ordering, ['alphabetical', 'curated'] %>
+  <%= f.fields_for :children, @browse_page.sorted_children do |c| %>
+    <%= c.text_field :index, label: c.object.slug %>
+  <% end %>
+  <%= f.submit 'Save', class: 'btn-submit' %>
+<% end %>

--- a/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
+++ b/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
@@ -1,7 +1,7 @@
 <%= tag_header @browse_page, 'Manage child ordering' %>
 
 <%= form_for @browse_page do |f| %>
-  <%= f.select :child_ordering, ['alphabetical', 'curated'] %>
+  <%= f.select :child_ordering, Tag::ORDERING_TYPES %>
   <%= f.fields_for :children, @browse_page.sorted_children do |c| %>
     <%= c.text_field :index, label: c.object.slug %>
   <% end %>

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -2,6 +2,11 @@
   <%= link_to "Edit page",
     edit_mainstream_browse_page_path(@browse_page) %>
 
+  <% if @browse_page.can_have_children? %>
+    <%= link_to "Manage child ordering",
+      manage_child_ordering_mainstream_browse_page_path(@browse_page) %>
+  <% end %>
+
   <% if @browse_page.may_publish? %>
     <%= link_to "Publish mainstream browse page",
                publish_mainstream_browse_page_path(@browse_page),

--- a/app/views/shared/tags/_children.html.erb
+++ b/app/views/shared/tags/_children.html.erb
@@ -14,7 +14,7 @@
 
     <%=
       render partial: 'shared/tags/table', locals: {
-        resources: resource.children.includes(:lists).order(:title),
+        resources: resource.sorted_children.includes(:lists),
         include_children_column: false,
         empty_message: "No children exist yet.
           #{link_to('Add one', new_polymorphic_path(resource, parent_id: resource.id))}".html_safe

--- a/app/views/shared/tags/_metadata.html.erb
+++ b/app/views/shared/tags/_metadata.html.erb
@@ -19,5 +19,8 @@
 
     <dt>State</dt>
     <dd><%= status resource.state, resource.state %></dd>
+
+    <dt>Child ordering</dt>
+    <dd><%= resource.child_ordering %></dd>
   </dl>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
                                       except: :destroy do
     member do
       post :publish
+      get :"manage-child-ordering"
     end
   end
 

--- a/db/migrate/20150702143916_add_child_ordering_and_index_to_tags.rb
+++ b/db/migrate/20150702143916_add_child_ordering_and_index_to_tags.rb
@@ -1,0 +1,6 @@
+class AddChildOrderingAndIndexToTags < ActiveRecord::Migration
+  def change
+    add_column :tags, :child_ordering, :string, default: "alphabetical", null: false
+    add_column :tags, :index, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150625151822) do
+ActiveRecord::Schema.define(version: 20150702143916) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255
@@ -55,17 +55,19 @@ ActiveRecord::Schema.define(version: 20150625151822) do
 
   create_table "tags", force: :cascade do |t|
     t.string   "type",             limit: 255
-    t.string   "slug",             limit: 255,                      null: false
-    t.string   "title",            limit: 255,                      null: false
+    t.string   "slug",             limit: 255,                               null: false
+    t.string   "title",            limit: 255,                               null: false
     t.string   "description",      limit: 255
     t.integer  "parent_id",        limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "content_id",       limit: 255,                      null: false
-    t.string   "state",            limit: 255,                      null: false
-    t.boolean  "dirty",            limit: 1,        default: false, null: false
+    t.string   "content_id",       limit: 255,                               null: false
+    t.string   "state",            limit: 255,                               null: false
+    t.boolean  "dirty",            limit: 1,        default: false,          null: false
     t.boolean  "beta",             limit: 1,        default: false
     t.text     "published_groups", limit: 16777215
+    t.string   "child_ordering",   limit: 255,      default: "alphabetical", null: false
+    t.integer  "index",            limit: 4,        default: 0,              null: false
   end
 
   add_index "tags", ["content_id"], name: "index_tags_on_content_id", unique: true, using: :btree

--- a/spec/features/mainstream_browse_pages_spec.rb
+++ b/spec/features/mainstream_browse_pages_spec.rb
@@ -262,4 +262,52 @@ RSpec.describe "managing mainstream browse pages" do
 
     assert_not_requested :put, /benefits/
   end
+
+  describe "displays child pages in the specified order" do
+    # Given a parent page with 2 children
+
+    let!(:pizzas) {
+      create(:mainstream_browse_page, :published, :title => "Pizzas")
+    }
+    let!(:four_seasons) {
+      create(:mainstream_browse_page, :parent => pizzas, :title => "Four seasons")
+    }
+    let!(:pepperoni) {
+      create(:mainstream_browse_page, :parent => pizzas, :title => "Pepperoni")
+    }
+
+    it "display them in curated order" do
+      visit mainstream_browse_pages_path
+
+      click_on 'Pizzas'
+      click_on 'Manage child ordering'
+      select 'curated', :from => 'Child ordering'
+      fill_in "#{four_seasons.slug}", with: '1'
+      fill_in "#{pepperoni.slug}", with: '0'
+
+      click_on 'Save'
+
+      titles = page.all('.tags-list tbody td:first-child').map(&:text)
+      expect(titles).to eq([
+        'Pepperoni',
+        'Four seasons',
+      ])
+    end
+
+    it "display them in alphabetical order" do
+      visit mainstream_browse_pages_path
+
+      click_on 'Pizzas'
+      click_on 'Manage child ordering'
+      select 'alphabetical', :from => 'Child ordering'
+
+      click_on 'Save'
+
+      titles = page.all('.tags-list tbody td:first-child').map(&:text)
+      expect(titles).to eq([
+        'Four seasons',
+        'Pepperoni',
+      ])
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe Tag do
       expect(tag.errors).to have_key(:title)
     end
 
+    it 'must have a valid ordering type' do
+      tag.child_ordering = "from-E-to-D"
+
+      expect(tag).not_to be_valid
+      expect(tag.errors).to have_key(:child_ordering)
+    end
+
     describe "on slug" do
       it "is required" do
         tag.slug = ''


### PR DESCRIPTION
This PR is the first step towards allowing publishers to re-order mainstream pages.

Added a page where publishers can select the type of child ordering of a page (alphabetical or curated).
In the same page, the user will be able to input the order in which s/he wants to display them (in case of curated list).

Next step: When updating the child ordering, collections-publisher should send to content-store the parent page and the children in the publisher's wanted order.

NB: Cosmetic work will follow. This is absolutely not what it should and will look like.

Ticket: https://trello.com/c/Tpgjz0HI/167-collections-publisher-can-control-order-of-mainstream-browse-columns

