### PR TITLE
 Rename rake tasks to use updated document_type name

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -10,8 +10,8 @@ namespace :publishing_api do
     TagRepublisher.new.republish_tags(Tag.published)
   end
 
-  desc "Publish task list to publishing api"
-  task publish_task_list: :environment do
+  desc "Publish /learn-to-drive-a-car step navigation to publishing api"
+  task publish_learn_to_drive_a_car_step_nav: :environment do
     content_id = "e01e924b-9c7c-4c71-8241-66a575c2f61f"
     params = {
       base_path: "/learn-to-drive-a-car",
@@ -20,7 +20,7 @@ namespace :publishing_api do
       public_updated_at: Time.zone.now.iso8601,
       update_type: "major",
       schema_name: "generic",
-      document_type: "task_list",
+      document_type: "step_by_step_nav",
       title: "Learn to drive a car: step by step",
       description: "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
       details: {},
@@ -37,14 +37,14 @@ namespace :publishing_api do
     Services.publishing_api.publish(content_id)
   end
 
-  desc "Unpublish /end-a-civil-partnership task list to publishing api"
-  task unpublish_end_a_civil_partnership_task_list: :environment do
+  desc "Unpublish /end-a-civil-partnership step navigation to publishing api"
+  task unpublish_end_a_civil_partnership_step_nav: :environment do
     content_id = "b6ee74ca-123c-4e89-82b5-369be9362159"
     Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/end-civil-partnership")
   end
 
-  desc "Publish /end-a-civil-partnership task list to publishing api"
-  task publish_end_a_civil_partnership_task_list: :environment do
+  desc "Publish /end-a-civil-partnership step navigation to publishing api"
+  task publish_end_a_civil_partnership_step_nav: :environment do
     content_id = "b6ee74ca-123c-4e89-82b5-369be9362159"
     params = {
       base_path: "/end-a-civil-partnership",
@@ -53,7 +53,7 @@ namespace :publishing_api do
       public_updated_at: Time.zone.now.iso8601,
       update_type: "major",
       schema_name: "generic",
-      document_type: "task_list",
+      document_type: "step_by_step_nav",
       title: "End a civil partnership: step by step",
       description: "Grounds for ending a partnership, child arrangements, "\
         "money and property, file an application, D8 form, apply for a consent "\
@@ -72,14 +72,14 @@ namespace :publishing_api do
     Services.publishing_api.publish(content_id)
   end
 
-  desc "Unpublish /get-a-divorce task list to publishing api"
-  task unpublish_get_a_divorce_task_list: :environment do
+  desc "Unpublish /get-a-divorce step navigation to publishing api"
+  task unpublish_get_a_divorce_step_nav: :environment do
     content_id = "3d1279d9-73e9-4871-8b82-7389955b4c1b"
     Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/divorce")
   end
 
-  desc "Publish /get-a-divorce task list to publishing api"
-  task publish_get_a_divorce_task_list: :environment do
+  desc "Publish /get-a-divorce step navigation publishing api"
+  task publish_get_a_divorce_step_nav: :environment do
     content_id = "3d1279d9-73e9-4871-8b82-7389955b4c1b"
     params = {
       base_path: "/get-a-divorce",
@@ -88,7 +88,7 @@ namespace :publishing_api do
       public_updated_at: Time.zone.now.iso8601,
       update_type: "major",
       schema_name: "generic",
-      document_type: "task_list",
+      document_type: "step_by_step_nav",
       title: "Get a divorce: step by step",
       description: "Grounds for divorce, child arrangements, money and "\
         "property, file for divorce, D8 form, apply for a decree nisi and "\

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -72,7 +72,7 @@ namespace :publishing_api do
     Services.publishing_api.publish(content_id)
   end
 
-  desc "Unublish /get-a-divorce task list to publishing api"
+  desc "Unpublish /get-a-divorce task list to publishing api"
   task unpublish_get_a_divorce_task_list: :environment do
     content_id = "3d1279d9-73e9-4871-8b82-7389955b4c1b"
     Services.publishing_api.unpublish(content_id, type: "redirect", alternative_path: "/divorce")


### PR DESCRIPTION
The Modelling Services team are renaming the `document_type` from `task_list` to `step_by_step_nav` as the term `task list` has already been used to define something else. 