### PR TITLE
Fix loading of `Services` module in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,7 @@ module CollectionsPublisher
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/lib)
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
By default, code in `/lib` isn't loaded by Sidekiq in production, because Sidekiq has disabled autoloading for reasons of thread-safety. This means we have to explicitly tell Rails to eager load things in the `/lib` directory when booting up.

https://github.com/mperham/sidekiq/wiki/FAQ#why-doesnt-sidekiq-autoload-my-rails-application-code

This fix was also made in https://github.com/alphagov/whitehall/pull/2303. It was reverted in https://github.com/alphagov/whitehall/pull/2318 because there were files in `/lib` that couldn't be eager loaded because it depended on ActiveRecord::Migration code, which Rails won't load when booting up normally. 

We don't have that problem so eager loading everything in `/lib` is safe here.

This PR supersedes https://github.com/alphagov/collections-publisher/pull/148, which had almost the same solution but not the correct diagnosis.

Trello: https://trello.com/c/aBe4IMSt
