### PR TITLE
Add content id to step by step pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,3 +65,4 @@ Metrics/BlockLength:
   Exclude:
     - 'lib/tasks/**/*.rake'
     - 'spec/**/*_spec.rb'
+    - 'spec/factories.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem 'byebug'
   gem 'capybara'
   gem 'database_cleaner'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'govuk-content-schema-test-helpers'
   gem 'govuk-lint'
   gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,10 +79,10 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
@@ -208,7 +208,7 @@ GEM
       rack (>= 0.4)
     rack-protection (2.0.1)
       rack
-    rack-test (0.8.2)
+    rack-test (0.8.3)
       rack (>= 1.0, < 3)
     rails (5.1.5)
       actioncable (= 5.1.5)
@@ -360,7 +360,7 @@ DEPENDENCIES
   byebug
   capybara
   database_cleaner
-  factory_girl_rails
+  factory_bot_rails
   gds-api-adapters (~> 51.4)
   gds-sso (~> 13.6)
   generic_form_builder (~> 0.13)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include GDS::SSO::ControllerMethods
-  before_action :require_signin_permission!
+  before_action :authenticate_user!
   before_action :set_authenticated_user_header
 
   add_flash_types :success, :info, :warning, :danger

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -48,6 +48,6 @@ private
   end
 
   def step_by_step_page_params
-    params.require(:step_by_step_page).permit(:title, :base_path, :introduction, :description)
+    params.require(:step_by_step_page).permit(:title, :slug, :introduction, :description)
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,9 +1,9 @@
 class StepByStepPage < ApplicationRecord
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
-  validates :title, :base_path, :introduction, :description, presence: true
-  validates :base_path, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }
-  validates :base_path, uniqueness: true
+  validates :title, :slug, :introduction, :description, presence: true
+  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }
+  validates :slug, uniqueness: true
 
   before_validation :generate_content_id, on: :create
 

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -4,4 +4,12 @@ class StepByStepPage < ApplicationRecord
   validates :title, :base_path, :introduction, :description, presence: true
   validates :base_path, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }
   validates :base_path, uniqueness: true
+
+  before_validation :generate_content_id, on: :create
+
+private
+
+  def generate_content_id
+    self.content_id ||= SecureRandom.uuid
+  end
 end

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -29,7 +29,7 @@
 
   <div class="form-group row">
     <div class="<%= left_col %>">
-      <%= form.text_field :base_path, label: "Slug" %>
+      <%= form.text_field :slug, label: "Slug" %>
     </div>
   </div>
 

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -38,7 +38,7 @@
           </ul>
         </td>
         <td>
-          <%= step_by_step_page.base_path %>
+          <%= step_by_step_page.slug %>
         </td>
       </tr>
     <% end %>

--- a/db/migrate/20180302155853_add_content_id_to_step_by_step_pages.rb
+++ b/db/migrate/20180302155853_add_content_id_to_step_by_step_pages.rb
@@ -1,0 +1,12 @@
+class AddContentIdToStepByStepPages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :step_by_step_pages, :content_id, :string
+
+    StepByStepPage.find_each do |step|
+      step.update_column :content_id, SecureRandom.uuid
+    end
+
+    change_column_null :step_by_step_pages, :content_id, false
+    add_index :step_by_step_pages, :content_id, unique: true
+  end
+end

--- a/db/migrate/20180302165039_rename_step_by_step_base_path_to_slug.rb
+++ b/db/migrate/20180302165039_rename_step_by_step_base_path_to_slug.rb
@@ -1,0 +1,7 @@
+class RenameStepByStepBasePathToSlug < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :step_by_step_pages, :base_path, :slug
+
+    add_index :step_by_step_pages, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180221152119) do
+ActiveRecord::Schema.define(version: 20180302165039) do
 
   create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "base_path"
@@ -53,11 +53,14 @@ ActiveRecord::Schema.define(version: 20180221152119) do
 
   create_table "step_by_step_pages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "title"
-    t.string "base_path"
+    t.string "slug"
     t.text "introduction"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "content_id", null: false
+    t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
+    t.index ["slug"], name: "index_step_by_step_pages_on_slug", unique: true
   end
 
   create_table "steps", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     base_path "how-to-be-the-amazing-1"
     introduction "Find out the steps to become amazing"
     description "How to be amazing - find out the steps to become amazing"
+    content_id SecureRandom.uuid
 
     factory :step_by_step_page_with_steps do
       after(:create) do |step_by_step_page|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :step_by_step_page do
     title "How to be amazing"
     base_path "how-to-be-the-amazing-1"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :step_by_step_page do
     title "How to be amazing"
-    base_path "how-to-be-the-amazing-1"
+    slug "how-to-be-the-amazing-1"
+    content_id SecureRandom.uuid
     introduction "Find out the steps to become amazing"
     description "How to be amazing - find out the steps to become amazing"
