### PR TITLE
Fix CI deployment pipeline stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,12 +84,15 @@ node {
       govuk.runRakeTask("default")
     }
 
-    stage("Push release tag") {
-      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+    if (env.BRANCH_NAME == "master") {
+      stage("Push release tag") {
+        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
+
+      stage("Deploy to integration") {
+        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+      }
     }
-
-    govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
-
   } catch (e) {
     currentBuild.result = "FAILED"
     step([$class: 'Mailer',


### PR DESCRIPTION
- Explicitly check that the branch is `master` before tagging the build and deploying to Integration. This is already done by the Jenkinsfile helper, but this makes it more obvious that deployment only happens on `master`.
- Wrap the Integration deployment in a pipeline stage, since this definition has been removed from the `deployIntegration` helper since this project's Jenkinsfile was created.