### PR TITLE
Set descriptions for topics

### DIFF
--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -4,6 +4,8 @@
   <%= f.text_field :slug, :disabled => true %>
   <%= f.text_field :title %>
   <%= f.text_field :description %>
+  <em>This description will be displayed in the search results.</em>
+
   <%= f.check_box :beta %>
   <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -11,6 +11,8 @@
   <%= f.text_field :slug %>
   <%= f.text_field :title %>
   <%= f.text_field :description %>
+  <em>This description will be displayed in the search results.</em>
+
   <%= f.check_box :beta %>
 
   <%= f.submit 'Create', class: 'btn-submit' %>

--- a/db/migrate/20150723161808_add_description_to_topics.rb
+++ b/db/migrate/20150723161808_add_description_to_topics.rb
@@ -1,0 +1,12 @@
+class AddDescriptionToTopics < ActiveRecord::Migration
+  def up
+    Topic.find_each do |topic|
+      next if topic.description.present?
+
+      topic.update!(description: "List of information about #{topic.title}.")
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150723134305) do
+ActiveRecord::Schema.define(version: 20150723161808) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255


### PR DESCRIPTION
The frontend app is [currently generating fallback descriptions for topics](https://github.com/alphagov/frontend/blob/2b64f4989fcb7089d8e2c7255c78170ee7c624da/app/presenters/search_result.rb#L65). This migration adds the same description to the database, so that we don't need special code in `frontend` or `rummager`.

We need to run `rake rummager:index_topics` after deploying this change.

## Before

![screen shot 2015-07-23 at 12 23 36](https://cloud.githubusercontent.com/assets/233676/8849206/bb355152-3135-11e5-8bf7-b27c873b695d.png)

## After

![screen shot 2015-07-23 at 12 23 29](https://cloud.githubusercontent.com/assets/233676/8849210/c0d27112-3135-11e5-8133-a84f9f421a2d.png)

Trello: https://trello.com/c/AM4LQ2i3
