### PR TITLE
Fix typo in topic redirect

### DIFF
--- a/db/migrate/20150806150340_fix_typo_in_topic_redirect.rb
+++ b/db/migrate/20150806150340_fix_typo_in_topic_redirect.rb
@@ -1,0 +1,23 @@
+class FixTypoInTopicRedirect < ActiveRecord::Migration
+  def up
+    redirect_item = {
+      "format" => "redirect",
+      "publishing_app" => "collections-publisher",
+      "update_type" => "major",
+      "redirects" => [
+        {
+          "path" => "/immigration-operational-guidance/european-casework-instructions",
+          "type" => "exact",
+          "destination" => "/government/collections/eea-swiss-nationals-and-ec-association-agreements-modernised-guidance",
+        },
+      ],
+    }
+
+    publishing_api = CollectionsPublisher.services(:publishing_api)
+    resp = publishing_api.put_content_item("/immigration-operational-guidance/european-casework-instructions", redirect_item)
+    puts resp.body
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806142025) do
+ActiveRecord::Schema.define(version: 20150806150340) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255


### PR DESCRIPTION
Previous commit https://github.com/alphagov/collections-publisher/pull/130 had a typo in the destination address. The topic should've redirected to
/government/collections/eea-swiss-nationals-and-ec-association-agreements-modernised-guidance.