### PR TITLE
Send step by step drafts to publishing api 

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -26,14 +26,17 @@ class StepByStepPagesController < ApplicationController
 
   def update
     if @step_by_step_page.update(step_by_step_page_params)
+      StepNavPublisher.update(@step_by_step_page) if @step_by_step_page.steps.any?
+
       redirect_to step_by_step_page_path, notice: 'Step by step page was successfully updated.'
     else
       render :edit
     end
   end
 
-  # DELETE /step_by_step_pages/1
   def destroy
+    StepNavPublisher.discard_draft(@step_by_step_page.content_id)
+
     if @step_by_step_page.destroy
       redirect_to step_by_step_pages_path, notice: 'Step by step page was successfully deleted.'
     else

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -26,7 +26,7 @@ class StepByStepPagesController < ApplicationController
 
   def update
     if @step_by_step_page.update(step_by_step_page_params)
-      StepNavPublisher.update(@step_by_step_page) if @step_by_step_page.steps.any?
+      StepNavPublisher.update(@step_by_step_page)
 
       redirect_to step_by_step_page_path, notice: 'Step by step page was successfully updated.'
     else

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -8,6 +8,7 @@ class StepsController < ApplicationController
     @step = step_by_step_page.steps.new(step_params)
 
     if @step.save
+      StepNavPublisher.update(step_by_step_page.reload)
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully created.'
     else
       render :new
@@ -22,6 +23,7 @@ class StepsController < ApplicationController
     step_params = params.require(:step).permit!
 
     if step.update(step_params)
+      StepNavPublisher.update(step_by_step_page.reload)
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully updated.'
     else
       render :edit
@@ -29,6 +31,7 @@ class StepsController < ApplicationController
   end
 
   def destroy
+    StepNavPublisher.update(step_by_step_page)
     if step.destroy
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully deleted.'
     else

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -1,0 +1,77 @@
+class StepNavPresenter
+  def initialize(step_nav)
+    @step_nav = step_nav
+  end
+
+  def render_for_publishing_api
+    required_fields
+  end
+
+private
+  attr_reader :step_nav
+
+  def required_fields
+    {
+      base_path: base_path,
+      description: step_nav.description,
+      details: details,
+      document_type: "step_by_step_nav",
+      links: edition_links,
+      locale: "en",
+      need_ids: [],
+      public_updated_at: public_updated_at,
+      publishing_app: "collections-publisher",
+      redirects: [],
+      rendering_app: "collections",
+      routes: routes,
+      schema_name: "step_by_step_nav",
+      title: step_nav.title,
+      update_type: "minor",
+    }
+  end
+
+  def base_path
+    "/#{step_nav.slug}"
+  end
+
+  def public_updated_at
+    step_nav.updated_at.to_datetime.rfc3339(3)
+  end
+
+  def routes
+    [{ path: base_path, type: 'exact' }]
+  end
+
+  def details
+    {
+      step_by_step_nav: {
+        title: step_nav.title,
+        introduction: [
+          {
+            content_type: "text/govspeak",
+            content: step_nav.introduction
+          }
+        ],
+        steps: steps
+      }
+    }
+  end
+
+  def steps
+    step_content_parser = StepContentParser.new
+
+    step_nav.steps.map do |step|
+      {
+        title: step.title,
+        contents: step_content_parser.parse(step.contents),
+      }.tap do |optional_content|
+        optional_content[:optional] = !! step.optional # if it's nil return false.
+        optional_content[:logic] = step.logic if %w(and or).include?(step.logic)
+      end
+    end
+  end
+
+  def edition_links
+    {}
+  end
+end

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -8,6 +8,7 @@ class StepNavPresenter
   end
 
 private
+
   attr_reader :step_nav
 
   def required_fields

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,0 +1,11 @@
+class StepNavPublisher
+  def self.update(step_nav)
+    presenter = StepNavPresenter.new(step_nav)
+    payload = presenter.render_for_publishing_api
+    Services.publishing_api.put_content(step_nav.content_id, payload)
+  end
+
+  def self.discard_draft(content_id)
+    Services.publishing_api.discard_draft(content_id)
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     step_by_step_page
 
     factory :or_step do
+      title "Dress like the Fonz"
       optional "true"
       logic "or"
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     factory :step_by_step_page_with_steps do
       after(:create) do |step_by_step_page|
         create(:step, step_by_step_page: step_by_step_page)
+        create(:or_step, step_by_step_page: step_by_step_page)
       end
     end
   end
@@ -19,13 +20,18 @@ FactoryBot.define do
     contents <<~CONTENT
       This is a great step
 
-      - Good stuff
-      - Also good stuff
+      - [Good stuff](/good/stuff)
+      - [Also good stuff](/also/good/stuff)
 
