### PR TITLE
Fix list item base_paths

### DIFF
--- a/db/migrate/20150811131142_fix_list_item_base_paths.rb
+++ b/db/migrate/20150811131142_fix_list_item_base_paths.rb
@@ -1,0 +1,8 @@
+class FixListItemBasePaths < ActiveRecord::Migration
+  def up
+    ListItem.find_each do |item|
+      item.base_path = item.base_path.gsub('%2F', '/')
+      item.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150806150340) do
+ActiveRecord::Schema.define(version: 20150811131142) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255


### PR DESCRIPTION
The contentapi URLs contained % encoded slashes. This wasn't accounted
for by the migration that replced these with base_paths, causing several
list items to show up as untagged.