### PR TITLE
Eager load Services to fix circular dependency error

### DIFF
--- a/config/initializers/eager_load.rb
+++ b/config/initializers/eager_load.rb
@@ -1,0 +1,2 @@
+# Eager load Services to prevent intermittent circular dependency errors.
+require 'services'


### PR DESCRIPTION
We've gotten a few errors on production where Rails can't find the `Services` module and crashes with a circular dependency error.

The "Circular dependency detected while autoloading constant Services" is raised when Rails thinks it will encounter an infinite loop. In this case, when first seeing the constant `Services`, it loads a file named
`services.rb` to load the `Services` module.

However, if Rails has already loaded a file named `services.rb` and the constant is still missing, it assumes that there is a circular dependency.

My guess in this case is that Rails is incorrect in thinking it has already loaded _our_ `services.rb`, but is trying to load some other file. By explicitly loading our `services.rb` on boot time, we skip the
autoloading step and avoid the error.

It's still worth investigating why this error occurs, this mitigation is a temporary step.

Trello: https://trello.com/c/aBe4IMSt