### PR TITLE
Parse simple step nav content

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -1,7 +1,7 @@
 class StepContentParser
-  BULLETED_LIST_REGEX = /^\*\s\[.+\]\(.+\)$/ # to match * [Link text](url)
-  LIST_REGEX = /^\-\s\[.+\]\(.+\)$/          # to match - [Link text](url)
-  LINK_CAPTURE_REGEX = /\[(.+)\]\((.+)\)$/   # to capture $1 = "Link text", $2 = "url" from above
+  BULLETED_LIST_REGEX = /^\*\s\[.+\]\(.+\).*$/ # to match * [Link text](url)context
+  LIST_REGEX = /^\-\s\[.+\]\(.+\).*$/          # to match - [Link text](url)context
+  LINK_CAPTURE_REGEX = /\[(.+)\]\((.+)\)(.*)$/ # to capture $1 = "Link text", $2 = "url" $3 = "context" from above
 
   def parse(step_text)
     sections = step_text.split("\n\n").map do |section|
@@ -42,10 +42,18 @@ private
   def link_content(section)
     section.map do |line|
       if line =~ LINK_CAPTURE_REGEX
-        {
-          "text": $1,
-          "href": $2
-        }
+        if $3.blank?
+          {
+            "text": $1,
+            "href": $2
+          }
+        else
+          {
+            "text": $1,
+            "href": $2,
+            "context": $3
+          }
+        end
       end
     end
   end

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -1,0 +1,52 @@
+class StepContentParser
+  BULLETED_LIST_REGEX = /^\*\s\[.+\]\(.+\)$/ # to match * [Link text](url)
+  LIST_REGEX = /^\-\s\[.+\]\(.+\)$/          # to match - [Link text](url)
+  LINK_CAPTURE_REGEX = /\[(.+)\]\((.+)\)$/   # to capture $1 = "Link text", $2 = "url" from above
+
+  def parse(step_text)
+    sections = step_text.split("\n\n").map do |section|
+      section.lines.map(&:chomp)
+    end
+
+    sections.map do |section|
+      if standard_list?(section)
+        {
+          "type": "list",
+          "contents": link_content(section)
+        }
+      elsif bulleted_list?(section)
+        {
+          "type": "list",
+          "style": "choice",
+          "contents": link_content(section)
+        }
+      else
+        {
+          "type": "paragraph",
+          "text": section.join
+        }
+      end
+    end
+  end
+
+private
+
+  def standard_list?(section)
+    section.all? { |line| line =~ LIST_REGEX }
+  end
+
+  def bulleted_list?(section)
+    section.all? { |line| line =~ BULLETED_LIST_REGEX }
+  end
+
+  def link_content(section)
+    section.map do |line|
+      if line =~ LINK_CAPTURE_REGEX
+        {
+          "text": $1,
+          "href": $2
+        }
+      end
+    end
+  end
+end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -33,6 +33,40 @@ RSpec.describe StepContentParser do
         }
       ])
     end
+
+    it "copes with multiple blank lines and trailing blank lines" do
+      step_text = <<~HEREDOC
+        Ladies and gentlemen:
+
+
+        Grieg's piano concerto.
+
+
+        By Grieg
+
+        Conducted by Mr Andrew Preview
+
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "paragraph",
+          "text": "Ladies and gentlemen:"
+        },
+        {
+          "type": "paragraph",
+          "text": "Grieg's piano concerto."
+        },
+        {
+          "type": "paragraph",
+          "text": "By Grieg"
+        },
+        {
+          "type": "paragraph",
+          "text": "Conducted by Mr Andrew Preview"
+        }
+      ])
+    end
   end
 
   context "list of bulleted links" do

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe StepContentParser do
+  subject { described_class.new }
+
+  context "paragraphs" do
+    it "a single line of text is parsed to an array with one paragraph section" do
+      step_text = "This is a paragraph."
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "paragraph",
+          "text": "This is a paragraph."
+        }
+      ])
+    end
+
+    it "Generates multiple paragraphs if they are separated by blank lines" do
+      step_text = <<~HEREDOC
+        These are all the right notes
+
+        Just not necessarily in the right order
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "paragraph",
+          "text": "These are all the right notes"
+        },
+        {
+          "type": "paragraph",
+          "text": "Just not necessarily in the right order"
+        }
+      ])
+    end
+  end
+
+  context "list of bulleted links" do
+    it "is parsed to a 'choice' list of links" do
+      step_text = <<~HEREDOC
+        * [Apply for a provisional driving licence](/apply-provisional-licence)
+        * [Check that you can drive](/vehicles-can-drive)
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "list",
+          "style": "choice",
+          "contents": [
+            {
+              "href": "/apply-provisional-licence",
+              "text": "Apply for a provisional driving licence"
+            },
+            {
+              "href": "/vehicles-can-drive",
+              "text": "Check that you can drive"
+            }
+          ]
+        }
+      ])
+    end
+  end
+
+  context "list of non-bulleted links" do
+    it "is parsed to a standard list of links" do
+      step_text = <<~HEREDOC
+        - [Open the box](/open-the-box)
+        - [Keep the money](/keep-the-money)
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "list",
+          "contents": [
+            {
+              "href": "/open-the-box",
+              "text": "Open the box"
+            },
+            {
+              "href": "/keep-the-money",
+              "text": "Keep the money"
+            }
+          ]
+        }
+      ])
+    end
+  end
+end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe StepContentParser do
       ])
     end
 
