### PR TITLE
Send `/topic` main page to content store

### DIFF
--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -1,0 +1,48 @@
+class RootTopicPresenter
+  def render_for_publishing_api
+    {
+      content_id: "76e9abe7-dac8-49f0-bb5e-53e4b0d2cdba",
+      format: "topic",
+      title: "Topics",
+      locale: 'en',
+      public_updated_at: public_updated_at,
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+      routes: routes,
+      update_type: "major",
+      links: links,
+      details: {
+        beta: true
+      }
+    }
+  end
+
+private
+
+  def topics
+    Topic.sorted_parents
+  end
+
+  def public_updated_at
+    if links["children"].empty?
+      raise "We can't publish a root topic page without topics"
+    else
+      topics
+        .map(&:updated_at)
+        .max
+        .iso8601
+    end
+  end
+
+  def routes
+    [
+      { path: "/topic", type: "exact" },
+    ]
+  end
+
+  def links
+    {
+      "children" => topics.map(&:content_id)
+    }
+  end
+end

--- a/app/services/tag_republisher.rb
+++ b/app/services/tag_republisher.rb
@@ -16,10 +16,12 @@ class TagRepublisher
     log "Done: #{done} tags sent to publishing-api."
 
     log "Sending root browse page to publishing-api"
-    publishing_api.put_content_item(
-      "/browse",
-      RootBrowsePagePresenter.new.render_for_publishing_api
-    )
+    with_retry do
+      publishing_api.put_content_item(
+        "/browse",
+        RootBrowsePagePresenter.new.render_for_publishing_api
+      )
+    end
 
     log "All done"
   end
@@ -27,14 +29,20 @@ class TagRepublisher
 private
 
   def republish_tag(tag)
+    with_retry do
+      PublishingAPINotifier.new(tag).send_single_tag_to_publishing_api
+    end
+  end
+
+  def with_retry
     retries = 0
 
     begin
-      PublishingAPINotifier.new(tag).send_single_tag_to_publishing_api
+      yield
     rescue GdsApi::TimedOutException, Timeout::Error => e
       retries += 1
       if retries <= 3
-        log "Timeout (tag #{tag.base_path}): retry #{retries}"
+        log "Timeout: retry #{retries}"
         sleep 0.5
         retry
       end

--- a/app/services/tag_republisher.rb
+++ b/app/services/tag_republisher.rb
@@ -23,6 +23,14 @@ class TagRepublisher
       )
     end
 
+    log "Sending root topic to publishing-api"
+    with_retry do
+      publishing_api.put_content_item(
+        "/topic",
+        RootTopicPresenter.new.render_for_publishing_api
+      )
+    end
+
     log "All done"
   end
 

--- a/app/services/tag_republisher.rb
+++ b/app/services/tag_republisher.rb
@@ -1,0 +1,31 @@
+class TagRepublisher
+  def republish_tags(tags)
+    puts "Sending #{tags.count} tags to the publishing-api"
+    done = 0
+    tags.find_each do |tag|
+      retries = 0
+      begin
+        PublishingAPINotifier.new(tag).send_single_tag_to_publishing_api
+      rescue GdsApi::TimedOutException, Timeout::Error => e
+        retries += 1
+        if retries <= 3
+          puts "Timeout (tag #{tag.base_path}): retry #{retries}"
+          sleep 0.5
+          retry
+        end
+        raise
+      end
+
+      done += 1
+      if done % 100 == 0
+        puts "#{done} completed..."
+      end
+    end
+    puts "Done: #{done} tags sent to publishing-api."
+
+    puts "Sending root browse page to publishing-api"
+    CollectionsPublisher.services(:publishing_api).put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
+
+    puts "All done"
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,42 +1,11 @@
 namespace :publishing_api do
-
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
   task :send_all_tags => :environment do
-    republish_tags(Tag.all)
+    TagRepublisher.new.republish_tags(Tag.all)
   end
 
   desc "Send all published tags to the publishing-api, skipping any marked as dirty"
   task :send_published_tags => :environment do
