### PR TITLE
Send browse page parent tag to publishing-api

### DIFF
--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -114,9 +114,16 @@ private
     tag.published_groups
   end
 
-  # potentially extended in subclasses
   def links
-    {}
+    if @tag.has_parent?
+      {
+        "parent" => [@tag.parent.content_id],
+      }
+    else
+      {
+        "children" => @tag.children.order(:title).map(&:content_id),
+      }
+    end
   end
 
   attr_reader :tag

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -14,16 +14,4 @@ private
       :beta => @tag.beta,
     })
   end
-
-  def links
-    if @tag.has_parent?
-      super.merge({
-        "parent" => [@tag.parent.content_id],
-      })
-    else
-      super.merge({
-        "children" => @tag.children.order(:title).map(&:content_id),
-      })
-    end
-  end
 end

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe MainstreamBrowsePagePresenter do
     end
   end
 
+  describe "#links" do
+    it "includes the parent in the links" do
+      browse_page = create(
+        :mainstream_browse_page,
+        parent: create(:mainstream_browse_page, content_id: "9bb05887-d741-4a98-95b2-2c45dfc31556")
+      )
+
+      presenter = MainstreamBrowsePagePresenter.new(browse_page)
+
+      expect(
+        presenter.render_links_for_publishing_api[:links]["parent"]
+      ).to eql(["9bb05887-d741-4a98-95b2-2c45dfc31556"])
+    end
+  end
+
   describe "rendering for publishing-api" do
     let(:browse_page) {
       create(:mainstream_browse_page, {


### PR DESCRIPTION
This application currently does not send the `parent` in the links for browse pages, but it does for topics. This commit moves the parent (or children) code up to the superclass so topic and browse pages act the same.

Having the parent in the links will allow us to render the breadcrumb from the content-store in collections.

https://trello.com/c/xvM9vb5L

After this is deployed we need to run the rake task that re-sends all content to the publishing-api.