### PR TITLE
Add SlugValidator to StepByStepPage model

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -2,9 +2,7 @@ class StepByStepPage < ApplicationRecord
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, :slug, :introduction, :description, presence: true
-  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }
-  validates :slug, uniqueness: true
-
+  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true, slug: true
   before_validation :generate_content_id, on: :create
 
 private

--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -1,0 +1,7 @@
+class SlugValidator < ActiveModel::Validator
+  def validate(record)
+    unless Services.publishing_api.lookup_content_id(base_path: "/#{record.slug}" , with_drafts: true).nil?
+      record.errors[:slug] << "Slug has already been taken."
+    end
+  end
+end

--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -1,6 +1,6 @@
 class SlugValidator < ActiveModel::Validator
   def validate(record)
-    unless Services.publishing_api.lookup_content_id(base_path: "/#{record.slug}" , with_drafts: true).nil?
+    unless Services.publishing_api.lookup_content_id(base_path: "/#{record.slug}", with_drafts: true).nil?
       record.errors[:slug] << "Slug has already been taken."
     end
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -29,6 +29,14 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_a_validation_error
   end
 
+  scenario "The slug has already been taken" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_visit_the_new_step_by_step_form
+    and_the_slug_has_been_taken
+    and_I_fill_in_the_form_with_a_taken_slug
+    then_I_see_a_slug_already_taken_error
+  end
+
   scenario "User edits step by step information when there is a step" do
     given_there_is_a_step_by_step_page_with_steps
     when_I_edit_the_step_by_step_page
@@ -76,6 +84,16 @@ RSpec.feature "Managing step by step pages" do
     fill_in "Slug", with: "how-to-bake-a-cake"
     fill_in "Introduction", with: "Learn how you can bake a cake"
     fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
+
+    click_on "Save and continue"
+  end
+
+  def and_I_fill_in_the_form_with_a_taken_slug
+    fill_in "Title", with: "How to bake a cake"
+    fill_in "Slug", with: @step_by_step_page.slug
+    fill_in "Introduction", with: "Learn how you can bake a cake"
+    fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
+
     click_on "Save and continue"
   end
 
@@ -100,5 +118,19 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Slug can't be blank")
     expect(page).to have_content("Introduction can't be blank")
     expect(page).to have_content("Meta description can't be blank")
+  end
+
+  def and_the_slug_has_been_taken
+    expect(
+      Services.publishing_api
+    ).to(
+      receive(:lookup_content_id)
+      .with(base_path: "/#{@step_by_step_page.slug}", with_drafts: true)
+      .and_return("A-TAKEN-CONTENT-ID")
+    )
+  end
+
+  def then_I_see_a_slug_already_taken_error
+    expect(page).to have_content("Slug has already been taken")
   end
 end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe StepByStepPage do
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
   let(:step_by_step_page) { build(:step_by_step_page) }
 
   describe 'validations' do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Step do
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
   let(:step_item) { build(:step) }
 
   describe 'validations' do

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe StepNavPresenter do
   include GovukContentSchemaTestHelpers
 
   describe "#render_for_publishing_api" do
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
     let(:step_nav) { create(:step_by_step_page_with_steps) }
+
     subject { described_class.new(step_nav) }
 
     it "presents a step by step page in the correct format" do

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe StepNavPublisher do
   before do
     stub_any_publishing_api_call
     allow(Services.publishing_api).to receive(:put_content)
+    allow(Services.publishing_api).to receive(:lookup_content_id)
   end
 
   context ".update" do

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -2,6 +2,7 @@ module StepNavSteps
   def setup_publishing_api
     allow(Services.publishing_api).to receive(:put_content)
     allow(Services.publishing_api).to receive(:discard_draft)
+    allow(Services.publishing_api).to receive(:lookup_content_id)
   end
 
   def then_the_content_is_sent_to_publishing_api


### PR DESCRIPTION
The Modelling Services team have been working on implementing the `Step by step` publishing tool.

To prevent users from creating slugs that have already been taken, we are using the SlugValidator as part of our validations on the `StepByStepPage` model. 

Trello card: [Add SlugValidator in Collections Publisher](https://trello.com/c/daxHC9M9/549-add-slugvalidator-in-collections-publisher)