### PR TITLE
Wrap publishing in a transaction

### DIFF
--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -49,11 +49,7 @@ class MainstreamBrowsePagesController < ApplicationController
 
   def publish
     browse_page = find_browse_page
-
-    browse_page.publish!
-    PanopticonNotifier.publish_tag(MainstreamBrowsePagePresenter.new(browse_page))
-    PublishingAPINotifier.send_to_publishing_api(browse_page)
-    RummagerNotifier.new(browse_page).notify
+    TagPublisher.new(browse_page).publish
     redirect_to browse_page
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -48,11 +48,7 @@ class TopicsController < ApplicationController
   # Change the topic from draft to published state
   def publish
     topic = find_topic
-
-    topic.publish!
-    PanopticonNotifier.publish_tag(TopicPresenter.new(topic))
-    PublishingAPINotifier.send_to_publishing_api(topic)
-    RummagerNotifier.new(topic).notify
+    TagPublisher.new(topic).publish
     redirect_to topic
   end
 

--- a/app/services/tag_publisher.rb
+++ b/app/services/tag_publisher.rb
@@ -6,9 +6,11 @@ class TagPublisher
   end
 
   def publish
-    tag.publish!
-    PanopticonNotifier.publish_tag(TagPresenter.presenter_for(tag))
-    PublishingAPINotifier.send_to_publishing_api(tag)
-    RummagerNotifier.new(tag).notify
+    Tag.transaction do
+      tag.publish!
+      PanopticonNotifier.publish_tag(TagPresenter.presenter_for(tag))
+      PublishingAPINotifier.send_to_publishing_api(tag)
+      RummagerNotifier.new(tag).notify
+    end
   end
 end

--- a/app/services/tag_publisher.rb
+++ b/app/services/tag_publisher.rb
@@ -1,0 +1,14 @@
+class TagPublisher
+  attr_reader :tag
+
+  def initialize(tag)
+    @tag = tag
+  end
+
+  def publish
+    tag.publish!
+    PanopticonNotifier.publish_tag(TagPresenter.presenter_for(tag))
+    PublishingAPINotifier.send_to_publishing_api(tag)
+    RummagerNotifier.new(tag).notify
+  end
+end

--- a/spec/services/tag_publisher_spec.rb
+++ b/spec/services/tag_publisher_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe TagPublisher do
+  describe '#publish' do
+    it "doesn't save to the database when an API call fails" do
+      tag = create(:topic, parent: create(:topic))
+      allow(PanopticonNotifier).to receive(:publish_tag).and_raise(RuntimeError)
+
+      expect { TagPublisher.new(tag).publish }.to raise_error(RuntimeError)
+      tag.reload
+
+      expect(tag.published?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
During the publishing of a tag, we currently update the database and then try to send the document to the external services. When a downstream service like whitehall fails this will result in the item being `published?`, but the item will not have be sent to external services.

Calling `publish` on a published item will then result in `AASM:​:Inva​lidTr​ansit​ion: ​Event​ 'pub​lish'​ cann​ot tr​ansit​ion f​rom '​publi​shed'` exceptions. This has happened in production a couple of times, and happens often in development because a dependent app isn't running.

![screen shot 2015-09-07 at 15 29 18](https://cloud.githubusercontent.com/assets/233676/9718602/3c04c8ae-5575-11e5-97f6-de041599ffec.png)

