### PR TITLE
Link tagged documents to Content Tagger

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def website_url(base_path)
     Plek.new.website_root + base_path
   end
+
+  def content_tagger_url
+    Plek.new.find('content-tagger')
+  end
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,12 +1,16 @@
 class ListItem < ActiveRecord::Base
   belongs_to :list
 
-  validates :index, numericality: {greater_than_or_equal_to: 0}
+  validates :index, numericality: { greater_than_or_equal_to: 0 }
 
   attr_accessor :tagged
   alias :tagged? :tagged
 
   def display_title
     list.tag.tagged_document_for_base_path(base_path).try(:title) || title
+  end
+
+  def content_id
+    list.tag.tagged_document_for_base_path(base_path).content_id
   end
 end

--- a/app/models/tagged_documents.rb
+++ b/app/models/tagged_documents.rb
@@ -9,7 +9,7 @@ class TaggedDocuments
 
   def documents
     @documents ||= search_result.map do |result|
-      Document.new(result["title"], result["base_path"])
+      Document.new(result["title"], result["base_path"], result["content_id"])
     end
   end
 
@@ -19,7 +19,7 @@ private
     @search_result ||= Services.publishing_api.get_linked_items(
       tag.content_id,
       link_type: filter_name,
-      fields: %i[title base_path],
+      fields: %i[title base_path content_id],
     )
   end
 
@@ -31,5 +31,5 @@ private
     end
   end
 
-  Document = Struct.new(:title, :base_path)
+  Document = Struct.new(:title, :base_path, :content_id)
 end

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -4,7 +4,9 @@
 
 <h2>Links</h2>
 
-<p>Links for this tag have been curated into lists.</p>
+<p>
+  Links for this tag have been curated into lists. Click on the title for editing on Content Tagger.
+</p>
 
 <% tag.lists.each do |list| %>
   <h4><%= list.name %></h4>
@@ -14,10 +16,14 @@
   <ul>
   <% list.list_items_with_tagging_status.each do |list_item| %>
     <li>
-      <% unless list_item.tagged? %>
+      <% if list_item.tagged? %>
+        <a href=<%= content_tagger_url + '/taggings/' + list_item.content_id %>>
+          <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
+        </a>
+      <% else %>
         <p class='label label-warning'>Tag was removed</p>
+        <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
       <% end %>
-      <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
     </li>
   <% end %>
   </ul>
@@ -26,6 +32,10 @@
 <h4>Uncurated items <em>(not shown to user)</em></h4>
 <ul>
 <% tag.uncurated_tagged_documents.each do |item| %>
-  <li><%= item.title %></li>
+  <li class="tagged-document">
+    <a href=<%= content_tagger_url + '/taggings/lookup' + item.content_id %>>
+      <%= item.title %>
+    </a>
+  </li>
 <% end %>
 </ul>

--- a/app/views/shared/tags/_uncurated_links_preview.html.erb
+++ b/app/views/shared/tags/_uncurated_links_preview.html.erb
@@ -4,10 +4,16 @@
 
 <h2>Links</h2>
 
-<p>Links for this tag have not been curated into lists.</p>
+<p>
+  Links for this tag have not been curated into lists. Click on the title for editing on Content Tagger.
+</p>
 
 <ul>
 <% tag.tagged_documents.each do |link| %>
-  <li><%= link.title %></li>
+  <li class="tagged-document">
+    <a href=<%= content_tagger_url + '/taggings/' + link.content_id %>>
+      <%= link.title %>
+    </a>
+  </li>
 <% end %>
 </ul>

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -16,10 +16,10 @@ RSpec.feature "Curating topic contents" do
       publishing_api_has_linked_items(
         topic.content_id,
         items: [
-          { title: 'Oil rig safety requirements', base_path: '/oil-rig-safety-requirements' },
-          { title: 'Oil rig staffing', base_path: '/oil-rig-staffing' },
-          { title: 'North sea shipping lanes', base_path: '/north-sea-shipping-lanes' },
-          { title: 'Undersea piping restrictions', base_path: '/undersea-piping-restrictions' },
+          { title: 'Oil rig safety requirements', base_path: '/oil-rig-safety-requirements', content_id: "1f825f77-a82a-4c9c-ab88-78b8a5d9f836" },
+          { title: 'Oil rig staffing', base_path: '/oil-rig-staffing', content_id: "4646c58b-8bae-4fcb-b2bf-830716cae00c" },
+          { title: 'North sea shipping lanes', base_path: '/north-sea-shipping-lanes', content_id: "977d0edf-93c8-4049-9183-3d38554df0fa" },
+          { title: 'Undersea piping restrictions', base_path: '/undersea-piping-restrictions', content_id: "6a6b2955-52a9-4e99-aadb-b4430f92bb49" },
         ]
       )
     end
