### PR TITLE
Exclude archived child pages from child ordering page

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -77,6 +77,10 @@ class Tag < ActiveRecord::Base
     end
   end
 
+  def sorted_children_that_are_not_archived
+    sorted_children.reject { |child| child.state == "archived" }
+  end
+
   def title_including_parent
     if has_parent?
       "#{parent.title} / #{title}"

--- a/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
+++ b/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
@@ -2,8 +2,8 @@
 
 <%= form_for @browse_page do |f| %>
   <%= f.select :child_ordering, Tag::ORDERING_TYPES %>
-  <%= f.fields_for :children, @browse_page.sorted_children do |c| %>
-    <%= c.text_field :index, label: c.object.slug %>
+  <%= f.fields_for :children, @browse_page.sorted_children_that_are_not_archived do |c| %>
+    <%= c.text_field :index, label: "#{c.object.title} (#{c.object.slug})" %>
   <% end %>
   <%= f.submit 'Save', class: 'btn-submit' %>
 <% end %>


### PR DESCRIPTION
This commit excludes archived mainstream browse pages from being shown on the “manage child ordering” page, since ordering them does not make sense.

It also adds the name of the child pages above each text box, along with the existing slug.

Trello: https://trello.com/c/D3TtciUU/227-withdrawn-child-pages-showing-in-ordering-view-in-collections-publisher

Before:

![screen shot 2017-02-08 at 10 00 52](https://cloud.githubusercontent.com/assets/444232/22733453/c167aefe-ede9-11e6-9b1d-6121f30369f9.png)

After:

![screen shot 2017-02-08 at 10 01 03](https://cloud.githubusercontent.com/assets/444232/22733460/c60b29ae-ede9-11e6-87ff-842e2a9ea1b9.png)
