### PR TITLE
Update StepByStep validation

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,5 +1,5 @@
 class StepByStepPage < ApplicationRecord
   validates :title, :base_path, presence: true
-  validates :base_path, format: { with: /\A([a-z0-9]+-)+[a-z0-9]+\z/ }
+  validates :base_path, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }
   validates :base_path, uniqueness: true
 end


### PR DESCRIPTION
The current format regex for the `base_path` does not accept a single word. This has now been updated.

This is part of https://github.com/alphagov/collections-publisher/pull/320