@@ -174,8 +174,6 @@ RSpec.feature "Curating topic contents" do
       # When I publish the topic
       click_on('Publish changes to GOV.UK')
 
-
-
       #Then the curated lists should have been sent to the publishing API
       stub_publishing_api_put_content(
         content_id,
@@ -212,7 +210,7 @@ RSpec.feature "Curating topic contents" do
     publishing_api_has_linked_items(
       topic.content_id,
       items: [
-        { base_path: '/oil-rig-safety-requirements' },
+        { base_path: '/oil-rig-safety-requirements', content_id: "0de31f13-08e5-4793-940d-f42e7087fe48" },
       ]
     )
 
@@ -233,10 +231,10 @@ RSpec.feature "Curating topic contents" do
       publishing_api_has_linked_items(
         offshore.content_id,
         items: [
-          { title: 'Oil rig safety requirements', base_path: '/oil-rig-safety-requirements' },
-          { title: 'Oil rig staffing', base_path: '/oil-rig-staffing' },
-          { title: 'North sea shipping lanes', base_path: '/north-sea-shipping-lanes' },
-          { title: 'Undersea piping restrictions', base_path: '/undersea-piping-restrictions' },
+          { title: 'Oil rig safety requirements', base_path: '/oil-rig-safety-requirements', content_id: "d1c574f1-9f1a-4d26-9af3-abb918e25319" },
+          { title: 'Oil rig staffing', base_path: '/oil-rig-staffing', content_id: "0437055c-c626-4543-b0f4-6c3ee38fdb0d" },
+          { title: 'North sea shipping lanes', base_path: '/north-sea-shipping-lanes', content_id: "5efc2e34-0131-4f4d-9296-7aa37d8f1031" },
+          { title: 'Undersea piping restrictions', base_path: '/undersea-piping-restrictions', content_id: "e8c756dc-6b10-46a5-8110-a1bb787dd319" },
         ]
       )
 

--- a/spec/features/navigating_topics_spec.rb
+++ b/spec/features/navigating_topics_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Navigating topics" do
     publishing_api_has_linked_items(
       @business_tax.content_id,
       items: [
-        { title: 'A link that only exists in Publishing API.' }
+        { title: 'A link that only exists in Publishing API.', content_id: "7eee3968-89df-4742-8f30-6c1cb58813cd" }
       ]
     )
   end
@@ -59,7 +59,7 @@ RSpec.feature "Navigating topics" do
     publishing_api_has_linked_items(
       @paye.content_id,
       items: [
-        { title: 'A link that only exists in Publishing API.' }
+        { title: 'A link that only exists in Publishing API.', content_id: "cb2176d6-713e-42c7-8899-f856927c5eb8" }
       ]
     )
     click_on 'PAYE'
@@ -83,7 +83,7 @@ RSpec.feature "Navigating topics" do
     publishing_api_has_linked_items(
       @vat_topic.content_id,
       items: [
-        { title: 'A link that only exists in Publishing API.' }
+        { title: 'A link that only exists in Publishing API.', content_id: "29941ec1-4a41-4bfd-86a9-5c866bbd4c7a" }
       ]
     )
     @vat_topic.lists.create!


### PR DESCRIPTION
To make it easier to remove the tags from the content.

Feel free to highlight how bad my HTML is, might learn something new!
https://trello.com/c/j0AgxRd5/74-collections-publisher-should-link-to-content-tagger-for-topic-links


## Before:
![screen shot 2016-08-30 at 11 27 24](https://cloud.githubusercontent.com/assets/5038475/18085834/c890ee58-6ea4-11e6-937e-bcdaf3414651.png)

## After:
![screen shot 2016-08-30 at 11 25 12](https://cloud.githubusercontent.com/assets/5038475/18085840/d06dd8ac-6ea4-11e6-9d03-cc7787081c53.png)
## Links to:
![screen shot 2016-08-30 at 11 25 51](https://cloud.githubusercontent.com/assets/5038475/18085837/ce3ac1f8-6ea4-11e6-91fa-6405d3c98d7b.png)

