### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,80 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'collections-publisher'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'collections-publisher',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+  ])
+
+  try {
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("Clean up workspace") {
+      govuk.cleanupGit()
+    }
+
+    stage("git merge") {
+      govuk.mergeMasterBranch()
+    }
+
+    stage("Configure Rails environment") {
+      govuk.setEnvar("RAILS_ENV", "test")
+    }
+
+    stage("Set up content schema dependency") {
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+    }
+
+    stage("bundle install") {
+      govuk.bundleApp()
+    }
+
+    stage("rubylinter") {
+      govuk.rubyLinter()
+    }
+
+    stage("Set up the DB") {
+      govuk.runRakeTask("db:drop db:create db:schema:load")
+    }
+
+    stage("Precompile assets") {
+      govuk.precompileAssets()
+    }
+
+    stage("Run tests") {
+      govuk.runRakeTask("default")
+    }
+
+    stage("Push release tag") {
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+    }
+
+    govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}


### PR DESCRIPTION
This adds the Jenkins configuration to allow pipeline builds on the Jenkins 2 CI server.

I've based it on this project's [jenkins.sh](https://github.com/alphagov/collections-publisher/blob/master/jenkins.sh) script and alphagov/rummager#723.

Note that this currently just replaces jenkins.sh. I'm not yet sure how to replace jenkins-schema.sh. Do we need to configure some new jobs on the new CI server first?

The new build for this is currently broken because of an error in the Groovy build script, but should be fixed once alphagov/govuk-puppet#5254 is deployed.