### PR TITLE
Import router-data redirects for browse pages and topics

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -12,7 +12,8 @@
 #
 # Indexes
 #
-#  index_redirects_on_tag_id  (tag_id)
+#  index_redirects_on_from_base_path  (from_base_path) UNIQUE
+#  index_redirects_on_tag_id          (tag_id)
 #
 
 class Redirect < ActiveRecord::Base

--- a/db/migrate/20150713123425_add_redirect_uniqueness.rb
+++ b/db/migrate/20150713123425_add_redirect_uniqueness.rb
@@ -1,0 +1,5 @@
+class AddRedirectUniqueness < ActiveRecord::Migration
+  def change
+    add_index :redirects, :from_base_path, :unique => true
+  end
+end

--- a/db/migrate/20150713124417_import_router_data_browse_redirects.rb
+++ b/db/migrate/20150713124417_import_router_data_browse_redirects.rb
@@ -1,0 +1,111 @@
+class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
+  def up
+    @redirects = []
+    Redirect.transaction do
+      create_redirects
+    end
+
+    # register the redirects so the paths get claimed in url-arbiter
+    register_redirects
+  end
+
+  def create_redirects
+
+    # /browse/births-deaths-marriages/registry-offices,/browse/births-deaths-marriages/register-offices
+    register_offices = MainstreamBrowsePage.joins(:parent).find_by!(:parents_tags => {:slug => "births-deaths-marriages"}, :slug => "register-offices")
+    @redirects << Redirect.create!(
+      :tag => register_offices,
+      :original_tag_base_path => "/browse/births-deaths-marriages/registry-offices",
+      :from_base_path => "/browse/births-deaths-marriages/registry-offices",
+      :to_base_path => register_offices.base_path,
+    )
+
+    # /browse/citizenship/coasts-countryside,/browse/environment-countryside
+    environment_countryside = MainstreamBrowsePage.only_parents.find_by!(:slug => 'environment-countryside')
+    @redirects << Redirect.create!(
+      :tag => environment_countryside,
+      :original_tag_base_path => "/browse/citizenship/coasts-countryside",
+      :from_base_path => "/browse/citizenship/coasts-countryside",
+      :to_base_path => environment_countryside.base_path,
+    )
+
+    # /browse/driving/passports-travelling-abroad,/browse/abroad
+    abroad = MainstreamBrowsePage.only_parents.find_by!(:slug => 'abroad')
+    @redirects << Redirect.create!(
+      :tag => abroad,
+      :original_tag_base_path => "/browse/driving/passports-travelling-abroad",
+      :from_base_path => "/browse/driving/passports-travelling-abroad",
+      :to_base_path => abroad.base_path,
+    )
+    # /browse/citizenship/passports,/browse/abroad/passports
+    passports = abroad.children.find_by!(:slug => 'passports')
+    @redirects << Redirect.create!(
+      :tag => passports,
+      :original_tag_base_path => "/browse/citizenship/passports",
+      :from_base_path => "/browse/citizenship/passports",
+      :to_base_path => passports.base_path,
+    )
+
+    # /browse/housing,/browse/housing-local-services
+    housing_local_services = MainstreamBrowsePage.only_parents.find_by!(:slug => 'housing-local-services')
+    @redirects << Redirect.create!(
+      :tag => housing_local_services,
+      :original_tag_base_path => "/browse/housing",
+      :from_base_path => "/browse/housing",
+      :to_base_path => housing_local_services.base_path,
+    )
+    [
+      "council-housing-association",
+      "council-tax",
+      "landlords",
+      "local-councils",
+      "noise-neighbours",
+      "owning-renting-property",
+      "planning-permission",
+      "recycling-rubbish",
+      "repossessions-evictions",
+      "safety-environment",
+    ].each do |slug|
+      new_tag = housing_local_services.children.find_by!(:slug => slug)
+      @redirects << Redirect.create!(
+        :tag => new_tag,
+        :original_tag_base_path => "/browse/housing/#{slug}",
+        :from_base_path => "/browse/housing/#{slug}",
+        :to_base_path => new_tag.base_path,
+      )
+    end
+
+    visas_immigration = MainstreamBrowsePage.only_parents.find_by!(:slug => 'visas-immigration')
+    {
+      "after-youve-applied" => "manage-your-application",
+      "employers-sponsorship" => "sponsor-workers-students",
+      "long-stay-visas" => "family-visas",
+      "long-visit-visas" => "family-visas",
+      "settling-in-the-uk" => "settle-in-the-uk",
+      "short-stay-visas" => "tourist-short-stay-visas",
+      "short-visit-visas" => "tourist-short-stay-visas",
+      "sponsoring-workers-students" => "sponsor-workers-students",
+      "study-visas" => "student-visas",
+      "visit-visas" => "tourist-short-stay-visas",
+      "working-visas" => "work-visas",
+      "your-visa" => "manage-your-application",
+    }.each do |old_slug, new_slug|
+      new_tag = visas_immigration.children.find_by!(:slug => new_slug)
+      @redirects << Redirect.create!(
+        :tag => new_tag,
+        :original_tag_base_path => "#{visas_immigration.base_path}/#{old_slug}",
+        :from_base_path => "#{visas_immigration.base_path}/#{old_slug}",
+        :to_base_path => new_tag.base_path,
+      )
+    end
+  end
+
+  def register_redirects
+    publishing_api = CollectionsPublisher.services(:publishing_api)
+
+    @redirects.group_by(&:original_tag_base_path).each do |old_base_path, redirects|
+      presenter = RedirectPresenter.new(redirects)
+      publishing_api.put_content_item(old_base_path, presenter.render_for_publishing_api)
+    end
+  end
+end

