### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'unicorn', '~> 5.0'
 
 # GDS managed dependencies
 gem 'gds-sso', '~> 13.0'
-gem 'gds-api-adapters', '~> 41.0'
+gem 'gds-api-adapters', '~> 47.2'
 gem 'govuk_admin_template', '~> 5.0'
 gem 'govuk_sidekiq', '~> 1.0'
 gem 'plek', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (41.5.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -191,7 +191,7 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    rack (2.0.1)
+    rack (2.0.3)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -228,7 +228,7 @@ GEM
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.2)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -332,7 +332,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   factory_girl_rails
-  gds-api-adapters (~> 41.0)
+  gds-api-adapters (~> 47.2)
   gds-sso (~> 13.0)
   generic_form_builder (~> 0.13)
   govuk-content-schema-test-helpers
@@ -356,4 +356,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.5
+   1.15.0

--- a/app/notifiers/content_item_publisher.rb
+++ b/app/notifiers/content_item_publisher.rb
@@ -1,22 +1,19 @@
 class ContentItemPublisher
-  # Setting the update type to minor means we won't send email alerts for
-  # changes to a topic title or description.
-  DEFAULT_UPDATE_TYPE = 'minor'.freeze
-  attr_reader :presenter, :update_type
+  attr_reader :presenter, :override_update_type
 
   delegate :content_id, to: :presenter
   delegate :publishing_api, to: Services
 
-  def initialize(presenter, update_type: DEFAULT_UPDATE_TYPE)
+  def initialize(presenter, update_type: nil)
     @presenter = presenter
-    @update_type = update_type
+    @override_update_type = update_type
   end
 
   def send_to_publishing_api
     publishing_api.put_content(content_id, presenter.render_for_publishing_api)
 
     unless presenter.draft?
-      publishing_api.publish(content_id, update_type)
+      publishing_api.publish(content_id, override_update_type)
     end
 
     unless presenter.archived?

--- a/app/presenters/archived_tag_presenter.rb
+++ b/app/presenters/archived_tag_presenter.rb
@@ -19,6 +19,7 @@ class ArchivedTagPresenter
       schema_name: 'redirect',
       publishing_app: 'collections-publisher',
       redirects: RedirectRoutePresenter.new(@tag).routes,
+      update_type: 'minor',
     }
   end
 

--- a/app/presenters/redirect_item_presenter.rb
+++ b/app/presenters/redirect_item_presenter.rb
@@ -33,6 +33,7 @@ class RedirectItemPresenter
       schema_name: 'redirect',
       publishing_app: 'collections-publisher',
       redirects: RedirectRoutePresenter.new(self).routes,
+      update_type: 'minor',
     }
   end
 end

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -27,6 +27,7 @@ class RootBrowsePagePresenter
       rendering_app: "collections",
       routes: routes,
       details: {},
+      update_type: 'minor',
     }
   end
 

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -28,7 +28,8 @@ class RootTopicPresenter
       routes: routes,
       details: {
         internal_name: "Topic index page",
-      }
+      },
+      update_type: 'minor',
     }
   end
 

--- a/app/presenters/tag_presenter.rb
+++ b/app/presenters/tag_presenter.rb
@@ -62,6 +62,7 @@ class TagPresenter
       routes: routes,
       redirects: RedirectRoutePresenter.new(@tag).routes,
       details: details,
+      update_type: 'minor',
     }
   end
 

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe ArchivedTagPresenter do
             destination: "/topic/parent",
             type: "exact"
           },
-        ]
+        ],
+        update_type: "minor",
       }
       presenter = ArchivedTagPresenter.new(child)
       expect(presenter.render_for_publishing_api).to eq expected_child_content


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)