### PR TITLE
Upgrade Sidekiq to 3.X

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.2.5.1'
 gem 'mysql2', '~> 0.3.20'
 
 gem 'plek', '~> 1.11.0'
-gem 'airbrake', '~> 4.3.1'
+gem 'airbrake', '~> 5.0'
 
 gem 'gds-sso', '~> 11.0.0'
 gem 'gds-api-adapters', '~> 26.6'
@@ -24,7 +24,7 @@ gem 'logstasher', '0.6.2'
 
 # sidekiq-web depends on sinatra
 gem 'sinatra', require: nil
-gem 'sidekiq', '~> 2.17.2'
+gem 'sidekiq', '~> 3.5.4'
 gem 'sidekiq-statsd', '0.1.5'
 
 gem 'byebug', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,9 +39,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (4.3.4)
-      builder
-      multi_json
+    airbrake (5.0.4)
+      airbrake-ruby (~> 1.0)
+    airbrake-ruby (1.0.4)
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -66,8 +66,23 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
+    celluloid (0.17.3)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.5)
+      timers (>= 4.1.1)
     cliver (0.3.2)
     coderay (1.1.0)
     concurrent-ruby (1.0.0)
@@ -116,6 +131,7 @@ GEM
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
     hashie (3.4.3)
+    hitimes (1.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -254,12 +270,12 @@ GEM
       tilt (>= 1.1, < 3)
     select2-rails (3.5.9.3)
       thor (~> 0.14)
-    sidekiq (2.17.8)
-      celluloid (= 0.15.2)
-      connection_pool (~> 2.0)
-      json
-      redis (~> 3.1)
-      redis-namespace (~> 1.3)
+    sidekiq (3.5.4)
+      celluloid (~> 0.17.2)
+      connection_pool (~> 2.2, >= 2.2.0)
+      json (~> 1.0)
+      redis (~> 3.2, >= 3.2.1)
+      redis-namespace (~> 1.5, >= 1.5.2)
     sidekiq-statsd (0.1.5)
       activesupport
       sidekiq (>= 2.6)
@@ -280,7 +296,8 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.1)
     timecop (0.8.0)
-    timers (1.1.0)
+    timers (4.1.1)
+      hitimes
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -312,7 +329,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 4.3.0)
-  airbrake (~> 4.3.1)
+  airbrake (~> 5.0)
   better_errors
   binding_of_caller
   byebug
@@ -334,7 +351,7 @@ DEPENDENCIES
   rspec-rails (~> 3.3.3)
   sass-rails (~> 5.0.3)
   select2-rails (~> 3.5.9)
-  sidekiq (~> 2.17.2)
+  sidekiq (~> 3.5.4)
   sidekiq-statsd (= 0.1.5)
   sinatra
   timecop (~> 0.8.0)


### PR DESCRIPTION
This commit upgrades Sidekiq to 3.5.4, the latest version in the 3.X series (4.0 has come out a few months ago). It is necessary to upgrade because there are a couple of vulnerabilities reported in 2.X.

These issues were found by [bundler-audit](https://github.com/alphagov/govuk_security_audit):

```
~/govuk/ft-audit  ᐅ bundle exec govuk_security_audit github alphagov collections-publisher master         
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Current branch master is up to date.
ruby-advisory-db: 262 advisories
Name: sidekiq
Version: 2.17.8
Advisory: 125675
Criticality: Unknown
URL: https://github.com/mperham/sidekiq/pull/2422
Title: Sidekiq Gem for Ruby Multiple Unspecified CSRF
Solution: upgrade to >= 3.4.2

Name: sidekiq
Version: 2.17.8
Advisory: 125676
Criticality: Unknown
URL: https://github.com/mperham/sidekiq/issues/2330
Title: Sidekiq Gem for Ruby web/views/queue.erb CurrentMessagesInQueue Element
Reflected XSS
Solution: upgrade to >= 3.4.0

Name: sidekiq
Version: 2.17.8
Advisory: 125678
Criticality: Unknown
URL: https://github.com/mperham/sidekiq/pull/2309
Title: Sidekiq Gem for Ruby web/views/queue.erb msg.display_class Element XSS
Solution: upgrade to >= 3.4.0

Vulnerabilities found!
```

As mentioned in [the upgrade guide](https://github.com/mperham/sidekiq/blob/master/3.0-Upgrade.md), we've upgraded the Airbrake gem as well. Other items in the upgrade guide are not applicable.

Trello: https://trello.com/c/J8jN7OFV

cc @Davidslv 

---

### After

```
~/govuk/ft-audit  ᐅ bundle exec govuk_security_audit github alphagov collections-publisher upgrade-sidekiq
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Current branch master is up to date.
ruby-advisory-db: 262 advisories
No vulnerabilities found
```