### PR TITLE
Use V2 content schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,5 +44,5 @@ group :test, :development do
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'webmock', '~> 1.21.0', require: false
   gem 'timecop', '~> 0.8.0'
-  gem 'govuk-content-schema-test-helpers', '~> 1.3'
+  gem 'govuk-content-schema-test-helpers', '~> 1.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     generic_form_builder (0.13.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
-    govuk-content-schema-test-helpers (1.3.0)
+    govuk-content-schema-test-helpers (1.4.0)
       json-schema (~> 2.5.1)
     govuk-lint (0.5.0)
       rubocop (~> 0.32)
@@ -122,8 +122,8 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    json-schema (2.5.1)
-      addressable (~> 2.3.7)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     jwt (1.5.1)
     kgio (2.10.0)
     link_header (0.0.8)
@@ -320,7 +320,7 @@ DEPENDENCIES
   gds-api-adapters (~> 26.3)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.13.0)
-  govuk-content-schema-test-helpers (~> 1.3)
+  govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (= 0.5.0)
   govuk_admin_template (~> 3.0.0)
   logstasher (= 0.6.2)
@@ -339,3 +339,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (~> 4.9.0)
   webmock (~> 1.21.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -21,7 +21,6 @@ class RootBrowsePagePresenter
 
   def render_for_publishing_api
     {
-      content_id: content_id,
       format: "mainstream_browse_page",
       base_path: '/browse',
       title: "Browse",
@@ -30,8 +29,6 @@ class RootBrowsePagePresenter
       publishing_app: "collections-publisher",
       rendering_app: "collections",
       routes: routes,
-      update_type: update_type,
-      links: links,
     }
   end
 

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -21,7 +21,6 @@ class RootTopicPresenter
 
   def render_for_publishing_api
     {
-      content_id: content_id,
       base_path: '/topic',
       format: "topic",
       title: "Topics",
@@ -30,7 +29,6 @@ class RootTopicPresenter
       publishing_app: "collections-publisher",
       rendering_app: "collections",
       routes: routes,
-      update_type: update_type,
       details: {
         beta: true,
         internal_name: "Topic index page",

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -43,7 +43,6 @@ class TagPresenter
   def render_for_publishing_api
     {
       base_path: base_path,
-      content_id: @tag.content_id,
       format: format,
       title: @tag.title,
       description: @tag.description,
@@ -54,7 +53,6 @@ class TagPresenter
       rendering_app: "collections",
       routes: routes,
       redirects: RedirectRoutePresenter.new(@tag).routes,
-      update_type: "major",
       details: details,
     }.merge(phase_state)
   end

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe ArchivedTagPresenter do
       presenter = ArchivedTagPresenter.new(child)
       expect(presenter.render_for_publishing_api).to eq expected_child_content
     end
+
+    it "is valid against the schemas" do
+      presenter = ArchivedTagPresenter.new(child)
+
+      expect(presenter.render_for_publishing_api).to be_valid_against_schema("redirect")
+    end
   end
 
   describe '#base_path' do

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
     it "includes the base fields" do
       expect(presented_data).to include({
-        :content_id => browse_page.content_id,
         :format => 'mainstream_browse_page',
         :title => 'Benefits',
         :description => 'All about benefits',
@@ -44,7 +43,6 @@ RSpec.describe MainstreamBrowsePagePresenter do
         :publishing_app => 'collections-publisher',
         :rendering_app => 'collections',
         :redirects => [],
-        :update_type => "major",
       })
     end
 

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -16,18 +16,6 @@ RSpec.describe RootBrowsePagePresenter do
       expect(rendered).to be_valid_against_schema('mainstream_browse_page')
     end
 
-    it "includes draft and published top-level browse pages" do
-      page_1 = create(:mainstream_browse_page, :published, title: "Top-Level Page 1")
-      page_2 = create(:mainstream_browse_page, :draft, title: "Top-Level Page 2")
-
-      rendered = RootBrowsePagePresenter.new('state' => 'draft').render_for_publishing_api
-
-      expect(rendered[:links]["top_level_browse_pages"]).to eq([
-        page_1.content_id,
-        page_2.content_id,
-      ])
-    end
-
     it ":public_updated_at equals the time of last browse page update" do
       page_1 = create(:mainstream_browse_page, title: "Top-Level Page 1")
       page_2 = create(:mainstream_browse_page, title: "Top-Level Page 2")
@@ -43,6 +31,25 @@ RSpec.describe RootBrowsePagePresenter do
     end
   end
 
+  describe "#render_links_for_publishing_api" do
+    it "validates against the schema" do
+      rendered = RootBrowsePagePresenter.new('state' => 'draft').render_links_for_publishing_api
+
+      expect(rendered).to be_valid_against_links_schema("mainstream_browse_page")
+    end
+
+    it "includes draft and published top-level browse pages" do
+      page_1 = create(:mainstream_browse_page, :published, title: "Top-Level Page 1")
+      page_2 = create(:mainstream_browse_page, :draft, title: "Top-Level Page 2")
+
+      rendered = RootBrowsePagePresenter.new('state' => 'draft').render_links_for_publishing_api
+
+      expect(rendered[:links]["top_level_browse_pages"]).to eq([
+        page_1.content_id,
+        page_2.content_id,
+      ])
+    end
+  end
 
   describe '#draft?' do
     it 'should return false if instantiated with a parameter of true' do

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe TopicPresenter do
 
       it "includes the base fields" do
         expect(presented_data).to include({
-          :content_id => topic.content_id,
           :format => 'topic',
           :title => 'Working at sea',
           :description => 'The sea, the sky, the sea, the sky...',
@@ -25,7 +24,6 @@ RSpec.describe TopicPresenter do
           :publishing_app => 'collections-publisher',
           :rendering_app => 'collections',
           :redirects => [],
-          :update_type => "major",
         })
       end
 
@@ -85,7 +83,6 @@ RSpec.describe TopicPresenter do
 
       it "includes the base fields" do
         expect(presented_data).to include({
-          :content_id => topic.content_id,
           :format => 'topic',
           :title => 'Offshore',
           :description => 'Oil rigs, pipelines etc.',
@@ -94,7 +91,6 @@ RSpec.describe TopicPresenter do
           :publishing_app => 'collections-publisher',
           :rendering_app => 'collections',
           :redirects => [],
-          :update_type => "major",
         })
       end
 

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,7 +1,7 @@
 require 'govuk-content-schema-test-helpers'
 
 GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = 'publisher'
+  config.schema_type = 'publisher_v2'
   config.project_root = Rails.root
 end
 


### PR DESCRIPTION
The V2 content schemas differ a little bit from V1 (no content_id, update_type). This commit makes the examples validate against `publisher_v2`.

https://trello.com/c/catWOsWC