### PR TITLE
Add browse page archiving

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -34,3 +34,8 @@ button {
   @extend .btn;
   @extend .btn-default;
 }
+
+#new_mainstream_browse_page_archival_form,
+#new_topic_archival_form {
+  padding-bottom: 2em;
+}

--- a/app/assets/stylesheets/topics.scss
+++ b/app/assets/stylesheets/topics.scss
@@ -31,7 +31,3 @@ h1 .label {
   font-size: 60%;
   vertical-align: middle;
 }
-
-#new_archival_form{
-  padding-bottom: 2em;
-}

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -8,6 +8,7 @@ class MainstreamBrowsePagesController < ApplicationController
 
   def show
     @browse_page = find_browse_page
+    render 'archived_browse_page' if @browse_page.archived?
   end
 
   def edit
@@ -51,6 +52,21 @@ class MainstreamBrowsePagesController < ApplicationController
     redirect_to browse_page
   end
 
+  def propose_archive
+    @archival = MainstreamBrowsePageArchivalForm.new(tag: find_browse_page)
+  end
+
+  def archive
+    @archival = MainstreamBrowsePageArchivalForm.new(params[:mainstream_browse_page_archival_form])
+    @archival.tag = find_browse_page
+
+    if @archival.archive_or_remove
+      redirect_to mainstream_browse_pages_path, success: 'The mainstream browse page has been archived or removed.'
+    else
+      render 'propose_archive'
+    end
+  end
+
   def manage_child_ordering
     @browse_page = find_browse_page
   end
@@ -67,7 +83,7 @@ private
 
   def browse_page_params
     # Convert the String ids to Topic objects so that
-    # `update_attributes` correct updates and associates
+    # `update_attributes` correctly updates and associates
     # them with the given `MainstreamBrowsePage` object.
     if params.require(:mainstream_browse_page).key? :topics
       topic_ids = params.require(:mainstream_browse_page)[:topics]

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -52,11 +52,11 @@ class TopicsController < ApplicationController
   end
 
   def propose_archive
-    @archival = ArchivalForm.new(tag: find_topic)
+    @archival = TopicArchivalForm.new(tag: find_topic)
   end
 
   def archive
-    @archival = ArchivalForm.new(params[:archival_form])
+    @archival = TopicArchivalForm.new(params[:topic_archival_form])
     @archival.tag = find_topic
 
     if @archival.archive_or_remove

--- a/app/forms/mainstream_browse_page_archival_form.rb
+++ b/app/forms/mainstream_browse_page_archival_form.rb
@@ -1,11 +1,11 @@
-class ArchivalForm
+class MainstreamBrowsePageArchivalForm
   include ActiveModel::Model
   attr_accessor :tag, :successor, :successor_path
 
   validates :successor_path, presence: true, valid_govuk_path: true, if: :redirecting_to_path?
 
-  def topics
-    published_topics - [tag]
+  def browse_pages
+    published_browse_pages - [tag]
   end
 
   def archive_or_remove
@@ -30,14 +30,15 @@ private
 
   def successor_object
     if redirecting_to_path?
-      OpenStruct.new(base_path: successor_path, subroutes: [])
+      Struct.new("RedirectToPath", :base_path, :subroutes)
+      Struct::RedirectToPath.new(successor_path, [])
     else
-      Topic.find_by_id(successor)
+      MainstreamBrowsePage.find_by_id(successor)
     end
   end
 
-  def published_topics
-    Topic.includes(:parent).published.sort_by(&:title_including_parent)
+  def published_browse_pages
+    MainstreamBrowsePage.includes(:parent).published.sort_by(&:title_including_parent)
   end
 
   def redirecting_to_path?

