### PR TITLE
StepContentParser handle new line endings

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -10,7 +10,7 @@ class StepContentParser
   LIST_REGEX = /^\[.+\]\(.+\).*$/
 
   def parse(step_text)
-    sections = step_text.gsub("\r", "").split("\n\n").map do |section|
+    sections = step_text.delete("\r").split("\n\n").map do |section|
       section.lines.map(&:chomp)
     end
 

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -10,7 +10,7 @@ class StepContentParser
   LIST_REGEX = /^\[.+\]\(.+\).*$/
 
   def parse(step_text)
-    sections = step_text.split("\n\n").map do |section|
+    sections = step_text.gsub("\r", "").split("\n\n").map do |section|
       section.lines.map(&:chomp)
     end
 
@@ -55,7 +55,7 @@ private
           "href": href
         }
 
-        payload[:context] = context unless context.blank?
+        payload[:context] = context.strip unless context.blank?
         payload
       end
     end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -241,6 +241,58 @@ RSpec.describe StepContentParser do
   end
 
   context "mixed content" do
+    it "handles different line endings" do
+      step_text = "Paragraphs are separated by empty lines.\r\n\r\nUse non-bulleted lists for tasks. Add any costs after the link:\r\n\r\n[task name](/link) £10 to £20\r\n[task name](/link)\r\n\r\nOnly use bullets to show when a task has a number of options to choose from:\r\n\r\n- [download form option 1](/link)\r\n- [download form option 2](/link)\r\n- bullet with no link"
+
+      expect(
+        subject.parse(step_text)
+      ).to eql([
+        {
+          "type": "paragraph",
+          "text": "Paragraphs are separated by empty lines."
+        },
+        {
+          "type": "paragraph",
+          "text": "Use non-bulleted lists for tasks. Add any costs after the link:"
+        },
+        {
+          "type": "list",
+          "contents": [
+            {
+              "text": "task name",
+              "href": "/link",
+              "context": "£10 to £20"
+            },
+            {
+              "text": "task name",
+              "href": "/link"
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "text": "Only use bullets to show when a task has a number of options to choose from:"
+        },
+        {
+          "type": "list",
+          "style": "choice",
+          "contents": [
+            {
+              "text": "download form option 1",
+              "href": "/link",
+            },
+            {
+              "text": "download form option 2",
+              "href": "/link",
+            },
+            {
+              "text": "bullet with no link"
+            }
+          ]
+        }
+      ])
+    end
+
     it "is parsed as expected" do
       step_text = <<~HEREDOC
         There are several prizes on offer on today's Generation Game conveyor belt including:


### PR DESCRIPTION
Currently it was not accounting for "\r" endings.
This commit fixes that and adds a test for it.

Trello: https://trello.com/c/28INLtX8/552-markdown-parser-to-handle-new-line-endings