### PR TITLE
Send base_path instead of api_url to content-store

### DIFF
--- a/app/assets/javascripts/curated_lists.js
+++ b/app/assets/javascripts/curated_lists.js
@@ -76,7 +76,7 @@
           list_item: {
             index: index,
             title: $row.data('title'),
-            api_url: $row.data('api-url')
+            base_path: $row.data('base-path')
           }
         }),
         contentType: 'application/json',
@@ -130,8 +130,8 @@
     redrawUncategorizedList: function () {
       $('.is-curated').removeClass('is-curated');
       $(".drag-and-droppable tr").each(function() {
-        var url = $(this).data('api-url')
-        $("[data-api-url='" + url + "']").addClass('is-curated');
+        var path = $(this).data('base-path')
+        $("[data-base-path='" + path + "']").addClass('is-curated');
       })
     }
   };

--- a/app/assets/stylesheets/curated_lists.scss
+++ b/app/assets/stylesheets/curated_lists.scss
@@ -4,7 +4,7 @@ html.js {
     display: none;
   }
 
-  .api-url {
+  .base-path {
     display: none;
   }
 }

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -82,6 +82,6 @@ private
   end
 
   def list_item_params
-    params.require(:list_item).permit(:title, :api_url, :index)
+    params.require(:list_item).permit(:title, :base_path, :index)
   end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -27,7 +27,7 @@ class List < ActiveRecord::Base
   def list_items_with_tagging_status
     @list_items_with_tagging_status ||= begin
       list_items.order(:index).map do |list_item|
-        list_item.tagged = tagged_api_paths.include?(list_item.api_path)
+        list_item.tagged = tagged_base_paths.include?(list_item.base_path)
         list_item
       end
     end
@@ -35,7 +35,7 @@ class List < ActiveRecord::Base
 
 private
 
-  def tagged_api_paths
-    @tagged_api_paths ||= tag.list_items_from_contentapi.map(&:api_path)
+  def tagged_base_paths
+    @tagged_base_paths ||= tag.list_items_from_contentapi.map(&:base_path)
   end
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -22,13 +22,4 @@ class ListItem < ActiveRecord::Base
 
   attr_accessor :tagged
   alias :tagged? :tagged
-
-  # FIXME: remove these once everything has been migrated to use base_path
-  def api_url
-    return nil if self.base_path.nil?
-    Plek.find('contentapi') + base_path + '.json'
-  end
-  def api_url=(value)
-    self.base_path = URI.parse(value).path.chomp('.json')
-  end
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -26,13 +26,9 @@ class ListItem < ActiveRecord::Base
   # FIXME: remove these once everything has been migrated to use base_path
   def api_url
     return nil if self.base_path.nil?
-    Plek.find('contentapi') + api_path
+    Plek.find('contentapi') + base_path + '.json'
   end
   def api_url=(value)
     self.base_path = URI.parse(value).path.chomp('.json')
-  end
-
-  def api_path
-    base_path + '.json'
   end
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -3,7 +3,7 @@
 # Table name: list_items
 #
 #  id         :integer          not null, primary key
-#  api_url    :string(255)
+#  base_path  :string(255)
 #  index      :integer          default(0), not null
 #  list_id    :integer
 #  created_at :datetime
@@ -23,7 +23,16 @@ class ListItem < ActiveRecord::Base
   attr_accessor :tagged
   alias :tagged? :tagged
 
+  # FIXME: remove these once everything has been migrated to use base_path
+  def api_url
+    return nil if self.base_path.nil?
+    Plek.find('contentapi') + api_path
+  end
+  def api_url=(value)
+    self.base_path = URI.parse(value).path.chomp('.json')
+  end
+
   def api_path
-    URI(api_url).path
+    base_path + '.json'
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -122,8 +122,8 @@ class Tag < ActiveRecord::Base
   # returns unsaved ListItems for content tagged to this tag, but not in a
   # list.
   def uncategorized_list_items
-    curated_api_urls = list_items.map(&:api_url)
-    list_items_from_contentapi.reject {|li| curated_api_urls.include?(li.api_url) }
+    curated_base_paths = list_items.map(&:base_path)
+    list_items_from_contentapi.reject {|li| curated_base_paths.include?(li.base_path) }
   end
 
   def list_items_from_contentapi
