### PR TITLE
Add position order of Steps

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,5 +1,5 @@
 class StepByStepPage < ApplicationRecord
-  has_many :steps, dependent: :destroy
+  has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, :base_path, presence: true
   validates :base_path, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -66,4 +66,16 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_with_step.steps.length).to eql(0)
     end
   end
+
+  describe 'when it has many steps' do
+    let(:step_by_step_with_step) { create(:step_by_step_page) }
+
+    it 'should list steps in ascending order' do
+      step1 = create(:step, step_by_step_page: step_by_step_with_step)
+      step2 = create(:step, step_by_step_page: step_by_step_with_step)
+      step3 = create(:step, step_by_step_page: step_by_step_with_step)
+
+      expect(step_by_step_with_step.reload.steps).to eq([step1, step2, step3])
+    end
+  end
 end


### PR DESCRIPTION
The Modelling Services team are implementing the Step by step publishing tool into Collections Publisher.

We want to ensure that the `Steps` for a `StepByStepPage` are returned in ascending order.

This PR addresses the comment in: https://github.com/alphagov/collections-publisher/pull/324#pullrequestreview-99604806