-    content_id SecureRandom.uuid
 
     factory :step_by_step_page_with_steps do
       after(:create) do |step_by_step_page|
@@ -16,6 +16,15 @@ FactoryBot.define do
   factory :step do
     title "Check how awesome you are"
     logic "number"
+    contents <<~CONTENT
+      This is a great step
+
+      - Good stuff
+      - Also good stuff
+
+      * Not as great
+      * But good nonetheless
+    CONTENT
     step_by_step_page
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_a_validation_error
     expect(page).to have_content("Title can't be blank")
-    expect(page).to have_content("Base path can't be blank")
+    expect(page).to have_content("Slug can't be blank")
     expect(page).to have_content("Introduction can't be blank")
     expect(page).to have_content("Meta description can't be blank")
   end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe List do
   describe "validations" do
-    let(:list) { FactoryGirl.build(:list) }
+    let(:list) { FactoryBot.build(:list) }
 
     it "requires a tag" do
       list.tag = nil

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe StepByStepPage do
   end
 
   describe 'steps association' do
-    let(:step_by_step_with_step) { create(:step_by._step_page_with_steps) }
+    let(:step_by_step_with_step) { create(:step_by_step_page_with_steps) }
 
     it 'is created with a step' do
       expect(step_by_step_with_step.steps.length).to eql(1)

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.errors).to have_key(:title)
     end
 
-    it 'requires a base path' do
-      step_by_step_page.base_path = ''
+    it 'requires a slug' do
+      step_by_step_page.slug = ''
 
       expect(step_by_step_page).not_to be_valid
-      expect(step_by_step_page.errors).to have_key(:base_path)
+      expect(step_by_step_page.errors).to have_key(:slug)
     end
 
     it 'requires an introduction' do
@@ -46,28 +46,37 @@ RSpec.describe StepByStepPage do
         "Not-a-Valid-Path",
         "-hyphen",
         "hyphen-"
-      ].each do |base_path|
-        step_by_step_page.base_path = base_path
+      ].each do |slug|
+        step_by_step_page.slug = slug
 
         expect(step_by_step_page).not_to be_valid
-        expect(step_by_step_page.errors).to have_key(:base_path)
+        expect(step_by_step_page.errors).to have_key(:slug)
       end
     end
 
-    it 'must be a unique base path' do
-      step_by_step_page.base_path = "new-step-by-step"
+    it 'must be a unique slug' do
+      step_by_step_page.slug = "new-step-by-step"
       step_by_step_page.save
 
       duplicate = build(:step_by_step_page)
-      duplicate.base_path = step_by_step_page.base_path
+      duplicate.slug = step_by_step_page.slug
 
       expect(duplicate.save).to eql false
-      expect(duplicate.errors).to have_key(:base_path)
+      expect(duplicate.errors).to have_key(:slug)
+    end
+
+    it 'must be a unique content_id' do
+      duplicate = create(:step_by_step_page)
+      step_by_step_page.content_id = duplicate.content_id
+
+      expect {
+        step_by_step_page.save(validate: false)
+      }.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
 
   describe 'steps association' do
-    let(:step_by_step_with_step) { create(:step_by_step_page_with_steps) }
+    let(:step_by_step_with_step) { create(:step_by._step_page_with_steps) }
 
     it 'is created with a step' do
       expect(step_by_step_with_step.steps.length).to eql(1)
@@ -91,5 +100,14 @@ RSpec.describe StepByStepPage do
 
       expect(step_by_step_with_step.reload.steps).to eq([step1, step2, step3])
     end
+  end
+
+  it 'must be a unique content_id' do
+    duplicate = create(:step_by_step_page)
+    step_by_step_page.content_id = duplicate.content_id
+
+    expect {
+      step_by_step_page.save(validate: false)
+    }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.errors).to have_key(:description)
     end
 
-    it 'must have a valid base path' do
+    it 'must have a valid slug' do
       [
         "not/a/valid/path",
         "not_a_valid_path",

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -8,7 +8,7 @@ module AuthenticationControllerHelpers
   end
 
   def stub_user
-    @stub_user ||= FactoryGirl.create(:user)
+    @stub_user ||= FactoryBot.create(:user)
   end
 
   def login_as_stub_user
@@ -18,7 +18,7 @@ end
 
 module AuthenticationFeatureHelpers
   def stub_user
-    @stub_user ||= FactoryGirl.create(:user)
+    @stub_user ||= FactoryBot.create(:user)
   end
 
   def login_as_stub_user

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,1 +1,1 @@
-RSpec.configuration.include FactoryGirl::Syntax::Methods
+RSpec.configuration.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
This commit introduces the `content_id` to all the step by step pages.
Renames base_path to slug.
It also fixes some linting problems and a typo.