@@ -131,7 +131,7 @@ class Tag < ActiveRecord::Base
       CollectionsPublisher.services(:content_api)
         .with_tag(full_slug, legacy_tag_type, draft: true)
         .map { |content_blob|
-          ListItem.new(title: content_blob.title, api_url: content_blob.id)
+          ListItem.new(title: content_blob.title, base_path: (content_blob.web_url ? URI.parse(content_blob.web_url).path : nil))
         }
     rescue GdsApi::HTTPNotFound
       []

--- a/app/presenters/groups_presenter.rb
+++ b/app/presenters/groups_presenter.rb
@@ -7,7 +7,7 @@ class GroupsPresenter
     @tag.lists.ordered.map do |list|
       {
         name: list.name,
-        contents: list.tagged_list_items.map(&:api_url)
+        contents: list.tagged_list_items.map(&:base_path)
       }
     end
   end

--- a/app/views/lists/_all_list_items.html.erb
+++ b/app/views/lists/_all_list_items.html.erb
@@ -6,14 +6,14 @@
       <% tag.list_items_from_contentapi.each do |list_item| %>
         <tr class='item'
             data-title='<%= list_item.title %>'
-            data-api-url='<%= list_item.api_url %>'>
+            data-base-path='<%= list_item.base_path %>'>
 
           <td class='title'>
             <%= raw list_item.title %>
           </td>
 
-          <td class='api-url'>
-            <%= raw list_item.api_url %>
+          <td class='base-path'>
+            <%= raw list_item.base_path %>
           </td>
 
           <td class='removal-button'>

--- a/app/views/lists/_list_editor.html.erb
+++ b/app/views/lists/_list_editor.html.erb
@@ -48,7 +48,7 @@
                 <% end %>
 
                 <span>
-                  <%= raw list_item.title || "<em>Unknown title (#{list_item.api_path})</em>" %>
+                  <%= raw list_item.title || "<em>Unknown title (#{list_item.base_path})</em>" %>
                 </span>
               </td>
 

--- a/app/views/lists/_list_editor.html.erb
+++ b/app/views/lists/_list_editor.html.erb
@@ -40,7 +40,7 @@
                 data-list-id='<%= list.id %>'
                 data-update-url='<%= tag_list_list_item_path(tag, list, list_item) %>'
                 data-title='<%= list_item.title %>'
-                data-api-url='<%= list_item.api_url %>'>
+                data-base-path='<%= list_item.base_path %>'>
 
               <td class='title'>
                 <% unless list_item.tagged? %>
@@ -52,8 +52,8 @@
                 </span>
               </td>
 
-              <td class='api-url'>
-                <%= raw list_item.api_url %>
+              <td class='base-path'>
+                <%= raw list_item.base_path %>
               </td>
 
               <td class='removal-button'>
@@ -71,7 +71,7 @@
       </table>
 
       <%= form_for(ListItem.new, url: tag_list_list_items_path(tag, list), html: {id: nil}) do |f| %>
-        <%= f.text_field :api_url, label: 'API URL' %>
+        <%= f.text_field :base_path, label: 'Base Path' %>
         <%= f.number_field :index %>
         <button class='btn btn-primary'>Add</button>
       <% end %>

--- a/db/migrate/20150723112749_change_list_item_api_url_to_base_path.rb
+++ b/db/migrate/20150723112749_change_list_item_api_url_to_base_path.rb
@@ -1,0 +1,17 @@
+class ChangeListItemApiUrlToBasePath < ActiveRecord::Migration
+  def up
+    rename_column :list_items, :api_url, :base_path
+    ListItem.find_each do |item|
+      base_path = URI.parse(item.base_path).path.chomp(".json")
+      item.update_column(:base_path, base_path)
+    end
+  end
+
+  def down
+    ListItem.find_each do |item|
+      api_url = Plek.find('contentapi') + item.base_path + '.json'
+      item.update_column(:base_path, api_url)
+    end
+    rename_column :list_items, :base_path, :api_url
+  end
+end

