### PR TITLE
Update taxon form object to gracefully handle taxons with blank links

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -7,11 +7,11 @@ class TaxonsController < ApplicationController
 
   def new
     @taxons_for_select = Taxonomy::TaxonFetcher.new.taxons_for_select
-    @new_taxon = CreateTaxon.new
+    @new_taxon = TaxonForm.new
   end
 
   def create
-    new_taxon = CreateTaxon.new(params[:create_taxon])
+    new_taxon = TaxonForm.new(params[:taxon_form])
     new_taxon.create!
     redirect_to taxons_path
   end
@@ -22,7 +22,7 @@ class TaxonsController < ApplicationController
     content_item = Services.publishing_api.get_content(params[:id])
     links = Services.publishing_api.get_links(params[:id]).links
 
-    @taxon = CreateTaxon.new(
+    @taxon = TaxonForm.new(
       content_id: content_item.content_id,
       title: content_item.title,
       base_path: content_item.base_path,
@@ -31,7 +31,7 @@ class TaxonsController < ApplicationController
   end
 
   def update
-    new_taxon = CreateTaxon.new(params[:create_taxon])
+    new_taxon = TaxonForm.new(params[:taxon_form])
     new_taxon.create!
     redirect_to :back
   end

--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -18,16 +18,7 @@ class TaxonsController < ApplicationController
 
   def edit
     @taxons_for_select = Taxonomy::TaxonFetcher.new.taxons_for_select
-
-    content_item = Services.publishing_api.get_content(params[:id])
-    links = Services.publishing_api.get_links(params[:id]).links
-
-    @taxon = TaxonForm.new(
-      content_id: content_item.content_id,
-      title: content_item.title,
-      base_path: content_item.base_path,
-      parent: links.parent.to_a.first,
-    )
+    @taxon = TaxonForm.build(content_id: params[:id])
   end
 
   def update

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -1,4 +1,4 @@
-class CreateTaxon
+class TaxonForm
   attr_accessor :title, :parent, :content_id, :base_path
   include ActiveModel::Model
 

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -2,6 +2,22 @@ class TaxonForm
   attr_accessor :title, :parent, :content_id, :base_path
   include ActiveModel::Model
 
+  def self.build(content_id:)
+    content_item = Services.publishing_api.get_content(content_id)
+    links = Services.publishing_api.get_links(content_id).try(:links)
+    form = new(
+      content_id: content_id,
+      title: content_item.title,
+      base_path: content_item.base_path,
+    )
+
+    if links.present? && links.parent.present?
+      form.parent = links.parent.to_a.first
+    end
+
+    form
+  end
+
   def create!
     self.content_id ||= SecureRandom.uuid
     self.base_path ||= '/alpha-taxonomy/' + title.parameterize

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -1,5 +1,5 @@
 module Taxonomy
-  # Return a links of taxons from the publishing API with links included.
+  # Return a list of taxons from the publishing API with links included.
   class TaxonFetcher
     def taxons
       Services.publishing_api.get_content_items(

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -62,10 +62,11 @@ RSpec.feature "Curating topic contents" do
       visit_topic_list_curation_page
 
       within :xpath, xpath_section_for('Oil rigs') do
+        expect(page).to have_selector('td.title', count: 2)
         titles = page.all('td.title').map(&:text)
+
         # Note: order reversed because we dragged the items to the top of the list above.
         expect(titles).to eq([
-          'Oil rig staffing',
           'Oil rig staffing',
           'Oil rig safety requirements',
         ])

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Managing taxonomies" do
   end
 
   def when_I_submit_the_form_with_a_title
-    fill_in :create_taxon_title, with: "My Lovely Taxon"
+    fill_in :taxon_form_title, with: "My Lovely Taxon"
     click_on "Save"
   end
 


### PR DESCRIPTION
- Check if a links>parent value is available before attempting to assign
  the attribute in the form object.
- Move all logic around instantiating the taxon form object into a
  factory method on TaxonForm.

Fixes bug decribed in: https://trello.com/c/biyzQj52