### PR TITLE
Fix all Rubocop linter warnings

### DIFF
--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -21,9 +21,9 @@ class ListItemsController < ApplicationController
       }
       format.js {
         if saved
-          render json: {errors: [], updateURL: tag_list_list_item_path(@tag, @list, list_item)}
+          render json: { errors: [], updateURL: tag_list_list_item_path(@tag, @list, list_item) }
         else
-          render json: {errors: list_item.errors.to_json}, status: 422
+          render json: { errors: list_item.errors.to_json }, status: 422
         end
       }
     end
@@ -49,9 +49,9 @@ class ListItemsController < ApplicationController
       }
       format.js {
         if destroyed
-          render json: {errors: []}
+          render json: { errors: [] }
         else
-          render json: {errors: list_item.errors.to_json}, status: 422
+          render json: { errors: list_item.errors.to_json }, status: 422
         end
       }
     end
@@ -67,9 +67,9 @@ class ListItemsController < ApplicationController
         if list_item.save
           @tag.mark_as_dirty!
 
-          render json: {errors: []}
+          render json: { errors: [] }
         else
-          render json: {errors: list_item.errors.to_json}, status: 422
+          render json: { errors: list_item.errors.to_json }, status: 422
         end
       }
     end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -57,9 +57,9 @@ class ListsController < ApplicationController
       }
       format.js {
         if saved
-          render json: {errors: []}
+          render json: { errors: [] }
         else
-          render json: {errors: list.errors.to_json}, status: 422
+          render json: { errors: list.errors.to_json }, status: 422
         end
       }
     end

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -88,7 +88,7 @@ private
     if params.require(:mainstream_browse_page).key? :topics
       topic_ids = params.require(:mainstream_browse_page)[:topics]
       topics = topic_ids.reject(&:blank?).map { |t| Topic.find(t) }
-      tag_params.merge({"topics" => topics})
+      tag_params.merge("topics" => topics)
     else
       tag_params
     end

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -3,7 +3,7 @@ module IconHelper
     curated: 'list-alt',
     a_to_z: 'sort-by-alphabet',
     add: 'plus',
-  }
+  }.freeze
 
   def icon(name)
     return unless name

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 class Tag < ActiveRecord::Base
   include AASM
   include ActiveModel::Dirty
-  ORDERING_TYPES = %w(alphabetical curated)
+  ORDERING_TYPES = %w(alphabetical curated).freeze
 
   belongs_to :parent, class_name: 'Tag'
   has_many :children, class_name: 'Tag', foreign_key: :parent_id
@@ -18,7 +18,7 @@ class Tag < ActiveRecord::Base
 
   validates :slug, :title, :content_id, presence: true
   validates :slug, uniqueness: { scope: ["parent_id"] }, format: { with: /\A[a-z0-9-]*\z/ }
-  validates :child_ordering, inclusion: {in: ORDERING_TYPES}
+  validates :child_ordering, inclusion: { in: ORDERING_TYPES }
   validate :parent_is_not_a_child
   validate :cannot_change_slug
 

--- a/app/notifiers/content_item_publisher.rb
+++ b/app/notifiers/content_item_publisher.rb
@@ -1,7 +1,7 @@
 class ContentItemPublisher
   # Setting the update type to minor means we won't send email alerts for
   # changes to a topic title or description.
-  DEFAULT_UPDATE_TYPE = 'minor'
+  DEFAULT_UPDATE_TYPE = 'minor'.freeze
   attr_reader :presenter, :update_type
 
   delegate :content_id, to: :presenter

--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -25,8 +25,6 @@ private
     )
   end
 
-private
-
   def active_top_level_browse_page_id
     if @tag.has_parent?
       [@tag.parent.content_id]

--- a/app/presenters/redirect_item_presenter.rb
+++ b/app/presenters/redirect_item_presenter.rb
@@ -14,7 +14,7 @@ class RedirectItemPresenter
   end
 
   def redirect_routes
-    [ item ]
+    [item]
   end
 
   def draft?

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -55,8 +55,8 @@ private
 
   def routes
     [
-      {path: "/browse", type: "exact"},
-      {path: "/browse.json", type: "exact"},
+      { path: "/browse", type: "exact" },
+      { path: "/browse.json", type: "exact" },
     ]
   end
 

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -10,8 +10,6 @@ private
   end
 
   def details
