### PR TITLE
Publish taxons on create and update

### DIFF
--- a/app/forms/create_taxon.rb
+++ b/app/forms/create_taxon.rb
@@ -13,7 +13,7 @@ class CreateTaxon
       title: title,
       content_id: content_id,
       publishing_app: 'collections-publisher',
-      rendering_app: 'collections-publisher',
+      rendering_app: 'collections',
       public_updated_at: Time.now,
       routes: [
         { path: base_path, type: "exact" },

--- a/app/forms/create_taxon.rb
+++ b/app/forms/create_taxon.rb
@@ -20,6 +20,8 @@ class CreateTaxon
       ]
     )
 
+    Services.publishing_api.publish(content_id, "major")
+
     Services.publishing_api.put_links(
       content_id,
       links: { parent: parent_ids }

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature "Managing taxonomies" do
     @create_item = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/content*]).
       to_return(status: 200, body: {}.to_json)
 
+    @publish_item = stub_request(:post, %r[https://publishing-api.test.gov.uk/v2/.*/publish]).
+      to_return(status: 200, body: {}.to_json)
+
     @create_links = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/links*]).
       to_return(status: 200, body: {}.to_json)
   end
@@ -59,6 +62,7 @@ RSpec.feature "Managing taxonomies" do
 
   def then_a_taxon_is_created
     expect(@create_item).to have_been_requested
+    expect(@publish_item).to have_been_requested
     expect(@create_links).to have_been_requested
   end
 


### PR DESCRIPTION
Previously we thought we could build the prototype from the draft content-store. We didn't think about that not being available outside the GOV.UK network. Therefore we will be publishing the taxons automatically.

The collections app will start serving 404's for these pages.

Trello: https://trello.com/c/bsZAwZ35/450-improve-alpha-taxonomy-tagging