### PR TITLE
Simplify Jenkins schema build check using helper functions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,17 +33,8 @@ node {
   ])
 
   try {
-    if (env.BRANCH_NAME == 'deployed-to-production') {
-      if (env.IS_SCHEMA_TEST == "true") {
-        echo "Branch is 'deployed-to-production' and this is a schema test " +
-          "build. Proceeding with build."
-      } else {
-        echo "Branch is 'deployed-to-production', but this is not marked as " +
-          "a schema test build. 'deployed-to-production' should only be " +
-          "built as part of a schema test, so this build will stop here."
-        currentBuild.result = "SUCCESS"
-        return
-      }
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
     }
 
     stage("Checkout") {


### PR DESCRIPTION
The branch check for distinguishing between regular branch builds and schema test builds has been extracted to the shared helper file, so replace these checks with a call to the shared function.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration