### PR TITLE
Add wait_for_ajax helpers to prevent intermittently breaking topic curation feature

### DIFF
--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.feature "Curating topic contents" do
   include PublishingApiHelpers
+  include WaitForAjax
 
   before :each do
     stub_any_publishing_api_call
@@ -36,7 +37,9 @@ RSpec.feature "Curating topic contents" do
       expect(page).to have_selector('h4', :text => 'Oil rigs')
 
       link_with_title('Oil rig staffing').drag_to droptarget_for_list('Oil rigs')
+      wait_for_ajax
       link_with_title('Oil rig safety requirements').drag_to droptarget_for_list('Oil rigs')
+      wait_for_ajax
 
       within :xpath, xpath_section_for('Oil rigs') do
         expect(page).to have_content('Oil rig safety requirements')
@@ -52,6 +55,7 @@ RSpec.feature "Curating topic contents" do
       expect(page).to have_selector('.list h4', :text => 'Piping')
 
       link_with_title('Undersea piping restrictions').drag_to droptarget_for_list('Piping')
+      wait_for_ajax
 
       within :xpath, xpath_section_for('Piping') do
         expect(page).to have_content('Undersea piping restrictions')

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,12 @@
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+


### PR DESCRIPTION
There's a race condition in the curation JS. When an item is dragged to
a list, it is 'reindexed' - if the item is newly placed, a ListItem is
created. If the item is reordered, the ListItem is updated.

When two drag and drops happen in quick succession (like they do in the
specs), a given item can be 'created' twice resulting in duplicate
entries in the list.

Until we solve this definitively in the client, this change is a band aid to
ensure that, when executing a drag and drop, the spec waits for the ajax
request to complete before continuing.