-      * Not as great
-      * But good nonetheless
+      * [Not as great](/not/as/great)£25
+      * [But good nonetheless](http://example.com/good)
     CONTENT
     step_by_step_page
+
+    factory :or_step do
+      optional "true"
+      logic "or"
+    end
   end
 
   factory :redirect_item do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -6,10 +6,11 @@ RSpec.feature "Managing step by step pages" do
 
   before do
     given_I_am_a_GDS_editor
+    setup_publishing_api
   end
 
   scenario "User visits the index page" do
-    given_there_is_published_step_by_step_page
+    given_there_is_a_step_by_step_page
     when_I_visit_the_step_by_step_pages_index
     then_I_see_the_step_by_step_page
   end
@@ -27,12 +28,42 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_a_validation_error
   end
 
-  def given_there_is_published_step_by_step_page
+  scenario "User edits step by step information when there is a step" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_edit_the_step_by_step_page
+    and_I_fill_in_the_form
+    then_the_content_is_sent_to_publishing_api
+    then_I_see_the_new_step_by_step_page
+  end
+
+  scenario "User deletes a step by step page", js: true do
+    given_there_is_a_step_by_step_page_with_steps
+    and_I_visit_the_index_page
+    and_I_delete_the_step_by_step_page
+    then_the_draft_is_discarded
+    and_the_page_is_deleted
+  end
+
+  def given_there_is_a_step_by_step_page
     @step_by_step_page = create(:step_by_step_page)
+  end
+
+  def given_there_is_a_step_by_step_page_with_steps
+    @step_by_step_page = create(:step_by_step_page_with_steps)
   end
 
   def and_I_visit_the_index_page
     when_I_visit_the_step_by_step_pages_index
+  end
+
+  def and_I_delete_the_step_by_step_page
+    accept_confirm do
+      click_on "Delete"
+    end
+  end
+
+  def when_I_edit_the_step_by_step_page
+    visit edit_step_by_step_page_path(@step_by_step_page)
   end
 
   def then_I_see_the_step_by_step_page
@@ -51,6 +82,10 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("How to bake a cake")
   end
 
+  def and_the_page_is_deleted
+    expect(page).to_not have_content("How to bake a cake")
+  end
+
   def and_I_fill_in_the_form_with_invalid_data
     fill_in "Title", with: ""
     fill_in "Slug", with: ""
@@ -64,5 +99,18 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Slug can't be blank")
     expect(page).to have_content("Introduction can't be blank")
     expect(page).to have_content("Meta description can't be blank")
+  end
+
+  def setup_publishing_api
+    allow(Services.publishing_api).to receive(:put_content)
+    allow(Services.publishing_api).to receive(:discard_draft)
+  end
+
+  def then_the_content_is_sent_to_publishing_api
+    expect(Services.publishing_api).to have_received(:put_content)
+  end
+
+  def then_the_draft_is_discarded
+    expect(Services.publishing_api).to have_received(:discard_draft)
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "Managing step by step pages" do
   include CommonFeatureSteps
   include NavigationSteps
+  include StepNavSteps
 
   before do
     given_I_am_a_GDS_editor
@@ -99,18 +100,5 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Slug can't be blank")
     expect(page).to have_content("Introduction can't be blank")
     expect(page).to have_content("Meta description can't be blank")
-  end
-
-  def setup_publishing_api
-    allow(Services.publishing_api).to receive(:put_content)
-    allow(Services.publishing_api).to receive(:discard_draft)
-  end
-
-  def then_the_content_is_sent_to_publishing_api
-    expect(Services.publishing_api).to have_received(:put_content)
-  end
-
-  def then_the_draft_is_discarded
-    expect(Services.publishing_api).to have_received(:discard_draft)
   end
 end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.feature "Managing step by step pages" do
+  include CommonFeatureSteps
+  include NavigationSteps
+  include StepNavSteps
+
+  before do
+    given_I_am_a_GDS_editor
+    setup_publishing_api
+  end
+
+  scenario "User creates a step" do
+    given_there_is_a_step_by_step_page
+    when_I_visit_the_step_by_step_page
+    and_I_create_a_new_step
+    and_I_fill_in_the_form
+    then_the_content_is_sent_to_publishing_api
+    and_I_see_the_step_on_the_step_by_step_details_page
+  end
+
+  scenario "User edits step" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_visit_the_step_by_step_page
+    and_I_edit_the_first_step
+    then_I_can_see_the_edit_page
+    and_I_fill_in_the_form
+    then_the_content_is_sent_to_publishing_api
+    and_I_see_the_step_on_the_step_by_step_details_page
+  end
+
+  scenario "User deletes step", js: true do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_visit_the_step_by_step_page
+    and_I_can_see_the_first_step
+    and_I_delete_the_first_step
+    then_the_content_is_sent_to_publishing_api
+    and_the_step_is_deleted
+  end
+
+  def given_there_is_a_step_by_step_page_with_steps
+    @step_by_step_page = create(:step_by_step_page_with_steps)
+  end
+
+  def given_there_is_a_step_by_step_page
+    @step_by_step_page = create(:step_by_step_page)
+  end
+
+  def when_I_visit_the_step_by_step_page
+    visit step_by_step_page_path(@step_by_step_page)
+  end
+
+  def and_I_create_a_new_step
+    click_on "Add a new step"
+  end
+
+  def and_I_edit_the_first_step
+    within("table") do
+      click_on "Edit", match: :first
+    end
+  end
+
+  def and_I_can_see_the_first_step
+    expect(page).to have_css("th", text: "Check how awesome you are")
+  end
+
+  def and_I_delete_the_first_step
+    accept_confirm do
+      click_on "Delete", match: :first
+    end
+  end
+
+  def and_the_step_is_deleted
+    expect(page).not_to have_css("th", text: "Check how awesome you are")
+  end
+
+  def then_I_can_see_the_edit_page
+    expect(page).to have_css("label", text: "Step title")
+  end
+
+  def and_I_fill_in_the_form
+    fill_in "Step title", with: "Buy Mary Berry's 'Simple Cakes' book"
+    choose "number"
+    choose "essential"
+    fill_in "Content in this step", with: "* [Booky booky book book.com](http://bbbb.com)\n* [Words inside cardboard.com](http://wic.com)"
+    click_on "Save step"
+  end
+
+  def and_I_see_the_step_on_the_step_by_step_details_page
+    expect(page).to have_content("Add a new step")
+    expect(page).to have_content("Buy Mary Berry's 'Simple Cakes' book")
+  end
+end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe StepByStepPage do
     let(:step_by_step_with_step) { create(:step_by_step_page_with_steps) }
 
     it 'is created with a step' do
-      expect(step_by_step_with_step.steps.length).to eql(1)
+      expect(step_by_step_with_step.steps.length).to eql(2)
     end
 
     it 'deletes steps when the StepByStepPage is deleted' do

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe StepNavPresenter do
+  include GovukContentSchemaTestHelpers
+
+  describe "#render_for_publishing_api" do
+    let(:step_nav) { create(:step_by_step_page_with_steps) }
+    subject { described_class.new(step_nav) }
+
+    it "presents a step by step page in the correct format" do
+      presented = subject.render_for_publishing_api
+      expect(presented).to be_valid_against_schema("step_by_step_nav")
+
+      expect(presented[:base_path]).to eq("/how-to-be-the-amazing-1")
+      expect(presented[:routes]).to eq([{ path: "/how-to-be-the-amazing-1", type: "exact" }])
+    end
+
+    it "copes with optional properties" do
+      presented = subject.render_for_publishing_api
+      steps = presented[:details][:step_by_step_nav][:steps]
+
+      expect(steps[0][:optional]).to be false
+      expect(steps[1][:optional]).to be true
+
+      expect(steps[0][:logic]).to be nil
+      expect(steps[1][:logic]).to eq "or"
+    end
+
+    it "presents edition links correctly" do
+      presented = subject.render_for_publishing_api
+      expect(presented[:links]).to eq({})
+    end
+  end
+end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe StepNavPublisher do
       expect(Services.publishing_api).to have_received(:put_content)
     end
   end
-
 end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe StepNavPublisher do
+  let(:step_nav) { create(:step_by_step_page_with_steps) }
+
+  before do
+    stub_any_publishing_api_call
+    allow(Services.publishing_api).to receive(:put_content)
+  end
+
+  context ".update" do
+    it "sends the rendered step nav to the publishing api" do
+      StepNavPublisher.update(step_nav)
+      expect(Services.publishing_api).to have_received(:put_content)
+    end
+  end
+
+end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -1,0 +1,14 @@
+module StepNavSteps
+  def setup_publishing_api
+    allow(Services.publishing_api).to receive(:put_content)
+    allow(Services.publishing_api).to receive(:discard_draft)
+  end
+
+  def then_the_content_is_sent_to_publishing_api
+    expect(Services.publishing_api).to have_received(:put_content)
+  end
+
+  def then_the_draft_is_discarded
+    expect(Services.publishing_api).to have_received(:discard_draft)
+  end
+end


### PR DESCRIPTION
I've added a bunch of tests to the existing step by step pages and steps so that we can ensure we're covered on this.

I think we'll refactor the step tests soon to make use of shared steps a bit more, but we need to get this stuff in master soon as we've got too many branches in flight. 