### PR TITLE
Print rake task logs

### DIFF
--- a/app/services/tag_republisher.rb
+++ b/app/services/tag_republisher.rb
@@ -60,6 +60,7 @@ private
   end
 
   def log(string)
+    puts string
     Rails.logger.info(string)
   end
 end


### PR DESCRIPTION
This is so that I do not have to ssh into a machine to read the logs, the change will allow me to read them on Jenkins or via the console from which I am running the rake task