### PR TITLE
Handle bullets in the publisher tool markdown to align it with govspeak

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -1,7 +1,6 @@
 class StepContentParser
-  BULLETED_LIST_REGEX = /^\*\s\[.+\]\(.+\).*$/ # to match * [Link text](url)context
-  LIST_REGEX = /^\-\s\[.+\]\(.+\).*$/          # to match - [Link text](url)context
-  LINK_CAPTURE_REGEX = /\[(.+)\]\((.+)\)(.*)$/ # to capture $1 = "Link text", $2 = "url" $3 = "context" from above
+  BULLETED_LIST_REGEX = /^[\*\-]\s\[.+\]\(.+\).*$/ # to match * [Link text](url)context
+  LIST_REGEX = /^\[.+\]\(.+\).*$/                  # to match [Link text](url)context
 
   def parse(step_text)
     sections = step_text.split("\n\n").map do |section|
@@ -41,19 +40,14 @@ private
 
   def link_content(section)
     section.map do |line|
-      if line =~ LINK_CAPTURE_REGEX
-        if $3.blank?
-          {
-            "text": $1,
-            "href": $2
-          }
-        else
-          {
-            "text": $1,
-            "href": $2,
-            "context": $3
-          }
-        end
+      if /\[(?<text>(.+))\]\((?<href>(.+))\)((?<context>.*))$/ =~ line
+        payload = {
+          "text": text,
+          "href": href
+        }
+
+        payload[:context] = context unless context.blank?
+        payload
       end
     end
   end

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -1,6 +1,13 @@
 class StepContentParser
-  BULLETED_LIST_REGEX = /^[\*\-]\s\[.+\]\(.+\).*$/ # to match * [Link text](url)context
-  LIST_REGEX = /^\[.+\]\(.+\).*$/                  # to match [Link text](url)context
+  # it matches the following:
+  # * [Link text](url) context
+  # - [Link text](url) context
+  # * A bullet point without a link
+  # - A bullet point without a link
+  BULLETED_LIST_REGEX = /^[\*\-]\s(\[.+\]\(.+\))?.*$/
+
+  # it matches [Link text](url)context
+  LIST_REGEX = /^\[.+\]\(.+\).*$/
 
   def parse(step_text)
     sections = step_text.split("\n\n").map do |section|
@@ -40,7 +47,9 @@ private
 
   def link_content(section)
     section.map do |line|
-      if /\[(?<text>(.+))\]\((?<href>(.+))\)((?<context>.*))$/ =~ line
+      if line.scan(/\[/).empty?
+        { "text": line[2..-1] }
+      elsif /\[(?<text>(.+))\]\((?<href>(.+))\)((?<context>.*))$/ =~ line
         payload = {
           "text": text,
           "href": href

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -122,6 +122,24 @@ RSpec.describe StepContentParser do
     end
 
     context 'and using "-" character for bullet points' do
+      it 'parses lists without links' do
+        step_text = <<~HEREDOC
+          - Apply for a provisional driving licence
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "style": "choice",
+            "contents": [
+              {
+                "text": "Apply for a provisional driving licence"
+              }
+            ]
+          }
+        ])
+      end
+
       it "is parsed to a 'choice' list of links" do
         step_text = <<~HEREDOC
           - [Apply for a provisional driving licence](/apply-provisional-licence)
@@ -232,9 +250,11 @@ RSpec.describe StepContentParser do
 
         If you get the mystery prize, this may be one of several things:
 
-        * [A speed boat](/speed-boat)
+        * A speed boat
+        - [A very expensive speed boat](/i-love-speed-boats)
         * [Spending money](/spending-money)£5000 or so
         - [A dishwasher](http://dishwashers.org/bargain-basement)
+        - And I'm a healthy bullet (although I eat ice cream everyday)
 
         You have to remember them all!
       HEREDOC
@@ -267,8 +287,11 @@ RSpec.describe StepContentParser do
           "style": "choice",
           "contents": [
             {
-              "text": "A speed boat",
-              "href": "/speed-boat"
+              "text": "A speed boat"
+            },
+            {
+              "text": "A very expensive speed boat",
+              "href": "/i-love-speed-boats",
             },
             {
               "text": "Spending money",
@@ -278,6 +301,9 @@ RSpec.describe StepContentParser do
             {
               "text": "A dishwasher",
               "href": "http://dishwashers.org/bargain-basement"
+            },
+            {
+              "text": "And I'm a healthy bullet (although I eat ice cream everyday)"
             }
           ]
         },

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -70,61 +70,114 @@ RSpec.describe StepContentParser do
   end
 
   context "list of bulleted links" do
-    it "is parsed to a 'choice' list of links" do
-      step_text = <<~HEREDOC
-        * [Apply for a provisional driving licence](/apply-provisional-licence)
-        * [Check that you can drive](/vehicles-can-drive)
-      HEREDOC
+    context 'and using "*" character for bullet points' do
+      it "is parsed to a 'choice' list of links" do
+        step_text = <<~HEREDOC
+          * [Apply for a provisional driving licence](/apply-provisional-licence)
+          * [Check that you can drive](/vehicles-can-drive)
+        HEREDOC
 
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "list",
-          "style": "choice",
-          "contents": [
-            {
-              "text": "Apply for a provisional driving licence",
-              "href": "/apply-provisional-licence"
-            },
-            {
-              "text": "Check that you can drive",
-              "href": "/vehicles-can-drive"
-            }
-          ]
-        }
-      ])
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "style": "choice",
+            "contents": [
+              {
+                "text": "Apply for a provisional driving licence",
+                "href": "/apply-provisional-licence"
+              },
+              {
+                "text": "Check that you can drive",
+                "href": "/vehicles-can-drive"
+              }
+            ]
+          }
+        ])
+      end
+
+      it "is parsed to a 'choice' list of links with optional context" do
+        step_text = <<~HEREDOC
+          * [A speed boat](/speed-boat)
+          * [Spending money](/spending-money)£5000 or so
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "style": "choice",
+            "contents": [
+              {
+                "text": "A speed boat",
+                "href": "/speed-boat"
+              },
+              {
+                "text": "Spending money",
+                "href": "/spending-money",
+                "context": "£5000 or so"
+              }
+            ]
+          }
+        ])
+      end
     end
 