--- a/app/forms/topic_archival_form.rb
+++ b/app/forms/topic_archival_form.rb
@@ -1,0 +1,47 @@
+class TopicArchivalForm
+  include ActiveModel::Model
+  attr_accessor :tag, :successor, :successor_path
+
+  validates :successor_path, presence: true, valid_govuk_path: true, if: :redirecting_to_path?
+
+  def topics
+    published_topics - [tag]
+  end
+
+  def archive_or_remove
+    return false unless valid?
+
+    if tag.published?
+      TagArchiver.new(tag, successor_object).archive
+    else
+      DraftTagRemover.new(tag).remove
+    end
+
+    true
+  rescue GdsApi::HTTPConflict
+    errors.add :base, "The tag could not be deleted because there are documents tagged to it."
+    false
+  rescue GdsApi::HTTPClientError
+    errors.add :base, "The tag could not be deleted because of an error."
+    false
+  end
+
+private
+
+  def successor_object
+    if redirecting_to_path?
+      Struct.new("RedirectToPath", :base_path, :subroutes)
+      Struct::RedirectToPath.new(successor_path, [])
+    else
+      Topic.find_by_id(successor)
+    end
+  end
+
+  def published_topics
+    Topic.includes(:parent).published.sort_by(&:title_including_parent)
+  end
+
+  def redirecting_to_path?
+    !successor_path.nil?
+  end
+end

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -4,7 +4,12 @@ class TagPresenter
   def self.presenter_for(tag)
     case tag
     when MainstreamBrowsePage
-      MainstreamBrowsePagePresenter.new(tag)
+      case tag.state
+      when 'published', 'draft'
+        MainstreamBrowsePagePresenter.new(tag)
+      when 'archived'
+        ArchivedTagPresenter.new(tag)
+      end
     when Topic
       case tag.state
       when 'published', 'draft'

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -1,4 +1,4 @@
-# TagArchiver removes a tag from the site. It sets op a redirect for the page
+# TagArchiver removes a tag from the site. It sets up a redirect for the page
 # to its successor and removes the tag from the search engine. It does not remove
 # the tag from panopticon - that has to be done manually.
 class TagArchiver

--- a/app/views/mainstream_browse_pages/_redirects.html.erb
+++ b/app/views/mainstream_browse_pages/_redirects.html.erb
@@ -1,0 +1,16 @@
+<h3>Redirects</h3>
+
+<table class='table'>
+  <tr>
+    <th>Added</th>
+    <th>From</th>
+    <th>To</th>
+  </tr>
+  <% redirect_routes.order('created_at DESC').each do |redirect_route| %>
+    <tr>
+      <td><%= redirect_route.created_at.to_formatted_s(:long) %></td>
+      <td><%= link_to redirect_route.from_base_path, website_url(redirect_route.from_base_path), target: '_blank' %></td>
+      <td><%= link_to redirect_route.to_base_path, website_url(redirect_route.to_base_path), target: '_blank' %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/mainstream_browse_pages/archived_browse_page.html.erb
+++ b/app/views/mainstream_browse_pages/archived_browse_page.html.erb
@@ -1,0 +1,7 @@
+<%= tag_header @browse_page %>
+
+<p class="no-content">
+  This mainstream browse page has been archived.
+</p>
+
+<%= render 'redirects', redirect_routes: @browse_page.redirect_routes %>

--- a/app/views/mainstream_browse_pages/propose_archive.html.erb
+++ b/app/views/mainstream_browse_pages/propose_archive.html.erb
@@ -1,4 +1,4 @@
-<%= tag_header @archival.tag, 'Archive topic' %>
+<%= tag_header @archival.tag, 'Archive mainstream browse page' %>
 
 <% if @archival.errors[:base].any? %>
   <div class="alert alert-danger">
@@ -6,16 +6,16 @@
   </div>
 <% end %>
 
-<%= form_for @archival, url: archive_topic_path(@archival.tag) do |f| %>
+<%= form_for @archival, url: archive_mainstream_browse_page_path(@archival.tag) do |f| %>
   <%= f.select :successor,
-    options_from_collection_for_select(@archival.topics, :id, :title_including_parent),
-    { label: 'Choose a topic to redirect to:' },
+    options_from_collection_for_select(@archival.browse_pages, :id, :title_including_parent),
+    { label: 'Choose a mainstream browse page to redirect to:' },
     { class: 'select2' } %>
 
-  <%= f.submit 'Archive and redirect to a topic', class: 'btn-submit btn-danger' %>
+  <%= f.submit 'Archive and redirect to a mainstream browse page', class: 'btn-submit btn-danger' %>
 <% end %>
 
-<%= form_for @archival, url: archive_topic_path(@archival.tag) do |f| %>
+<%= form_for @archival, url: archive_mainstream_browse_page_path(@archival.tag) do |f| %>
   <%= f.text_field :successor_path,
     { label: 'Or type in a URL to redirect to a page:',
       placeholder: 'Please specify it as a relative path (for example "/government/publications/what-hmrc-does-to-prevent-tax-evasion")' } %>

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -12,6 +12,16 @@
                publish_mainstream_browse_page_path(@browse_page),
                method: :post %>
   <% end %>
