### PR TITLE
Delete old Jenkins shell scripts

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-export REPO_NAME="alphagov/govuk-content-schemas"
-export CONTEXT_MESSAGE="Verify collections-publisher against content schemas"
-
-exec ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-export REPO_NAME=${REPO_NAME:-"alphagov/collections-publisher"}
-curl https://raw.githubusercontent.com/alphagov/govuk-ci-scripts/master/rails-app.sh | bash


### PR DESCRIPTION
The contents of these scripts have been migrated to the Jenkinsfile.

These were not safe to delete until now because they were still used to test the content schemas on Jenkins 1, but those tests have now also been migrated to Jenkins 2.

https://trello.com/c/S4DZbsPa/285-jenkins-2-migration