### PR TITLE
Delete 'beta' flag from tags in DB

### DIFF
--- a/db/migrate/20170117160733_remove_beta_from_tags.rb
+++ b/db/migrate/20170117160733_remove_beta_from_tags.rb
@@ -1,0 +1,9 @@
+class RemoveBetaFromTags < ActiveRecord::Migration
+  def up
+    remove_column :tags, :beta
+  end
+
+  def down
+    add_column :tags, :beta, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160205144906) do
+ActiveRecord::Schema.define(version: 20170117160733) do
 
   create_table "list_items", force: :cascade do |t|
     t.string   "base_path",  limit: 255
@@ -77,7 +77,6 @@ ActiveRecord::Schema.define(version: 20160205144906) do
     t.string   "content_id",       limit: 255,                               null: false
     t.string   "state",            limit: 255,                               null: false
     t.boolean  "dirty",                             default: false,          null: false
-    t.boolean  "beta",                              default: false
     t.text     "published_groups", limit: 16777215
     t.string   "child_ordering",   limit: 255,      default: "alphabetical", null: false
     t.integer  "index",            limit: 4,        default: 0,              null: false


### PR DESCRIPTION
The 'beta' flag was removed from the rest of the codebase in a previous commit. This cleans up the now-unused field from the DB.

The only kinds of content edited in collections-publisher are topics and browse pages. Topics are no longer in beta and browse pages never were, so it's safe to remove the beta flag data entirely.

https://trello.com/c/oW7gSMoB/328-remove-beta-tags-from-topics-in-collections

