### PR TITLE
Use linkables endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.11.0'
 gem 'airbrake', '~> 4.3.5'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 28.0.1'
+gem 'gds-api-adapters', '~> 29.3.1'
 
 gem 'govuk_admin_template', '~> 4.1'
 gem 'generic_form_builder', '~> 0.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160128)
+    domain_name (0.5.20160216)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -103,7 +103,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (28.0.1)
+    gds-api-adapters (29.3.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -336,7 +336,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   database_cleaner (~> 1.5.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (~> 28.0.1)
+  gds-api-adapters (~> 29.3.1)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.13.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -38,7 +38,7 @@ class TaxonForm
 
     Services.publishing_api.publish(content_id, "minor")
 
-    Services.publishing_api.put_links(
+    Services.publishing_api.patch_links(
       content_id,
       links: { parent: parent_ids }
     )

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -45,7 +45,7 @@ private
       publishing_api = Services.publishing_api
       publishing_api.put_content(presenter.content_id, presenter.render_for_publishing_api)
       publishing_api.publish(presenter.content_id, UPDATE_TYPE) unless presenter.draft?
-      publishing_api.put_links(presenter.content_id, presenter.render_links_for_publishing_api) unless presenter.archived?
+      publishing_api.patch_links(presenter.content_id, presenter.render_links_for_publishing_api) unless presenter.archived?
     end
   end
 

--- a/app/services/taxonomy/taxon_fetcher.rb
+++ b/app/services/taxonomy/taxon_fetcher.rb
@@ -2,9 +2,8 @@ module Taxonomy
   # Return a list of taxons from the publishing API with links included.
   class TaxonFetcher
     def taxons
-      Services.publishing_api.get_content_items(
-        content_format: 'taxon',
-        fields: %i[title base_path content_id]
+      Services.publishing_api.get_linkables(
+        document_type: 'taxon'
       ).sort_by { |taxon| taxon["title"] }
     end
 

--- a/spec/features/browse_hierarchy_spec.rb
+++ b/spec/features/browse_hierarchy_spec.rb
@@ -94,19 +94,19 @@ RSpec.feature "Browse hierarchy" do
 
   def and_the_newly_created_page_is_sent_to_the_publishing_api_as_draft
     stub_publishing_api_put_content(@content_id, {})
-    assert_publishing_api_put_links(@content_id)
+    assert_publishing_api_patch_links(@content_id)
     assert_publishing_api_not_published(@content_id)
   end
 
   def and_the_parent_page_is_sent_to_the_publishing_api
     stub_publishing_api_put_content(@parent.content_id, {})
-    assert_publishing_api_put_links(@parent.content_id)
+    assert_publishing_api_patch_links(@parent.content_id)
     assert_publishing_api_publish(@parent.content_id)
   end
 
   def and_the_child_page_is_sent_to_the_publishing_api
     stub_publishing_api_put_content(@child.content_id, {})
-    assert_publishing_api_put_links(@child.content_id)
+    assert_publishing_api_patch_links(@child.content_id)
     assert_publishing_api_publish(@child.content_id)
   end
 end

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature "Curating topic contents" do
 
       # And have been published and links sent
       assert_publishing_api_publish(content_id)
-      assert_publishing_api_put_links(content_id)
+      assert_publishing_api_patch_links(content_id)
     end
 
     it "without javascript" do
@@ -198,7 +198,7 @@ RSpec.feature "Curating topic contents" do
 
       # And then be published and links sent
       assert_publishing_api_publish(content_id)
-      assert_publishing_api_put_links(content_id)
+      assert_publishing_api_patch_links(content_id)
     end
   end
 

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature "Managing browse pages" do
       format: "mainstream_browse_page",
     )
 
-    assert_publishing_api_put_links(@content_id)
+    assert_publishing_api_patch_links(@content_id)
 
     assert_publishing_api_not_published(@content_id)
 
@@ -145,7 +145,7 @@ RSpec.feature "Managing browse pages" do
       format: "mainstream_browse_page",
     )
 
-    assert_publishing_api_put_links(@page.content_id)
+    assert_publishing_api_patch_links(@page.content_id)
 
     assert_publishing_api_publish(@page.content_id)
 

--- a/spec/features/managing_topic_pages_spec.rb
+++ b/spec/features/managing_topic_pages_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature "Managing topics" do
       format: "topic",
     )
 
-    assert_publishing_api_put_links(@content_id)
+    assert_publishing_api_patch_links(@content_id)
 
     assert_publishing_api_not_published(@content_id)
 
@@ -145,7 +145,7 @@ RSpec.feature "Managing topics" do
       format: "topic",
     )
 
-    assert_publishing_api_put_links(@page.content_id)
+    assert_publishing_api_patch_links(@page.content_id)
 
     assert_publishing_api_publish(@page.content_id)
 

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Managing taxonomies" do
     @publish_item = stub_request(:post, %r[https://publishing-api.test.gov.uk/v2/.*/publish]).
       to_return(status: 200, body: {}.to_json)
 
-    @create_links = stub_request(:put, %r[https://publishing-api.test.gov.uk/v2/links*]).
+    @create_links = stub_request(:patch, %r[https://publishing-api.test.gov.uk/v2/links*]).
       to_return(status: 200, body: {}.to_json)
   end
 

--- a/spec/features/taxonomy_manager_spec.rb
+++ b/spec/features/taxonomy_manager_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Managing taxonomies" do
   def given_there_is_a_taxon
     item = { title: "I Am A Taxon", content_id: "ID-1", base_path: "/foo" }
 
-    stub_request(:get, "https://publishing-api.test.gov.uk/v2/content?content_format=taxon&fields%5B%5D=base_path&fields%5B%5D=content_id&fields%5B%5D=title").
+    stub_request(:get, "https://publishing-api.test.gov.uk/v2/linkables?document_type=taxon").
       to_return(body: [item].to_json)
 
     stub_request(:get, "https://publishing-api.test.gov.uk/v2/links/ID-1").

--- a/spec/services/taxonomy/taxon_fetcher_spec.rb
+++ b/spec/services/taxonomy/taxon_fetcher_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
+
+RSpec.describe Taxonomy::TaxonFetcher do
+  include GdsApi::TestHelpers::PublishingApiV2
+  describe '#taxons' do
+    it 'retrieves content items from publishing api and orders by title' do
+      linkables = [
+        {"title" => "foo", "base_path" => "/foo", "content_id" => SecureRandom.uuid},
+        {"title" => "bar", "base_path" => "/bar", "content_id" => SecureRandom.uuid},
+        {"title" => "aha", "base_path" => "/aha", "content_id" => SecureRandom.uuid},
+      ]
+
+      publishing_api_has_linkables(linkables, document_type: 'taxon')
+
+      result = described_class.new.taxons
+
+      expect(result.first["title"]).to eq("aha")
+      expect(result.last["title"]).to eq("foo")
+    end
+  end
+end

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -46,7 +46,7 @@ module ContentStoreHelpers
       @stored_published_slugs << item[:base_path]
     end
 
-    def put_links(content_id, links)
+    def patch_links(content_id, links)
       item = @stored_items[content_id]
       raise "Item #{content_id} not previously written to content store as draft" if item.nil?
       @stored_links[content_id] = links


### PR DESCRIPTION
Paired with @steventux on this! 

Switches the datasource for populating drop downs to the v2 linkable endpoint. Further description can be found [here on Trello](https://trello.com/c/2kHBXfOd/618-modify-collections-publisher-to-use-linkables-endpoint).