### PR TITLE
Use `document_type` and `schema_name`

### DIFF
--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -22,18 +22,15 @@ class TaxonForm
     self.content_id ||= SecureRandom.uuid
     self.base_path ||= '/alpha-taxonomy/' + title.parameterize
 
+    presenter = TaxonPresenter.new(
+      content_id: content_id,
+      base_path: base_path,
+      title: title,
+    )
+
     Services.publishing_api.put_content(
       content_id,
-      base_path: base_path,
-      format: 'taxon',
-      title: title,
-      content_id: content_id,
-      publishing_app: 'collections-publisher',
-      rendering_app: 'collections',
-      public_updated_at: Time.now,
-      routes: [
-        { path: base_path, type: "exact" },
-      ]
+      presenter.payload
     )
 
     Services.publishing_api.publish(content_id, "minor")

--- a/app/forms/taxon_form.rb
+++ b/app/forms/taxon_form.rb
@@ -23,7 +23,6 @@ class TaxonForm
     self.base_path ||= '/alpha-taxonomy/' + title.parameterize
 
     presenter = TaxonPresenter.new(
-      content_id: content_id,
       base_path: base_path,
       title: title,
     )

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -17,7 +17,8 @@ class RootBrowsePagePresenter
 
   def render_for_publishing_api
     {
-      format: "mainstream_browse_page",
+      schema_name: "mainstream_browse_page",
+      document_type: "mainstream_browse_page",
       base_path: '/browse',
       title: "Browse",
       locale: 'en',

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -18,7 +18,8 @@ class RootTopicPresenter
   def render_for_publishing_api
     {
       base_path: '/topic',
-      format: "topic",
+      schema_name: "topic",
+      document_type: "topic",
       title: "Topics",
       locale: 'en',
       public_updated_at: public_updated_at,

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -40,7 +40,8 @@ class TagPresenter
   def render_for_publishing_api
     {
       base_path: base_path,
-      format: format,
+      document_type: format,
+      schema_name: format,
       title: @tag.title,
       description: @tag.description,
       locale: 'en',

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -7,7 +7,8 @@ class TaxonPresenter
   def payload
     {
       base_path: base_path,
-      format: 'taxon',
+      document_type: 'taxon',
+      schema_name: 'taxon',
       title: title,
       publishing_app: 'collections-publisher',
       rendering_app: 'collections',

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -1,6 +1,5 @@
 class TaxonPresenter
-  def initialize(content_id:, base_path:, title:)
-    @content_id = content_id
+  def initialize(base_path:, title:)
     @base_path = base_path
     @title = title
   end
@@ -10,10 +9,10 @@ class TaxonPresenter
       base_path: base_path,
       format: 'taxon',
       title: title,
-      content_id: content_id,
       publishing_app: 'collections-publisher',
       rendering_app: 'collections',
-      public_updated_at: Time.now,
+      public_updated_at: Time.now.iso8601,
+      locale: 'en',
       routes: [
         { path: base_path, type: "exact" },
       ]
@@ -22,5 +21,5 @@ class TaxonPresenter
 
 private
 
-  attr_reader :content_id, :base_path, :title
+  attr_reader :base_path, :title
 end

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -1,0 +1,26 @@
+class TaxonPresenter
+  def initialize(content_id:, base_path:, title:)
+    @content_id = content_id
+    @base_path = base_path
+    @title = title
+  end
+
+  def payload
+    {
+      base_path: base_path,
+      format: 'taxon',
+      title: title,
+      content_id: content_id,
+      publishing_app: 'collections-publisher',
+      rendering_app: 'collections',
+      public_updated_at: Time.now,
+      routes: [
+        { path: base_path, type: "exact" },
+      ]
+    }
+  end
+
+private
+
+  attr_reader :content_id, :base_path, :title
+end

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -123,7 +123,8 @@ RSpec.feature "Managing browse pages" do
       @content_id,
       title: "Citizenship",
       description: "Living in the UK",
-      format: "mainstream_browse_page",
+      document_type: "mainstream_browse_page",
+      schema_name: "mainstream_browse_page",
     )
 
     assert_publishing_api_patch_links(@content_id)

--- a/spec/features/managing_topic_pages_spec.rb
+++ b/spec/features/managing_topic_pages_spec.rb
@@ -123,7 +123,8 @@ RSpec.feature "Managing topics" do
       @content_id,
       title: "Citizenship",
       description: "Living in the UK",
-      format: "topic",
+      schema_name: "topic",
+      document_type: "topic",
     )
 
     assert_publishing_api_patch_links(@content_id)
@@ -142,7 +143,8 @@ RSpec.feature "Managing topics" do
     stub_publishing_api_put_content(
       @page.content_id,
       title: "Citizenship in the UK",
-      format: "topic",
+      document_type: "topic",
+      schema_name: "topic",
     )
 
     assert_publishing_api_patch_links(@page.content_id)

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
     it "includes the base fields" do
       expect(presented_data).to include({
-        :format => 'mainstream_browse_page',
+        :schema_name => 'mainstream_browse_page',
+        :document_type => 'mainstream_browse_page',
         :title => 'Benefits',
         :description => 'All about benefits',
         :locale => 'en',

--- a/spec/presenters/taxon_presenter_spec.rb
+++ b/spec/presenters/taxon_presenter_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe TaxonPresenter do
+  describe "#payload" do
+    it "generates a valid payload" do
+      presenter = TaxonPresenter.new(
+        title: "My Title",
+        content_id: "e8d62d8c-22d2-4890-9d5c-805da489d16f",
+        base_path: "/taxons/my-taxon"
+      )
+
+      payload = presenter.payload
+
+      expect(payload).to be_valid_against_schema('taxon')
+    end
+  end
+end

--- a/spec/presenters/taxon_presenter_spec.rb
+++ b/spec/presenters/taxon_presenter_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe TaxonPresenter do
     it "generates a valid payload" do
       presenter = TaxonPresenter.new(
         title: "My Title",
-        content_id: "e8d62d8c-22d2-4890-9d5c-805da489d16f",
         base_path: "/taxons/my-taxon"
       )
 

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe TopicPresenter do
 
       it "includes the base fields" do
         expect(presented_data).to include({
-          :format => 'topic',
+          :schema_name => 'topic',
+          :document_type => 'topic',
           :title => 'Working at sea',
           :description => 'The sea, the sky, the sea, the sky...',
           :locale => 'en',
@@ -83,7 +84,8 @@ RSpec.describe TopicPresenter do
 
       it "includes the base fields" do
         expect(presented_data).to include({
-          :format => 'topic',
+          :schema_name => 'topic',
+          :document_type => 'topic',
           :title => 'Offshore',
           :description => 'Oil rigs, pipelines etc.',
           :locale => 'en',


### PR DESCRIPTION
The `format` field is deprecated and should not be used anymore.

Includes some new schema testing for the taxons.