### PR TITLE
Ensure Jenkins build parameters are set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = 'collections-publisher'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
@@ -27,9 +28,14 @@ node {
           description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
         [$class: 'StringParameterDefinition',
           name: 'SCHEMA_BRANCH',
-          defaultValue: 'deployed-to-production',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
           description: 'The branch of govuk-content-schemas to test against']]
     ]
+  ])
+
+  govuk.initializeParameters([
+    'IS_SCHEMA_TEST': 'false',
+    'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
   ])
 
   try {


### PR DESCRIPTION
This is a work-around for Jenkins bug JENKINS-40574, where parameters are not set on the very first build of a pipeline job.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration