### PR TITLE
Set authenticated user header in sidekiq work

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   include GDS::SSO::ControllerMethods
   before_filter :require_signin_permission!
+  before_filter :set_authenticated_user_header
 
   add_flash_types :success, :info, :warning, :danger
 
@@ -35,5 +36,11 @@ private
 
   def find_tag
     @tag = Tag.find_by!(content_id: params[:tag_id])
+  end
+
+  def set_authenticated_user_header
+    if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
   end
 end

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -2,19 +2,28 @@ class WorkerBase
   include Sidekiq::Worker
 
   def self.perform_async(*args)
-    args << { request_id: GdsApi::GovukHeaders.headers[:govuk_request_id] }
+    args << govuk_headers
     super(*args)
   end
 
   def perform(*args)
     last_arg = args.last
 
-    if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
+    if last_arg.is_a?(Hash) && last_arg.keys.include?("request_id")
       args.pop
       request_id = last_arg["request_id"]
+      authenticated_user = last_arg["authenticated_user"]
       GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, authenticated_user)
     end
 
     call(*args)
+  end
+
+  def self.govuk_headers
+    {
+      request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      authenticated_user: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+    }
   end
 end

--- a/spec/workers/worker_base_spec.rb
+++ b/spec/workers/worker_base_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe WorkerBase do
+
+  class MyWorker < WorkerBase
+    def call(*args); end
+  end
+
+  describe "perform_async" do
+    it "appends govuk headers to job arguments" do
+      allow(GdsApi::GovukHeaders).to receive(:headers).and_return({
+        govuk_request_id: "12345-67890",
+        x_govuk_authenticated_user: "abcdef-09876",
+      })
+
+      expect(WorkerBase).to receive(:client_push)
+        .with("class" => MyWorker,
+              "args" => [
+                "foo",
+                { request_id: "12345-67890", authenticated_user: "abcdef-09876" }
+              ])
+
+      MyWorker.perform_async("foo")
+    end
+  end
+
+  describe "perform" do
+    it "populates govuk headers from job arguments" do
+      MyWorker.new.perform(
+        "foo",
+        { "request_id" => "12345-67890", "authenticated_user" => "abcdef-09876" }
+      )
+
+      expect(GdsApi::GovukHeaders.headers[:govuk_request_id]).to eq("12345-67890")
+      expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq("abcdef-09876")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/6nDCqZXi/729-user-id-into-event-log

Events logged in the publishing API should contain the uid present in the x_govuk_authenticated_user header. So ensure that the header is populated for each request and that the header is repopulated in any Sidekiq worker processes.