### PR TITLE
Request tracing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'plek', '~> 1.11.0'
 gem 'airbrake', '~> 4.3.5'
 
 gem 'gds-sso', '~> 11.0.0'
-gem 'gds-api-adapters', '~> 29.3.1'
+gem 'gds-api-adapters', '~> 30.2.0'
 
 gem 'govuk_admin_template', '~> 4.1'
 gem 'generic_form_builder', '~> 0.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160216)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -103,7 +103,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (29.3.1)
+    gds-api-adapters (30.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -336,7 +336,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   database_cleaner (~> 1.5.0)
   factory_girl_rails (~> 4.5.0)
-  gds-api-adapters (~> 29.3.1)
+  gds-api-adapters (~> 30.2.0)
   gds-sso (~> 11.0.0)
   generic_form_builder (~> 0.13.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/app/workers/dependent_tag_publish_worker.rb
+++ b/app/workers/dependent_tag_publish_worker.rb
@@ -1,7 +1,5 @@
-class DependentTagPublishWorker
-  include Sidekiq::Worker
-
-  def perform(tag_id)
+class DependentTagPublishWorker < WorkerBase
+  def call(tag_id)
     tag = Tag.find(tag_id)
 
     tag.dependent_tags.each do |tag|

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -1,0 +1,20 @@
+class WorkerBase
+  include Sidekiq::Worker
+
+  def self.perform_async(*args)
+    args << { request_id: GdsApi::GovukHeaders.headers[:govuk_request_id] }
+    super(*args)
+  end
+
+  def perform(*args)
+    last_arg = args.last
+
+    if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
+      args.pop
+      request_id = last_arg["request_id"]
+      GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+    end
+
+    call(*args)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require "active_record/railtie"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
+require "tilt/erubis"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
https://trello.com/c/Eddv2AiS/688-for-migrated-formats-update-for-request-tracing

This change makes it so that a request_id is passed into Sidekiq jobs so that we can send this as a header downstream, via GdsApi::GovukHeaders. Currently, this header is lost when the Sidekiq jobs run because they run in a separate process to the one in which the request was processed.

This is based on this pull request: alphagov/whitehall#2567