### PR TITLE
Add functionality to remove a topic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'plek', '~> 1.10.0'
 gem 'airbrake', '~> 4.2.0'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '20.1.1'
+gem 'gds-api-adapters', '24.3.0'
 
 gem 'govuk_admin_template', '~> 2.3.1'
 gem 'generic_form_builder', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -298,7 +298,7 @@ DEPENDENCIES
   capybara (~> 2.4.1)
   database_cleaner (~> 1.3.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 24.3.0)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.9.0)
   govuk-content-schema-test-helpers (~> 1.3)

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -1,5 +1,6 @@
 class MainstreamBrowsePagesController < ApplicationController
   before_filter :require_gds_editor_permissions!
+  before_filter :protect_archived_browse_pages!, only: %i[edit update publish]
 
   def index
     @browse_pages = MainstreamBrowsePage.sorted_parents
@@ -83,5 +84,13 @@ private
   def tag_params
     params.require(:mainstream_browse_page)
       .permit(:slug, :title, :description, :parent_id, :child_ordering, children_attributes: [:index, :id])
+  end
+
+  def protect_archived_browse_pages!
+    browse_page = find_browse_page
+    if browse_page.archived?
+      flash[:error] = 'You cannot modify an archived mainstream browse page.'
+      redirect_to browse_page
+    end
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,5 +1,6 @@
 class TopicsController < ApplicationController
   before_filter :require_gds_editor_permissions!, except: %i[index show]
+  before_filter :protect_archived_tags!, only: %i[edit update publish]
 
   def index
     @topics = Topic.sorted_parents
@@ -61,5 +62,13 @@ private
 
   def find_topic
     @_topic ||= Topic.find_by!(content_id: params[:id])
+  end
+
+  def protect_archived_tags!
+    topic = find_topic
+    if topic.archived?
+      flash[:error] = 'You cannot modify an archived topic.'
+      redirect_to topic
+    end
   end
 end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -54,6 +54,23 @@ class TopicsController < ApplicationController
     redirect_to topic
   end
 
+  def propose_archive
+    @archival = ArchivalForm.new(tag: find_topic)
+  end
+
+  def archive
+    topic = find_topic
+
+    if topic.published?
+      successor = Topic.find(params[:archival_form][:successor])
+      TagArchiver.new(topic, successor).archive
+      redirect_to topic_path(topic), notice: 'The topic has been archived.'
+    else
+      DraftTagRemover.new(topic).remove
+      redirect_to topics_path, notice: 'The topic has been removed.'
+    end
+  end
+
 private
 
   def topic_params

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -69,6 +69,9 @@ class TopicsController < ApplicationController
       DraftTagRemover.new(topic).remove
       redirect_to topics_path, notice: 'The topic has been removed.'
     end
+  rescue GdsApi::HTTPConflict
+    flash[:error] = "The tag could not be deleted because there are documents tagged to it"
+    redirect_to :back
   end
 
 private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,6 +7,7 @@ class TopicsController < ApplicationController
 
   def show
     @topic = find_topic
+    render 'archived_topic' if @topic.archived?
   end
 
   def edit

--- a/app/forms/archival_form.rb
+++ b/app/forms/archival_form.rb
@@ -1,0 +1,14 @@
+class ArchivalForm
+  include ActiveModel::Model
+  attr_accessor :tag, :successor
+
+  def topics
+    published_topics - [tag]
+  end
+
+private
+
+  def published_topics
+    Topic.includes(:parent).published.where(archived: false).sort_by(&:title_including_parent)
+  end
+end

--- a/app/forms/archival_form.rb
+++ b/app/forms/archival_form.rb
@@ -9,6 +9,6 @@ class ArchivalForm
 private
 
   def published_topics
-    Topic.includes(:parent).published.where(archived: false).sort_by(&:title_including_parent)
+    Topic.includes(:parent).published.sort_by(&:title_including_parent)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,13 @@
 module ApplicationHelper
 
   def alert_classes(key)
-    classes = "alert alert-"
+    key = {
+      'notice' => 'warning',
+      'alert' => 'warning',
+      'error' => 'danger',
+    }.fetch(key, key)
 
-    if key == :notice || key == :alert
-      key = "warning"
-    end
-
-    classes + key
+    classes = "alert alert-#{key}"
   end
 
   def website_url(base_path)

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -13,6 +13,7 @@ module StatusHelper
     labels << draft_tag if tag.draft?
     labels << beta_tag if tag.beta?
     labels << dirty_tag if tag.dirty?