--- a/db/migrate/20150723134305_update_serialised_curated_lists.rb
+++ b/db/migrate/20150723134305_update_serialised_curated_lists.rb
@@ -1,0 +1,28 @@
+class UpdateSerialisedCuratedLists < ActiveRecord::Migration
+  def up
+    Tag.find_each do |tag|
+      next if tag.published_groups.empty?
+
+      tag.published_groups.each do |group|
+        group['contents'].map! do |url|
+          URI.parse(url).path.chomp('.json')
+        end
+      end
+      tag.save!
+    end
+  end
+
+  def down
+    base_url = Plek.find('contentapi')
+    Tag.find_each do |tag|
+      next if tag.published_groups.empty?
+
+      tag.published_groups.each do |group|
+        group['contents'].map! do |path|
+          base_url + path + '.json'
+        end
+      end
+      tag.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150723112749) do
+ActiveRecord::Schema.define(version: 20150723134305) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150716103715) do
+ActiveRecord::Schema.define(version: 20150723112749) do
 
   create_table "list_items", force: :cascade do |t|
-    t.string   "api_url",    limit: 255
+    t.string   "base_path",  limit: 255
     t.integer  "index",      limit: 4,   default: 0, null: false
     t.integer  "list_id",    limit: 4
     t.datetime "created_at"

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -91,13 +91,13 @@ RSpec.describe "Curating the contents of topics" do
             "groups" => [
               { "name" => 'Oil rigs',
                 "contents" => [
-                  contentapi_url_for_slug('oil-rig-staffing'),
-                  contentapi_url_for_slug('oil-rig-staffing'),
-                  contentapi_url_for_slug('oil-rig-safety-requirements'),
+                  '/oil-rig-staffing',
+                  '/oil-rig-staffing',
+                  '/oil-rig-safety-requirements',
               ]},
               { "name" => 'Piping',
                 "contents" => [
-                  contentapi_url_for_slug('undersea-piping-restrictions'),
+                  '/undersea-piping-restrictions',
               ]},
             ],
             "beta" => false,
@@ -169,12 +169,12 @@ RSpec.describe "Curating the contents of topics" do
             "groups" => [
               { "name" => 'Oil rigs',
                 "contents" => [
-                  contentapi_url_for_slug('oil-rig-safety-requirements'),
-                  contentapi_url_for_slug('oil-rig-staffing'),
+                  '/oil-rig-safety-requirements',
+                  '/oil-rig-staffing',
               ]},
               { "name" => 'Piping',
                 "contents" => [
-                  contentapi_url_for_slug('undersea-piping-restrictions'),
+                  '/undersea-piping-restrictions',
               ]},
             ],
             "beta" => false,

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -221,10 +221,10 @@ RSpec.describe "Curating the contents of topics" do
       oil_rigs = create(:list, :tag => offshore, :name => 'Oil rigs', :index => 0)
       piping = create(:list, :tag => offshore, :name => 'Piping', :index => 1)
 
-      create(:list_item, :list => oil_rigs, :index => 0, :title => 'Oil rig safety requirements', :api_url => contentapi_url_for_slug('oil-rig-safety-requirements'))
-      create(:list_item, :list => oil_rigs, :index => 1, :title => 'Oil rig staffing', :api_url => contentapi_url_for_slug('oil-rig-staffing'))
-      create(:list_item, :list => piping, :index => 0, :title => 'Undersea piping restrictions', :api_url => contentapi_url_for_slug('undersea-piping-restrictions'))
-      create(:list_item, :list => piping, :index => 1, :title => 'Non-existent', :api_url => contentapi_url_for_slug('non-existent'))
+      create(:list_item, :list => oil_rigs, :index => 0, :title => 'Oil rig safety requirements', :base_path => '/oil-rig-safety-requirements')
+      create(:list_item, :list => oil_rigs, :index => 1, :title => 'Oil rig staffing', :base_path => '/oil-rig-staffing')
+      create(:list_item, :list => piping, :index => 0, :title => 'Undersea piping restrictions', :base_path => '/undersea-piping-restrictions')
+      create(:list_item, :list => piping, :index => 1, :title => 'Non-existent', :base_path => '/non-existent')
     end
 
     it "viewing the topic curation page" do

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -118,11 +118,11 @@ RSpec.describe "Curating the contents of topics" do
       end
 
       within :xpath, xpath_section_for('Oil rigs') do
