### PR TITLE
Remove content_ids from redirect presenters

### DIFF
--- a/app/presenters/archived_tag_presenter.rb
+++ b/app/presenters/archived_tag_presenter.rb
@@ -13,7 +13,6 @@ class ArchivedTagPresenter
 
   def render_for_publishing_api
     {
-      content_id: content_id,
       base_path: base_path,
       document_type: 'redirect',
       schema_name: 'redirect',

--- a/app/presenters/redirect_item_presenter.rb
+++ b/app/presenters/redirect_item_presenter.rb
@@ -27,7 +27,6 @@ class RedirectItemPresenter
 
   def render_for_publishing_api
     {
-      content_id: content_id,
       base_path: base_path,
       document_type: 'redirect',
       schema_name: 'redirect',

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe ArchivedTagPresenter do
 
     it 'renders a redirect to a parent with no subroutes correctly' do
       expected_child_content = {
-        content_id: child.content_id,
         base_path: "/topic/parent/child-1",
         document_type: "redirect",
         schema_name: "redirect",


### PR DESCRIPTION
This removes legacy content_ids from the payloads to Publishing API.
These do not currently throw a schema error because the schema is
incorrect:
https://github.com/alphagov/govuk-content-schemas/blob/04ce3f8bbba0f205f65354f8173718e67fa18834/formats/redirect/publisher_v2/schema.json#L16-L18

This is being fixed to try help merge in correct schemas.