### PR TITLE
Send 2nd level browse pages in the details hash

### DIFF
--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -20,7 +20,8 @@ private
 
   def details
     super.merge(
-      "second_level_ordering" => second_level_ordering
+      "second_level_ordering" => second_level_ordering,
+      "ordered_second_level_browse_pages" => second_level_browse_pages,
     )
   end
 

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -240,9 +240,15 @@ RSpec.describe MainstreamBrowsePagePresenter do
         :child_ordering => "curated",
       )}
 
-      let!(:second_level_page) { create(
+      let!(:second_level_page_1) { create(
         :mainstream_browse_page,
         :title => "Second-level page",
+        :parent => top_level_page,
+      )}
+
+      let!(:second_level_page_2) { create(
+        :mainstream_browse_page,
+        :title => "Another second-level page",
         :parent => top_level_page,
       )}
 
@@ -252,6 +258,10 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
         it "returns the order in which its children are ordered" do
           expect(presented_data[:details]["second_level_ordering"]).to eq("curated")
+          expect(presented_data[:details]["ordered_second_level_browse_pages"]).to eq([
+            second_level_page_1.content_id,
+            second_level_page_2.content_id,
+          ])
         end
 
         it "is valid against the schema" do
@@ -260,11 +270,15 @@ RSpec.describe MainstreamBrowsePagePresenter do
       end
 
       context "for a second level page" do
-        let(:presenter) { MainstreamBrowsePagePresenter.new(second_level_page) }
+        let(:presenter) { MainstreamBrowsePagePresenter.new(second_level_page_1) }
         let(:presented_data) { presenter.render_for_publishing_api }
 
         it "returns the order in which self and its siblings are ordered" do
           expect(presented_data[:details]["second_level_ordering"]).to eq("curated")
+          expect(presented_data[:details]["ordered_second_level_browse_pages"]).to eq([
+            second_level_page_1.content_id,
+            second_level_page_2.content_id,
+          ])
         end
 
         it "is valid against the schema" do


### PR DESCRIPTION
content-store does not retain the order of the items that are sent in the links
hash, therefore in order to allow custom 2nd level browse pages ordering we
have to read the links order from the details hash.

Deploy and run rake task to republish all items pages/tags before merging and deploy:
https://github.com/alphagov/collections/compare/sort-2nd-level-browse-pages

Depends on: https://github.com/alphagov/govuk-content-schemas/pull/343

paired on it with @rubenarakelyan 