### PR TITLE
Step nav frontend improvements

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -6,3 +6,7 @@ p.step-actions,
 ul.step-actions {
   padding: 15px 0;
 }
+
+pre.markdown-example {
+  white-space: pre-wrap;
+}

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -1,0 +1,5 @@
+module StepHelper
+  def has_help_section?(step)
+    !(step.optional_heading.blank? || step.optional_contents.blank?)
+  end
+end

--- a/app/views/shared/steps/_form_errors.html.erb
+++ b/app/views/shared/steps/_form_errors.html.erb
@@ -1,0 +1,16 @@
+<% if resource.errors.any? %>
+  <% error_explanation = capture do %>
+    <h2 class="h4">There is a problem</h2>
+
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= render "shared/steps/form_notice",
+    status: "danger",
+    message: error_explanation
+  %>
+<% end %>

--- a/app/views/shared/steps/_heading.html.erb
+++ b/app/views/shared/steps/_heading.html.erb
@@ -1,0 +1,4 @@
+<h1>
+  <small><%= action %><span class="sr-only"> - </span></small><br />
+  <%= step_nav %>
+</h1>

--- a/app/views/shared/steps/_markdown_help.html.erb
+++ b/app/views/shared/steps/_markdown_help.html.erb
@@ -1,3 +1,5 @@
+<p><%= link_to "Content design guide", "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4" %> for step by step navigation</p>
+
 <%# intentionally not indented properly because the PRE formats all whitespace %>
 <pre class="small markdown-example">Paragraphs are separated by empty lines.
 Use non-bulleted lists for tasks. Add any costs after the link:

--- a/app/views/shared/steps/_markdown_help.html.erb
+++ b/app/views/shared/steps/_markdown_help.html.erb
@@ -1,14 +1,13 @@
-<%# sensible formatting not included because the PRE formats all whitespace %>
-<pre class="small">Paragraphs are separated by empty lines.
+<%# intentionally not indented properly because the PRE formats all whitespace %>
+<pre class="small markdown-example">Paragraphs are separated by empty lines.
+Use non-bulleted lists for tasks. Add any costs after the link:
 
-This is a list of bulleted links...
+[task name](/link) £10 to £20
+[task name](/link)
 
-* [Link text](/link/href/value)
-* [Link text](/link/href/value)
+Only use bullets to show when a task has a number of options to choose from:
 
-This is a list of non-bulleted links...
-
-- [Link text](/link/href/value)
-- [Link text](/link/href/value)
-
+- [download form option 1](/link)
+- [download form option 2](/link)
+- bullet with no link
 </pre>

--- a/app/views/shared/steps/_page_title.html.erb
+++ b/app/views/shared/steps/_page_title.html.erb
@@ -1,0 +1,7 @@
+<% page_title = '' %>
+
+<% links.each do |link| %>
+  <% page_title = "#{link[:text]} | #{page_title}" %>
+<% end %>
+
+<% content_for :page_title, page_title %>

--- a/app/views/shared/steps/_step_breadcrumb.html.erb
+++ b/app/views/shared/steps/_step_breadcrumb.html.erb
@@ -1,4 +1,4 @@
-<% if links.length %>
+<% if links.any? %>
   <ol class="breadcrumb">
     <% links.each do |link| %>
       <% if link[:href] %>

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -43,9 +43,6 @@
     <div class="<%= left_col %>">
       <%= form.text_area :description, label: "Meta description", class: "form-control", rows: 8 %>
     </div>
-    <div class="<%= right_col %>">
-      <p><%= link_to 'Guidance on summaries', 'https://www.gov.uk/guidance/content-design/writing-for-gov-uk#summaries' %></p>
-    </div>
   </div>
 
   <div class="form-group">

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -4,22 +4,7 @@
 %>
 
 <%= form_for(@step_by_step_page) do |form| %>
-  <% if step_by_step_page.errors.any? %>
-    <% error_explanation = capture do %>
-      <h2 class="h4">There are <%= pluralize(step_by_step_page.errors.count, "error") %></h2>
-
-      <ul>
-      <% step_by_step_page.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    <% end %>
-
-    <%= render "shared/steps/form_notice",
-      status: "danger",
-      message: error_explanation
-    %>
-  <% end %>
+  <%= render "shared/steps/form_errors", resource: step_by_step_page %>
 
   <div class="form-group row">
     <div class="<%= left_col %>">

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -29,7 +29,7 @@
 
   <div class="form-group row">
     <div class="<%= left_col %>">
