### PR TITLE
Fix bug that doesn't allow to archive topics when they're not in panopticon

### DIFF
--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -26,7 +26,11 @@ private
   def remove_tag_from_panopticon
     presenter = TagPresenter.presenter_for(tag)
     tag_hash = presenter.render_for_panopticon
-    Services.panopticon.delete_tag!(tag_hash[:tag_type], tag_hash[:tag_id])
+    begin
+      Services.panopticon.delete_tag!(tag_hash[:tag_type], tag_hash[:tag_id])
+    rescue GdsApi::HTTPNotFound
+      Rails.logger.info("Tag with id #{tag_hash[:tag_id]}, not found in Panopticon")
+    end
   end
 
   def update_tag

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -127,5 +127,18 @@ RSpec.describe TagArchiver do
 
       expect(Services.panopticon).to have_received(:delete_tag!)
     end
+
+    it "is okay with tags that don't exist anymore in Panopticon" do
+      tag = create(:topic, :published, parent: create(:topic))
+      allow(Services.panopticon).to receive(:delete_tag!).and_raise(
+        GdsApi::HTTPNotFound.new(404)
+      )
+
+      TagArchiver.new(tag, build(:topic)).archive
+      tag.reload
+
+      expect(tag.archived?).to be(true)
+    end
+
   end
 end


### PR DESCRIPTION
Topics might not be present in Panopticon but we still might want to archive them.

Rescuing `GdsApi::HTTPNotFound` will allow us to continue the archiving process.