+    labels << archived_tag if tag.archived?
     raw labels.join(' ')
   end
 
@@ -22,6 +23,10 @@ module StatusHelper
 
   def dirty_tag
     status 'Unpublished changes', :danger
+  end
+
+  def archived_tag
+    status 'Archived', :default
   end
 
   def draft_tag

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -48,6 +48,10 @@ class MainstreamBrowsePage < Tag
     end
   end
 
+  def subroutes
+    %w[.json]
+  end
+
   def top_level_mainstream_browse_page?
     !child?
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -91,6 +91,7 @@ class Tag < ActiveRecord::Base
   end
 
   alias child? has_parent?
+  alias parent? can_have_children?
 
   def self.sorted_parents
     only_parents.includes(children: [:lists]).order(:title)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -67,6 +67,11 @@ class Tag < ActiveRecord::Base
   aasm column: :state, no_direct_assignment: true do
     state :draft, initial: true
     state :published
+    state :archived
+
+    event :move_to_archive do
+      transitions from: :published, to: :archived
+    end
 
     event :publish do
       transitions from: :draft, to: :published

--- a/app/models/tagged_documents.rb
+++ b/app/models/tagged_documents.rb
@@ -2,7 +2,7 @@ class TaggedDocuments
   PAGE_SIZE_TO_GET_EVERYTHING = 10_000
 
   include Enumerable
-  delegate :each, to: :documents
+  delegate :each, :empty?, to: :documents
   attr_reader :tag
 
   def initialize(tag)

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -38,6 +38,11 @@ class Topic < Tag
     "/topic/#{full_slug}"
   end
 
+  def subroutes
+    return [] unless subtopic?
+    %w[/latest /email-signup]
+  end
+
   def dependent_tags
     if has_parent?
       [parent]

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -13,7 +13,10 @@ class PublishingAPINotifier
 
   def send_single_tag_to_publishing_api
     if tag.published?
-      publishing_api.put_content_item(presenter.base_path, presenter.render_for_publishing_api)
+      unless tag.archived?
+        publishing_api.put_content_item(presenter.base_path, presenter.render_for_publishing_api)
+      end
+
       add_redirects
     else
       publishing_api.put_draft_content_item(presenter.base_path, presenter.render_for_publishing_api)

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -39,7 +39,7 @@ private
   end
 
   def publishing_api
-    @publishing_api ||= CollectionsPublisher.services(:publishing_api)
+    Services.publishing_api
   end
 
   def self.publish_root_page(tag)
@@ -65,14 +65,14 @@ private
   class RootBrowsePageWorker
     include Sidekiq::Worker
     def perform
-      CollectionsPublisher.services(:publishing_api).put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
+      Services.publishing_api.put_content_item("/browse", RootBrowsePagePresenter.new.render_for_publishing_api)
     end
   end
 
   class RootTopicWorker
     include Sidekiq::Worker
     def perform
-      CollectionsPublisher.services(:publishing_api).put_content_item("/topic", RootTopicPresenter.new.render_for_publishing_api)
+      Services.publishing_api.put_content_item("/topic", RootTopicPresenter.new.render_for_publishing_api)
     end
   end
 end

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -13,12 +13,11 @@ class PublishingAPINotifier
 
   def send_single_tag_to_publishing_api
     if tag.published?
-      unless tag.archived?
-        publishing_api.put_content_item(presenter.base_path, presenter.render_for_publishing_api)
-      end
-
+      publishing_api.put_content_item(presenter.base_path, presenter.render_for_publishing_api)
       add_redirects
-    else
+    elsif tag.archived?
+      add_redirects
+    elsif tag.draft?
       publishing_api.put_draft_content_item(presenter.base_path, presenter.render_for_publishing_api)
     end
   end

--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -27,12 +27,6 @@ private
 
 private
 
-  def routes
-    super + [
-      {path: "#{base_path}.json", type: "exact"},
-    ]
-  end
-
   def active_top_level_browse_page_id
     if @tag.has_parent?
       [@tag.parent.content_id]

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -66,9 +66,14 @@ private
     raise "Need to subclass"
   end
 
-  # potentially extended in subclasses
   def routes
-    [ {path: base_path, type: "exact"} ]
+    [{ path: base_path, type: "exact" }] + subroutes
+  end
+
+  def subroutes
+    @tag.subroutes.map do |suffix|
+      { path: "#{base_path}#{suffix}", type: "exact" }
+    end
   end
 
   # potentially extended in subclasses

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -55,6 +55,10 @@ class TagPresenter
     }
   end
 
