### PR TITLE
Send `content_id` to Rummager

### DIFF
--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -28,6 +28,7 @@ class TagPresenter
 
   def render_for_rummager
     {
+      content_id: tag.content_id,
       format: rummager_format,
       title: tag.title,
       description: tag.description,

--- a/spec/notifiers/rummager_notifier_spec.rb
+++ b/spec/notifiers/rummager_notifier_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe RummagerNotifier do
 
     it 'sends published topics to rummager' do
       topic = create(:topic, :published,
+        content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
         title: 'A Topic',
         slug: 'a-test-topic',
         description: 'A description.')
@@ -32,6 +33,7 @@ RSpec.describe RummagerNotifier do
 
       expect(rummager).to have_received(:add_document)
         .with("edition", "/topic/a-test-topic", {
+          content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
           format: 'specialist_sector',
           title: 'A Topic',
           description: 'A description.',
@@ -42,6 +44,7 @@ RSpec.describe RummagerNotifier do
 
     it 'sends published browse pages to rummager' do
       browse_page = create(:mainstream_browse_page, :published,
+        content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
         title: 'A Browse Page',
         slug: 'a-browse-page',
         description: 'A description.')
@@ -50,6 +53,7 @@ RSpec.describe RummagerNotifier do
 
       expect(rummager).to have_received(:add_document)
         .with("edition", "/browse/a-browse-page", {
+          content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
           format: 'mainstream_browse_page',
           title: 'A Browse Page',
           description: 'A description.',


### PR DESCRIPTION
Rummager needs to have a `content_id` for easier lookups.

Trello: https://trello.com/c/ppe8Upar