### PR TITLE
Solve content-items having invalid redirects

### DIFF
--- a/app/models/redirect_item.rb
+++ b/app/models/redirect_item.rb
@@ -1,0 +1,4 @@
+class RedirectItem < ActiveRecord::Base
+  # `related_tag` is a temporary association to allow a reversable migration.
+  belongs_to :related_tag, class_name: 'Tag'
+end

--- a/app/presenters/redirect_item_presenter.rb
+++ b/app/presenters/redirect_item_presenter.rb
@@ -1,0 +1,42 @@
+class RedirectItemPresenter
+  attr_reader :item
+
+  def initialize(item)
+    @item = item
+  end
+
+  def content_id
+    item.content_id
+  end
+
+  def base_path
+    item.from_base_path
+  end
+
+  def update_type
+    'republish'
+  end
+
+  def redirect_routes
+    [ item ]
+  end
+
+  def draft?
+    false
+  end
+
+  def archived?
+    true
+  end
+
+  def render_for_publishing_api
+    {
+      content_id: content_id,
+      base_path: base_path,
+      format: 'redirect',
+      publishing_app: 'collections-publisher',
+      update_type: update_type,
+      redirects: RedirectRoutePresenter.new(self).routes,
+    }
+  end
+end

--- a/app/services/redirect_publisher.rb
+++ b/app/services/redirect_publisher.rb
@@ -1,0 +1,8 @@
+class RedirectPublisher
+  def republish_redirects
+    RedirectItem.all.each do |item|
+      presenter = RedirectItemPresenter.new(item)
+      PublishingAPINotifier::PublishingApiContentWriter.write(presenter)
+    end
+  end
+end

--- a/db/migrate/20151204133010_create_redirect_items.rb
+++ b/db/migrate/20151204133010_create_redirect_items.rb
@@ -1,0 +1,14 @@
+class CreateRedirectItems < ActiveRecord::Migration
+  def change
+    create_table :redirect_items do |t|
+      t.string :content_id, null: false
+      t.string :from_base_path, null: false
+      t.string :to_base_path, null: false
+      t.references :related_tag
+      t.timestamps null: false
+    end
+
+    add_index :redirect_items, :content_id, unique: true
+    add_index :redirect_items, :from_base_path, unique: true
+  end
+end

--- a/db/migrate/20151204140913_add_redirect_items.rb
+++ b/db/migrate/20151204140913_add_redirect_items.rb
@@ -1,0 +1,30 @@
+class AddRedirectItems < ActiveRecord::Migration
+  def up
+    RedirectItem.delete_all
+
+    Tag.includes(:redirect_routes).each do |tag|
+      tag.redirect_routes.each do |route|
+        next if route.from_base_path.starts_with?(tag.base_path) || route.from_base_path == tag.base_path
+
+        RedirectItem.create!(
+          content_id: SecureRandom.uuid,
+          from_base_path: route.from_base_path,
+          to_base_path: route.to_base_path,
+          related_tag: tag,
+        )
+
+        route.destroy!
+      end
+    end
+  end
+
+  def down
+    RedirectItem.all.each do |redirect_item|
+      RedirectRoute.create!(
+        tag: redirect_item.related_tag,
+        from_base_path: redirect_item.from_base_path,
+        to_base_path: redirect_item.to_base_path,
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124153356) do
+ActiveRecord::Schema.define(version: 20151204140913) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255
@@ -43,6 +43,18 @@ ActiveRecord::Schema.define(version: 20151124153356) do
   add_index "newest_redirects", ["content_id"], name: "index_newest_redirects_on_content_id", unique: true, using: :btree
   add_index "newest_redirects", ["original_tag_base_path"], name: "index_newest_redirects_on_original_tag_base_path", unique: true, using: :btree
   add_index "newest_redirects", ["tag_id"], name: "index_newest_redirects_on_tag_id", using: :btree
+
+  create_table "redirect_items", force: :cascade do |t|
+    t.string   "content_id",     limit: 255, null: false
+    t.string   "from_base_path", limit: 255, null: false
+    t.string   "to_base_path",   limit: 255, null: false
+    t.integer  "related_tag_id", limit: 4
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "redirect_items", ["content_id"], name: "index_redirect_items_on_content_id", unique: true, using: :btree
+  add_index "redirect_items", ["from_base_path"], name: "index_redirect_items_on_from_base_path", unique: true, using: :btree
 
   create_table "redirect_routes", force: :cascade do |t|
     t.integer  "redirect_id",    limit: 4

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -2,6 +2,7 @@ namespace :publishing_api do
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
   task :send_all_tags => :environment do
     TagRepublisher.new.republish_tags(Tag.all)
+    RedirectPublisher.new.republish_redirects
   end
 
   desc "Send all published tags to the publishing-api, skipping any marked as dirty"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,10 @@
 FactoryGirl.define do
+  factory :redirect_item do
+    content_id SecureRandom.uuid
+    from_base_path "/from/foo"
+    to_base_path "/to/bar"
+  end
+
   factory :redirect_route do
     from_base_path "/some/route"
     to_base_path "/to/some/route"

--- a/spec/presenters/redirect_item_presenter_spec.rb
+++ b/spec/presenters/redirect_item_presenter_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe RedirectItemPresenter do
+  describe "#render_for_publishing_api" do
+    it "is valid against the schema" do
+      item = create(:redirect_item)
+
+      rendered = RedirectItemPresenter.new(item).render_for_publishing_api
+
+      expect(rendered).to be_valid_against_schema('redirect')
+    end
+  end
+end

--- a/spec/services/redirect_publisher_spec.rb
+++ b/spec/services/redirect_publisher_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe RedirectPublisher do
+  include ContentStoreHelpers
+
+  describe '#republish_redirects' do
+    it "sends all redirects to the publishing-api" do
+      stub_content_store!
+      create(:redirect_item, from_base_path: '/foo')
+
+      RedirectPublisher.new.republish_redirects
+
+      expect(stubbed_content_store).to have_content_item_slug('/foo')
+
+    end
+  end
+end


### PR DESCRIPTION
Collections-publisher currently sends invalid content-items to the publishing-api. This is because some tags have redirect-routes that don't "belong" to the tag. Eg, they have a path that doesn't start with the tag's `base_path`:

For example:

https://collections-publisher.preview.alphagov.co.uk/topics/4505d908-89f2-4322-956b-29ac243c608b

Has a redirect for `/benefits-credits`

This is illegal because `/benefits-credits` is not under the tag's base path, `/topic/benefits-credits`.

`/topic/benefits-credits/yolo` would still be legal.

This PR adds a table that we can populate with these redirects. When running the rake task, they will be sent independently, as full redirect content-items to the publishing-api.

Note:
- The functionality introduced in https://github.com/alphagov/collections-publisher/pull/163 is still valid, and works like it should. It will generate redirect routes for *itself*, so it will work with the publishing-api.
- `RedirectItem#related_tag` has no other purpose than making the data migration reversible. It will be removed in the future.