-    super.merge({
-      :beta => @tag.beta,
-    })
+    super.merge(:beta => @tag.beta)
   end
 end

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -40,11 +40,11 @@ private
       # Only setup a redirect to the subroute when the successor also has that
       # route (when redirectinga subtopic to a subtopic), not when redirecting
       # to a parent topic (from /topic/foo/bar to /topic/foo).
-      if route_suffix.in?(successor.subroutes)
-        to_base_path = "#{successor.base_path}#{route_suffix}"
-      else
-        to_base_path = successor.base_path
-      end
+      to_base_path = if route_suffix.in?(successor.subroutes)
+                       "#{successor.base_path}#{route_suffix}"
+                     else
+                       successor.base_path
+                     end
 
       tag.redirect_routes.create!(
         from_base_path: [tag.base_path, route_suffix].join,

--- a/app/workers/dependent_tag_publish_worker.rb
+++ b/app/workers/dependent_tag_publish_worker.rb
@@ -4,20 +4,20 @@ class DependentTagPublishWorker
   def perform(tag_id)
     tag = Tag.find(tag_id)
 
-    tag.dependent_tags.each do |tag|
-      presenter = TagPresenter.presenter_for(tag)
+    tag.dependent_tags.each do |dependent_tag|
+      presenter = TagPresenter.presenter_for(dependent_tag)
       ContentItemPublisher.new(presenter).send_to_publishing_api
     end
 
     return unless tag.can_have_children?
 
     if tag.is_a?(MainstreamBrowsePage)
-      presenter = RootBrowsePagePresenter.new({ 'state' => tag.state })
+      presenter = RootBrowsePagePresenter.new('state' => tag.state)
       ContentItemPublisher.new(presenter).send_to_publishing_api
     end
 
     if tag.is_a?(Topic)
-      presenter = RootTopicPresenter.new({ 'state' => tag.state })
+      presenter = RootTopicPresenter.new('state' => tag.state)
       ContentItemPublisher.new(presenter).send_to_publishing_api
     end
   end

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
+APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
+require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,6 @@ module CollectionsPublisher
     # config.i18n.default_locale = :de
 
     config.action_view.default_form_builder = GenericFormBuilder
-    config.action_view.field_error_proc = proc {|html_tag, _| html_tag }
+    config.action_view.field_error_proc = proc { |html_tag, _| html_tag }
   end
 end

--- a/db/migrate/20150623122832_add_published_groups_to_tags.rb
+++ b/db/migrate/20150623122832_add_published_groups_to_tags.rb
@@ -1,6 +1,6 @@
 class AddPublishedGroupsToTags < ActiveRecord::Migration
   def change
-    # 65536+1 forces the text column to be `mediumtext` / 16MB 
+    # 65536+1 forces the text column to be `mediumtext` / 16MB
     add_column :tags, :published_groups, :text, limit: 65536 + 1
   end
 end

--- a/db/migrate/20150713124417_import_router_data_browse_redirects.rb
+++ b/db/migrate/20150713124417_import_router_data_browse_redirects.rb
@@ -10,9 +10,8 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
   end
 
   def create_redirects
-
     # /browse/births-deaths-marriages/registry-offices,/browse/births-deaths-marriages/register-offices
-    register_offices = MainstreamBrowsePage.joins(:parent).find_by!(:parents_tags => {:slug => "births-deaths-marriages"}, :slug => "register-offices")
+    register_offices = MainstreamBrowsePage.joins(:parent).find_by!(:parents_tags => { :slug => "births-deaths-marriages" }, :slug => "register-offices")
     @redirects << Redirect.create!(
       :tag => register_offices,
       :original_tag_base_path => "/browse/births-deaths-marriages/registry-offices",

--- a/db/migrate/20150714140302_import_router_data_topic_redirects.rb
+++ b/db/migrate/20150714140302_import_router_data_topic_redirects.rb
@@ -10,7 +10,6 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
   end
 
   def create_redirects
-
     # /childrens-services,/topic/schools-colleges-childrens-services
     schools_colleges_childrens_services = Topic.only_parents.find_by!(:slug => 'schools-colleges-childrens-services')
     @redirects << Redirect.create!(
@@ -96,7 +95,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
     )
 
     # /paye,/topic/business-tax/paye
-    paye = Topic.joins(:parent).find_by!(:parents_tags => {:slug => 'business-tax'}, :slug => 'paye')
+    paye = Topic.joins(:parent).find_by!(:parents_tags => { :slug => 'business-tax' }, :slug => 'paye')
     [
       "/paye",
       "/paye/annual-tasks",

--- a/db/migrate/20150716103715_remove_unused_mainstream_browse_pages.rb
+++ b/db/migrate/20150716103715_remove_unused_mainstream_browse_pages.rb
@@ -1,9 +1,8 @@
 class RemoveUnusedMainstreamBrowsePages < ActiveRecord::Migration
-
   SLUGS = %w(
     time-off-new-child
     child-into-care
-  )
+  ).freeze
 
   def self.up
     SLUGS.each { |slug|
@@ -15,5 +14,4 @@ class RemoveUnusedMainstreamBrowsePages < ActiveRecord::Migration
   def self.down
     # Nothing to do here
   end
-
 end

--- a/db/migrate/20151124153356_add_tag_id_to_redirect_routes.rb
+++ b/db/migrate/20151124153356_add_tag_id_to_redirect_routes.rb
@@ -17,4 +17,3 @@ def update_statement
   INNER JOIN (SELECT r.id, r.tag_id FROM newest_redirects r) AS j ON (rr.redirect_id = j.id)
   SET rr.tag_id = j.tag_id"
 end
-

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,8 +24,8 @@ FactoryGirl.define do
   end
 
   factory :tag do
-    sequence(:title) {|n| "Browse page #{n}" }
-    sequence(:slug) {|n| "browse-page-#{n}" }
+    sequence(:title) { |n| "Browse page #{n}" }
+    sequence(:slug) { |n| "browse-page-#{n}" }
     description "Example description"
 
     trait :draft do

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -100,11 +100,11 @@ RSpec.feature "Curating topic contents" do
                 "contents" => [
                   '/oil-rig-staffing',
                   '/oil-rig-safety-requirements',
-              ]},
+              ] },
               { "name" => 'Piping',
                 "contents" => [
                   '/undersea-piping-restrictions',
-              ]},
+              ] },
             ],
             "beta" => false,
             "internal_name" => "Oil and Gas / Offshore"