+  def routes
+    [{ path: base_path, type: "exact" }] + subroutes
+  end
+
 private
 
   def phase_state
@@ -64,10 +68,6 @@ private
 
   def format
     raise "Need to subclass"
-  end
-
-  def routes
-    [{ path: base_path, type: "exact" }] + subroutes
   end
 
   def subroutes

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -10,15 +10,6 @@ private
     'topic'
   end
 
-  def routes
-    return super unless @tag.has_parent?
-
-    super + [
-      {path: "#{base_path}/latest", type: "exact"},
-      {path: "#{base_path}/email-signup", type: "exact"},
-    ]
-  end
-
   def details
     super.merge({
       :beta => @tag.beta,

--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -8,6 +8,7 @@ class DraftTagRemover
   def remove
     return if tag.published? || tag.parent? || tag.tagged_documents.any?
 
+    remove_tag_from_panopticon
     add_gone_item
     tag.destroy!
   end
@@ -15,8 +16,6 @@ class DraftTagRemover
 private
 
   def add_gone_item
-    presenter = TagPresenter.presenter_for(tag)
-
     Services.publishing_api.put_draft_content_item(tag.base_path,
       format: 'gone',
       publishing_app: 'collections-publisher',
@@ -24,5 +23,14 @@ private
       content_id: tag.content_id,
       routes: presenter.routes
     )
+  end
+
+  def remove_tag_from_panopticon
+    tag_hash = presenter.render_for_panopticon
+    Services.panopticon.delete_tag!(tag_hash[:tag_type], tag_hash[:tag_id])
+  end
+
+  def presenter
+    @presenter ||= TagPresenter.presenter_for(tag)
   end
 end

--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -8,9 +8,11 @@ class DraftTagRemover
   def remove
     return if tag.published? || tag.parent? || tag.tagged_documents.any?
 
-    remove_tag_from_panopticon
-    add_gone_item
-    tag.destroy!
+    Tag.transaction do
+      remove_tag_from_panopticon
+      add_gone_item
+      tag.destroy!
+    end
   end
 
 private

--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -1,0 +1,28 @@
+class DraftTagRemover
+  attr_reader :tag
+
+  def initialize(tag)
+    @tag = tag
+  end
+
+  def remove
+    return if tag.published? || tag.parent? || tag.tagged_documents.any?
+
+    add_gone_item
+    tag.destroy!
+  end
+
+private
+
+  def add_gone_item
+    presenter = TagPresenter.presenter_for(tag)
+
+    Services.publishing_api.put_draft_content_item(tag.base_path,
+      format: 'gone',
+      publishing_app: 'collections-publisher',
+      update_type: 'major',
+      content_id: tag.content_id,
+      routes: presenter.routes
+    )
+  end
+end

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -30,7 +30,7 @@ private
   end
 
   def update_tag
-    tag.update!(archived: true)
+    tag.move_to_archive!
   end
 
   def setup_redirects

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -33,6 +33,21 @@ private
       from_base_path: tag.base_path,
       to_base_path: successor.base_path,
     )
+
+    tag.subroutes.each do |route_suffix|
+      # Only setup a redirect to the subroute when the successor also has that
+      # route (when redirectinga subtopic to a subtopic), not when redirecting
+      # to a parent topic (from /topic/foo/bar to /topic/foo).
+      to_base_path = route_suffix.in?(successor.subroutes) ?
+        "#{successor.base_path}#{route_suffix}" :
+        successor.base_path
+
+      tag.redirects.create!(
+        original_tag_base_path: tag.base_path,
+        from_base_path: [tag.base_path, route_suffix].join,
+        to_base_path: to_base_path,
+      )
+    end
   end
 
   def remove_from_search_index

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -12,9 +12,11 @@ class TagArchiver
   def archive
     return if tag.can_have_children? || tag.tagged_documents.any?
 
-    update_tag
-    setup_redirects
-    remove_from_search_index
+    Tag.transaction do
+      update_tag
+      setup_redirects
+      remove_from_search_index
+    end
   end
 
 private

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -13,6 +13,7 @@ class TagArchiver
     return if tag.can_have_children? || tag.tagged_documents.any?
 
     Tag.transaction do
+      remove_tag_from_panopticon
       update_tag
       setup_redirects
       remove_from_search_index
@@ -21,6 +22,12 @@ class TagArchiver
   end
 
 private
+
+  def remove_tag_from_panopticon
+    presenter = TagPresenter.presenter_for(tag)
+    tag_hash = presenter.render_for_panopticon
+    Services.panopticon.delete_tag!(tag_hash[:tag_type], tag_hash[:tag_id])
+  end
 
   def update_tag
     tag.update!(archived: true)

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -16,6 +16,7 @@ class TagArchiver
       update_tag
       setup_redirects
       remove_from_search_index
+      republish_tag
     end
   end
 
@@ -57,5 +58,9 @@ private
       'edition',
       tag.base_path
     )
