### PR TITLE
Use "minor" update type for tag publishing

### DIFF
--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -36,7 +36,7 @@ class TaxonForm
       ]
     )
 
-    Services.publishing_api.publish(content_id, "major")
+    Services.publishing_api.publish(content_id, "minor")
 
     Services.publishing_api.put_links(
       content_id,

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -37,10 +37,14 @@ private
   end
 
   class PublishingApiContentWriter
+    # Setting the update type to minor means we won't send email alerts for
+    # changes to a topic title or description.
+    UPDATE_TYPE = 'minor'
+
     def self.write(presenter)
       publishing_api = Services.publishing_api
       publishing_api.put_content(presenter.content_id, presenter.render_for_publishing_api)
-      publishing_api.publish(presenter.content_id, presenter.update_type) unless presenter.draft?
+      publishing_api.publish(presenter.content_id, UPDATE_TYPE) unless presenter.draft?
       publishing_api.put_links(presenter.content_id, presenter.render_links_for_publishing_api) unless presenter.archived?
     end
   end

--- a/app/presenters/archived_tag_presenter.rb
+++ b/app/presenters/archived_tag_presenter.rb
@@ -17,7 +17,6 @@ class ArchivedTagPresenter
       base_path: base_path,
       format: 'redirect',
       publishing_app: 'collections-publisher',
-      update_type: update_type,
       redirects: RedirectRoutePresenter.new(@tag).routes,
     }
   end
@@ -28,9 +27,5 @@ class ArchivedTagPresenter
 
   def content_id
     @tag.content_id
-  end
-
-  def update_type
-    'major'
   end
 end

--- a/app/presenters/redirect_item_presenter.rb
+++ b/app/presenters/redirect_item_presenter.rb
@@ -13,10 +13,6 @@ class RedirectItemPresenter
     item.from_base_path
   end
 
-  def update_type
-    'republish'
-  end
-
   def redirect_routes
     [ item ]
   end
@@ -35,7 +31,6 @@ class RedirectItemPresenter
       base_path: base_path,
       format: 'redirect',
       publishing_app: 'collections-publisher',
-      update_type: update_type,
       redirects: RedirectRoutePresenter.new(self).routes,
     }
   end

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -7,10 +7,6 @@ class RootBrowsePagePresenter
     "8413047e-570a-448b-b8cb-d288a12807dd"
   end
 
-  def update_type
-    "major"
-  end
-
   def draft?
     @state == 'draft'
   end

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -7,10 +7,6 @@ class RootTopicPresenter
     "76e9abe7-dac8-49f0-bb5e-53e4b0d2cdba"
   end
 
-  def update_type
-    "major"
-  end
-
   def draft?
     @state == 'draft'
   end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -26,10 +26,6 @@ class TagPresenter
     tag.content_id
   end
 
-  def update_type
-    'major'
-  end
-
   def render_for_rummager
     {
       format: rummager_format,

--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -26,7 +26,6 @@ private
       base_path: tag.base_path,
       format: 'gone',
       publishing_app: 'collections-publisher',
-      update_type: 'major',
       content_id: tag.content_id,
       routes: presenter.routes
     }

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ArchivedTagPresenter do
         base_path: "/topic/parent/child-1",
         format: "redirect",
         publishing_app: "collections-publisher",
-        update_type: "major",
         redirects: [
           {
             path: "/topic/parent/child-1",


### PR DESCRIPTION
Setting the update type to minor means we won't send email alerts for changes to a topic title or description. This will become relevant if topics will be tagged to other topics (we have no plans to do this, but we need to be careful).

Since there is only ever one update type, all methods have been replaced by a constant.

The only change is in the `RedirectItemPresenter` which previously was sent with a "republish" update type. This was incorrect, as the app is publishing new data, [not republishing old data](https://github.com/alphagov/publishing-api/blob/d5f63c13497147d7f366ef3c02e0439c4cf18300/doc/semantics-of-the-publishing-api.md#update_type).

Related: https://github.com/alphagov/content-tagger/pull/25
Trello: https://trello.com/c/GRt7NSbL