### PR TITLE
Send browse pages to Rummager

### DIFF
--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -20,6 +20,7 @@ class MainstreamBrowsePagesController < ApplicationController
     if browse_page.update_attributes(browse_page_params)
       PanopticonNotifier.update_tag(MainstreamBrowsePagePresenter.new(browse_page))
       PublishingAPINotifier.send_to_publishing_api(browse_page)
+      RummagerNotifier.new(browse_page).notify
       redirect_to browse_page
     else
       @browse_page = browse_page
@@ -52,6 +53,7 @@ class MainstreamBrowsePagesController < ApplicationController
     browse_page.publish!
     PanopticonNotifier.publish_tag(MainstreamBrowsePagePresenter.new(browse_page))
     PublishingAPINotifier.send_to_publishing_api(browse_page)
+    RummagerNotifier.new(browse_page).notify
     redirect_to browse_page
   end
 

--- a/app/notifiers/rummager_notifier.rb
+++ b/app/notifiers/rummager_notifier.rb
@@ -1,30 +1,23 @@
 class RummagerNotifier
-  attr_reader :topic
+  attr_reader :tag
 
-  def initialize(topic)
-    @topic = topic
+  def initialize(tag)
+    @tag = tag
   end
 
   def notify
-    return if topic.draft?
+    return if tag.draft?
 
-    # Will add it to mainstream index with type 'edition'.
     CollectionsPublisher.services(:rummager).add_document(
       'edition',
-      topic.base_path,
-      payload
+      presenter.base_path,
+      presenter.render_for_rummager
     )
   end
 
-  private
+private
 
-  def payload
-    {
-      format: 'specialist_sector',
-      title: topic.title,
-      description: topic.description,
-      link: topic.base_path,
-      slug: topic.full_slug,
-    }
+  def presenter
+    @presenter ||= TagPresenter.presenter_for(tag)
   end
 end

--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -2,6 +2,10 @@ class MainstreamBrowsePagePresenter < TagPresenter
 
 private
 
+  def rummager_format
+    'mainstream_browse_page'
+  end
+
   def format
     'mainstream_browse_page'
   end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -16,6 +16,16 @@ class TagPresenter
     @tag = tag
   end
 
+  def render_for_rummager
+    {
+      format: rummager_format,
+      title: tag.title,
+      description: tag.description,
+      link: tag.base_path,
+      slug: tag.full_slug,
+    }
+  end
+
   def render_for_publishing_api
     {
       content_id: @tag.content_id,

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -1,6 +1,11 @@
 class TopicPresenter < TagPresenter
 
 private
+
+  def rummager_format
+    'specialist_sector'
+  end
+
   def format
     'topic'
   end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,8 +1,8 @@
 namespace :rummager do
-  desc 'Send all topics to Rummager'
-  task index_topics: [:environment] do
-    Topic.published.find_each do |topic|
-      RummagerNotifier.new(topic).notify
+  desc 'Send all tags to Rummager'
+  task index_tags: [:environment] do
+    Tag.published.find_each do |tag|
+      RummagerNotifier.new(tag).notify
     end
   end
 end

--- a/spec/controllers/mainstream_browse_pages_controller_spec.rb
+++ b/spec/controllers/mainstream_browse_pages_controller_spec.rb
@@ -46,8 +46,9 @@ RSpec.describe MainstreamBrowsePagesController do
       create(:mainstream_browse_page)
     }
 
-    it 'notifies panopticon' do
+    it 'notifies panopticon and rummager' do
       expect(PanopticonNotifier).to receive(:update_tag).with(presenter)
+      expect_any_instance_of(RummagerNotifier).to receive(:notify)
 
       put :update, id: mainstream_browse_page.content_id, mainstream_browse_page: attributes.merge(:slug => mainstream_browse_page.slug)
     end

--- a/spec/features/mainstream_browse_pages_spec.rb
+++ b/spec/features/mainstream_browse_pages_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "managing mainstream browse pages" do
   before :each do
     stub_user.permissions << "GDS Editor"
     stub_all_panopticon_tag_calls
+    allow_any_instance_of(RummagerNotifier).to receive(:notify)
 
     # Stub the content-api with empty because the `show` pages are trying to
     # fetch the links to show as preview.

--- a/spec/notifiers/rummager_notifier_spec.rb
+++ b/spec/notifiers/rummager_notifier_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe RummagerNotifier do
         })
     end
 
+    it 'sends published browse pages to rummager' do
+      browse_page = create(:mainstream_browse_page, :published,
+        title: 'A Browse Page',
+        slug: 'a-browse-page',
+        description: 'A description.')
+
+      RummagerNotifier.new(browse_page).notify
+
+      expect(rummager).to have_received(:add_document)
+        .with("edition", "/browse/a-browse-page", {
+          format: 'mainstream_browse_page',
+          title: 'A Browse Page',
+          description: 'A description.',
+          link: '/browse/a-browse-page',
+          slug: 'a-browse-page',
+        })
+    end
+
     it 'sends the full slug for a subtopic' do
       parent = create(:topic, :published, :slug => 'a-parent')
       topic = create(:topic, :published,


### PR DESCRIPTION
We'd like to use the mainstream browse pages in rummager. This PR makes collections-publisher send the content of browse pages to rummager in the same way as happened with topics.

Trello: https://trello.com/c/6vXKBd5d

PR on rummager to then hide the browse pages from search results: https://github.com/alphagov/rummager/pull/471