### PR TITLE
Fix curated list item titles

### DIFF
--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -5,4 +5,8 @@ class ListItem < ActiveRecord::Base
 
   attr_accessor :tagged
   alias :tagged? :tagged
+
+  def display_title
+    list.tag.tagged_document_for_base_path(base_path).try(:title) || title
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -108,6 +108,10 @@ class Tag < ActiveRecord::Base
     @_tagged_documents ||= TaggedDocuments.new(self)
   end
 
+  def tagged_document_for_base_path(base_path)
+    tagged_documents.find { |document| document.base_path == base_path }
+  end
+
   def legacy_tag_type
     nil
   end

--- a/app/views/lists/_all_list_items.html.erb
+++ b/app/views/lists/_all_list_items.html.erb
@@ -3,17 +3,17 @@
 
   <table class='links-table'>
     <tbody>
-      <% tag.tagged_documents.each do |list_item| %>
+      <% tag.tagged_documents.each do |item| %>
         <tr class='item'
-            data-title='<%= list_item.title %>'
-            data-base-path='<%= list_item.base_path %>'>
+            data-title='<%= item.title %>'
+            data-base-path='<%= item.base_path %>'>
 
           <td class='title'>
-            <%= raw list_item.title %>
+            <%= raw item.title %>
           </td>
 
           <td class='base-path'>
-            <%= raw list_item.base_path %>
+            <%= raw item.base_path %>
           </td>
 
           <td class='removal-button'>

--- a/app/views/lists/_list_editor.html.erb
+++ b/app/views/lists/_list_editor.html.erb
@@ -48,7 +48,7 @@
                 <% end %>
 
                 <span>
-                  <%= raw list_item.title || "<em>Unknown title (#{list_item.base_path})</em>" %>
+                  <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
                 </span>
               </td>
 

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -12,8 +12,13 @@
     <em>No items in list</em>
   <% end %>
   <ul>
-  <% list.list_items.each do |item| %>
-    <li><%= item.title %></li>
+  <% list.list_items_with_tagging_status.each do |list_item| %>
+    <li>
+      <% unless list_item.tagged? %>
+        <p class='label label-warning'>Tag was removed</p>
+      <% end %>
+      <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
+    </li>
   <% end %>
   </ul>
 <% end %>

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -235,9 +235,9 @@ RSpec.feature "Curating topic contents" do
       oil_rigs = create(:list, :tag => offshore, :name => 'Oil rigs', :index => 0)
       piping = create(:list, :tag => offshore, :name => 'Piping', :index => 1)
 
-      create(:list_item, :list => oil_rigs, :index => 0, :title => 'Oil rig safety requirements', :base_path => '/oil-rig-safety-requirements')
-      create(:list_item, :list => oil_rigs, :index => 1, :title => 'Oil rig staffing', :base_path => '/oil-rig-staffing')
-      create(:list_item, :list => piping, :index => 0, :title => 'Undersea piping restrictions', :base_path => '/undersea-piping-restrictions')
+      create(:list_item, :list => oil_rigs, :index => 0, :base_path => '/oil-rig-safety-requirements')
+      create(:list_item, :list => oil_rigs, :index => 1, :base_path => '/oil-rig-staffing')
+      create(:list_item, :list => piping, :index => 0, :base_path => '/undersea-piping-restrictions')
       create(:list_item, :list => piping, :index => 1, :title => 'Non-existent', :base_path => '/non-existent')
     end
 

--- a/spec/features/tagging_browse_with_topics_spec.rb
+++ b/spec/features/tagging_browse_with_topics_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Tagging browse pages with topics" do
   before do
     given_I_am_a_GDS_editor
     stub_all_panopticon_tag_calls
-    stub_rummager_linked_content_call
+    stub_any_call_to_rummager_with_no_documents
     stub_any_publishing_api_call
   end
 

--- a/spec/models/list_item_spec.rb
+++ b/spec/models/list_item_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ListItem do
+  describe "#display_title" do
+    it "shows the rummager title by default" do
+      stub_any_call_to_rummager_with_documents([{ link: "/some-link", title: "The Title" },
+                                                { link: "/some-other-link", title: "Another Title" }])
+
+      tag = create(:topic)
+      list_item = create(:list_item, base_path: "/some-link", list: create(:list, tag: tag))
+
+      expect(list_item.display_title).to eql('The Title')
+    end
+
+    it "falls back to the cached title" do
+      stub_any_call_to_rummager_with_no_documents
+
+      tag = create(:topic, slug: "my-tag-slug")
+      list_item = create(:list_item, base_path: "/some-link", title: "My persisted title", list: create(:list, tag: tag))
+
+      expect(list_item.display_title).to eql('My persisted title')
+    end
+  end
+end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -2,7 +2,7 @@ module CommonFeatureSteps
   def and_external_services_are_stubbed
     stub_all_panopticon_tag_calls
     allow_any_instance_of(RummagerNotifier).to receive(:notify)
-    stub_rummager_linked_content_call
+    stub_any_call_to_rummager_with_no_documents
     stub_any_publishing_api_call
   end
 

--- a/spec/support/rummager_helper.rb
+++ b/spec/support/rummager_helper.rb
@@ -1,7 +1,7 @@
 module RummagerHelper
   SEARCH_ENDPOINT = Plek.find('rummager') + '/unified_search.json'
 
-  def stub_rummager_linked_content_call
+  def stub_any_call_to_rummager_with_no_documents
     stub_any_call_to_rummager_with_documents([])
   end
 


### PR DESCRIPTION
Item titles for display in collections-publisher are currently looked up from data
persisted to the mysql db at list curation time.
This is not consistent with the collections frontend, which looks up titles from rummager.

It is possible for an item to appear in a curated list but to since have had its tag removed
or been deleted. In this case the collections frontend doesn't display the item.

Also, it is possible for a content item to have been renamed since it was included in a
curated list. It can then be added again under its new title.
In this case, collections-publisher will display two items which, while pointing to the
same base_path, appear different becase the persisted titles are different.
Collections frontend will display both items using the most recent title from rummager,
giving the appearance of duplicates which cannot be found in collections-publisher.

See https://trello.com/c/gfzHlBUn/620-collections-publisher-duplicates-in-list-editor-issue

Finally, it is possible for the persisted title to be null, in which case
collections-publisher can display an empty `<li>` element.

Once all taggable content is being published via publishing-api, we can dispense with
the rummager lookup in favour of publishing-api.

In the meantime, this commit fixes the display issues in collections-publisher by using
the rummager title where it exists, and falling back to the persisted title or placeholder
text where it does not.

@benhyland and @tijmenb 