+  end
+
+  def republish_tag
+    PublishingAPINotifier.new(tag).send_single_tag_to_publishing_api
   end
 end

--- a/app/services/tag_republisher.rb
+++ b/app/services/tag_republisher.rb
@@ -59,7 +59,7 @@ private
   end
 
   def publishing_api
-    CollectionsPublisher.services(:publishing_api)
+    Services.publishing_api
   end
 
   def log(string)

--- a/app/views/shared/tags/_lists_of_links_preview.html.erb
+++ b/app/views/shared/tags/_lists_of_links_preview.html.erb
@@ -1,4 +1,6 @@
-<% if tag.display_curated_links? %>
+<% if tag.tagged_documents.empty? %>
+  <p>There are no documents tagged to this item.</p>
+<% elsif tag.display_curated_links? %>
   <%= render 'shared/tags/curated_links_preview', tag: tag %>
 <% else %>
   <%= render 'shared/tags/uncurated_links_preview', tag: tag %>

--- a/app/views/topics/_redirects.html.erb
+++ b/app/views/topics/_redirects.html.erb
@@ -4,11 +4,13 @@
   <tr>
     <th>From</th>
     <th>To</th>
+    <th>Added</th>
   </tr>
-  <% redirects.each do |redirect| %>
+  <% redirects.order('created_at DESC').each do |redirect| %>
     <tr>
-      <td><%= link_to website_url(redirect.from_base_path) %></td>
-      <td><%= link_to website_url(redirect.to_base_path) %></td>
+      <td><%= redirect.created_at.to_formatted_s(:long) %></td>
+      <td><%= link_to redirect.from_base_path, website_url(redirect.from_base_path), target: '_blank' %></td>
+      <td><%= link_to redirect.to_base_path, website_url(redirect.to_base_path), target: '_blank' %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/topics/archived_topic.html.erb
+++ b/app/views/topics/archived_topic.html.erb
@@ -1,0 +1,7 @@
+<%= tag_header @topic %>
+
+<p class="no-content">
+  This topic has been archived.
+</p>
+
+<%= render 'redirects', redirects: @topic.redirects %>

--- a/app/views/topics/propose_archive.html.erb
+++ b/app/views/topics/propose_archive.html.erb
@@ -1,0 +1,10 @@
+<h1>Archive a topic</h1>
+
+<%= form_for @archival, url: archive_topic_path(@archival.tag) do |f| %>
+  <%= f.select :successor,
+    options_from_collection_for_select(@archival.topics, :id, :title_including_parent),
+    { label: 'Choose a topic to redirect to:' },
+    { class: "select2" } %>
+
+  <%= f.submit 'Archive', class: 'btn-submit btn-danger' %>
+<% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -6,6 +6,16 @@
     <% if @topic.may_publish? %>
       <%= link_to 'Publish topic', publish_topic_path(@topic), method: :post %>
     <% end %>
+
+    <% if @topic.child? && @topic.tagged_documents.empty? %>
+      <% if @topic.published? %>
+        <%= link_to 'Archive topic', propose_archive_topic_path(@topic) %>
+      <% else %>
+        <%= link_to 'Remove topic', archive_topic_path(@topic),
+          method: 'post',
+          data: { confirm: 'Are you sure?' } %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -29,18 +29,9 @@ module Services
   end
 end
 
-class GdsApi::HTTPConflict < GdsApi::HTTPClientError
-end
-
 class GdsApi::Panopticon < GdsApi::Base
   def delete_tag!(tag_type, tag_id)
     delete_json!(tag_url(tag_type, tag_id))
-  rescue GdsApi::HTTPClientError => e
-    if e.code == 409
-      raise GdsApi::HTTPConflict.new(e.code, e.message, e.error_details)
-    else
-      raise e
-    end
   end
 end
 

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -18,7 +18,12 @@ module CollectionsPublisher
 end
 
 require 'gds_api/publishing_api'
