### PR TITLE
Delete all 'beta' messages from topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -69,7 +69,7 @@ class TopicsController < ApplicationController
 private
 
   def topic_params
-    params.require(:topic).permit(:slug, :title, :description, :parent_id, :beta)
+    params.require(:topic).permit(:slug, :title, :description, :parent_id)
   end
 
   def find_topic

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -12,14 +12,9 @@ module StatusHelper
   def labels_for_tag(tag)
     labels = []
     labels << draft_tag if tag.draft?
-    labels << beta_tag if tag.beta?
     labels << dirty_tag if tag.dirty?
     labels << archived_tag if tag.archived?
     raw labels.join(' ')
-  end
-
-  def beta_tag
-    status 'In Beta', :warning
   end
 
   def dirty_tag

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -26,9 +26,7 @@ class RootTopicPresenter
       publishing_app: "collections-publisher",
       rendering_app: "collections",
       routes: routes,
-      phase: 'beta',
       details: {
-        beta: true,
         internal_name: "Topic index page",
       }
     }

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -57,7 +57,7 @@ class TagPresenter
       routes: routes,
       redirects: RedirectRoutePresenter.new(@tag).routes,
       details: details,
-    }.merge(phase_state)
+    }
   end
 
 
@@ -72,11 +72,6 @@ class TagPresenter
   end
 
 private
-
-  def phase_state
-    return {} unless @tag.beta?
-    { phase: "beta" }
-  end
 
   def format
     raise "Need to subclass"

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -8,8 +8,4 @@ private
   def format
     'topic'
   end
-
-  def details
-    super.merge(:beta => @tag.beta)
-  end
 end

--- a/app/views/shared/tags/_table.html.erb
+++ b/app/views/shared/tags/_table.html.erb
@@ -21,7 +21,6 @@
         <td><%= link_to resource.base_path, Plek.new.website_root + resource.base_path %></td>
         <td>
           <%= status(resource.state, resource.state) %>
-          <%= beta_tag if resource.beta? %>
           <%= dirty_tag if resource.dirty? %>
         </td>
 

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -6,6 +6,5 @@
   <%= f.text_field :description %>
   <em>This description will be displayed in the search results.</em>
 
-  <%= f.check_box :beta %>
   <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -13,7 +13,5 @@
   <%= f.text_field :description %>
   <em>This description will be displayed in the search results.</em>
 
-  <%= f.check_box :beta %>
-
   <%= f.submit 'Create', class: 'btn-submit' %>
 <% end %>

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -106,7 +106,6 @@ RSpec.feature "Curating topic contents" do
                   '/undersea-piping-restrictions',
               ] },
             ],
-            "beta" => false,
             "internal_name" => "Oil and Gas / Offshore"
           }
         )
@@ -189,7 +188,6 @@ RSpec.feature "Curating topic contents" do
                   '/undersea-piping-restrictions',
               ] },
             ],
-            "beta" => false,
             "internal_name" => "Oil and Gas / Offshore"
           }
         )


### PR DESCRIPTION
Topic pages are no longer in beta, and they will be deprecated soon when the new taxonomy-based navigation is added. This means that the 'beta' tag is out-of-date, and can be deleted.

The 'beta' tag is not relevant to browse pages either, so all references have been removed from the code.

New topics will be created with default values for properties related to 'beta' content. This currently means that they will be created in the 'live' phase, and with no 'beta' property in 'details'.

https://trello.com/c/oW7gSMoB/328-remove-beta-tags-from-topics-in-collections

A few things I'm not sure of:

- Is it OK that if you update an existing beta topic, it removes the `beta` property in the `details` section? Or do we need to preserve those for existing topics?
- There's still a `beta` column in the collections-publisher DB, which is no longer referenced by the code. Should I remove it? It should be equivalent to the 'beta' value in the content store, so we shouldn't lose any data by removing it. (It would just make it hard to roll this change back if we needed to.)
- And should we remove the `beta` property from the content schema for topics?

Once deployed:

- [ ] Merge #236 
- [ ] Remove `beta` from the content schema for topics