### PR TITLE
Add new StepByStepPage model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,3 +64,4 @@ Layout/SpaceInsideParens:
 Metrics/BlockLength:
   Exclude:
     - 'lib/tasks/**/*.rake'
+    - 'spec/**/*_spec.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
-    ast (2.3.0)
+    ast (2.4.0)
     autoprefixer-rails (7.2.5)
       execjs
     better_errors (2.4.0)
@@ -86,7 +86,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.21)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -188,8 +188,8 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     parallel (1.12.1)
-    parser (2.4.0.2)
-      ast (~> 2.3)
+    parser (2.5.0.1)
+      ast (~> 2.4.0)
     plek (2.1.1)
     poltergeist (1.17.0)
       capybara (~> 2.1)
@@ -382,4 +382,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       sass (>= 3.3.0)
     builder (3.2.3)
     byebug (9.1.0)
-    capybara (2.17.0)
+    capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
@@ -202,7 +202,7 @@ GEM
     pry-byebug (3.5.1)
       byebug (~> 9.1)
       pry (~> 0.10)
-    public_suffix (3.0.1)
+    public_suffix (3.0.2)
     rack (2.0.4)
     rack-cache (1.7.1)
       rack (>= 0.4)

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,0 +1,5 @@
+class StepByStepPage < ApplicationRecord
+  validates :title, :base_path, presence: true
+  validates :base_path, format: { with: /\A([a-z0-9]+-)+[a-z0-9]+\z/ }
+  validates :base_path, uniqueness: true
+end

--- a/db/migrate/20180219165923_create_step_by_step_pages.rb
+++ b/db/migrate/20180219165923_create_step_by_step_pages.rb
@@ -1,0 +1,11 @@
+class CreateStepByStepPages < ActiveRecord::Migration[5.1]
+  def change
+    create_table :step_by_step_pages do |t|
+      t.string "title"
+      t.string "base_path"
+      t.text "introduction"
+      t.text "description"
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170117160733) do
+ActiveRecord::Schema.define(version: 20180219165923) do
 
   create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "base_path"
@@ -49,6 +49,15 @@ ActiveRecord::Schema.define(version: 20170117160733) do
     t.index ["from_base_path"], name: "index_redirect_routes_on_from_base_path", unique: true
     t.index ["redirect_id"], name: "index_redirect_routes_on_redirect_id"
     t.index ["tag_id"], name: "index_redirect_routes_on_tag_id"
+  end
+
+  create_table "step_by_step_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "title"
+    t.string "base_path"
+    t.text "introduction"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tag_associations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,9 @@
 FactoryGirl.define do
+  factory :step_by_step_page do
+    title "How to be amazing"
+    base_path "how-to-be-the-amazing-1"
+  end
+
   factory :redirect_item do
     content_id SecureRandom.uuid
     from_base_path "/from/foo"

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe StepByStepPage do
+  let(:step_by_step_page) { build(:step_by_step_page) }
+
+  describe 'validations' do
+    it 'is created with valid attributes' do
+      expect(step_by_step_page).to be_valid
+      expect(step_by_step_page.save).to eql true
+      expect(step_by_step_page).to be_persisted
+    end
+
+    it 'requires a title' do
+      step_by_step_page.title = ''
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors).to have_key(:title)
+    end
+
+    it 'requires a base path' do
+      step_by_step_page.base_path = ''
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors).to have_key(:base_path)
+    end
+
+    it 'must have a valid base path' do
+      [
+        "not/a/valid/path",
+        "not_a_valid_path",
+        "not a valid path",
+        "Not-a-Valid-Path",
+        "-hyphen",
+        "hyphen-"
+      ].each do |base_path|
+        step_by_step_page.base_path = base_path
+
+        expect(step_by_step_page).not_to be_valid
+        expect(step_by_step_page.errors).to have_key(:base_path)
+      end
+    end
+
+    it 'must be a unique base path' do
+      step_by_step_page.base_path = "new-step-by-step"
+      step_by_step_page.save
+
+      duplicate = create(:step_by_step_page)
+      duplicate.base_path = step_by_step_page.base_path
+
+      expect(duplicate.save).to eql false
+      expect(duplicate.errors).to have_key(:base_path)
+    end
+  end
+end


### PR DESCRIPTION
The Modelling Services team are implementing the `Step by step` publishing tool into Collections Publisher.

We want to store `Step by step` content in the database, and use the data to generate the json content we want to send as part of the payload to `publishing_api`.

A second PR is required after ths one to add the `Step` model, which will have a `belongs_to` relationship with the `StepByStepPage` model.

Trello card: [Allow Step by Step Pages to be stored in Collections Publisher](https://trello.com/c/oZX9zHNf/506-allow-step-by-step-pages-to-be-stored-in-collections-publisher)