-CollectionsPublisher.services(:publishing_api, GdsApi::PublishingApi.new(Plek.new.find('publishing-api')))
+
+module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
+  end
+end
 
 require 'gds_api/panopticon'
 CollectionsPublisher.services(

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -23,6 +23,25 @@ module Services
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApi.new(Plek.new.find('publishing-api'))
   end
+
+  def self.panopticon
+    @panopticon ||= CollectionsPublisher.services(:panopticon)
+  end
+end
+
+class GdsApi::HTTPConflict < GdsApi::HTTPClientError
+end
+
+class GdsApi::Panopticon < GdsApi::Base
+  def delete_tag!(tag_type, tag_id)
+    delete_json!(tag_url(tag_type, tag_id))
+  rescue GdsApi::HTTPClientError => e
+    if e.code == 409
+      raise GdsApi::HTTPConflict.new(e.code, e.message, e.error_details)
+    else
+      raise e
+    end
+  end
 end
 
 require 'gds_api/panopticon'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   resources :topics, except: :destroy do
     member do
       post :publish
+      get :propose_archive
+      post :archive
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,6 +33,13 @@ FactoryGirl.define do
       end
     end
 
+    trait :archived do
+      after :create do |tag|
+        tag.publish!
+        tag.move_to_archive!
+      end
+    end
+
     factory :topic, class: Topic
     factory :mainstream_browse_page, class: MainstreamBrowsePage
   end

--- a/spec/features/mainstream_browse_pages_spec.rb
+++ b/spec/features/mainstream_browse_pages_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe "managing mainstream browse pages" do
   end
 
   it "disallows modification of archived browse pages" do
-    topic = create(:mainstream_browse_page, :published, archived: true)
+    topic = create(:mainstream_browse_page, :archived)
 
     visit edit_mainstream_browse_page_path(topic)
 

--- a/spec/features/mainstream_browse_pages_spec.rb
+++ b/spec/features/mainstream_browse_pages_spec.rb
@@ -308,4 +308,12 @@ RSpec.describe "managing mainstream browse pages" do
       ])
     end
   end
+
+  it "disallows modification of archived browse pages" do
+    topic = create(:mainstream_browse_page, :published, archived: true)
+
+    visit edit_mainstream_browse_page_path(topic)
+
+    expect(page).to have_content 'You cannot modify an archived mainstream browse page.'
+  end
 end

--- a/spec/features/viewing_topics_spec.rb
+++ b/spec/features/viewing_topics_spec.rb
@@ -64,4 +64,13 @@ RSpec.describe "Viewing topics" do
     # And I should see the link
     expect(page).to have_content 'A link that only exists in Rummager.'
   end
+
+  it "disallows modification of archived topics" do
+    stub_user.permissions << "GDS Editor"
+    topic = create(:topic, :published, archived: true)
+
+    visit edit_topic_path(topic)
+
+    expect(page).to have_content 'You cannot modify an archived topic.'
+  end
 end

--- a/spec/features/viewing_topics_spec.rb
+++ b/spec/features/viewing_topics_spec.rb
@@ -76,10 +76,13 @@ RSpec.describe "Viewing topics" do
 
   it "allows users to archive published topics" do
     stub_any_call_to_rummager_with_documents([])
