### PR TITLE
Request less documents from rummager

### DIFF
--- a/app/models/tagged_documents.rb
+++ b/app/models/tagged_documents.rb
@@ -1,5 +1,5 @@
 class TaggedDocuments
-  PAGE_SIZE_TO_GET_EVERYTHING = 10_000
+  PAGE_SIZE_TO_GET_EVERYTHING = 1_000
 
   include Enumerable
   delegate :each, :empty?, to: :documents

--- a/lib/tasks/compare.rake
+++ b/lib/tasks/compare.rake
@@ -25,7 +25,7 @@ namespace :comparison do
       filter_key = tag.is_a?(Topic) ? "filter_specialist_sectors" : "filter_mainstream_browse_pages"
       rummager_data = Services.rummager.unified_search({
         :start => 0,
-        :count => 10_000,
+        :count => 1_000,
         filter_key => [tag.full_slug],
         :fields => %w(title link format),
       }).results

--- a/spec/models/tagged_documents_spec.rb
+++ b/spec/models/tagged_documents_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe TaggedDocuments do
     it 'returns empty array for topics that have no documents tagged to them' do
       topic = create(:topic, slug: 'a-child', parent: create(:topic, slug: 'a-parent'))
       stub_request(:get, RummagerHelper::SEARCH_ENDPOINT)
-        .with(query: { count: 10000, fields: %w[link title], filter_specialist_sectors: %w[a-parent/a-child], start: 0 })
+        .with(query: { count: 1_000, fields: %w[link title], filter_specialist_sectors: %w[a-parent/a-child], start: 0 })
         .to_return(body: JSON.dump(results: []))
 
       documents = TaggedDocuments.new(topic).documents
@@ -16,7 +16,7 @@ RSpec.describe TaggedDocuments do
     it 'returns the documents tagged to a topic' do
       topic = create(:topic, slug: 'a-child', parent: create(:topic, slug: 'a-parent'))
       stub_request(:get, RummagerHelper::SEARCH_ENDPOINT)
-        .with(query: { count: 10000, fields: %w[link title], filter_specialist_sectors: %w[a-parent/a-child], start: 0 })
+        .with(query: { count: 1_000, fields: %w[link title], filter_specialist_sectors: %w[a-parent/a-child], start: 0 })
         .to_return(body: JSON.dump(results: [ { link: "/some-link", title: "The Title" }, { link: "/some-other-link", title: "Another Title" }]))
 
       documents = TaggedDocuments.new(topic).documents
@@ -27,7 +27,7 @@ RSpec.describe TaggedDocuments do
     it 'returns the documents tagged to a mainstream-browse-page' do
       topic = create(:mainstream_browse_page, slug: 'a-child', parent: create(:mainstream_browse_page, slug: 'a-parent'))
       stub_request(:get, RummagerHelper::SEARCH_ENDPOINT)
-        .with(query: { count: 10000, fields: %w[link title], filter_mainstream_browse_pages: %w[a-parent/a-child], start: 0 })
+        .with(query: { count: 1_000, fields: %w[link title], filter_mainstream_browse_pages: %w[a-parent/a-child], start: 0 })
         .to_return(body: JSON.dump(results: [ { link: "/some-link", title: "The Title" }, { link: "/some-other-link", title: "Another Title" }]))
 
       documents = TaggedDocuments.new(topic).documents
@@ -38,7 +38,7 @@ RSpec.describe TaggedDocuments do
     it 'returns turns the results into document classes' do
       topic = create(:topic, slug: 'a-child', parent: create(:topic, slug: 'a-parent'))
       stub_request(:get, RummagerHelper::SEARCH_ENDPOINT)
-        .with(query: { count: 10000, fields: %w[link title], filter_specialist_sectors: %w[a-parent/a-child], start: 0 })
+        .with(query: { count: 1_000, fields: %w[link title], filter_specialist_sectors: %w[a-parent/a-child], start: 0 })
         .to_return(body: JSON.dump(results: [ { link: "/some-link", title: "The Title" }]))
 
       document = TaggedDocuments.new(topic).documents.first


### PR DESCRIPTION
Rummager will refuse to return more than 1000 documents since https://github.com/alphagov/rummager/pull/634. This makes collections-publisher respect that limit.

Fixes:

https://errbit.integration.publishing.service.gov.uk/apps/53da383a0da11520d8004bb3/problems/572232616578637430910000