### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'logstasher', '0.6.2'
 # sidekiq-web depends on sinatra
 gem 'sinatra', require: nil
 gem 'sidekiq', '~> 2.17.2'
+gem 'sidekiq-statsd', '0.1.5'
 
 gem 'byebug', group: [:development, :test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,10 @@ GEM
       json
       redis (~> 3.1)
       redis-namespace (~> 1.3)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -255,6 +259,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    statsd-ruby (1.2.1)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -313,6 +318,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.3)
   select2-rails (~> 3.5.9)
   sidekiq (~> 2.17.2)
+  sidekiq-statsd (= 0.1.5)
   sinatra
   timecop (~> 0.8.0)
   uglifier (>= 1.3.0)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,6 +4,10 @@ redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.collections-publisher', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq