### PR TITLE
Add new Step model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem 'poltergeist'
   gem 'pry-byebug'
   gem 'rspec-rails'
+  gem 'shoulda-matchers', '~> 3.1'
   gem 'timecop'
   gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,8 @@ GEM
       thor (~> 0.14)
     sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     sidekiq (5.0.5)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -376,6 +378,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   select2-rails (~> 3.5.9)
+  shoulda-matchers (~> 3.1)
   sinatra
   timecop
   uglifier (~> 4.1)

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,0 +1,5 @@
+class Step < ApplicationRecord
+  belongs_to :step_by_step_page
+  validates_presence_of :step_by_step_page
+  validates :title, :logic, presence: true
+end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,4 +1,6 @@
 class StepByStepPage < ApplicationRecord
+  has_many :steps, dependent: :destroy
+
   validates :title, :base_path, presence: true
   validates :base_path, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }
   validates :base_path, uniqueness: true

--- a/db/migrate/20180221152119_create_steps.rb
+++ b/db/migrate/20180221152119_create_steps.rb
@@ -1,0 +1,16 @@
+class CreateSteps < ActiveRecord::Migration[5.1]
+  def change
+    create_table :steps do |t|
+      t.string "title"
+      t.string "logic"
+      t.boolean "optional"
+      t.text "contents"
+      t.string "optional_heading"
+      t.text "optional_contents"
+      t.integer "position"
+      t.references :step_by_step_page, foreign_key: true
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180219165923) do
+ActiveRecord::Schema.define(version: 20180221152119) do
 
   create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "base_path"
@@ -60,6 +60,20 @@ ActiveRecord::Schema.define(version: 20180219165923) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "steps", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "title"
+    t.string "logic"
+    t.boolean "optional"
+    t.text "contents"
+    t.string "optional_heading"
+    t.text "optional_contents"
+    t.integer "position"
+    t.bigint "step_by_step_page_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["step_by_step_page_id"], name: "index_steps_on_step_by_step_page_id"
+  end
+
   create_table "tag_associations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "from_tag_id", null: false
     t.integer "to_tag_id", null: false
@@ -103,6 +117,7 @@ ActiveRecord::Schema.define(version: 20180219165923) do
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
   add_foreign_key "lists", "tags", name: "lists_tag_id_fk", on_delete: :cascade
   add_foreign_key "redirect_routes", "tags"
+  add_foreign_key "steps", "step_by_step_pages"
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade
   add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,18 @@ FactoryGirl.define do
   factory :step_by_step_page do
     title "How to be amazing"
     base_path "how-to-be-the-amazing-1"
+
+    factory :step_by_step_page_with_steps do
+      after(:create) do |step_by_step_page|
+        create(:step, step_by_step_page: step_by_step_page)
+      end
+    end
+  end
+
+  factory :step do
+    title "Check how awesome you are"
+    logic "number"
+    step_by_step_page
   end
 
   factory :redirect_item do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -44,11 +44,26 @@ RSpec.describe StepByStepPage do
       step_by_step_page.base_path = "new-step-by-step"
       step_by_step_page.save
 
-      duplicate = create(:step_by_step_page)
+      duplicate = build(:step_by_step_page)
       duplicate.base_path = step_by_step_page.base_path
 
       expect(duplicate.save).to eql false
       expect(duplicate.errors).to have_key(:base_path)
+    end
+  end
+
+  describe 'steps association' do
+    let(:step_by_step_with_step) { create(:step_by_step_page_with_steps) }
+
+    it 'is created with a step' do
+      expect(step_by_step_with_step.steps.length).to eql(1)
+    end
+
+    it 'deletes steps when the StepByStepPage is deleted' do
+      step_by_step_with_step.destroy
+
+      expect { step_by_step_with_step.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(step_by_step_with_step.steps.length).to eql(0)
     end
   end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Step do
+  let(:step_item) { build(:step) }
+
+  describe 'validations' do
+    it 'should belong to a step_by_step_page' do
+      should validate_presence_of(:step_by_step_page)
+    end
+
+    it 'fails if step_by_step_page does not exist' do
+      step_item.step_by_step_page = nil
+
+      expect(step_item).not_to be_valid
+    end
+
+    it 'is created with valid attributes' do
+      expect(step_item).to be_valid
+      expect(step_item.save).to eql true
+      expect(step_item).to be_persisted
+    end
+
+    it 'requires a title' do
+      step_item.title = ''
+
+      expect(step_item).not_to be_valid
+      expect(step_item.errors).to have_key(:title)
+    end
+
+    it 'requires logic' do
+      step_item.logic = ''
+
+      expect(step_item).not_to be_valid
+      expect(step_item.errors).to have_key(:logic)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,7 @@
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'shoulda/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -14,6 +15,9 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.raise_errors_for_deprecations!
+
+  config.include(Shoulda::Matchers::ActiveModel, type: :model)
+  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
 
   # ## Mock Framework
   #


### PR DESCRIPTION
The Modelling Services team are implementing the Step by step publishing tool into Collections Publisher.

The `StepByStepPage` model has already been created in this pr: https://github.com/alphagov/collections-publisher/pull/320

This PR creates the `Step` model, which has a `belongs_to` relationship with `StepByStepPage`.

Trello card: [Allow Step by Step Pages and Steps to be stored in Collections Publisher](https://trello.com/c/oZX9zHNf/506-allow-step-by-step-pages-and-steps-to-be-stored-in-collections-publisher)