### PR TITLE
Send second_level_ordering to content-store

### DIFF
--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -15,6 +15,12 @@ private
     )
   end
 
+  def details
+    super.merge(
+      "second_level_ordering" => second_level_ordering
+    )
+  end
+
 private
 
   def routes
@@ -36,6 +42,14 @@ private
       @tag.parent.sorted_children.map(&:content_id)
     else
       @tag.sorted_children.map(&:content_id)
+    end
+  end
+
+  def second_level_ordering
+    if @tag.child?
+      @tag.parent.child_ordering
+    else
+      @tag.child_ordering
     end
   end
 

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe MainstreamBrowsePagePresenter do
         :rendering_app => 'collections',
         :redirects => [],
         :update_type => "major",
-        :details => { :groups=>[] },
       })
     end
 
@@ -231,6 +230,49 @@ RSpec.describe MainstreamBrowsePagePresenter do
             second_level_page_D.content_id,
             second_level_page_C.content_id,
           ])
+        end
+
+        it "is valid against the schema", :schema_test => true do
+          expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
+        end
+      end
+    end
+
+    describe "returning the order of relative second level browse pages" do
+
+      let!(:top_level_page) { create(
+        :mainstream_browse_page,
+        :title => "Top-level page",
+        :child_ordering => "curated",
+      )}
+
+      let!(:second_level_page) { create(
+        :mainstream_browse_page,
+        :title => "Second-level page",
+        :parent => top_level_page,
+      )}
+
+      context "for a top level page" do
+
+        let(:presenter) { MainstreamBrowsePagePresenter.new(top_level_page) }
+        let(:presented_data) { presenter.render_for_publishing_api }
+
+        it "returns the order in which its children are ordered" do
+          expect(presented_data[:details]["second_level_ordering"]).to eq("curated")
+        end
+
+        it "is valid against the schema", :schema_test => true do
+          expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
+        end
+      end
+
+      context "for a second level page" do
+
+        let(:presenter) { MainstreamBrowsePagePresenter.new(second_level_page) }
+        let(:presented_data) { presenter.render_for_publishing_api }
+
+        it "returns the order in which self and its siblings are ordered" do
+          expect(presented_data[:details]["second_level_ordering"]).to eq("curated")
         end
 
         it "is valid against the schema", :schema_test => true do


### PR DESCRIPTION
We are going to allow publishers to re-order mainstream browse pages. But currently, these pages are displayed along with an "A to Z".

These changes are necessary for letting know `collections` when to display the above mentioned label and when not to.

Part of this ticket:
https://trello.com/c/bcTrheDZ/244-don-t-show-a-to-z-on-mainstream-browse-columns-which-aren-t-in-alphabetical-order