@@ -183,11 +183,11 @@ RSpec.feature "Curating topic contents" do
                 "contents" => [
                   '/oil-rig-safety-requirements',
                   '/oil-rig-staffing',
-              ]},
+              ] },
               { "name" => 'Piping',
                 "contents" => [
                   '/undersea-piping-restrictions',
-              ]},
+              ] },
             ],
             "beta" => false,
             "internal_name" => "Oil and Gas / Offshore"

--- a/spec/features/order_browse_pages_spec.rb
+++ b/spec/features/order_browse_pages_spec.rb
@@ -43,8 +43,8 @@ RSpec.feature "Order browse pages" do
   end
 
   def and_I_submit_an_ordering
-    fill_in "#{@four_seasons.slug}", with: '1'
-    fill_in "#{@pepperoni.slug}", with: '0'
+    fill_in @four_seasons.slug.to_s, with: '1'
+    fill_in @pepperoni.slug.to_s, with: '0'
     click_on 'Save'
   end
 

--- a/spec/notifiers/rummager_notifier_spec.rb
+++ b/spec/notifiers/rummager_notifier_spec.rb
@@ -32,14 +32,12 @@ RSpec.describe RummagerNotifier do
       RummagerNotifier.new(topic).notify
 
       expect(rummager).to have_received(:add_document)
-        .with("edition", "/topic/a-test-topic", {
-          content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
+        .with("edition", "/topic/a-test-topic", content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
           format: 'specialist_sector',
           title: 'A Topic',
           description: 'A description.',
           link: '/topic/a-test-topic',
-          slug: 'a-test-topic',
-        })
+          slug: 'a-test-topic')
     end
 
     it 'sends published browse pages to rummager' do
@@ -52,14 +50,12 @@ RSpec.describe RummagerNotifier do
       RummagerNotifier.new(browse_page).notify
 
       expect(rummager).to have_received(:add_document)
