### PR TITLE
[DO NOT MERGE] Publish email alert signup pages

### DIFF
--- a/app/presenters/email_alert_signup_presenter.rb
+++ b/app/presenters/email_alert_signup_presenter.rb
@@ -1,0 +1,79 @@
+class EmailAlertSignupPresenter
+  def initialize(subtopic)
+    self.subtopic = subtopic
+  end
+
+  def content_payload
+    {
+      base_path: base_path,
+      document_type: "email_alert_signup",
+      schema_name: "email_alert_signup",
+      title: subtopic.title,
+      description: "#{subtopic.title} Email Alert Signup",
+      public_updated_at: public_updated_at,
+      locale: "en",
+      publishing_app: "collections-publisher",
+      rendering_app: "email-alert-frontend",
+      routes: routes,
+      details: details,
+      update_type: update_type,
+    }
+  end
+
+  def content_id
+    Services.publishing_api.lookup_content_id(base_path: base_path) || SecureRandom.uuid
+  end
+
+  def update_type
+    "republish"
+  end
+
+private
+
+  attr_accessor :subtopic
+
+  def subtopic_base_path
+    "/topic/#{subtopic.parent.slug}/#{subtopic.slug}"
+  end
+
+  def base_path
+    "#{subtopic_base_path}/email-signup"
+  end
+
+  def public_updated_at
+    Time.zone.now.iso8601
+  end
+
+  def routes
+    [{ path: base_path, type: "exact" }]
+  end
+
+  def details
+    {
+      subscriber_list: {
+        document_type: "topic",
+        links: subscriber_list_links,
+      },
+      summary: summary,
+      breadcrumbs: breadcrumbs,
+      govdelivery_title: subtopic.title,
+    }
+  end
+
+  def subscriber_list_links
+    { topics: [subtopic.content_id] }
+  end
+
+  def summary
+    "You’ll get an email each time content is published or updated in this topic."
+  end
+
+  def breadcrumbs
+    [
+      {
+        title: subtopic.title,
+        link: subtopic_base_path,
+      }
+    ]
+  end
+end

--- a/app/services/email_alert_signup_publisher.rb
+++ b/app/services/email_alert_signup_publisher.rb
@@ -1,0 +1,12 @@
+class EmailAlertSignupPublisher
+  def republish_email_alert_signups
+    Topic.all.each do |topic|
+      if topic.subtopic?
+        presenter = EmailAlertSignupPresenter.new(topic)
+        content_id = presenter.content_id
+        Services.publishing_api.put_content(content_id, presenter.content_payload)
+        Services.publishing_api.publish(content_id, presenter.update_type)
+      end
+    end
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -9,4 +9,9 @@ namespace :publishing_api do
   task :send_published_tags => :environment do
     TagRepublisher.new.republish_tags(Tag.published)
   end
+
+  desc "Send all email alert signup pages to publishing-api"
+  task :send_email_alert_signups => :environment do
+    EmailAlertSignupPublisher.new.republish_email_alert_signups
+  end
 end

--- a/spec/presenters/email_alert_signup_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup_presenter_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe EmailAlertSignupPresenter do
+  describe "#content_payload" do
+    it "is valid against the schema" do
+      parent_topic = create(:topic, title: "Parent Topic", slug: "parent-topic")
+      child_topic = create(:topic, title: "Child Topic", slug: "child-topic", parent_id: parent_topic.id)
+
+      rendered = EmailAlertSignupPresenter.new(child_topic).content_payload
+
+      expect(rendered).to be_valid_against_schema('email_alert_signup')
+    end
+  end
+end

--- a/spec/services/email_alert_signup_publisher_spec.rb
+++ b/spec/services/email_alert_signup_publisher_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe EmailAlertSignupPublisher do
+  include ContentStoreHelpers
+
+  describe '#republish_email_alert_signups' do
+    it "sends all email alert signup content items to the publishing-api" do
+      stub_content_store!
+      parent_topic = create(:topic, title: "Parent Topic", slug: "parent-topic")
+      create(:topic, title: "Child Topic", slug: "child-topic", parent_id: parent_topic.id)
+
+      EmailAlertSignupPublisher.new.republish_email_alert_signups
+
+      expect(stubbed_content_store).to have_content_item_slug('/topic/parent-topic/child-topic/email-signup')
+    end
+  end
+end

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -55,5 +55,14 @@ module ContentStoreHelpers
     def item_by_content_id(content_id)
       @stored_items.fetch(content_id)
     end
+
+    def lookup_content_id(base_path:)
+      @stored_items.each_pair do |content_id, item|
+        if item[:base_path] == base_path
+          return content_id
+        end
+      end
+      nil
+    end
   end
 end


### PR DESCRIPTION
This commit publishes content items for email alert signup pages for all subtopics, to allow email alert signups to be handled by `email-alert-frontend` rather than `collections`.