### PR TITLE
Update task list page description

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -22,7 +22,7 @@ namespace :publishing_api do
       schema_name: "generic",
       document_type: "task_list",
       title: "Learn to drive a car: step by step",
-      description: "Check what you need to do to learn to drive.",
+      description: "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
       details: {},
       locale: "en",
       routes: [


### PR DESCRIPTION
We've specified a meta description on the [task list page](https://github.com/alphagov/collections/blob/d2e95a7c052be9982b8d07eff0ea7de6384f1510/app/views/tasklist/show.html.erb#L4), so we want to make this consistent.

https://trello.com/c/wAMac6Dz/282-update-task-list-description-in-publishing-api