-        .with("edition", "/browse/a-browse-page", {
-          content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
+        .with("edition", "/browse/a-browse-page", content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
           format: 'mainstream_browse_page',
           title: 'A Browse Page',
           description: 'A description.',
           link: '/browse/a-browse-page',
-          slug: 'a-browse-page',
-        })
+          slug: 'a-browse-page')
     end
 
     it 'sends the full slug for a subtopic' do
@@ -73,9 +69,7 @@ RSpec.describe RummagerNotifier do
       RummagerNotifier.new(topic).notify
 
       expect(rummager).to have_received(:add_document)
-        .with("edition", "/topic/a-parent/a-test-topic", hash_including({
-          slug: 'a-parent/a-test-topic',
-        }))
+        .with("edition", "/topic/a-parent/a-test-topic", hash_including(slug: 'a-parent/a-test-topic'))
     end
   end
 

--- a/spec/presenters/groups_presenter_spec.rb
+++ b/spec/presenters/groups_presenter_spec.rb
@@ -3,12 +3,10 @@ require 'rails_helper'
 RSpec.describe GroupsPresenter do
   describe "#groups" do
     let(:tag) do
-      create(:tag, {
-        :parent => create(:tag, :slug => 'oil-and-gas'),
+      create(:tag, :parent => create(:tag, :slug => 'oil-and-gas'),
         :slug => 'offshore',
         :title => 'Offshore',
-        :description => 'Oil rigs, pipelines etc.',
-      })
+        :description => 'Oil rigs, pipelines etc.')
     end
 
     it "contains an empty groups array with no curated lists" do

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -18,11 +18,9 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
   describe "rendering for publishing-api" do
     let(:browse_page) {
-      create(:mainstream_browse_page, {
-        :slug => 'benefits',
+      create(:mainstream_browse_page, :slug => 'benefits',
         :title => 'Benefits',
-        :description => 'All about benefits',
-      })
+        :description => 'All about benefits')
     }
     let(:presenter) { MainstreamBrowsePagePresenter.new(browse_page) }
     let(:presented_data) { presenter.render_for_publishing_api }
@@ -32,8 +30,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
     end
 
     it "includes the base fields" do
-      expect(presented_data).to include({
-        :schema_name => 'mainstream_browse_page',
+      expect(presented_data).to include(:schema_name => 'mainstream_browse_page',
         :document_type => 'mainstream_browse_page',
         :title => 'Benefits',
         :description => 'All about benefits',
@@ -41,8 +38,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         :need_ids => [],
         :publishing_app => 'collections-publisher',
         :rendering_app => 'collections',
-        :redirects => [],
-      })
+        :redirects => [])
     end
 
     it "sets public_updated_at based on the browse page update time" do
@@ -55,8 +51,8 @@ RSpec.describe MainstreamBrowsePagePresenter do
 
     it "includes the necessary routes" do
       expect(presented_data[:routes]).to eq([
-        {:path => "/browse/benefits", :type => "exact"},
-        {:path => "/browse/benefits.json", :type => "exact"},
+        { :path => "/browse/benefits", :type => "exact" },
+        { :path => "/browse/benefits.json", :type => "exact" },
       ])
     end
 

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -34,12 +34,10 @@ RSpec.describe TagPresenter do
 
   describe '#render_for_publishing_api' do
     let(:tag) do
-      create(:topic, {
-        :parent => create(:tag, :slug => 'oil-and-gas'),
+      create(:topic, :parent => create(:tag, :slug => 'oil-and-gas'),
         :slug => 'offshore',
         :title => 'Offshore',
-        :description => 'Oil rigs, pipelines etc.',
-      })
+        :description => 'Oil rigs, pipelines etc.')
     end
 
     it "is valid against the schema without lists" do
@@ -68,7 +66,7 @@ RSpec.describe TagPresenter do
 
       presented_data = TopicPresenter.new(tag).render_for_publishing_api
 
