### PR TITLE
 Set up access permissions for Step by Step pages

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -1,4 +1,5 @@
 class StepByStepPagesController < ApplicationController
-  def index
-  end
+  before_action :require_gds_editor_permissions!
+
+  def index; end
 end

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -1,0 +1,4 @@
+class StepByStepPagesController < ApplicationController
+  def index
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,12 @@
   <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
     <%= link_to 'Topics', topics_path %>
   </li>
+
+  <% if gds_editor? %>
+    <li class='<%= active_navigation_item == 'step_by_step_pages' ? 'active' : nil %>'>
+      <%= link_to 'Step by step pages', step_by_step_pages_path %>
+    </li>
+  <% end %>
 <% end %>
 
 <% content_for :body_end do %>

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -1,0 +1,2 @@
+<h1>StepByStepPages#index</h1>
+<p>Find me in app/views/step_by_step_pages/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,7 @@ Rails.application.routes.draw do
 
   root to: redirect('/topics', status: 302)
 
-  resources :step_by_step_pages, path: 'step-by-step-pages' do
-  end
+  get :"step-by-step-pages", to: 'step_by_step_pages#index'
 
   resources :mainstream_browse_pages, path: 'mainstream-browse-pages',
                                       except: :destroy do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
 
   root to: redirect('/topics', status: 302)
 
+  resources :step_by_step_pages, path: 'step-by-step-pages' do
+  end
+
   resources :mainstream_browse_pages, path: 'mainstream-browse-pages',
                                       except: :destroy do
     member do

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe StepByStepPagesController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -1,12 +1,19 @@
 require 'rails_helper'
 
-RSpec.describe StepByStepPagesController, type: :controller do
-
-  describe "GET #index" do
-    it "returns http success" do
+RSpec.describe StepByStepPagesController do
+  describe "GET Step by step index page" do
+    it "can only be accessed by users with GDS editor permissions" do
+      stub_user.permissions << "GDS Editor"
       get :index
-      expect(response).to have_http_status(:success)
+
+      expect(response.status).to eq(200)
+    end
+
+    it "cannot be accessed by users without GDS editor permissions" do
+      stub_user.permissions = ["signin"]
+      get :index
+
+      expect(response.status).to eq(403)
     end
   end
-
 end


### PR DESCRIPTION
The Modelling Services team are working on implementing the Step by Step pages into the publisher.
We want to be able to develop features and deploy them without affecting the workflow already in place.

Users with GDS editor permissions should be able to see the `Step by step pages` link next to `Topics`.

Trello Card: [Step by Step Page behind access permissions](https://trello.com/c/LjXNfJg1/504-step-by-step-page-behind-access-permissions)

![screen shot 2018-02-19 at 11 23 06](https://user-images.githubusercontent.com/19667619/36375620-dd062342-1567-11e8-869b-c09fa948dcc9.png)
