### PR TITLE
Properly send document state to publishing-api

### DIFF
--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -26,6 +26,7 @@ class RootTopicPresenter
       publishing_app: "collections-publisher",
       rendering_app: "collections",
       routes: routes,
+      phase: 'beta',
       details: {
         beta: true,
         internal_name: "Topic index page",


### PR DESCRIPTION
The `phase` attribute was added after this content item code was written, so it used a older `details.beta` attribute. If we start using `phase` here, we can convert collections to use this attribute and remove some data duplication.