### PR TITLE
Restrict editing taxons

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,10 +8,14 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :active_navigation_item
+  helper_method :gds_editor?, :active_navigation_item, :can_edit_taxonomy?
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
+  end
+
+  def can_edit_taxonomy?
+    current_user.has_permission? "Edit Taxonomy"
   end
 
   # Can be overridden to allow controllers to choose the active menu item.

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -1,5 +1,5 @@
 class TaxonsController < ApplicationController
-  before_filter :require_gds_editor_permissions!
+  before_filter :require_permissions!
 
   def index
     @taxons = Taxonomy::TaxonFetcher.new.taxons
@@ -34,5 +34,11 @@ class TaxonsController < ApplicationController
     new_taxon = CreateTaxon.new(params[:create_taxon])
     new_taxon.create!
     redirect_to :back
+  end
+
+private
+
+  def require_permissions!
+    authorise_user!("Edit Taxonomy")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <%= link_to 'Topics', topics_path %>
   </li>
 
-  <% if gds_editor? %>
+  <% if can_edit_taxonomy? %>
     <li class='<%= active_navigation_item == 'taxons' ? 'active' : nil %>'>
       <%= link_to 'Taxons', taxons_path %>
     </li>

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Managing taxonomies" do
   before do
-    stub_user.permissions << "GDS Editor"
+    stub_user.permissions << "Edit Taxonomy"
 
     @create_item = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/content*]).
       to_return(status: 200, body: {}.to_json)


### PR DESCRIPTION
Only people with the `Edit Taxonomy` permission should be able to edit the taxonomy. This will prevent regular GDS Editors from seeing it.

https://trello.com/c/1Sp00cFo