+
+  <% if @browse_page.child? && @browse_page.tagged_documents.empty? %>
+    <% if @browse_page.published? %>
+      <%= link_to 'Archive mainstream browse page', propose_archive_mainstream_browse_page_path(@browse_page) %>
+    <% else %>
+      <%= link_to 'Remove mainstream browse page', archive_mainstream_browse_page_path(@browse_page),
+        method: 'post',
+        data: { confirm: 'Are you sure?' } %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <%= render 'shared/tags/metadata', resource: @browse_page %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
                                       except: :destroy do
     member do
       post :publish
+      get :propose_archive
+      post :archive
       get :"manage-child-ordering"
     end
   end

--- a/spec/features/archiving_mainstream_browse_page_tags_spec.rb
+++ b/spec/features/archiving_mainstream_browse_page_tags_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.feature "Archiving mainstream browse page tags" do
+  include PublishingApiHelpers
+  include CommonFeatureSteps
+  include GdsApi::TestHelpers::ContentStore
+
+  before do
+    # Stub rummager so that mainstream browse pages do not have links.
+    stub_any_call_to_rummager_with_documents([])
+
+    stub_any_publishing_api_call
+
+    @rummager_deletion = stub_request(:delete, %r[#{Plek.find('rummager')}/*]).to_return(body: "{}")
+    @panopticon_deletion = stub_request(:delete, %r[#{Plek.find('panopticon')}/*]).to_return(body: "{}")
+
+    # Background
+    given_I_am_a_GDS_editor
+    and_there_is_a_mainstream_browse_page_that_can_be_used_as_a_replacement
+  end
+
+  scenario "User visits an archived tag" do
+    given_there_is_an_archived_mainstream_browse_page
+    when_I_visit_the_mainstream_browse_page_edit_page
+    then_I_see_that_archived_mainstream_browse_pages_cannot_be_modified
+  end
+
+  scenario "User archives published tag" do
+    given_there_is_a_published_mainstream_browse_page
+    and_I_visit_the_mainstream_browse_page
+    and_I_go_to_the_archive_page
+
+    when_I_redirect_the_mainstream_browse_page_to_a_successor_mainstream_browse_page
+    then_the_tag_is_archived
+    and_the_tag_is_removed_from_search
+    and_the_tag_is_removed_from_panopticon
+
+    when_I_visit_the_mainstream_browse_page_edit_page
+    then_I_see_that_I_cannot_edit_the_page
+  end
+
+  scenario "User attempts to archive tag with incoming links" do
+    given_there_is_a_published_mainstream_browse_page
+    and_the_mainstream_browse_page_has_content_tagged_to_it
+    and_I_visit_the_mainstream_browse_page
+    and_I_go_to_the_archive_page
+    when_I_redirect_the_mainstream_browse_page_to_a_successor_mainstream_browse_page
+    then_I_see_that_archiving_is_impossible_because_there_is_content_tagged
+  end
+
+  scenario "User archives draft tag" do
+    given_there_is_a_draft_mainstream_browse_page
+    and_I_visit_the_mainstream_browse_page
+    when_I_click_the_remove_button
+    then_the_tag_is_deleted
+    and_the_tag_is_removed_from_panopticon
+  end
+
+  scenario "User redirects to invalid basepath" do
+    given_there_is_a_published_mainstream_browse_page
+    and_I_visit_the_mainstream_browse_page
+    and_I_go_to_the_archive_page
+    when_I_submit_an_invalid_base_path_as_redirect
+    then_I_see_that_the_URL_isnt_valid
+  end
+
+  def then_the_tag_is_deleted
+    expect { @mainstream_browse_page.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  def when_I_redirect_the_mainstream_browse_page_to_a_successor_mainstream_browse_page
+    select 'The Successor Mainstream Browse Page', from: "mainstream_browse_page_archival_form_successor"
+    click_button 'Archive and redirect to a mainstream browse page'
+  end
+
+  def when_I_visit_the_mainstream_browse_page_edit_page
+    visit edit_mainstream_browse_page_path(@mainstream_browse_page)
+  end
+
+  def and_I_visit_the_mainstream_browse_page
+    visit mainstream_browse_page_path(@mainstream_browse_page)
+  end
+
+  def then_I_see_that_archived_mainstream_browse_pages_cannot_be_modified
+    expect(page).to have_content 'You cannot modify an archived mainstream browse page.'
+  end
+
+  def given_there_is_an_archived_mainstream_browse_page
+    @mainstream_browse_page = create(:mainstream_browse_page, :archived)
+  end
+
+  def given_there_is_a_published_mainstream_browse_page
+    @mainstream_browse_page = create(:mainstream_browse_page, :published, slug: 'bar', parent: create(:mainstream_browse_page, slug: 'foo'))
+  end
+
+  def given_there_is_a_draft_mainstream_browse_page
+    @mainstream_browse_page = create(:mainstream_browse_page, :draft, slug: 'bar', parent: create(:mainstream_browse_page, slug: 'foo'))
+  end
+
+  def and_there_is_a_mainstream_browse_page_that_can_be_used_as_a_replacement
+    create(:mainstream_browse_page, :published, title: 'The Successor Mainstream Browse Page')
+  end
+
+  def when_I_click_the_remove_button
+    click_link 'Remove mainstream browse page'
+  end
+
+  def and_I_go_to_the_archive_page
+    click_link 'Archive mainstream browse page'
+  end
+
+  def and_the_mainstream_browse_page_has_content_tagged_to_it
+    stub_request(:delete, "https://panopticon.test.gov.uk/tags/section/foo/bar.json")
+      .to_return(status: 409, body: "{}")
+  end
+
+  def then_I_see_that_archiving_is_impossible_because_there_is_content_tagged
+    expect(page).to have_content 'The tag could not be deleted because there are documents tagged to it'
+  end
+
+  def and_the_tag_is_removed_from_panopticon
+    expect(@panopticon_deletion).to have_been_requested
+  end
+
+  def then_the_tag_is_archived
+    expect(@mainstream_browse_page.reload.archived?).to eql(true)
+  end
+
+  def and_the_tag_is_removed_from_search
+    expect(@rummager_deletion).to have_been_requested
+  end
+
+  def then_I_see_that_I_cannot_edit_the_page
+    expect(page).to have_content 'You cannot modify an archived mainstream browse page.'
+  end
+
+  def when_I_submit_an_invalid_base_path_as_redirect
+    content_store_does_not_have_item('/not-here')
+    fill_in "mainstream_browse_page_archival_form[successor_path]", with: '/not-here'
+    click_button "Archive and redirect to a page"
+  end
+
+  def then_I_see_that_the_URL_isnt_valid
+    expect(page).to have_content("This URL isn't a valid target for a redirect on GOV.UK.")
+  end
+end

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/content_store'
 
-RSpec.feature "Archiving tags" do
+RSpec.feature "Archiving topic tags" do
   include PublishingApiHelpers
   include CommonFeatureSteps
   include GdsApi::TestHelpers::ContentStore
@@ -70,7 +70,7 @@ RSpec.feature "Archiving tags" do
   end
 
   def when_I_redirect_the_topic_to_a_successor_topic
-    select 'The Successor Topic', from: "archival_form_successor"
+    select 'The Successor Topic', from: "topic_archival_form_successor"
     click_button 'Archive and redirect to a topic'
   end
 
@@ -137,7 +137,7 @@ RSpec.feature "Archiving tags" do
 
   def when_I_submit_an_invalid_base_path_as_redirect
     content_store_does_not_have_item('/not-here')
-    fill_in "archival_form[successor_path]", with: '/not-here'
+    fill_in "topic_archival_form[successor_path]", with: '/not-here'
     click_button "Archive and redirect to a page"
   end
 

--- a/spec/forms/mainstream_browse_page_archival_form_spec.rb
+++ b/spec/forms/mainstream_browse_page_archival_form_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_store'
+
+RSpec.describe MainstreamBrowsePageArchivalForm do
+  include GdsApi::TestHelpers::ContentStore
+
+  describe '#browse_pages' do
+    it 'returns published mainstream browse pages that can be successors' do
+      create(:mainstream_browse_page, :draft)
+      create(:mainstream_browse_page, :archived)
+      published = create(:mainstream_browse_page, :published)
+      mainstream_browse_page_self = create(:mainstream_browse_page, :published)
+
+      mainstream_browse_pages = MainstreamBrowsePageArchivalForm.new(tag: mainstream_browse_page_self).browse_pages
+
+      expect(mainstream_browse_pages).to eql([published])
+    end
+  end
+
+  describe '#successor_path' do
+    it 'is not valid if the URL returns a 404 status code' do
+      content_store_does_not_have_item('/not-here')
+
+      form = MainstreamBrowsePageArchivalForm.new(successor_path: "/not-here")
+
+      expect(form.valid?).to eql(false)
+    end
+
+    it 'is not valid if its not really a URL' do
+      form = MainstreamBrowsePageArchivalForm.new(successor_path: "/i-Am Not A URL")
+
+      expect(form.valid?).to eql(false)
+    end
+
+    it 'is not valid if it does not start with a slash' do
+      form = MainstreamBrowsePageArchivalForm.new(successor_path: "am-not-a-url")
+
+      expect(form.valid?).to eql(false)
+    end
+
+    it 'is valid if the URL returns 200' do
+      content_store_has_item('/existing-item')
+
+      form = MainstreamBrowsePageArchivalForm.new(successor_path: "/existing-item")
+
+      expect(form.valid?).to eql(true)
+    end
+  end
+end

--- a/spec/forms/topic_archival_form_spec.rb
+++ b/spec/forms/topic_archival_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/content_store'
 
-RSpec.describe ArchivalForm do
+RSpec.describe TopicArchivalForm do
   include GdsApi::TestHelpers::ContentStore
 
   describe '#topics' do
@@ -11,7 +11,7 @@ RSpec.describe ArchivalForm do
       published = create(:topic, :published)
       topic_self = create(:topic, :published)
 
-      topics = ArchivalForm.new(tag: topic_self).topics
+      topics = TopicArchivalForm.new(tag: topic_self).topics
 
       expect(topics).to eql([published])
     end
@@ -21,19 +21,19 @@ RSpec.describe ArchivalForm do
     it 'is not valid if the URL returns a 404 status code' do
       content_store_does_not_have_item('/not-here')
 
-      form = ArchivalForm.new(successor_path: "/not-here")
+      form = TopicArchivalForm.new(successor_path: "/not-here")
 
       expect(form.valid?).to eql(false)
     end
 
     it 'is not valid if its not really a URL' do
-      form = ArchivalForm.new(successor_path: "/i-Am Not A URL")
+      form = TopicArchivalForm.new(successor_path: "/i-Am Not A URL")
 
       expect(form.valid?).to eql(false)
     end
 
     it 'is not valid if it does not start with a slash' do
-      form = ArchivalForm.new(successor_path: "am-not-a-url")
+      form = TopicArchivalForm.new(successor_path: "am-not-a-url")
 
       expect(form.valid?).to eql(false)
     end
@@ -41,7 +41,7 @@ RSpec.describe ArchivalForm do
     it 'is valid if the URL returns 200' do
       content_store_has_item('/existing-item')
 
-      form = ArchivalForm.new(successor_path: "/existing-item")
+      form = TopicArchivalForm.new(successor_path: "/existing-item")
 
       expect(form.valid?).to eql(true)
     end


### PR DESCRIPTION
Currently, Collections Publisher allows users to archive or delete topics that are no longer required, but does not allow the same functionality with mainstream browse pages. The underlying functionality to do this exists in the Publishing API but is not exposed here.

This commit adds the user-facing functionality to allow mainstream browse pages to be deleted (if they have not yet been published) or archived and redirected (if they have already been published). The user experience is identical to archiving/deleting topics.

Paired with @jackscotti 

Trello: https://trello.com/c/olZEBaef/67-make-it-possible-to-redirect-browse-pages-in-collections-publisher

Unpublished mainstream browse page has a "remove" button:
![screen shot 2016-08-12 at 15 25 48](https://cloud.githubusercontent.com/assets/444232/17625552/4b68952c-60a1-11e6-865f-0e9b27db2914.png)

Published mainstream browse page has an "archive" button:
![screen shot 2016-08-12 at 15 25 57](https://cloud.githubusercontent.com/assets/444232/17625566/5a953d3e-60a1-11e6-810c-daa3efe938de.png)

Archiving a mainstream browse page can redirect it either to another browse page or any path on GOV.UK:
![screen shot 2016-08-12 at 15 26 07](https://cloud.githubusercontent.com/assets/444232/17625597/70e21cba-60a1-11e6-910a-f265e0b59a94.png)
