### PR TITLE
Update learn to drive with new schema

### DIFF
--- a/lib/tasks/step_nav/learn_to_drive_a_car.rake
+++ b/lib/tasks/step_nav/learn_to_drive_a_car.rake
@@ -16,7 +16,12 @@ namespace :step_nav do
       details: {
         step_by_step_nav: {
           title: "Learn to drive a car: step by step",
-          introduction: "Check what you need to do to learn to drive.",
+          introduction: [
+            {
+              content_type: "text/govspeak",
+              content: "Check what you need to do to learn to drive."
+            }
+          ],
           steps: [
             {
               title: "Check you're allowed to drive",


### PR DESCRIPTION
The schema has changed to allow [introduction to be markdown](https://github.com/alphagov/govuk-content-schemas/blob/master/examples/step_by_step_nav/publisher_v2/learn_to_drive_a_car.json#L26)