### PR TITLE
Use `document_type` and `schema_name`

### DIFF
--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -24,7 +24,8 @@ private
   def render_gone_item
     {
       base_path: tag.base_path,
-      format: 'gone',
+      document_type: 'gone',
+      schema_name: 'gone',
       publishing_app: 'collections-publisher',
       content_id: tag.content_id,
       routes: presenter.routes


### PR DESCRIPTION
`document_type` and `schema_name` have replaced `format`.

Related: https://github.com/alphagov/govuk-content-schemas/pull/348