### PR TITLE
Downgrade Airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '4.2.5.1'
 gem 'mysql2', '~> 0.3.20'
 
 gem 'plek', '~> 1.11.0'
-gem 'airbrake', '~> 5.0'
+gem 'airbrake', '~> 4.3.5'
 
 gem 'gds-sso', '~> 11.0.0'
 gem 'gds-api-adapters', '~> 26.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,9 +39,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (5.0.4)
-      airbrake-ruby (~> 1.0)
-    airbrake-ruby (1.0.4)
+    airbrake (4.3.5)
+      builder
+      multi_json
     arel (6.0.3)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -329,7 +329,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm (~> 4.3.0)
-  airbrake (~> 5.0)
+  airbrake (~> 4.3.5)
   better_errors
   binding_of_caller
   byebug


### PR DESCRIPTION
4.3.5 looks compatible with Sidekiq 3.0. We can't yet upgrade to Airbrake 5.X, because it requires a `project_id` to be set, which errbit doesn't seem to provide.

@mobaig 