-      <%= form.text_field :slug, label: "Slug" %>
+      <%= form.text_field :slug, label: "Slug (no slashes)" %>
     </div>
   </div>
 

--- a/app/views/step_by_step_pages/edit.html.erb
+++ b/app/views/step_by_step_pages/edit.html.erb
@@ -5,16 +5,20 @@
       href: step_by_step_pages_path
     },
     {
-      text: 'Edit content',
+      text: @step_by_step_page.title,
       href: @step_by_step_page
     },
     {
-      text: 'Edit'
+      text: 'Edit nav'
     }
   ]
 %>
+
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
-<h1>Editing Step By Step</h1>
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Edit step by step navigation'
+%>
 
 <%= render 'form', step_by_step_page: @step_by_step_page %>

--- a/app/views/step_by_step_pages/edit.html.erb
+++ b/app/views/step_by_step_pages/edit.html.erb
@@ -16,6 +16,8 @@
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
+<%= render 'shared/steps/page_title', links: links %>
+
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
   action: 'Edit step by step navigation'

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -8,6 +8,8 @@
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
+<%= render 'shared/steps/page_title', links: links %>
+
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
 <h1>Step by step navigation publisher</h1>

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -33,7 +33,7 @@
         </th>
         <td>
           <ul class="list-inline">
-            <li><%= link_to 'Edit content', step_by_step_page %></li>
+            <li><%= link_to 'Edit', step_by_step_page %></li>
             <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Are you sure?' } %></li>
           </ul>
         </td>

--- a/app/views/step_by_step_pages/new.html.erb
+++ b/app/views/step_by_step_pages/new.html.erb
@@ -12,6 +12,8 @@
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
+<%= render 'shared/steps/page_title', links: links %>
+
 <h1>Create a new step by step navigation</h1>
 
 <%= render 'form', step_by_step_page: @step_by_step_page %>

--- a/app/views/step_by_step_pages/new.html.erb
+++ b/app/views/step_by_step_pages/new.html.erb
@@ -5,13 +5,13 @@
       href: step_by_step_pages_path
     },
     {
-      text: 'Create'
+      text: 'Create new'
     }
   ]
 %>
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
-<h1>Create step by step navigation</h1>
+<h1>Create a new step by step navigation</h1>
 
 <%= render 'form', step_by_step_page: @step_by_step_page %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -1,3 +1,4 @@
+
 <%
   links = [
     {
@@ -5,7 +6,7 @@
       href: step_by_step_pages_path
     },
     {
-      text: 'Edit content'
+      text: @step_by_step_page.title
     }
   ]
 %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -13,6 +13,8 @@
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
+<%= render 'shared/steps/page_title', links: links %>
+
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
 <h1><%= @step_by_step_page.title %></h1>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -78,7 +78,6 @@
     </div>
 
     <div class="<%= right_col %>">
-      <p><%= link_to "Guidance", "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4" %></p>
       <%= render 'shared/steps/markdown_help' %>
     </div>
   </div>
@@ -114,7 +113,6 @@
         </div>
 
         <div class="<%= right_col %>">
-          <p><%= link_to "Guidance", "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4" %></p>
           <%= render 'shared/steps/markdown_help' %>
         </div>
       </div>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -3,22 +3,7 @@
   right_col = "col-md-5"
 %>
 
-<% if step.errors.any? %>
-  <% error_explanation = capture do %>
-    <h2 class="h4">There are <%= pluralize(step.errors.count, "error") %></h2>
-
-    <ul>
-    <% step.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-    <% end %>
-    </ul>
-  <% end %>
-
-  <%= render "shared/steps/form_notice",
-    status: "danger",
-    message: error_explanation
-  %>
-<% end %>
+<%= render "shared/steps/form_errors", resource: step %>
 
 <div class="form-group">
   <div class="row">

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -84,29 +84,45 @@
   </div>
 </div>
 
