### PR TITLE
Republish all tags to panopticon

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -1,7 +1,7 @@
 namespace :panopticon do
   desc "Republish all tags to panopticon"
   task :republish_tags => [:environment] do
-    Tag.published.find_each do |tag|
+    Tag.where(state: %w[published draft]).find_each do |tag|
       PanopticonNotifier.update_tag(TagPresenter.presenter_for(tag))
     end
   end


### PR DESCRIPTION
The current rake task only republishes published tags. Tags that are `draft` (but not `archived`) have entries in panopticon too, so there's no reason for this behaviour. It was added here: https://github.com/alphagov/collections-publisher/commit/d7db8d31d0fc3f5c4a5c5b7b1df6e0697966c76e

Trello: https://trello.com/c/IgYwT6yM