### PR TITLE
Fix schema tests 

### DIFF
--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -26,6 +26,7 @@ class RootBrowsePagePresenter
       publishing_app: "collections-publisher",
       rendering_app: "collections",
       routes: routes,
+      details: {},
     }
   end
 

--- a/app/presenters/taxon_presenter.rb
+++ b/app/presenters/taxon_presenter.rb
@@ -14,6 +14,7 @@ class TaxonPresenter
       rendering_app: 'collections',
       public_updated_at: Time.now.iso8601,
       locale: 'en',
+      details: {},
       routes: [
         { path: base_path, type: "exact" },
       ]

--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -2,6 +2,5 @@
 
 export REPO_NAME="alphagov/govuk-content-schemas"
 export CONTEXT_MESSAGE="Verify collections-publisher against content schemas"
-export TEST_TASK="spec:schema"
 
 exec ./jenkins.sh

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,11 +1,3 @@
 if Rails.env.development? || Rails.env.test?
-
   require 'rspec/core/rake_task'
-
-  namespace :spec do
-    desc "Run all schema specs"
-    RSpec::Core::RakeTask.new(:schema => "spec:prepare") do |t|
-      t.rspec_opts = '-t schema_test'
-    end
-  end
 end

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe PublishingAPINotifier do
     end
 
     context "for a draft tag" do
-      it "sends the presented details to the publishing-api", schema_test: true do
+      it "sends the presented details to the publishing-api" do
         tag = create(:topic, :draft, slug: 'foo')
 
         PublishingAPINotifier.notify(tag)
@@ -125,7 +125,7 @@ RSpec.describe PublishingAPINotifier do
     end
 
     context "for a published tag" do
-      it "sends the presented details to the publishing-api", schema_test: true do
+      it "sends the presented details to the publishing-api" do
         tag = create(:topic, :published, slug: 'foo')
 
         PublishingAPINotifier.notify(tag)
@@ -134,7 +134,7 @@ RSpec.describe PublishingAPINotifier do
         expect(stubbed_content_store.last_updated_item).to be_valid_against_schema('topic')
       end
 
-      it "sends topic redirects to the publishing-api", schema_test: true do
+      it "sends topic redirects to the publishing-api" do
         tag = create(:topic, :published, slug: 'foo')
 
         create(:redirect_route,

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
       ])
     end
 
-    it "is valid against the schema", :schema_test => true do
+    it "is valid against the schema" do
       expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
     end
 
@@ -98,7 +98,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           ])
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end
@@ -165,7 +165,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           ])
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end
@@ -181,7 +181,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           ])
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end
@@ -210,7 +210,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           ])
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end
@@ -227,7 +227,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           ])
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end
@@ -254,7 +254,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           expect(presented_data[:details]["second_level_ordering"]).to eq("curated")
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end
@@ -267,7 +267,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
           expect(presented_data[:details]["second_level_ordering"]).to eq("curated")
         end
 
-        it "is valid against the schema", :schema_test => true do
+        it "is valid against the schema" do
           expect(presented_data).to be_valid_against_schema('mainstream_browse_page')
         end
       end

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe TagPresenter do
       })
     end
 
-    it "is valid against the schema without lists", :schema_test => true do
+    it "is valid against the schema without lists" do
       presented_data = TopicPresenter.new(tag).render_for_publishing_api
 
       expect(presented_data).to be_valid_against_schema('topic')
     end
 
-    it "is valid against the schema with lists", :schema_test => true do
+    it "is valid against the schema with lists" do
       create(:list, tag: tag, name: "List A")
       create(:list, tag: tag, name: "List B")
 

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TopicPresenter do
         })
       end
 
-      it "is valid against the schema", :schema_test => true do
+      it "is valid against the schema" do
         expect(presented_data).to be_valid_against_schema('topic')
       end
 
@@ -96,7 +96,7 @@ RSpec.describe TopicPresenter do
         })
       end
 
-      it "is valid against the schema", :schema_test => true do
+      it "is valid against the schema" do
         expect(presented_data).to be_valid_against_schema('topic')
       end
 


### PR DESCRIPTION
When a new PR is made on govuk-content-schemas, the Jenkins task runs `./jenkins-schema.sh`. This test task's purpose is to run a subset of all tests that interact with the schemas. This is done so that govuk-content-schema tests run faster.

The problem is that for this to happen, the developer needs to tag schema tests with `schema_test: true`. This is error prone, and we currently have multiple schema tests that aren't triggered by jenkins.
This causes an annoying thing where a govuk-content-schemas PR is merged that makes the tests (on master) for this repo fail.

To prevent this from happening again, we choose here to run _all_ the tests. This causes wasted CPU cycles, but I'm of the opinion that that's an acceptable loss compared to potential bugs not being caught
by CI. Especially now that publishing-api is working on validating the incoming requests against the schemas.