-<h3>"Get help completing this step" section</h3>
+<% unless has_help_section?(step) %>
+  <p class="checkbox">
+    <label>
+      <input type="checkbox" data-toggle="collapse" data-target="#help-section" aria-expanded="false" aria-controls="help-section" />
+      Include help section
+    </label>
+  </p>
+<% end %>
 
-<div class="form-group">
-  <div class="row">
-    <div class="<%= left_col %>">
-      <%= form.label :optional_heading, "Section heading", default_builder: true %>
-      <%= form.text_field :optional_heading, default_builder: true  %>
+<div class="<%= 'collapse' unless has_help_section?(step) %>" id="help-section">
+  <div class="<%= 'well' unless has_help_section?(step) %>">
+
+    <h3>"Get help completing this step" section</h3>
+
+    <div class="form-group">
+      <div class="row">
+        <div class="<%= left_col %>">
+          <%= form.label :optional_heading, "Section heading", default_builder: true %>
+          <%= form.text_field :optional_heading, default_builder: true  %>
+        </div>
+      </div>
     </div>
+
+    <div class="form-group">
+      <div class="row">
+        <div class="<%= left_col %>">
+          <%= form.text_area :optional_contents, class: "form-control", label: "Tasks", rows: 8 %>
+        </div>
+
+        <div class="<%= right_col %>">
+          <p><%= link_to "Guidance", "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4" %></p>
+          <%= render 'shared/steps/markdown_help' %>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>
 
-<div class="form-group">
-  <div class="row">
-    <div class="<%= left_col %>">
-      <%= form.text_area :optional_contents, class: "form-control", label: "Tasks", rows: 8 %>
-    </div>
-
-    <div class="<%= right_col %>">
-      <p><%= link_to "Guidance", "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4" %></p>
-      <%= render 'shared/steps/markdown_help' %>
-    </div>
-  </div>
-</div>
 
 <div class="form-group">
   <%= form.submit "Save step", class: "btn btn-primary" %>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -33,7 +33,7 @@
 
   <div class="radio">
     <label>
-      <%= form.radio_button :logic, "number", default_builder: true %>
+      <%= form.radio_button :logic, "number", default_builder: true, checked: true %>
       number
     </label>
   </div>
@@ -58,7 +58,7 @@
 
   <div class="radio">
     <label>
-      <%= form.radio_button :optional, "false", default_builder: true %>
+      <%= form.radio_button :optional, "false", default_builder: true, checked: true %>
       essential
     </label>
   </div>

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -5,7 +5,7 @@
       href: step_by_step_pages_path
     },
     {
-      text: 'Edit content',
+      text: @step_by_step_page.title,
       href: @step_by_step_page
     },
     {
@@ -13,11 +13,13 @@
     }
   ]
 %>
+
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
-<h1><%= @step_by_step_page.title %></h1>
-
-<h2>Edit: <%= @step.title %></h2>
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Edit step'
+%>
 
 <%= form_for @step, url: step_by_step_page_step_path(@step.step_by_step_page_id, @step) do |form| %>
   <%= render "form", step: @step, form: form %>

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -16,6 +16,8 @@
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
+<%= render 'shared/steps/page_title', links: links %>
+
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
   action: 'Edit step'

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -5,7 +5,7 @@
       href: step_by_step_pages_path
     },
     {
-      text: 'Edit content',
+      text: @step_by_step_page.title,
       href: @step_by_step_page
     },
     {
@@ -13,11 +13,13 @@
     }
   ]
 %>
+
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
-<h1><%= @step_by_step_page.title %></h1>
-
-<h2>Add a new step</h2>
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Add a new step'
+%>
 
 <%= form_for @step, url: step_by_step_page_steps_path do |form| %>
   <%= render "form", step: @step, form: form %>

--- a/app/views/steps/new.html.erb
+++ b/app/views/steps/new.html.erb
@@ -16,6 +16,8 @@
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
+<%= render 'shared/steps/page_title', links: links %>
+
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
   action: 'Add a new step'


### PR DESCRIPTION
These are some smaller frontend improvements to the step by step navigation publisher:

- Make titles and breadcrumbs more consistent
- Add unique page titles to every page
- Improve content of Markdown example snippet
- Make format of slugs clearer
- Add defaults for likely step options
- Hide optional step help section, show when needed
- Improve guidance links for step nav
- Fix breadcrumbs showing when empty
- Remove duplication and unnecessary complexity from form errors