### PR TITLE
Fix test assertions in integration test

### DIFF
--- a/spec/features/browse_hierarchy_spec.rb
+++ b/spec/features/browse_hierarchy_spec.rb
@@ -71,19 +71,19 @@ RSpec.feature "Browse hierarchy" do
   end
 
   def and_the_newly_created_page_is_sent_to_the_publishing_api_as_draft
-    stub_publishing_api_put_content(@content_id, {})
+    assert_publishing_api_put_content(@content_id)
     assert_publishing_api_patch_links(@content_id)
     assert_publishing_api_not_published(@content_id)
   end
 
   def and_the_parent_page_is_sent_to_the_publishing_api
-    stub_publishing_api_put_content(@parent.content_id, {})
+    assert_publishing_api_put_content(@parent.content_id)
     assert_publishing_api_patch_links(@parent.content_id)
     assert_publishing_api_publish(@parent.content_id)
   end
 
   def and_the_child_page_is_sent_to_the_publishing_api
-    stub_publishing_api_put_content(@child.content_id, {})
+    assert_publishing_api_put_content(@child.content_id)
     assert_publishing_api_patch_links(@child.content_id)
     assert_publishing_api_publish(@child.content_id)
   end

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -91,14 +91,13 @@ RSpec.feature "Curating topic contents" do
 
 
       #Then the curated lists should have been sent to the publishing API
-      stub_publishing_api_put_content(
+      assert_publishing_api_put_content(
         content_id,
-        {
+        request_json_includes(
           "details" => {
             "groups" => [
               { "name" => 'Oil rigs',
                 "contents" => [
-                  '/oil-rig-staffing',
                   '/oil-rig-staffing',
                   '/oil-rig-safety-requirements',
               ]},
@@ -110,7 +109,7 @@ RSpec.feature "Curating topic contents" do
             "beta" => false,
             "internal_name" => "Oil and Gas / Offshore"
           }
-        },
+        )
       )
 
       # And have been published and links sent
@@ -175,9 +174,9 @@ RSpec.feature "Curating topic contents" do
       click_on('Publish changes to GOV.UK')
 
       #Then the curated lists should have been sent to the publishing API
-      stub_publishing_api_put_content(
+      assert_publishing_api_put_content(
         content_id,
-        {
+        request_json_includes(
           "details" => {
             "groups" => [
               { "name" => 'Oil rigs',
@@ -193,7 +192,7 @@ RSpec.feature "Curating topic contents" do
             "beta" => false,
             "internal_name" => "Oil and Gas / Offshore"
           }
-        },
+        )
       )
 
       # And then be published and links sent

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -117,12 +117,14 @@ RSpec.feature "Managing browse pages" do
   end
 
   def and_the_draft_is_sent_to_the_publishing_pipeline
-    stub_publishing_api_put_content(
+    assert_publishing_api_put_content(
       @content_id,
-      title: "Citizenship",
-      description: "Living in the UK",
-      document_type: "mainstream_browse_page",
-      schema_name: "mainstream_browse_page",
+      request_json_includes(
+        title: "Citizenship",
+        description: "Living in the UK",
+        document_type: "mainstream_browse_page",
+        schema_name: "mainstream_browse_page",
+      )
     )
 
     assert_publishing_api_patch_links(@content_id)
@@ -131,10 +133,12 @@ RSpec.feature "Managing browse pages" do
   end
 
   def and_the_published_data_is_sent_to_the_publishing_pipeline
-    stub_publishing_api_put_content(
+    assert_publishing_api_put_content(
       @page.content_id,
-      title: "Citizenship in the UK",
-      format: "mainstream_browse_page",
+      request_json_includes(
+        title: "Citizenship in the UK",
+        document_type: "mainstream_browse_page"
+      )
     )
 
     assert_publishing_api_patch_links(@page.content_id)
@@ -143,9 +147,11 @@ RSpec.feature "Managing browse pages" do
   end
 
   def and_the_updated_item_is_sent_to_the_publishing_pipeline
-    stub_publishing_api_put_content(
+    assert_publishing_api_put_content(
       @content_id,
-      description: "A new description"
+      request_json_includes(
+        description: "A new description"
+      )
     )
   end
 

--- a/spec/features/managing_topic_pages_spec.rb
+++ b/spec/features/managing_topic_pages_spec.rb
@@ -117,12 +117,14 @@ RSpec.feature "Managing topics" do
   end
 
   def and_the_draft_is_sent_to_the_publishing_pipeline
-    stub_publishing_api_put_content(
+    assert_publishing_api_put_content(
       @content_id,
-      title: "Citizenship",
-      description: "Living in the UK",
-      schema_name: "topic",
-      document_type: "topic",
+      request_json_includes(
+        title: "Citizenship",
+        description: "Living in the UK",
+        schema_name: "topic",
+        document_type: "topic",
+      )
     )
 
     assert_publishing_api_patch_links(@content_id)
@@ -131,11 +133,13 @@ RSpec.feature "Managing topics" do
   end
 
   def and_the_published_data_is_sent_to_the_publishing_pipeline
-    stub_publishing_api_put_content(
+    assert_publishing_api_put_content(
       @page.content_id,
-      title: "Citizenship in the UK",
-      document_type: "topic",
-      schema_name: "topic",
+      request_json_includes(
+        title: "Citizenship in the UK",
+        document_type: "topic",
+        schema_name: "topic",
+      )
     )
 
     assert_publishing_api_patch_links(@page.content_id)
@@ -144,9 +148,11 @@ RSpec.feature "Managing topics" do
   end
 
   def and_the_updated_item_is_sent_to_the_publishing_pipeline
-    stub_publishing_api_put_content(
+    assert_publishing_api_put_content(
       @content_id,
-      description: "A new description"
+      request_json_includes(
+        description: "A new description"
+      )
     )
   end
 


### PR DESCRIPTION
In https://github.com/alphagov/collections-publisher/pull/173 I refactored the tests to use test helpers from gds-api-adapters. In doing that I replaced the `assert_publishing_api_put_item` method calls with `stub_publishing_api_put_content ` which doesn't assert anything.

https://trello.com/c/C8A9bnuO/344-work-on-making-the-document-type-concept-clearer