### PR TITLE
Add content_id to redirects

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -3,4 +3,12 @@ class Redirect < ActiveRecord::Base
 
   belongs_to :tag
   has_many :redirect_routes
+
+  before_save :ensure_content_id_is_present
+
+private
+
+  def ensure_content_id_is_present
+    self.content_id ||= SecureRandom.uuid
+  end
 end

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -7,10 +7,14 @@ class RedirectPresenter
 
   def render_for_publishing_api
     {
+      content_id: redirect.content_id,
       format: 'redirect',
       publishing_app: 'collections-publisher',
       update_type: 'major',
       redirects: redirect_routes,
+      links: {
+        replaced_content_item: [redirect.tag.content_id]
+      }
     }
   end
 

--- a/db/migrate/20151110150858_add_content_id_to_redirect.rb
+++ b/db/migrate/20151110150858_add_content_id_to_redirect.rb
@@ -1,0 +1,16 @@
+class AddContentIdToRedirect < ActiveRecord::Migration
+  def up
+    add_column :newest_redirects, :content_id, :string
+
+    Redirect.find_each do |redirect|
+      redirect.update_column :content_id, SecureRandom.uuid
+    end
+
+    change_column_null :newest_redirects, :content_id, false
+    add_index :newest_redirects, :content_id, unique: true
+  end
+
+  def down
+    remove_column :newest_redirects, :content_id
+  end
+end

--- a/db/migrate/20151110152255_make_tag_id_not_null.rb
+++ b/db/migrate/20151110152255_make_tag_id_not_null.rb
@@ -1,0 +1,5 @@
+class MakeTagIdNotNull < ActiveRecord::Migration
+  def change
+    change_column_null :newest_redirects, :tag_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151105220915) do
+ActiveRecord::Schema.define(version: 20151110152255) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255
@@ -33,12 +33,14 @@ ActiveRecord::Schema.define(version: 20151105220915) do
   add_index "lists", ["tag_id"], name: "index_lists_on_tag_id", using: :btree
 
   create_table "newest_redirects", force: :cascade do |t|
-    t.integer  "tag_id",                 limit: 4
+    t.integer  "tag_id",                 limit: 4,   null: false
     t.string   "original_tag_base_path", limit: 255
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
+    t.string   "content_id",             limit: 255, null: false
   end
 
+  add_index "newest_redirects", ["content_id"], name: "index_newest_redirects_on_content_id", unique: true, using: :btree
   add_index "newest_redirects", ["original_tag_base_path"], name: "index_newest_redirects_on_original_tag_base_path", unique: true, using: :btree
   add_index "newest_redirects", ["tag_id"], name: "index_newest_redirects_on_tag_id", using: :btree
 


### PR DESCRIPTION
Redirects need their own `content_id` so that they can live in the publishing-api.

We also add `replaced_content_item` to the item. This was added in alphagov/govuk-content-schemas#142. It allows publishing-api to add special behaviour for putting back redirects.

This change was made easy by https://github.com/alphagov/collections-publisher/pull/157.

Trello: https://trello.com/c/0pcDOcMd

/cc @elliotcm 