### PR TITLE
Delete unused mainstream browse pages

### DIFF
--- a/db/migrate/20150716103715_remove_unused_mainstream_browse_pages.rb
+++ b/db/migrate/20150716103715_remove_unused_mainstream_browse_pages.rb
@@ -1,0 +1,19 @@
+class RemoveUnusedMainstreamBrowsePages < ActiveRecord::Migration
+
+  SLUGS = %w(
+    time-off-new-child
+    child-into-care
+  )
+
+  def self.up
+    SLUGS.each { |slug|
+      tag = Tag.where(slug: slug)
+      Tag.destroy(tag) if tag
+    }
+  end
+
+  def self.down
+    # Nothing to do here
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150714140302) do
+ActiveRecord::Schema.define(version: 20150716103715) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "api_url",    limit: 255


### PR DESCRIPTION
Two childcare mainstream browse pages were created,
but then the content was updated and they're no longer needed.
They were never published, and never should be,
but need deleting to tidy things up.

Ticket:
https://trello.com/c/drh7LqiI/249-delete-two-unused-childcare-mainstream-browse-page-tags