### PR TITLE
Add content_store_document_type to be sent to rummager.

### DIFF
--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -35,6 +35,7 @@ class TagPresenter
     {
       content_id: tag.content_id,
       format: rummager_format,
+      content_store_document_type: format,
       title: tag.title,
       description: tag.description,
       link: tag.base_path,

--- a/spec/notifiers/rummager_notifier_spec.rb
+++ b/spec/notifiers/rummager_notifier_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe RummagerNotifier do
       expect(rummager).to have_received(:add_document)
         .with("edition", "/topic/a-test-topic", content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
           format: 'specialist_sector',
+          content_store_document_type: "topic",
           title: 'A Topic',
           description: 'A description.',
           link: '/topic/a-test-topic',
@@ -52,6 +53,7 @@ RSpec.describe RummagerNotifier do
       expect(rummager).to have_received(:add_document)
         .with("edition", "/browse/a-browse-page", content_id: '28ac662c-09cf-4baa-9e7c-98339a2a3bcd',
           format: 'mainstream_browse_page',
+          content_store_document_type: "mainstream_browse_page",
           title: 'A Browse Page',
           description: 'A description.',
           link: '/browse/a-browse-page',

--- a/spec/services/tag_republisher_spec.rb
+++ b/spec/services/tag_republisher_spec.rb
@@ -16,19 +16,25 @@ RSpec.describe TagRepublisher do
     it 'republishes given tags' do
       create(:mainstream_browse_page, :published, slug: 'a-browse-page')
 
-      TagRepublisher.new.republish_tags(Tag.all)
+      expect {
+        TagRepublisher.new.republish_tags(Tag.all)
+      }.to output.to_stdout
 
       expect(stubbed_content_store).to have_content_item_slug('/browse/a-browse-page')
     end
 
     it 'republishes the browse index page' do
-      TagRepublisher.new.republish_tags(Tag.all)
+      expect {
+        TagRepublisher.new.republish_tags(Tag.all)
+      }.to output.to_stdout
 
       expect(stubbed_content_store).to have_content_item_slug('/browse')
     end
 
     it 'republishes the topic index page' do
-      TagRepublisher.new.republish_tags(Tag.all)
+      expect {
+        TagRepublisher.new.republish_tags(Tag.all)
+      }.to output.to_stdout
 
       expect(stubbed_content_store).to have_content_item_slug('/topic')
     end


### PR DESCRIPTION
Finding Things has been working into adding a new field in rummager
called `content_store_document_type`.

This commit addds that field into rummager and also updates the spec to
test the output to stdout and avoid having it displayed when tests run.

Trello:
https://trello.com/c/iMotNdUv/461-add-more-document-type-to-search