### PR TITLE
Redirect to taxon list after updating a taxon

### DIFF
--- a/app/controllers/taxons_controller.rb
+++ b/app/controllers/taxons_controller.rb
@@ -32,7 +32,7 @@ class TaxonsController < ApplicationController
   def update
     new_taxon = TaxonForm.new(params[:taxon_form])
     new_taxon.create!
-    redirect_to :back
+    redirect_to taxons_path
   end
 
 private


### PR DESCRIPTION
When I edit a taxon, :back sends me back to the form itself, so
its not obvious whether anything happened. This change makes
create and update do the same thing, i.e. redirect back to the list.

This also makes it easier to edit multiple taxons at once.