### PR TITLE
Use stubbing from gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.11.0'
 gem 'airbrake', '~> 4.3.1'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 26.3'
+gem 'gds-api-adapters', '~> 26.6'
 
 gem 'govuk_admin_template', '~> 3.4'
 gem 'generic_form_builder', '~> 0.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   database_cleaner (~> 1.5.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (~> 26.3)
+  gds-api-adapters (~> 26.6)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.13.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TopicsController do
 
     it "allows only GDS Editors to publish topics" do
       stub_user.permissions << "GDS Editor"
-      stub_put_content_links_and_publish_to_publishing_api
+      stub_any_publishing_api_call
 
       topic = create(:topic)
       allow(PanopticonNotifier).to receive(:publish_tag)

--- a/spec/features/archiving_tags_spec.rb
+++ b/spec/features/archiving_tags_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Archiving tags" do
     # Stub rummager so that topics do not have links.
     stub_any_call_to_rummager_with_documents([])
 
-    stub_put_content_to_publishing_api
-    stub_publish_to_publishing_api
+    stub_any_publishing_api_call
 
     @rummager_deletion = stub_request(:delete, %r[#{Plek.find('rummager')}/*]).to_return(body: "{}")
     @panopticon_deletion = stub_request(:delete, %r[#{Plek.find('panopticon')}/*]).to_return(body: "{}")

--- a/spec/features/browse_hierarchy_spec.rb
+++ b/spec/features/browse_hierarchy_spec.rb
@@ -93,19 +93,19 @@ RSpec.feature "Browse hierarchy" do
   end
 
   def and_the_newly_created_page_is_sent_to_the_publishing_api_as_draft
-    assert_publishing_api_put_item(@content_id)
+    stub_publishing_api_put_content(@content_id, {})
     assert_publishing_api_put_links(@content_id)
     assert_publishing_api_not_published(@content_id)
   end
 
   def and_the_parent_page_is_sent_to_the_publishing_api
-    assert_publishing_api_put_item(@parent.content_id)
+    stub_publishing_api_put_content(@parent.content_id, {})
     assert_publishing_api_put_links(@parent.content_id)
     assert_publishing_api_publish(@parent.content_id)
   end
 
   def and_the_child_page_is_sent_to_the_publishing_api
-    assert_publishing_api_put_item(@child.content_id)
+    stub_publishing_api_put_content(@child.content_id, {})
     assert_publishing_api_put_links(@child.content_id)
     assert_publishing_api_publish(@child.content_id)
   end

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Curating topic contents" do
   include PublishingApiHelpers
 
   before :each do
-    stub_put_content_links_and_publish_to_publishing_api
+    stub_any_publishing_api_call
   end
 
   describe "Curating the content for a topic" do
@@ -84,7 +84,7 @@ RSpec.feature "Curating topic contents" do
 
 
       #Then the curated lists should have been sent to the publishing API
-      assert_publishing_api_put_item(
+      stub_publishing_api_put_content(
         content_id,
         {
           "details" => {
@@ -170,7 +170,7 @@ RSpec.feature "Curating topic contents" do
 
 
       #Then the curated lists should have been sent to the publishing API
-      assert_publishing_api_put_item(
+      stub_publishing_api_put_content(
         content_id,
         {
           "details" => {

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature "Managing browse pages" do
   end
 
   def and_the_draft_is_sent_to_the_publishing_pipeline
-    assert_publishing_api_put_item(
+    stub_publishing_api_put_content(
       @content_id,
       title: "Citizenship",
       description: "Living in the UK",
@@ -139,7 +139,7 @@ RSpec.feature "Managing browse pages" do
   end
 
   def and_the_published_data_is_sent_to_the_publishing_pipeline
-    assert_publishing_api_put_item(
+    stub_publishing_api_put_content(
       @page.content_id,
       title: "Citizenship in the UK",
       format: "mainstream_browse_page",
@@ -158,7 +158,7 @@ RSpec.feature "Managing browse pages" do
   end
 
   def and_the_updated_item_is_sent_to_the_publishing_pipeline
-    assert_publishing_api_put_item(
+    stub_publishing_api_put_content(
       @content_id,
       description: "A new description"
     )

--- a/spec/features/managing_topic_pages_spec.rb
+++ b/spec/features/managing_topic_pages_spec.rb
@@ -119,7 +119,7 @@ RSpec.feature "Managing topics" do
   end
 
   def and_the_draft_is_sent_to_the_publishing_pipeline
-    assert_publishing_api_put_item(
+    stub_publishing_api_put_content(
       @content_id,
       title: "Citizenship",
       description: "Living in the UK",
@@ -139,7 +139,7 @@ RSpec.feature "Managing topics" do
   end
 
   def and_the_published_data_is_sent_to_the_publishing_pipeline
-    assert_publishing_api_put_item(
+    stub_publishing_api_put_content(
       @page.content_id,
       title: "Citizenship in the UK",
       format: "topic",
@@ -158,7 +158,7 @@ RSpec.feature "Managing topics" do
   end
 
   def and_the_updated_item_is_sent_to_the_publishing_pipeline
-    assert_publishing_api_put_item(
+    stub_publishing_api_put_content(
       @content_id,
       description: "A new description"
     )

--- a/spec/features/tagging_browse_with_topics_spec.rb
+++ b/spec/features/tagging_browse_with_topics_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Tagging browse pages with topics" do
     given_I_am_a_GDS_editor
     stub_all_panopticon_tag_calls
     stub_rummager_linked_content_call
-    stub_put_content_links_and_publish_to_publishing_api
+    stub_any_publishing_api_call
   end
 
   scenario "User visits parent browse page" do

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TagArchiver do
     before do
       # By default make it so that there's nothing tagged to topics.
       stub_any_call_to_rummager_with_documents([])
-      stub_publish_to_publishing_api
+      stub_any_publishing_api_call
 
       # Succesful archivings will remove the result from rummager.
       allow(Services.rummager).to receive(:delete_document)

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -3,7 +3,7 @@ module CommonFeatureSteps
     stub_all_panopticon_tag_calls
     allow_any_instance_of(RummagerNotifier).to receive(:notify)
     stub_rummager_linked_content_call
-    stub_put_content_links_and_publish_to_publishing_api
+    stub_any_publishing_api_call
   end
 
   def given_I_am_a_GDS_editor

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -1,67 +1,12 @@
+require 'services'
+require 'gds_api/test_helpers/publishing_api_v2'
+
 module PublishingApiHelpers
-  PUBLISHING_API_ENDPOINT = Plek.current.find('publishing-api')
-
-  def stub_put_content_to_publishing_api
-    stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/v2/content})
-  end
-
-  def stub_put_links_to_publishing_api
-    stub_request(:put, %r{\A#{PUBLISHING_API_ENDPOINT}/v2/links})
-  end
-
-  def stub_put_content_and_links_to_publishing_api
-    stub_put_content_to_publishing_api
-    stub_put_links_to_publishing_api
-  end
-
-  def stub_publish_to_publishing_api
-    stub_request(:post, %r{\A#{PUBLISHING_API_ENDPOINT}/v2/content\/.*\/publish})
-  end
-
-  def stub_put_content_links_and_publish_to_publishing_api
-    stub_put_content_to_publishing_api
-    stub_put_links_to_publishing_api
-    stub_publish_to_publishing_api
-  end
-
-  def request_json_matching(required_attributes)
-    ->(request) do
-      data = JSON.parse(request.body)
-      required_attributes.to_a.all? { |key, value| data[key.to_s] == value }
-    end
-  end
-
-  def assert_publishing_api_put_item(content_id, attributes_or_matcher = {}, times = 1)
-    url = PUBLISHING_API_ENDPOINT + "/v2/content/" + content_id
-    assert_publishing_api_put(url, attributes_or_matcher, times)
-  end
-
-  def assert_publishing_api_publish(content_id)
-    url = "#{PUBLISHING_API_ENDPOINT}/v2/content/#{content_id}/publish"
-    assert_requested(:post, url, times: 1)
-  end
+  include GdsApi::TestHelpers::PublishingApiV2
 
   def assert_publishing_api_not_published(content_id)
-    url = "#{PUBLISHING_API_ENDPOINT}/v2/content/#{content_id}/publish"
+    url = Plek.current.find('publishing-api') + "/v2/content/#{content_id}/publish"
     assert_not_requested(:post, url)
-  end
-
-  def assert_publishing_api_put_links(content_id)
-    assert_requested(:put, "#{PUBLISHING_API_ENDPOINT}/v2/links/#{content_id}")
-  end
-
-  def assert_publishing_api_put(url, attributes_or_matcher = {}, times = 1)
-    if attributes_or_matcher.is_a?(Hash)
-      matcher = attributes_or_matcher.empty? ? nil : request_json_matching(attributes_or_matcher)
-    else
-      matcher = attributes_or_matcher
-    end
-
-    if matcher
-      assert_requested(:put, url, times: times, &matcher)
-    else
-      assert_requested(:put, url, times: times)
-    end
   end
 
   def extract_content_id_from(current_path)


### PR DESCRIPTION
Many stubs used here are not necessary anymore since gds-api-adapters has learned new methods:

https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/test_helpers/publishing_api_v2.rb

This will make it easier for developers to switch between projects.