### PR TITLE
Publish route for learn to drive task list page

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -9,4 +9,31 @@ namespace :publishing_api do
   task :send_published_tags => :environment do
     TagRepublisher.new.republish_tags(Tag.published)
   end
+
+  desc "Publish task list to publishing api"
+  task publish_task_list: :environment do
+    content_id = "e01e924b-9c7c-4c71-8241-66a575c2f61f"
+    params = {
+      base_path: "/learn-to-drive-a-car",
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+      public_updated_at: Time.zone.now.iso8601,
+      update_type: "major",
+      schema_name: "generic",
+      document_type: "task_list",
+      title: "Learn to drive a car: step by step",
+      description: "Check what you need to do to learn to drive.",
+      details: {},
+      locale: "en",
+      routes: [
+        {
+          path: "/learn-to-drive-a-car",
+          type: "exact"
+        }
+      ]
+    }
+
+    Services.publishing_api.put_content(content_id, params)
+    Services.publishing_api.publish(content_id)
+  end
 end


### PR DESCRIPTION
This commit aims to publish the route /learn-to-drive-a-car into
publishing-api.

This will be where the `task list` page for `learning to drive a car` will live within GOV.UK.

We talked with the search team and this seems to be the best way to
integrate this page with search later on.

Trello:
https://trello.com/c/WOhDbn9e/208-publish-route-for-the-task-list-page

## Preview

<img width="841" alt="screen shot 2017-10-10 at 13 37 18" src="https://user-images.githubusercontent.com/136777/31386843-3037c9fe-adc0-11e7-9fc0-dbdcf788d1ca.png">