-    republish_tags(Tag.published)
-  end
-
-  def republish_tags(tags)
-    puts "Sending #{tags.count} tags to the publishing-api"
-    done = 0
-    tags.find_each do |tag|
-      retries = 0
-      begin
-        PublishingAPINotifier.new(tag).send_single_tag_to_publishing_api
-      rescue GdsApi::TimedOutException, Timeout::Error => e
-        retries += 1
-        if retries <= 3
-          puts "Timeout (tag #{tag.base_path}): retry #{retries}"
-          sleep 0.5
-          retry
-        end
-        raise
-      end
-
-      done += 1
-      if done % 100 == 0
-        puts "#{done} completed..."
-      end
-    end
-    puts "Done: #{done} tags sent to publishing-api."
-
-    puts "Sending root browse page to publishing-api"
-    CollectionsPublisher.services(:publishing_api).put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
-
-    puts "All done"
+    TagRepublisher.new.republish_tags(Tag.published)
   end
 end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -93,11 +93,6 @@ RSpec.describe PublishingAPINotifier do
       end
 
       it "sends topic redirects to the publishing-api", schema_test: true do
-        # FIXME: We shouldn't have to stub this out, but otherwise test will
-        # fail because `stubbed_content_store.last_updated_item` isn't the
-        # redirect anymore but the /topic page.
-        allow(PublishingAPINotifier).to receive(:publish_root_page)
-
         tag = create(:topic, :published, slug: 'foo')
 
         create(:redirect, tag: tag,
@@ -107,10 +102,10 @@ RSpec.describe PublishingAPINotifier do
         )
 
         PublishingAPINotifier.send_to_publishing_api(tag)
+        content_item = stubbed_content_store.item_with_slug('/foo')
 