-    stub_request(:delete, %r[https://rummager.test.gov.uk/*]).to_return(body: "{}")
     stub_user.permissions << "GDS Editor"
 
-    topic = create(:topic, :published, parent: create(:topic))
+    rummager_deletion = stub_request(:delete, %r[https://rummager.test.gov.uk/*]).to_return(body: "{}")
+    panopticon_deletion = stub_request(:delete, "https://panopticon.test.gov.uk/tags/specialist_sector/foo/bar.json").to_return(body: "{}")
+
+    topic = create(:topic, :published, slug: 'bar', parent: create(:topic, slug: 'foo'))
+
     create(:topic, :published, title: 'The Successor Topic')
 
     visit topic_path(topic)
@@ -93,19 +96,43 @@ RSpec.describe "Viewing topics" do
     click_button 'Archive'
 
     expect(topic.reload.archived).to eql(true)
+    expect(rummager_deletion).to have_been_requested
+    expect(panopticon_deletion).to have_been_requested
+  end
+
+  it "doesn't archive a tag when panopticon doesn't want to delete it" do
+    stub_any_call_to_rummager_with_documents([])
+    stub_user.permissions << "GDS Editor"
+
+    panopticon_deletion = stub_request(:delete, "https://panopticon.test.gov.uk/tags/specialist_sector/foo/bar.json")
+      .to_return(status: 409, body: "{}")
+
+    topic = create(:topic, :published, slug: 'bar', parent: create(:topic, slug: 'foo'))
+
+    create(:topic, :published, title: 'The Successor Topic')
+
+    visit topic_path(topic)
+
+    click_link 'Archive topic'
+    select 'The Successor Topic', from: "archival_form_successor"
+    click_button 'Archive'
+
+    expect(page).to have_content 'The tag could not be deleted because there are documents tagged to it'
   end
 
   it "allows users to remove draft topics" do
     stub_any_call_to_rummager_with_documents([])
-    stub_request(:delete, %r[https://rummager.test.gov.uk/*]).to_return(body: "{}")
     stub_user.permissions << "GDS Editor"
+    panopticon_deletion = stub_request(:delete, "https://panopticon.test.gov.uk/tags/specialist_sector/foo/bar.json").to_return(body: "{}")
 
-    topic = create(:topic, :draft, parent: create(:topic))
+    topic = create(:topic, :draft, slug: 'bar', parent: create(:topic, slug: 'foo'))
 
     visit topic_path(topic)
 
     click_link 'Remove topic'
 
     expect { topic.reload }.to raise_error(ActiveRecord::RecordNotFound)
+
+    expect(panopticon_deletion).to have_been_requested
   end
 end

--- a/spec/features/viewing_topics_spec.rb
+++ b/spec/features/viewing_topics_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Viewing topics" do
 
   it "disallows modification of archived topics" do
     stub_user.permissions << "GDS Editor"
-    topic = create(:topic, :published, archived: true)
+    topic = create(:topic, :archived)
 
     visit edit_topic_path(topic)
 
@@ -95,7 +95,7 @@ RSpec.describe "Viewing topics" do
 
     click_button 'Archive'
 
-    expect(topic.reload.archived).to eql(true)
+    expect(topic.reload.archived?).to eql(true)
     expect(rummager_deletion).to have_been_requested
     expect(panopticon_deletion).to have_been_requested
   end

--- a/spec/forms/archival_form_spec.rb
+++ b/spec/forms/archival_form_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ArchivalForm do
+  describe '#topics' do
+    it 'returns published topics that can be successors' do
+      draft = create(:topic, :draft)
+      archived = create(:topic, :published, archived: true)
+      published = create(:topic, :published)
+      topic_self = create(:topic, :published)
+
+      topics = ArchivalForm.new(tag: topic_self).topics
+
+      expect(topics).to eql([published])
+    end
+  end
+end

--- a/spec/forms/archival_form_spec.rb
+++ b/spec/forms/archival_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ArchivalForm do
   describe '#topics' do
     it 'returns published topics that can be successors' do
       draft = create(:topic, :draft)
-      archived = create(:topic, :published, archived: true)
+      archived = create(:topic, :archived)
       published = create(:topic, :published)
       topic_self = create(:topic, :published)
 

--- a/spec/services/draft_tag_remover_spec.rb
+++ b/spec/services/draft_tag_remover_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe DraftTagRemover do
   before do
     stub_content_store!
     stub_any_call_to_rummager_with_documents([])
+    allow(Services.panopticon).to receive(:delete_tag!)
   end
 
   describe "#remove" do
@@ -52,6 +53,14 @@ RSpec.describe DraftTagRemover do
 
       expect(stubbed_content_store).to have_draft_content_item_slug('/topic/foo/bar')
       expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('gone')
+    end
+
+    it "removes the tag from panoption" do
+      topic = create(:topic, :draft, parent: create(:topic))
+
+      DraftTagRemover.new(topic).remove
+
+      expect(Services.panopticon).to have_received(:delete_tag!)
     end
   end
 end

--- a/spec/services/draft_tag_remover_spec.rb
+++ b/spec/services/draft_tag_remover_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe DraftTagRemover do
+  include ContentStoreHelpers
+
+  before do
+    stub_content_store!
+    stub_any_call_to_rummager_with_documents([])
+  end
+
+  describe "#remove" do
+    it "guards against removing published tags" do
+      topic = create(:topic, :published, parent: create(:topic))
+
+      DraftTagRemover.new(topic).remove
+
+      expect(topic.reload).to eql(topic)
+    end
+
+    it "guards against removing parent tags" do
+      topic = create(:topic, :draft)
+
+      DraftTagRemover.new(topic).remove
+
+      expect(topic.reload).to eql(topic)
+    end
+
+    it "won't remove tags with documents tagged to it" do
+      topic = create(:topic, :draft, parent: create(:topic))
+      stub_any_call_to_rummager_with_documents([
+        { link: '/content-page-1' },
+        { link: '/content-page-2' },
+      ])
+
+      DraftTagRemover.new(topic).remove
+
+      expect(topic.reload).to eql(topic)
+    end
+
+    it "removes the tag from the database" do
+      topic = create(:topic, :draft, parent: create(:topic))
+
+      DraftTagRemover.new(topic).remove
+
+      expect { topic.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "pushes a gone item to the content-store" do
+      topic = create(:topic, :draft, slug: 'bar', parent: create(:topic, slug: 'foo'))
+
+      DraftTagRemover.new(topic).remove
+
+      expect(stubbed_content_store).to have_draft_content_item_slug('/topic/foo/bar')
+      expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('gone')
+    end
+  end
+end

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -98,5 +98,16 @@ RSpec.describe TagArchiver do
 
       expect(CollectionsPublisher.services(:rummager)).to have_received(:delete_document)
     end
+
+    it "doesn't have side effects when a API call fails" do
+      tag = create(:topic, parent: create(:topic))
+      allow(CollectionsPublisher.services(:rummager)).to receive(:delete_document).and_raise(RuntimeError)
+
+      expect { TagArchiver.new(tag, build(:topic)).archive }.to raise_error(RuntimeError)
+      tag.reload
+
+      expect(tag.archived).to be(false)
+      expect(tag.redirects.size).to be(0)
+    end
   end
 end

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe TagArchiver do
       # Succesful archivings will remove the result from rummager.
       allow(CollectionsPublisher.services(:rummager)).to receive(:delete_document)
       allow(Services.publishing_api).to receive(:put_content_item)
+      allow(Services.panopticon).to receive(:delete_tag!)
     end
 
     it "won't archive parent tags" do
@@ -117,6 +118,14 @@ RSpec.describe TagArchiver do
 
       expect(tag.archived).to be(false)
       expect(tag.redirects.size).to be(0)
+    end
+
+    it "removes the tag from panoption" do
+      tag = create(:topic, :published, parent: create(:topic))
+
+      TagArchiver.new(tag, build(:topic)).archive
+
+      expect(Services.panopticon).to have_received(:delete_tag!)
     end
   end
 end

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe TagArchiver do
+  describe '#archive' do
+    before do
+      # By default make it so that there's nothing tagged to topics.
+      stub_any_call_to_rummager_with_documents([])
+
+      # Succesful archivings will remove the result from rummager.
+      allow(CollectionsPublisher.services(:rummager)).to receive(:delete_document)
+    end
+
+    it "won't archive parent tags" do
+      tag = create(:topic)
+
+      TagArchiver.new(tag, build(:topic)).archive
+      tag.reload
+
+      expect(tag.archived).to be(false)
+    end
+
+    it "won't archive tags with documents tagged to it" do
+      tag = create(:topic, parent: create(:topic))
+      stub_any_call_to_rummager_with_documents([
+        { link: '/content-page-1' },
+        { link: '/content-page-2' },
+      ])
+
+      TagArchiver.new(tag, build(:topic)).archive
+      tag.reload
+
+      expect(tag.archived).to be(false)
+    end
+
+    it "archives the tag" do
+      tag = create(:topic, parent: create(:topic))
+
+      TagArchiver.new(tag, build(:topic)).archive
+      tag.reload
+
+      expect(tag.archived).to be(true)
+    end
+
+    it "creates a redirect to its successor" do
+      tag = create(:topic, parent: create(:topic))
+      successor = create(:topic)
+
+      TagArchiver.new(tag, successor).archive
+      redirect = tag.redirects.last
+
+      expect(redirect.from_base_path).to eql tag.base_path
+      expect(redirect.to_base_path).to eql successor.base_path
+    end
+
+    it "removes the document from the search result" do
+      tag = create(:topic, parent: create(:topic))
+
+      TagArchiver.new(tag, build(:topic)).archive
+
+      expect(CollectionsPublisher.services(:rummager)).to have_received(:delete_document)
+    end
+  end
+end

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TagArchiver do
       TagArchiver.new(tag, build(:topic)).archive
       tag.reload
 
-      expect(tag.archived).to be(false)
+      expect(tag.archived?).to be(false)
     end
 
     it "won't archive tags with documents tagged to it" do
@@ -31,7 +31,7 @@ RSpec.describe TagArchiver do
       TagArchiver.new(tag, build(:topic)).archive
       tag.reload
 
-      expect(tag.archived).to be(false)
+      expect(tag.archived?).to be(false)
     end
 
     it "archives the tag" do
@@ -40,7 +40,7 @@ RSpec.describe TagArchiver do
       TagArchiver.new(tag, build(:topic)).archive
       tag.reload
 
-      expect(tag.archived).to be(true)
+      expect(tag.archived?).to be(true)
     end
 
     it "creates a redirect to its successor" do
@@ -116,7 +116,7 @@ RSpec.describe TagArchiver do
       expect { TagArchiver.new(tag, build(:topic)).archive }.to raise_error(RuntimeError)
       tag.reload
 
-      expect(tag.archived).to be(false)
+      expect(tag.archived?).to be(false)
       expect(tag.redirects.size).to be(0)
     end
 

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -13,8 +13,7 @@ module ContentStoreHelpers
 
   def stub_content_store!
     @stubbed_content_store = FakeContentStore.new
-    allow(CollectionsPublisher).to receive(:services)
-      .with(:publishing_api)
+    allow(Services).to receive(:publishing_api)
       .and_return(@stubbed_content_store)
   end
 


### PR DESCRIPTION
We're regularly getting requests to delete (old) topics. This is time consuming work, because we have to do this manually and in data migrations. For example: https://trello.com/c/ybdnGMhl, https://trello.com/c/dTPgvWYL and https://trello.com/c/7UEYsTr8. It is also error prone, as evidenced by https://github.com/alphagov/collections-publisher/pull/130 and https://github.com/alphagov/collections-publisher/pull/131.

This PR adds a `TagArchiver` class that archives tags by:

1. Setting a `archived` boolean to indicate that the topic is no longer in use
2. Adding a redirect in the content-store
3. Removing the topic from rummager

For draft tags, there's a `DraftTagRemover` class that _removes_ tags by:

1. Removing it from the database
2. Adding a "gone" item in the content-store

## Screenshots

Draft subtopics have a "Remove" button:

![screen shot 2015-09-07 at 15 50 38](https://cloud.githubusercontent.com/assets/233676/9718987/49417082-5578-11e5-98f5-6bb059057ded.png)

And can be removed by the user, who has to confirm with a javascript-confirm dialog.

![screen shot 2015-09-07 at 15 51 27](https://cloud.githubusercontent.com/assets/233676/9718998/6d70d52e-5578-11e5-9848-7462f730a738.png)

After which it is removed from the database.

---

Published topics have a "Archive topic" button:
 
![screen shot 2015-09-07 at 15 56 30](https://cloud.githubusercontent.com/assets/233676/9719056/058b3c00-5579-11e5-89a3-463198092fea.png)

Which leads to the page where the user has to select a successor to redirect to:

![screen shot 2015-09-07 at 16 00 06](https://cloud.githubusercontent.com/assets/233676/9719126/961a8eec-5579-11e5-8a4f-2d6c190ee16b.png)

Submitting this will cause the page to redirect and the topic to be archived.

![screen shot 2015-09-07 at 16 01 05](https://cloud.githubusercontent.com/assets/233676/9719293/d619414a-557a-11e5-83f7-5e886f0002ae.png)

### Discussion

- [x] Should we add a panopticon endpoint that removes the tag, so it can't be used for tagging? Code already exists [in a Rake task] ((https://github.com/alphagov/panopticon/blob/master/lib/tasks/specialist_sector_cleanup.rake). _(answer: yes)_
- [x] How do we deal with existing redirects? For example, most topics have redirects from their own non-namespaced variant to the `/topic/` namespace. These are not being redirected currently. _(answer: that's OK)_
- [x] Can we automate the untagging of documents, so we don't need the check for `tag.tagged_documents.any?` _(answer: not right now)_
- [x] Do we treat draft topics differently? Do they still need redirects? _(answer: don't redirect)_
- [x] How do we prevent updates to these topics? Must we do more to prevent republishing?

### Todo

- [x] Add panopticon endpoint to remove empty tag
- [x] Do this in a transaction
- [x] Take care of draft topics
- [x] Prevent topic updates
- [x] Add redirects for suffix-routes
- [x] Add UI for removing the topic