### PR TITLE
Fix N+1 on topic and browse page index pages

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -54,8 +54,6 @@ class Tag < ActiveRecord::Base
 
   scope :only_parents, -> { where('parent_id IS NULL') }
   scope :only_children, -> { where('parent_id IS NOT NULL') }
-  scope :in_alphabetical_order, -> { order(:title) }
-  scope :in_curated_order, -> { order(:index) }
 
   # The links last sent to the content-store.
   serialize :published_groups, JSON
@@ -94,10 +92,10 @@ class Tag < ActiveRecord::Base
   end
 
   def sorted_children
-    if self.child_ordering == "alphabetical"
-      children.in_alphabetical_order
+    if child_ordering == "alphabetical"
+      children.sort_by { |child| child.title.downcase }
     else
-      children.in_curated_order
+      children.sort_by(&:index)
     end
   end
 

--- a/app/views/shared/tags/_children.html.erb
+++ b/app/views/shared/tags/_children.html.erb
@@ -14,7 +14,7 @@
 
     <%=
       render partial: 'shared/tags/table', locals: {
-        resources: resource.sorted_children.includes(:lists),
+        resources: resource.sorted_children,
         include_children_column: false,
         empty_message: "No children exist yet.
           #{link_to('Add one', new_polymorphic_path(resource, parent_id: resource.id))}".html_safe

--- a/app/views/shared/tags/_metadata.html.erb
+++ b/app/views/shared/tags/_metadata.html.erb
@@ -20,7 +20,9 @@
     <dt>State</dt>
     <dd><%= status resource.state, resource.state %></dd>
 
-    <dt>Child ordering</dt>
-    <dd><%= resource.child_ordering %></dd>
+    <% if resource.top_level_mainstream_browse_page? %>
+      <dt>Child ordering</dt>
+      <dd><%= resource.child_ordering %></dd>
+    <% end %>
   </dl>
 </section>


### PR DESCRIPTION
A N+1 query was introduced recently because for each topic/browse page on the index page, we are making a query for the subtopics with either alphabetical or curated ordering. This caused a fair amount of extra database traffic.

To remedy this, this commit moves the sorting of the parents to ruby-land by using `sort_by`. This way all `children` for all tags are eager-loaded and we just have to execute one query.

Before: ActiveRecord: 159.5ms
After: ActiveRecord: 7.5ms

Not that [removing the .includes in _children.html.erb](https://github.com/alphagov/collections-publisher/commit/815dedf70821073f21a5902e36d29f34f4a38161#diff-21926eabfcc0366fe8005ef12ca6d26eL17) introduces a new N+1 query when loading the show page for mainstream browse pages with associated topics. These pages are less frequently accessed and cause less queries (@alext). 