### PR TITLE
Add SECRET_KEY_BASE for production

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,3 +15,9 @@ development:
 
 test:
   secret_key_base: 25c938de40760688ab5e438afd8a69cacb89c0edfa6190ffb5afb04d09ff8b0db1f7e64876928553f8be3ce0075fd84ded2ec4e3e2c7c8610bf8751c6e2f2323
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  


### PR DESCRIPTION
We will use this later, so that we don't have to overwrite secrets.yml from the alphagov-deployment repo.

https://trello.com/c/dKfYzDNx