### PR TITLE
Fix the comparison task

### DIFF
--- a/lib/tasks/compare.rake
+++ b/lib/tasks/compare.rake
@@ -3,6 +3,8 @@ namespace :comparison do
   desc "report on differences in items tagged as reported by rummager and contentapi"
   task :run => :environment do
     require 'csv'
+    require 'gds_api/content_api'
+    CollectionsPublisher.services(:content_api, GdsApi::ContentApi.new(Plek.new.find('content_api')))
 
     # Generates 2 CSV files reporting differences between the contentapi and
     # rummager views on the content items tagged to a given topic or


### PR DESCRIPTION
The task for comparing the results from rummager and content_api for
listing documents by tag was broken, because the content_api service has
been removed from the app everywhere.

It's still needed by the comparison task, so import and configure it
locally.