-        expect(stubbed_content_store).to have_content_item_slug('/foo')
-        expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('redirect')
-        expect(stubbed_content_store.last_updated_item[:redirects]).to eql([
+        expect(content_item).to be_valid_against_schema('redirect')
+        expect(content_item[:redirects]).to eql([
           { path: "/foo", type: "exact", destination: "/topic/foo" },
         ])
       end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe PublishingAPINotifier do
       expect(stubbed_content_store).to have_content_item_slug('/browse')
     end
 
+    it "sends /browse for top level mainstream browse pages" do
+      tag = create(:topic, :published, slug: 'foo')
+
+      PublishingAPINotifier.send_to_publishing_api(tag)
+
+      expect(stubbed_content_store).to have_content_item_slug('/topic')
+    end
+
     context "for a draft tag" do
       it "sends the presented details to the publishing-api", schema_test: true do
         tag = create(:topic, :draft, slug: 'foo')
@@ -85,6 +93,11 @@ RSpec.describe PublishingAPINotifier do
       end
 
       it "sends topic redirects to the publishing-api", schema_test: true do
+        # FIXME: We shouldn't have to stub this out, but otherwise test will
+        # fail because `stubbed_content_store.last_updated_item` isn't the
+        # redirect anymore but the /topic page.
+        allow(PublishingAPINotifier).to receive(:publish_root_page)
+
         tag = create(:topic, :published, slug: 'foo')
 
         create(:redirect, tag: tag,

--- a/spec/presenters/root_topic_presenter_spec.rb
+++ b/spec/presenters/root_topic_presenter_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe RootTopicPresenter do
+  describe "#render_for_publishing_api" do
+    it "raises if top-level browse pages are not present" do
+      expect {
+        RootTopicPresenter.new.render_for_publishing_api
+      }.to raise_error(RuntimeError)
+    end
+
+    it "is valid against the schema" do
+      create(:topic, title: "Top-Level Topic 1")
+      create(:topic, title: "Top-Level Topic 2")
+
+      rendered = RootTopicPresenter.new.render_for_publishing_api
+
+      expect(rendered).to be_valid_against_schema('topic')
+    end
+
+    it "includes draft and published top-level browse pages" do
+      page_1 = create(:topic, :published, title: "Top-Level Page 1")
+      page_2 = create(:topic, :draft, title: "Top-Level Page 2")
+
+      rendered = RootTopicPresenter.new.render_for_publishing_api
+
+      expect(rendered[:links]["children"]).to eq([
+        page_1.content_id,
+        page_2.content_id,
+      ])
+    end
+
+    it ":public_updated_at equals the time of last browse page update" do
+      page_1 = create(:topic, title: "Top-Level Topic 1")
+      page_2 = create(:topic, title: "Top-Level Topic 2")
+
+      Timecop.travel 3.hours.ago do
+        page_1.touch
+      end
+      page_2.touch
+
+      rendered = RootTopicPresenter.new.render_for_publishing_api
+
+      expect(rendered[:public_updated_at]).to eq(page_2.updated_at.iso8601)
+    end
+  end
+end

--- a/spec/services/tag_republisher_spec.rb
+++ b/spec/services/tag_republisher_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe TagRepublisher do
   include ContentStoreHelpers
 
   describe '#republish_tags' do
-    before { stub_content_store! }
+    before do
+      # Create a topic and a mainstream_browse_page, otherwise the publisher
+      # cannot send the root pages.
+      create(:topic, :published, slug: 'first-topic')
+      create(:mainstream_browse_page, :published, slug: 'first-page')
+
+      stub_content_store!
+    end
 
     it 'republishes given tags' do
       create(:mainstream_browse_page, :published, slug: 'a-browse-page')
@@ -15,11 +22,15 @@ RSpec.describe TagRepublisher do
     end
 
     it 'republishes the browse index page' do
-      create(:mainstream_browse_page, :published, slug: 'a-browse-page')
-
       TagRepublisher.new.republish_tags(Tag.all)
 
       expect(stubbed_content_store).to have_content_item_slug('/browse')
+    end
+
+    it 'republishes the topic index page' do
+      TagRepublisher.new.republish_tags(Tag.all)
+
+      expect(stubbed_content_store).to have_content_item_slug('/topic')
     end
   end
 end

--- a/spec/services/tag_republisher_spec.rb
+++ b/spec/services/tag_republisher_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe TagRepublisher do
+  include ContentStoreHelpers
+
+  describe '#republish_tags' do
+    before { stub_content_store! }
+
+    it 'republishes given tags' do
+      create(:mainstream_browse_page, :published, slug: 'a-browse-page')
+
+      TagRepublisher.new.republish_tags(Tag.all)
+
+      expect(stubbed_content_store).to have_content_item_slug('/browse/a-browse-page')
+    end
+
+    it 'republishes the browse index page' do
+      create(:mainstream_browse_page, :published, slug: 'a-browse-page')
+
+      TagRepublisher.new.republish_tags(Tag.all)
+
+      expect(stubbed_content_store).to have_content_item_slug('/browse')
+    end
+  end
+end

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -30,16 +30,23 @@ module ContentStoreHelpers
     def initialize
       @stored_slugs = []
       @stored_draft_slugs = []
+      @stored_items = {}
     end
 
     def put_content_item(slug, item)
       @stored_slugs << slug
       @last_updated_item = item
+      @stored_items[slug] = item
     end
 
     def put_draft_content_item(slug, item)
       @stored_draft_slugs << slug
       @last_updated_item = item
+      @stored_items[slug] = item
+    end
+
+    def item_with_slug(slug)
+      @stored_items.fetch(slug)
     end
   end
 end


### PR DESCRIPTION
We are adding a new `/topic` page that displays all parent topics. This PR makes sure we create and update the `/topic` page in the content-store every time a parent topic is changed.

Best reviewed one-by-one.

Trello: https://trello.com/c/L84pTDgJ/233-create-page-at-topic

https://github.com/alphagov/collections/pull/145 will take care of the front-end.