### PR TITLE
Allow users to edit alpha taxonomy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.11.0'
 gem 'airbrake', '~> 4.3.1'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 25.1'
+gem 'gds-api-adapters', '~> 26.3'
 
 gem 'govuk_admin_template', '~> 3.0.0'
 gem 'generic_form_builder', '~> 0.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (25.1.0)
+    gds-api-adapters (26.3.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -317,7 +317,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   database_cleaner (~> 1.5.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (~> 25.1)
+  gds-api-adapters (~> 26.3)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.13.0)
   govuk-content-schema-test-helpers (~> 1.3)
@@ -339,6 +339,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,0 +1,38 @@
+class TaxonsController < ApplicationController
+  before_filter :require_gds_editor_permissions!
+
+  def index
+    @taxons = Taxonomy::TaxonFetcher.new.taxons
+  end
+
+  def new
+    @taxons_for_select = Taxonomy::TaxonFetcher.new.taxons_for_select
+    @new_taxon = CreateTaxon.new
+  end
+
+  def create
+    new_taxon = CreateTaxon.new(params[:create_taxon])
+    new_taxon.create!
+    redirect_to taxons_path
+  end
+
+  def edit
+    @taxons_for_select = Taxonomy::TaxonFetcher.new.taxons_for_select
+
+    content_item = Services.publishing_api.get_content(params[:id])
+    links = Services.publishing_api.get_links(params[:id]).links
+
+    @taxon = CreateTaxon.new(
+      content_id: content_item.content_id,
+      title: content_item.title,
+      base_path: content_item.base_path,
+      parent: links.parent.to_a.first,
+    )
+  end
+
+  def update
+    new_taxon = CreateTaxon.new(params[:create_taxon])
+    new_taxon.create!
+    redirect_to :back
+  end
+end

--- a/app/forms/create_taxon.rb
+++ b/app/forms/create_taxon.rb
@@ -1,0 +1,32 @@
+class CreateTaxon
+  attr_accessor :title, :parent, :content_id, :base_path
+  include ActiveModel::Model
+
+  def create!
+    self.content_id ||= SecureRandom.uuid
+    self.base_path ||= '/alpha-taxonomy/' + title.parameterize
+
+    Services.publishing_api.put_content(
+      content_id,
+      base_path: base_path,
+      format: 'taxon',
+      title: title,
+      content_id: content_id,
+      publishing_app: 'collections-publisher',
+      rendering_app: 'collections-publisher',
+      public_updated_at: Time.now,
+      routes: [
+        { path: base_path, type: "exact" },
+      ]
+    )
+
+    Services.publishing_api.put_links(
+      content_id,
+      links: { parent: parent_ids }
+    )
+  end
+
+  def parent_ids
+    parent.present? ? [parent] : []
+  end
+end

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -1,0 +1,15 @@
+module Taxonomy
+  # Return a links of taxons from the publishing API with links included.
+  class TaxonFetcher
+    def taxons
+      Services.publishing_api.get_content_items(
+        content_format: 'taxon',
+        fields: %i[title base_path content_id]
+      ).sort_by { |taxon| taxon["title"] }
+    end
+
+    def taxons_for_select
+      taxons.map { |taxon| [taxon['title'], taxon['content_id']] }
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,14 @@
   <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
     <%= link_to 'Topics', topics_path %>
   </li>
+
+  <% if gds_editor? %>
+    <li class='<%= active_navigation_item == 'taxons' ? 'active' : nil %>'>
+      <%= link_to 'Taxons', taxons_path %>
+    </li>
+  <% end %>
 <% end %>
+
 
 <% if user_signed_in? %>
   <% content_for :navbar_right do %>

--- a/app/views/taxons/edit.html.erb
+++ b/app/views/taxons/edit.html.erb
@@ -1,0 +1,9 @@
+<%= header @taxon.title, breadcrumbs: [:taxons, @taxon] %>
+
+<%= form_for @taxon, url: taxon_path(@taxon.content_id), method: "patch" do |f| %>
+  <%= f.text_field :title %>
+  <%= f.hidden_field :content_id, value: @taxon.content_id %>
+  <%= f.hidden_field :base_path, value: @taxon.base_path %>
+  <%= f.select :parent, options_for_select(@taxons_for_select, @taxon.parent), { include_blank: true }, { class: "select2" } %>
+  <%= f.submit "Save", class: "btn btn-lg btn-primary" %>
+<% end %>

--- a/app/views/taxons/index.html.erb
+++ b/app/views/taxons/index.html.erb
@@ -1,0 +1,14 @@
+<%= header "Alpha Taxons", breadcrumbs: ["Taxons"] do %>
+  <%= link_to 'Add a taxon', new_taxon_path, class: 'btn btn-lg btn-default' %>
+<% end %>
+
+<table class="tags-list">
+<tr>
+  <th>Title</th>
+</tr>
+<% @taxons.each do |taxon| %>
+  <tr>
+    <td><%= link_to taxon['title'], edit_taxon_path(taxon['content_id']) %></td>
+  </tr>
+<% end %>
+</table>

--- a/app/views/taxons/new.html.erb
+++ b/app/views/taxons/new.html.erb
@@ -1,0 +1,7 @@
+<%= header "Taxons", breadcrumbs: [:taxons, "New taxon"] %>
+
+<%= form_for @new_taxon, url: taxons_path do |f| %>
+  <%= f.text_field :title %>
+  <%= f.select :parent, options_for_select(@taxons_for_select), { include_blank: true }, { class: "select2" } %>
+  <%= f.submit "Save", class: "btn btn-lg btn-primary" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   root to: redirect('/topics', status: 302)
 
+  resources :taxons
+
   resources :mainstream_browse_pages, path: 'mainstream-browse-pages',
                                       except: :destroy do
     member do

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.feature "Managing taxonomies" do
+  before do
+    stub_user.permissions << "GDS Editor"
+
+    @create_item = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/content*]).
+      to_return(status: 200, body: {}.to_json)
+
+    @create_links = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/links*]).
+      to_return(status: 200, body: {}.to_json)
+  end
+
+  scenario "User creates a taxon" do
+    given_there_is_a_taxon
+    when_I_visit_the_taxonomy_page
+    and_I_click_on_the_new_taxon_button
+    when_I_submit_the_form_with_a_title
+    then_a_taxon_is_created
+  end
+
+  scenario "User edits a taxon" do
+    given_there_is_a_taxon
+    when_I_visit_the_taxonomy_page
+    and_I_click_on_the_edit_taxon_link
+    when_I_submit_the_form_with_a_title
+    then_my_taxon_is_updated
+  end
+
+  def and_I_click_on_the_edit_taxon_link
+    click_on "I Am A Taxon"
+  end
+
+  def given_there_is_a_taxon
+    item = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content?content_format=taxon&fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=title").
+      to_return(body: [item].to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1").
+      to_return(body: { links: { parent: [] } }.to_json)
+
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content/ID-1").
+      to_return(body: item.to_json)
+  end
+
+  def when_I_visit_the_taxonomy_page
+    visit taxons_path
+  end
+
+  def and_I_click_on_the_new_taxon_button
+    click_on "Add a taxon"
+  end
+
+  def when_I_submit_the_form_with_a_title
+    fill_in :create_taxon_title, with: "My Lovely Taxon"
+    click_on "Save"
+  end
+
+  def then_a_taxon_is_created
+    expect(@create_item).to have_been_requested
+    expect(@create_links).to have_been_requested
+  end
+
+  def then_my_taxon_is_updated
+    then_a_taxon_is_created
+  end
+end


### PR DESCRIPTION
This PR adds a section to this app where users can manage the "alpha taxonomy". Basically it is editor to create and update content items with format "taxon". It allows users to select a `parent` (also a "taxon") that will be used to construct a hierarchy of taxons.

Because the publishing-api doesn't return the `links` hash for content-items, it is currently not performant to show the hierarchy on the index page. This might be added later.

There is also no validation yet on the position of the `parent` - a taxon can be its own parent, or be the parent of a descendent (a loop). We are assuming that we don't need this currently, as access to this
taxonomy will be restricted (GDS editors only).

## Screenshots

List taxons:

![screen shot 2015-12-07 at 18 23 56](https://cloud.githubusercontent.com/assets/233676/11635607/cf033e92-9d0f-11e5-88d3-09268cc8e73c.png)

Create a new one:

![screen shot 2015-12-07 at 18 24 08](https://cloud.githubusercontent.com/assets/233676/11635610/d44cb144-9d0f-11e5-94b5-25afcdf052eb.png)

Trello: https://trello.com/c/bsZAwZ35