### PR TITLE
Remove duplicate logstasher initializer

### DIFF
--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,8 +1,0 @@
-if Object.const_defined?('LogStasher') && LogStasher.enabled
-  LogStasher.add_custom_fields do |fields|
-    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
-    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
-    # Pass request Id to logging
-    fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-  end
-end


### PR DESCRIPTION
This is defined in govuk_app_config [1] and is no longer needed on a
per-application basis.

[1] https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_logging.rb#L26-L36