-    it "is parsed to a 'choice' list of links with optional context" do
-      step_text = <<~HEREDOC
-        * [A speed boat](/speed-boat)
-        * [Spending money](/spending-money)£5000 or so
-      HEREDOC
+    context 'and using "-" character for bullet points' do
+      it "is parsed to a 'choice' list of links" do
+        step_text = <<~HEREDOC
+          - [Apply for a provisional driving licence](/apply-provisional-licence)
+          - [Check that you can drive](/vehicles-can-drive)
+        HEREDOC
 
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "list",
-          "style": "choice",
-          "contents": [
-            {
-              "text": "A speed boat",
-              "href": "/speed-boat"
-            },
-            {
-              "text": "Spending money",
-              "href": "/spending-money",
-              "context": "£5000 or so"
-            }
-          ]
-        }
-      ])
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "style": "choice",
+            "contents": [
+              {
+                "text": "Apply for a provisional driving licence",
+                "href": "/apply-provisional-licence"
+              },
+              {
+                "text": "Check that you can drive",
+                "href": "/vehicles-can-drive"
+              }
+            ]
+          }
+        ])
+      end
+
+      it "is parsed to a 'choice' list of links with optional context" do
+        step_text = <<~HEREDOC
+          - [A speed boat](/speed-boat)
+          - [Spending money](/spending-money)£5000 or so
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "style": "choice",
+            "contents": [
+              {
+                "text": "A speed boat",
+                "href": "/speed-boat"
+              },
+              {
+                "text": "Spending money",
+                "href": "/spending-money",
+                "context": "£5000 or so"
+              }
+            ]
+          }
+        ])
+      end
     end
   end
 
   context "list of non-bulleted links" do
     it "is parsed to a standard list of links" do
       step_text = <<~HEREDOC
-        - [Open the box](/open-the-box)
-        - [Keep the money](/keep-the-money)
+        [Open the box](/open-the-box)
+        [Keep the money](/keep-the-money)
       HEREDOC
 
       expect(subject.parse(step_text)).to eq([
@@ -146,8 +199,8 @@ RSpec.describe StepContentParser do
 
     it "is parsed to a standard list of links with optional context" do
       step_text = <<~HEREDOC
-        - [A cuddly toy](/cuddly-toy)
-        - [Brucie bonus](/brucie-bonus)Mystery prize
+        [A cuddly toy](/cuddly-toy)
+        [Brucie bonus](/brucie-bonus)Mystery prize
       HEREDOC
 
       expect(subject.parse(step_text)).to eq([
@@ -174,14 +227,14 @@ RSpec.describe StepContentParser do
       step_text = <<~HEREDOC
         There are several prizes on offer on today's Generation Game conveyor belt including:
 
-        - [A cuddly toy](/cuddly-toy)
-        - [Brucie bonus](/brucie-bonus)Mystery prize
+        [A cuddly toy](/cuddly-toy)
+        [Brucie bonus](/brucie-bonus)Mystery prize
 
         If you get the mystery prize, this may be one of several things:
 
         * [A speed boat](/speed-boat)
         * [Spending money](/spending-money)£5000 or so
-        * [A dishwasher](http://dishwashers.org/bargain-basement)
+        - [A dishwasher](http://dishwashers.org/bargain-basement)
 
         You have to remember them all!
       HEREDOC


### PR DESCRIPTION
We want to accommodate content designers to continue writing their markdown
the same way was they have so far with Govspeak.

This means that both `-` and `*` can be used to indicate bulleted links and also accommodates when publishers want to use bullet points without any links (just text).

It also removes LINK_CAPTURE_REGEX constant to
enable taking advantage of named capture groups in regular expressions
to use named backreferences. This is possible when the regular
expression is on the left hand side of the operator `=~`, by doing so it
assigns the captured text to local variables with the corresponding
names. [Regex Docs](https://ruby-doc.org/core-2.1.1/Regexp.html)

Trello: https://trello.com/c/2zhfNYfj