### PR TITLE
Send `phase` to content-store

### DIFF
--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -42,7 +42,7 @@ class TagPresenter
       update_type: "major",
       details: details,
       links: links,
-    }
+    }.merge(phase_state)
   end
 
   def render_for_panopticon
@@ -56,6 +56,11 @@ class TagPresenter
   end
 
 private
+
+  def phase_state
+    return {} unless @tag.beta?
+    { phase: "beta" }
+  end
 
   def format
     raise "Need to subclass"

--- a/spec/features/topic_create_edit_spec.rb
+++ b/spec/features/topic_create_edit_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe "creating and editing topics" do
       "title" => 'Working on the ocean',
       "description" => "I woke up one morning, The sea was still there.",
       "format" => "topic",
+      "phase" => "beta",
       "details" => {
         "groups" => [],
         "beta" => true,


### PR DESCRIPTION
`phase` indicates whether the content item is in alpha or beta. By sending this attribute to the contents-store we can start to retire the `details.beta` field.