-      expect(presented_data[:details][:groups]).to eql({ 'foo' => 'bar' })
+      expect(presented_data[:details][:groups]).to eql('foo' => 'bar')
     end
   end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -4,19 +4,16 @@ RSpec.describe TopicPresenter do
   describe "rendering for publishing-api" do
     context "for a top-level topic" do
       let(:topic) {
-        create(:topic, {
-          :slug => 'working-at-sea',
+        create(:topic, :slug => 'working-at-sea',
           :title => 'Working at sea',
-          :description => 'The sea, the sky, the sea, the sky...',
-        })
+          :description => 'The sea, the sky, the sea, the sky...')
       }
       let(:presenter) { TopicPresenter.new(topic) }
       let(:presented_data) { presenter.render_for_publishing_api }
       let(:rendered_links) { presenter.render_links_for_publishing_api }
 
       it "includes the base fields" do
-        expect(presented_data).to include({
-          :schema_name => 'topic',
+        expect(presented_data).to include(:schema_name => 'topic',
           :document_type => 'topic',
           :title => 'Working at sea',
           :description => 'The sea, the sky, the sea, the sky...',
@@ -24,8 +21,7 @@ RSpec.describe TopicPresenter do
           :need_ids => [],
           :publishing_app => 'collections-publisher',
           :rendering_app => 'collections',
-          :redirects => [],
-        })
+          :redirects => [])
       end
 
       it "is valid against the schema" do
@@ -46,7 +42,7 @@ RSpec.describe TopicPresenter do
 
       it "includes the base route" do
         expect(presented_data[:routes]).to eq([
-          {:path => "/topic/working-at-sea", :type => "exact"},
+          { :path => "/topic/working-at-sea", :type => "exact" },
         ])
       end
 
@@ -67,12 +63,10 @@ RSpec.describe TopicPresenter do
     context "for a subtopic" do
       let(:parent) { create(:topic, :slug => 'oil-and-gas') }
       let(:topic) {
-        create(:topic, {
-          :parent => parent,
+        create(:topic, :parent => parent,
           :slug => 'offshore',
           :title => 'Offshore',
-          :description => 'Oil rigs, pipelines etc.',
-        })
+          :description => 'Oil rigs, pipelines etc.')
       }
       let(:presenter) { TopicPresenter.new(topic) }
       let(:presented_data) { presenter.render_for_publishing_api }
@@ -83,8 +77,7 @@ RSpec.describe TopicPresenter do
       end
 
       it "includes the base fields" do
-        expect(presented_data).to include({
-          :schema_name => 'topic',
+        expect(presented_data).to include(:schema_name => 'topic',
           :document_type => 'topic',
           :title => 'Offshore',
           :description => 'Oil rigs, pipelines etc.',
@@ -92,8 +85,7 @@ RSpec.describe TopicPresenter do
           :need_ids => [],
           :publishing_app => 'collections-publisher',
           :rendering_app => 'collections',
-          :redirects => [],
-        })
+          :redirects => [])
       end
 
       it "is valid against the schema" do
@@ -110,9 +102,9 @@ RSpec.describe TopicPresenter do
 
       it "includes routes for latest, and email_signups in addition to base route" do
         expect(presented_data[:routes]).to eq([
-          {:path => "/topic/oil-and-gas/offshore", :type => "exact"},
-          {:path => "/topic/oil-and-gas/offshore/latest", :type => "exact"},
-          {:path => "/topic/oil-and-gas/offshore/email-signup", :type => "exact"},
+          { :path => "/topic/oil-and-gas/offshore", :type => "exact" },
+          { :path => "/topic/oil-and-gas/offshore/latest", :type => "exact" },
+          { :path => "/topic/oil-and-gas/offshore/email-signup", :type => "exact" },
         ])
       end
 

--- a/spec/services/list_publisher_spec.rb
+++ b/spec/services/list_publisher_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ListPublisher do
 
       ListPublisher.new(topic).perform
 
-      expect(topic.published_groups).to eql([{"name"=>"A Listname", "contents"=>[]}])
+      expect(topic.published_groups).to eql([{ "name"=>"A Listname", "contents"=>[] }])
     end
 
     it 'sends the updated information to the content-store' do

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -9,4 +9,3 @@ module WaitForAjax
     page.evaluate_script('jQuery.active').zero?
   end
 end
-


### PR DESCRIPTION
This is in preparation for migrating the build to Jenkins 2. Jenkins 2 will require us to add new build scripts which could optionally include Rubocop linting, so this seems like a convenient point to add linting to this project.

All the Rubocop errors were trivial, and most could be fixed automatically.

I'll comment on the two manual fixes in case you want to look at those in more detail.