### PR TITLE
Rename `replaced_content_item` to `can_be_replaced_by`

### DIFF
--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -13,7 +13,7 @@ class RedirectPresenter
       update_type: 'major',
       redirects: redirect_routes,
       links: {
-        replaced_content_item: [redirect.tag.content_id]
+        can_be_replaced_by: [redirect.tag.content_id]
       }
     }
   end

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -8,6 +8,7 @@ class RedirectPresenter
   def render_for_publishing_api
     {
       content_id: redirect.content_id,
+      base_path: base_path,
       format: 'redirect',
       publishing_app: 'collections-publisher',
       update_type: 'major',


### PR DESCRIPTION
This fits better with the actual purpose of the
field and also is more flexible for different types
of substitute items.

Also adds base paths as that has now become a requirement.