### PR TITLE
Only build 'released-to-production' branch to test content schemas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,33 @@ node {
       paramsToUseForLimit: 'collections-publisher',
       throttleEnabled: true,
       throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: 'deployed-to-production',
+          description: 'The branch of govuk-content-schemas to test against']]
+    ]
   ])
 
   try {
+    if (env.BRANCH_NAME == 'deployed-to-production') {
+      if (env.IS_SCHEMA_TEST == "true") {
+        echo "Branch is 'deployed-to-production' and this is a schema test " +
+          "build. Proceeding with build."
+      } else {
+        echo "Branch is 'deployed-to-production', but this is not marked as " +
+          "a schema test build. 'deployed-to-production' should only be " +
+          "built as part of a schema test, so this build will stop here."
+        currentBuild.result = "SUCCESS"
+        return
+      }
+    }
+
     stage("Checkout") {
       checkout scm
     }
@@ -39,7 +63,7 @@ node {
     }
 
     stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
+      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 


### PR DESCRIPTION
Unlike dev branches, the 'released-to-production' branch should not be built when the branch is updated. The only reason to build it is to test it against changes to the content schemas.

This change adds Jenkins configuration which distinguish between updates to 'released-to-production' (in which case Jenkins should do nothing) and builds triggered by the content schema build (in which case, run the build as normal, but check out the correct content schema branch.

The govuk-content-schemas Jenkins config will be updated to trigger this build, and it will provide an 'IS_SCHEMA_TEST' parameter to identify it as a schema test.