### PR TITLE
Send `content_id` to panopticon

### DIFF
--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -47,11 +47,11 @@ class TagPresenter
 
   def render_for_panopticon
     {
-      tag_id: tag_id,
-      title: tag.title,
       description: tag.description,
-      tag_type: legacy_tag_type,
       parent_id: parent.slug,
+      tag_id: tag_id,
+      tag_type: legacy_tag_type,
+      title: tag.title,
     }
   end
 

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -47,6 +47,7 @@ class TagPresenter
 
   def render_for_panopticon
     {
+      content_id: tag.content_id,
       description: tag.description,
       parent_id: parent.slug,
       tag_id: tag_id,

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -1,0 +1,8 @@
+namespace :panopticon do
+  desc "Register application metadata with panopticon"
+  task :register => [:environment] do
+    Tag.published.find_each do |tag|
+      PanopticonNotifier.update_tag(TagPresenter.presenter_for(tag))
+    end
+  end
+end

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -1,6 +1,6 @@
 namespace :panopticon do
-  desc "Register application metadata with panopticon"
-  task :register => [:environment] do
+  desc "Republish all tags to panopticon"
+  task :republish_tags => [:environment] do
     Tag.published.find_each do |tag|
       PanopticonNotifier.update_tag(TagPresenter.presenter_for(tag))
     end

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -3,12 +3,11 @@ require 'rails_helper'
 RSpec.describe MainstreamBrowsePagePresenter do
 
   describe "rendering for panopticon" do
-    let(:mainstream_browse_page) { double(:mainstream_browse_page,
+    let(:mainstream_browse_page) { build(:mainstream_browse_page,
       slug: 'citizenship',
       title: 'Citizenship',
       description: 'Living in the UK, passports',
       parent: nil,
-      legacy_tag_type: 'section',
     ) }
 
     let(:presenter) { MainstreamBrowsePagePresenter.new(mainstream_browse_page) }

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -19,23 +19,20 @@ RSpec.describe TagPresenter do
   end
 
   describe '#render_for_panopticon' do
-    let(:attributes) {{
-      slug: 'citizenship',
-      title: 'Citizenship',
-      description: 'Living in the UK, passports',
-      parent: nil,
-      legacy_tag_type: nil,
-    }}
-
     it 'returns a hash of tag attributes' do
-      tag = double(:tag, attributes)
+      tag = build(:topic,
+        slug: 'citizenship',
+        title: 'Citizenship',
+        description: 'Living in the UK, passports',
+      )
+
       presenter = TagPresenter.new(tag)
 
       expect(presenter.render_for_panopticon).to eq(
         {
           tag_id: 'citizenship',
           title: 'Citizenship',
-          tag_type: nil,
+          tag_type: 'specialist_sector',
           description: 'Living in the UK, passports',
           parent_id: nil,
         }
@@ -43,9 +40,11 @@ RSpec.describe TagPresenter do
     end
 
     it 'builds a tag_id containing the parent' do
-      child_tag = double(:tag, attributes.merge(
-        parent: double(:tag, slug: 'parent')
-      ))
+      child_tag = build(:topic,
+        slug: 'citizenship',
+        parent: build(:topic, slug: 'parent')
+      )
+
       presenter = TagPresenter.new(child_tag)
 
       expect(presenter.render_for_panopticon[:tag_id]).to eq('parent/citizenship')

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe TagPresenter do
   describe '#render_for_panopticon' do
     it 'returns a hash of tag attributes' do
       tag = build(:topic,
+        content_id: 'A-UID',
         slug: 'citizenship',
         title: 'Citizenship',
         description: 'Living in the UK, passports',
@@ -30,6 +31,7 @@ RSpec.describe TagPresenter do
 
       expect(presenter.render_for_panopticon).to eq(
         {
+          content_id: 'A-UID',
           tag_id: 'citizenship',
           title: 'Citizenship',
           tag_type: 'specialist_sector',

--- a/spec/support/panopticon_helpers.rb
+++ b/spec/support/panopticon_helpers.rb
@@ -3,6 +3,23 @@ require 'gds_api/test_helpers/panopticon'
 module PanopticonHelpers
   include GdsApi::TestHelpers::Panopticon
 
+  # Override stub_panopticon_tag_creation & stub_panopticon_tag_update to take
+  # a hash for `body` instead of a JSON-string. This allows us to use the
+  # `kind_of()` matcher in our tests.
+  def stub_panopticon_tag_creation(attributes)
+    url = "#{PANOPTICON_ENDPOINT}/tags.json"
+    stub_request(:post, url)
+            .with(body: attributes)
+            .to_return(status: 201, body: attributes.to_json)
+  end
+
+  def stub_panopticon_tag_update(tag_type, tag_id, attributes)
+    url = "#{PANOPTICON_ENDPOINT}/tags/#{tag_type}/#{tag_id}.json"
+    stub_request(:put, url)
+            .with(body: attributes)
+            .to_return(status: 200)
+  end
+
   def stub_all_panopticon_tag_calls
     base_url = "#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/tags"
     stub_request(:post, "#{base_url}.json")
@@ -14,6 +31,7 @@ module PanopticonHelpers
   end
 
   def assert_tag_created_in_panopticon(payload)
+    payload[:content_id] ||= kind_of(String)
     payload[:parent_id] ||= nil
     payload = Hash[payload.sort]
     request = stub_panopticon_tag_creation(payload)
@@ -21,6 +39,7 @@ module PanopticonHelpers
   end
 
   def assert_tag_updated_in_panopticon(payload)
+    payload[:content_id] ||= kind_of(String)
     payload[:parent_id] = nil
     payload = Hash[payload.sort]
     request = stub_panopticon_tag_update(payload[:tag_type], payload[:tag_id], payload)

--- a/spec/support/panopticon_helpers.rb
+++ b/spec/support/panopticon_helpers.rb
@@ -13,25 +13,17 @@ module PanopticonHelpers
       .to_return(:status => 200)
   end
 
-  def assert_tag_created_in_panopticon(tag_id:, tag_type:, title:, description:, parent_id: nil)
-    request = stub_panopticon_tag_creation(
-      :tag_id => tag_id,
-      :title => title,
-      :description => description,
-      :tag_type => tag_type,
-      :parent_id => parent_id,
-    )
+  def assert_tag_created_in_panopticon(payload)
+    payload[:parent_id] ||= nil
+    payload = Hash[payload.sort]
+    request = stub_panopticon_tag_creation(payload)
     expect(request).to have_been_requested
   end
 
-  def assert_tag_updated_in_panopticon(tag_id:, tag_type:, title:, description:)
-    request = stub_panopticon_tag_update(tag_type, tag_id,
-      :tag_id => tag_id,
-      :title => title,
-      :description => description,
-      :tag_type => tag_type,
-      :parent_id => nil,
-    )
+  def assert_tag_updated_in_panopticon(payload)
+    payload[:parent_id] = nil
+    payload = Hash[payload.sort]
+    request = stub_panopticon_tag_update(payload[:tag_type], payload[:tag_id], payload)
     expect(request).to have_been_requested
   end
 


### PR DESCRIPTION
We need the `content_id` in panopticon for the new tagging infrastructure.

To make this change nice I've refactored the tests a little bit. More info in individual commits.

Trello: https://trello.com/c/IgYwT6yM