### PR TITLE
Enable the end-to-end tests for collections publisher

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
-  govuk.buildProject(sassLint: false)
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
+  govuk.buildProject(sassLint: false, publishingE2ETests: true)
 }


### PR DESCRIPTION
This will allow us to run the tests defined in the [E2E project](https://github.com/alphagov/publishing-e2e-tests) for collections publishing to ensure that publishing between applications still works when changes are made to this repo