-    it "Generates multiple paragraphs if they are separated by blank lines" do
+    it "generates multiple paragraphs if they are separated by blank lines" do
       step_text = <<~HEREDOC
         These are all the right notes
 
@@ -48,12 +48,37 @@ RSpec.describe StepContentParser do
           "style": "choice",
           "contents": [
             {
-              "href": "/apply-provisional-licence",
-              "text": "Apply for a provisional driving licence"
+              "text": "Apply for a provisional driving licence",
+              "href": "/apply-provisional-licence"
             },
             {
-              "href": "/vehicles-can-drive",
-              "text": "Check that you can drive"
+              "text": "Check that you can drive",
+              "href": "/vehicles-can-drive"
+            }
+          ]
+        }
+      ])
+    end
+
+    it "is parsed to a 'choice' list of links with optional context" do
+      step_text = <<~HEREDOC
+        * [A speed boat](/speed-boat)
+        * [Spending money](/spending-money)£5000 or so
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "list",
+          "style": "choice",
+          "contents": [
+            {
+              "text": "A speed boat",
+              "href": "/speed-boat"
+            },
+            {
+              "text": "Spending money",
+              "href": "/spending-money",
+              "context": "£5000 or so"
             }
           ]
         }
@@ -73,14 +98,105 @@ RSpec.describe StepContentParser do
           "type": "list",
           "contents": [
             {
-              "href": "/open-the-box",
-              "text": "Open the box"
+              "text": "Open the box",
+              "href": "/open-the-box"
             },
             {
-              "href": "/keep-the-money",
-              "text": "Keep the money"
+              "text": "Keep the money",
+              "href": "/keep-the-money"
             }
           ]
+        }
+      ])
+    end
+
+    it "is parsed to a standard list of links with optional context" do
+      step_text = <<~HEREDOC
+        - [A cuddly toy](/cuddly-toy)
+        - [Brucie bonus](/brucie-bonus)Mystery prize
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "list",
+          "contents": [
+            {
+              "text": "A cuddly toy",
+              "href": "/cuddly-toy"
+            },
+            {
+              "text": "Brucie bonus",
+              "href": "/brucie-bonus",
+              "context": "Mystery prize"
+            }
+          ]
+        }
+      ])
+    end
+  end
+
+  context "mixed content" do
+    it "is parsed as expected" do
+      step_text = <<~HEREDOC
+        There are several prizes on offer on today's Generation Game conveyor belt including:
+
+        - [A cuddly toy](/cuddly-toy)
+        - [Brucie bonus](/brucie-bonus)Mystery prize
+
+        If you get the mystery prize, this may be one of several things:
+
+        * [A speed boat](/speed-boat)
+        * [Spending money](/spending-money)£5000 or so
+        * [A dishwasher](http://dishwashers.org/bargain-basement)
+
+        You have to remember them all!
+      HEREDOC
+
+      expect(subject.parse(step_text)).to eq([
+        {
+          "type": "paragraph",
+          "text": "There are several prizes on offer on today's Generation Game conveyor belt including:"
+        },
+        {
+          "type": "list",
+          "contents": [
+            {
+              "text": "A cuddly toy",
+              "href": "/cuddly-toy"
+            },
+            {
+              "text": "Brucie bonus",
+              "href": "/brucie-bonus",
+              "context": "Mystery prize"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "If you get the mystery prize, this may be one of several things:"
+        },
+        {
+          "type": "list",
+          "style": "choice",
+          "contents": [
+            {
+              "text": "A speed boat",
+              "href": "/speed-boat"
+            },
+            {
+              "text": "Spending money",
+              "href": "/spending-money",
+              "context": "£5000 or so"
+            },
+            {
+              "text": "A dishwasher",
+              "href": "http://dishwashers.org/bargain-basement"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "You have to remember them all!"
         }
       ])
     end


### PR DESCRIPTION
We want to allow free text specification of step by step navigation content using markdown-like syntax.
At present this is:
```
single line of text for a paragraph

- [A link in a standard list](/a-link)
- [Another link](/another-link)

* [A link in a bulleted list](/a-link)
* [Another link](/another-link)
```
You can optionally add text after the link which is parsed as a `context` item.

These get parsed into the format that the [step by step nav component](https://government-frontend.herokuapp.com/component-guide/step_by_step_nav)
expects.

https://trello.com/c/FU7WB1dX/481-spike-find-a-way-to-parse-markdown