--- a/db/migrate/20150714140302_import_router_data_topic_redirects.rb
+++ b/db/migrate/20150714140302_import_router_data_topic_redirects.rb
@@ -1,0 +1,160 @@
+class ImportRouterDataTopicRedirects < ActiveRecord::Migration
+  def up
+    @redirects = []
+    Redirect.transaction do
+      create_redirects
+    end
+
+    # register the redirects so the paths get claimed in url-arbiter
+    register_redirects
+  end
+
+  def create_redirects
+
+    # /childrens-services,/topic/schools-colleges-childrens-services
+    schools_colleges_childrens_services = Topic.only_parents.find_by!(:slug => 'schools-colleges-childrens-services')
+    @redirects << Redirect.create!(
+      :tag => schools_colleges_childrens_services,
+      :original_tag_base_path => "/childrens-services",
+      :from_base_path => "/childrens-services",
+      :to_base_path => schools_colleges_childrens_services.base_path,
+    )
+    {
+      "adoption" => "adoption-fostering",
+      "child-poverty" => "support-for-children-young-people",
+      "childrens-social-care" => "looked-after-children",
+      "data-collection" => "data-collection-statistical-returns",
+      "early-learning-childcare" => "early-years",
+      "family-support" => "support-for-children-young-people",
+      "foster-care" => "adoption-fostering",
+      "safeguarding-children" => "safeguarding-children",
+      "special-educational-needs" => "special-educational-needs-disabilities",
+      "young-peoples-support" => "support-for-children-young-people",
+    }.each do |old_slug, new_slug|
+      new_tag = schools_colleges_childrens_services.children.find_by!(:slug => new_slug)
+      @redirects << Redirect.create!(
+        :tag => new_tag,
+        :original_tag_base_path => "/childrens-services/#{old_slug}",
+        :from_base_path => "/childrens-services/#{old_slug}",
+        :to_base_path => new_tag.base_path,
+      )
+    end
+
+    # /commercial-fishing-fisheries/monitoring-enforcement,/topic/commercial-fishing-fisheries/regulations-monitoring-enforcement
+    # /commercial-fishing-fisheries/regulations-restrictions,/topic/commercial-fishing-fisheries/regulations-monitoring-enforcement
+    commercial_fishing_fisheries = Topic.only_parents.find_by!(:slug => 'commercial-fishing-fisheries')
+    {
+      "monitoring-enforcement" => "regulations-monitoring-enforcement",
+      "regulations-restrictions" => "regulations-monitoring-enforcement",
+    }.each do |old_slug, new_slug|
+      new_tag = commercial_fishing_fisheries.children.find_by!(:slug => new_slug)
+      @redirects << Redirect.create!(
+        :tag => new_tag,
+        :original_tag_base_path => "/commercial-fishing-fisheries/#{old_slug}",
+        :from_base_path => "/commercial-fishing-fisheries/#{old_slug}",
+        :to_base_path => new_tag.base_path,
+      )
+    end
+
+    competition = Topic.only_parents.find_by!(:slug => 'competition')
+    [
+      "business-law-compliance",
+      "competition-law-compliance",
+      "consumer-protection-regulations",
+      "criminal-cartels",
+      "reviews-orders-undertakings",
+      "unfair-terms-regulations-compliance",
+    ].each do |slug|
+      @redirects << Redirect.create!(
+        :tag => competition,
+        :original_tag_base_path => "/competition/#{slug}",
+        :from_base_path => "/competition/#{slug}",
+        :to_base_path => competition.base_path,
+      )
+    end
+
+    {
+      "ca98-civil-cartels" => "competition-act-cartels",
+      "consumer-law-enforcement" => "consumer-protection",
+    }.each do |old_slug, new_slug|
+      new_tag = competition.children.find_by!(:slug => new_slug)
+      @redirects << Redirect.create!(
+        :tag => new_tag,
+        :original_tag_base_path => "/competition/#{old_slug}",
+        :from_base_path => "/competition/#{old_slug}",
+        :to_base_path => new_tag.base_path,
+      )
+    end
+
+    # /health-protection/migrant-health,/topic/health-protection
+    health_protection = Topic.only_parents.find_by!(:slug => 'health-protection')
+    @redirects << Redirect.create!(
+      :tag => health_protection,
+      :original_tag_base_path => "/health-protection/migrant-health",
+      :from_base_path => "/health-protection/migrant-health",
+      :to_base_path => health_protection.base_path,
+    )
+
+    # /paye,/topic/business-tax/paye
+    paye = Topic.joins(:parent).find_by!(:parents_tags => {:slug => 'business-tax'}, :slug => 'paye')
+    [
+      "/paye",
+      "/paye/annual-tasks",
+      "/paye/business-changes",
+      "/paye/employees",
+      "/paye/expenses-benefits",
+      "/paye/introduction",
+      "/paye/news-updates",
+      "/paye/registering-getting-started",
+      "/paye/regular-tasks",
+      "/paye/special-types-employee-pay",
+      "/paye/statutory-leave-pay",
+    ].each do |old_path|
+      @redirects << Redirect.create!(
+        :tag => paye,
+        :original_tag_base_path => old_path,
+        :from_base_path => old_path,
+        :to_base_path => paye.base_path,
+      )
+    end
+
+    # /schools-colleges,/topic/schools-colleges-childrens-services
+    schools_colleges_childrens_services = Topic.only_parents.find_by!(:slug => 'schools-colleges-childrens-services')
+    @redirects << Redirect.create!(
+      :tag => schools_colleges_childrens_services,
+      :original_tag_base_path => "/schools-colleges",
+      :from_base_path => "/schools-colleges",
+      :to_base_path => schools_colleges_childrens_services.base_path,
+    )
+    {
+      "academies-free-schools" => "opening-academy-free-school",
+      "administration-finance" => "school-college-funding-finance",
+      "behaviour-attendance" => "school-behaviour-attendance",
+      "careers-employment" => "school-careers-employment",
+      "curriculum-qualifications" => "curriculum-qualifications",
+      "data-collection" => "data-collection-statistical-returns",
+      "early-learning-childcare" => "early-years",
+      "governance" => "running-school-college",
+      "safeguarding-children" => "safeguarding-children",
+      "special-educational-needs" => "special-educational-needs-disabilities",
+      "young-peoples-support" => "support-for-children-young-people",
+    }.each do |old_slug, new_slug|
+      new_tag = schools_colleges_childrens_services.children.find_by!(:slug => new_slug)
+      @redirects << Redirect.create!(
+        :tag => new_tag,
+        :original_tag_base_path => "/schools-colleges/#{old_slug}",
+        :from_base_path => "/schools-colleges/#{old_slug}",
+        :to_base_path => new_tag.base_path,
+      )
+    end
+  end
+
+  def register_redirects
+    publishing_api = CollectionsPublisher.services(:publishing_api)
+
+    @redirects.group_by(&:original_tag_base_path).each do |old_base_path, redirects|
+      presenter = RedirectPresenter.new(redirects)
+      publishing_api.put_content_item(old_base_path, presenter.render_for_publishing_api)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713124417) do
+ActiveRecord::Schema.define(version: 20150714140302) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150710133820) do
+ActiveRecord::Schema.define(version: 20150713123425) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20150710133820) do
     t.datetime "updated_at",                         null: false
   end
 
+  add_index "redirects", ["from_base_path"], name: "index_redirects_on_from_base_path", unique: true, using: :btree
   add_index "redirects", ["tag_id"], name: "index_redirects_on_tag_id", using: :btree
 
   create_table "tag_associations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150713123425) do
+ActiveRecord::Schema.define(version: 20150713124417) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255


### PR DESCRIPTION
Now that we can model these here it makes sense to do so and reduce the volume of redirects in router-data.

This PR also adds a uniqueness constraint to the Redirects table to help avoid duplicates.