### PR TITLE
Update learn to drive

### DIFF
--- a/lib/tasks/step_nav/learn_to_drive_a_car.rake
+++ b/lib/tasks/step_nav/learn_to_drive_a_car.rake
@@ -15,6 +15,8 @@ namespace :step_nav do
       description: "Learn to drive a car in the UK - get a provisional licence, take driving lessons, prepare for your theory test, book your practical test.",
       details: {
         step_by_step_nav: {
+          title: "Learn to drive a car: step by step",
+          introduction: "Check what you need to do to learn to drive.",
           steps: [
             {
               title: "Check you're allowed to drive",

--- a/lib/tasks/step_nav/learn_to_drive_a_car.rake
+++ b/lib/tasks/step_nav/learn_to_drive_a_car.rake
@@ -92,6 +92,7 @@ namespace :step_nav do
             },
             {
               title: "Prepare for your theory test",
+              logic: "and",
               contents: [
                 {
                   type: "list",


### PR DESCRIPTION
Set the correct step logic to allow for the concurrent step.

Add the new title and introduction fields to allow us to render the enter step by step nav page from content store (added in https://github.com/alphagov/govuk-content-schemas/pull/720)

https://trello.com/c/3pQPJDmj/440-allow-collections-to-render-task-lists-from-the-publishing-api