### PR TITLE
Add 12-factor Airbrake & gds-sso config

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV["ERRBIT_API_KEY"].present?
+  errbit_uri = Plek.find_uri("errbit")
+
+  Airbrake.configure do |config|
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == "https"
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
+  end
+end

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,0 +1,6 @@
+GDS::SSO.config do |config|
+  config.user_model = "User"
+  config.oauth_id = ENV["OAUTH_ID"]
+  config.oauth_secret = ENV["OAUTH_SECRET"]
+  config.oauth_root_url = Plek.find("signon")
+end


### PR DESCRIPTION
Currently alphagov-deployment overwrites the airbrake.rb initializer ([here](https://github.gds/gds/alphagov-deployment/blob/18873afa146b334326b5804
3b758bff84a906b96/collections-publisher/initializers_by_organisation/pro
duction/airbrake.rb)).

We're moving to a 12 factor model, using environment variables to set configuration. This commit adds a default airbrake initializer (taken from [govuk-rails-app-template](https://github.com/alphagov/govuk-rails-app-template/blob/master/templates/config/initializers/airbrake.rb)).

Next we'll update govuk-puppet and alphagov-deployment.

Trello: https://trello.com/c/dKfYzDNx