### PR TITLE
Remove unused route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,6 @@ Rails.application.routes.draw do
   resources :tags, only: [] do
     post :publish_lists
 
-    # FIXME: Legacy route, may have been shown to user before deploying.
-    post '/republish', action: :publish_lists
-
     resources :lists, only: [:index, :edit, :create, :update, :destroy] do
       resources :list_items, only: [:create, :update, :destroy]
     end


### PR DESCRIPTION
This route was put in to prevent forms from breaking after renaming a route. We can now safely remove this.

Found during spelonking for https://trello.com/c/aBe4IMSt