-        fill_in 'API URL', :with => contentapi_url_for_slug('oil-rig-safety-requirements')
+        fill_in 'Base Path', :with => '/oil-rig-safety-requirements'
         fill_in 'Index', :with => 0
         click_on 'Add'
 
-        fill_in 'API URL', :with => contentapi_url_for_slug('oil-rig-staffing')
+        fill_in 'Base Path', :with => '/oil-rig-staffing'
         fill_in 'Index', :with => 1
         click_on 'Add'
       end
@@ -133,7 +133,7 @@ RSpec.describe "Curating the contents of topics" do
       end
 
       within :xpath, xpath_section_for('Piping') do
-        fill_in 'API URL', :with => contentapi_url_for_slug('undersea-piping-restrictions')
+        fill_in 'Base Path', :with => '/undersea-piping-restrictions'
         fill_in 'Index', :with => 0
         click_on 'Add'
       end
@@ -142,19 +142,19 @@ RSpec.describe "Curating the contents of topics" do
       visit_topic_list_curation_page
 
       within :xpath, xpath_section_for('Oil rigs') do
-        api_urls = page.all('tr').map { |tr| tr['data-api-url'] }.compact
+        base_paths = page.all('tr').map { |tr| tr['data-base-path'] }.compact
 
-        expect(api_urls).to eq([
-          contentapi_url_for_slug('oil-rig-safety-requirements'),
-          contentapi_url_for_slug('oil-rig-staffing'),
+        expect(base_paths).to eq([
+          '/oil-rig-safety-requirements',
+          '/oil-rig-staffing',
         ])
       end
 
       within :xpath, xpath_section_for('Piping') do
-        api_urls = page.all('tr').map { |tr| tr['data-api-url'] }.compact
+        base_paths = page.all('tr').map { |tr| tr['data-base-path'] }.compact
 
-        expect(api_urls).to eq([
-          contentapi_url_for_slug('undersea-piping-restrictions'),
+        expect(base_paths).to eq([
+          '/undersea-piping-restrictions',
         ])
       end
 

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe List do
 
     it "returns the list items with tagged set to true if they're tagged" do
       list = create(:list, tag: create(:tag, slug: 'subtag'))
-      tagged = create(:list_item, list: list, api_url: 'https://contentapi.production.alphagov.co.uk/tagged-item.json')
-      not_tagged = create(:list_item, list: list, api_url: 'https://contentapi.production.alphagov.co.uk/untagged-item.json')
+      tagged = create(:list_item, list: list, base_path: '/tagged-item')
+      not_tagged = create(:list_item, list: list, base_path: '/untagged-item')
       content_api_has_artefacts_with_a_tag('tag', 'subtag', ['tagged-item'])
 
       list_item = list.list_items_with_tagging_status.first
@@ -38,7 +38,7 @@ RSpec.describe List do
 
     it "returns the list items with tagged set to false if they're not tagged" do
       list = create(:list, tag: create(:tag, slug: 'subtag'))
-      not_tagged = create(:list_item, list: list, api_url: 'https://contentapi.production.alphagov.co.uk/untagged-item.json')
+      not_tagged = create(:list_item, list: list, base_path: '/untagged-item')
       content_api_has_artefacts_with_a_tag('tag', 'subtag', [])
 
       list_item = list.list_items_with_tagging_status.first

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -253,9 +253,9 @@ RSpec.describe Tag do
 
     it "returns ListItems for all content that's been tagged to the tag, but isn't in a list" do
       list1 = create(:list, :tag => subtag)
-      create(:list_item, :list => list1, :api_url => contentapi_url_for_slug('content-1'))
+      create(:list_item, :list => list1, :base_path => '/content-1')
       list2 = create(:list, :tag => subtag)
-      create(:list_item, :list => list2, :api_url => contentapi_url_for_slug('content-3'))
+      create(:list_item, :list => list2, :base_path => '/content-3')
 
       content_api_has_artefacts_with_a_tag('tag', 'tag/subtag', [
         'content-1',
@@ -264,9 +264,9 @@ RSpec.describe Tag do
         'content-4',
       ])
 
-      expect(subtag.uncategorized_list_items.map(&:api_url)).to match_array([
-        contentapi_url_for_slug('content-2'),
-        contentapi_url_for_slug('content-4'),
+      expect(subtag.uncategorized_list_items.map(&:base_path)).to match_array([
+        '/content-2',
+        '/content-4',
       ])
     end
   end
@@ -283,9 +283,9 @@ RSpec.describe Tag do
 
       items = subtag.list_items_from_contentapi
 
-      expect(items.map(&:api_url)).to eq([
-        contentapi_url_for_slug('example-content-1'),
-        contentapi_url_for_slug('example-content-2'),
+      expect(items.map(&:base_path)).to eq([
+        '/example-content-1',
+        '/example-content-2',
       ])
       expect(items.map(&:title)).to eq([
         "Example content 1",

--- a/spec/presenters/groups_presenter_spec.rb
+++ b/spec/presenters/groups_presenter_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe GroupsPresenter do
 
       it "provides the curated lists ordered by their index" do
         allow(oil_rigs).to receive(:tagged_list_items).and_return([
-          OpenStruct.new(:api_url => "http://api.example.com/oil-rig-safety-requirements"),
-          OpenStruct.new(:api_url => "http://api.example.com/oil-rig-staffing"),
+          OpenStruct.new(:base_path => "/oil-rig-safety-requirements"),
+          OpenStruct.new(:base_path => "/oil-rig-staffing"),
         ])
 
         allow(piping).to receive(:tagged_list_items).and_return([
-          OpenStruct.new(:api_url => "http://api.example.com/undersea-piping-restrictions"),
+          OpenStruct.new(:base_path => "/undersea-piping-restrictions"),
         ])
 
         allow(tag).to receive(:lists).and_return(double(:ordered => [piping, oil_rigs]))
@@ -36,14 +36,14 @@ RSpec.describe GroupsPresenter do
             {
               :name => "Piping",
               :contents => [
-                "http://api.example.com/undersea-piping-restrictions",
+                "/undersea-piping-restrictions",
               ]
             },
             {
               :name => "Oil rigs",
               :contents => [
-                "http://api.example.com/oil-rig-safety-requirements",
-                "http://api.example.com/oil-rig-staffing",
+                "/oil-rig-safety-requirements",
+                "/oil-rig-staffing",
               ]
             }
           ],

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe TagPresenter do
 
       # We need to "publish" these lists.
       allow_any_instance_of(List).to receive(:tagged_list_items).and_return(
-        [OpenStruct.new(:api_url => "http://api.example.com/oil-rig-safety-requirements")]
+        [OpenStruct.new(:base_path => "/oil-rig-safety-requirements")]
       )
       tag.update!(published_groups: GroupsPresenter.new(tag).groups, dirty: false)
 

--- a/spec/support/content_api_helpers.rb
+++ b/spec/support/content_api_helpers.rb
@@ -3,10 +3,6 @@ require 'gds_api/test_helpers/content_api'
 module ContentApiHelpers
   include GdsApi::TestHelpers::ContentApi
 
-  def contentapi_url_for_slug(slug)
-    "#{Plek.new.find('contentapi')}/#{slug}.json"
-  end
-
   def stub_content_api(result)
     stub_request(:get, %r[.contentapi]).to_return(body: JSON.dump(result))
   end


### PR DESCRIPTION
We want to update the frontend so that it can request tagged content
from rummager instead of contentapi. Rummager doesn't contain the
api_urls, so we'd have to fudge them from the base_path. This seems
wrong, and it would be better to send the base_paths in the curated
data. then we can match up the items by base_paths (both rummager and
contentapi have the base_path of the item).

This depends on alphagov/collections#148 being merged and deployed first.

This may be easier to review commit at a time.