### PR TITLE
Remove link to Taxons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,10 +15,6 @@
   <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
     <%= link_to 'Topics', topics_path %>
   </li>
-
-  <li>
-    <%= link_to 'Taxons', Plek.new.find('content-tagger') + '/taxons'  %>
-  </li>
 <% end %>
 
 <% content_for :body_end do %>


### PR DESCRIPTION
I believe it is now common knowledge that Taxons are managed in
`content-tagger`, so there is no need to keep this link here.