### PR TITLE
Send a internal_name to the content-store

### DIFF
--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -11,6 +11,9 @@ class RootBrowsePagePresenter
       routes: routes,
       update_type: "major",
       links: links,
+      details: {
+        internal_name: "Browse index page",
+      },
     }
   end
 

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -12,7 +12,8 @@ class RootTopicPresenter
       update_type: "major",
       links: links,
       details: {
-        beta: true
+        beta: true,
+        internal_name: "Topic index page",
       }
     }
   end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -86,6 +86,7 @@ private
   def details
     {
       :groups => categorized_groups,
+      :internal_name => tag.title_including_parent,
     }
   end
 

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe "Curating the contents of topics" do
               ]},
             ],
             "beta" => false,
+            "internal_name" => "Oil and Gas / Offshore"
           }
         },
       )
@@ -175,6 +176,7 @@ RSpec.describe "Curating the contents of topics" do
               ]},
             ],
             "beta" => false,
+            "internal_name" => "Oil and Gas / Offshore"
           }
         },
       )

--- a/spec/features/topic_workflow_spec.rb
+++ b/spec/features/topic_workflow_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe "creating and editing topics" do
       "details" => {
         "groups" => [],
         "beta" => true,
+        "internal_name" => "Working on the ocean",
       }
     })
 
@@ -259,6 +260,7 @@ RSpec.describe "creating and editing topics" do
       "details" => {
         "groups" => [],
         "beta" => false,
+        "internal_name" => "Working on the ocean",
       }
     })
   end


### PR DESCRIPTION
This field contains the parent topic/browse page, so that we can display a sorted list of tags in tagging interfaces.

The field is added in https://github.com/alphagov/govuk-content-schemas/pull/156.

This is needed to create the tagging interface: https://trello.com/c/XwVC0IM8