### PR TITLE
Send step nav edition links to publishing-api

### DIFF
--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -1,6 +1,7 @@
 class StepNavPresenter
   def initialize(step_nav)
     @step_nav = step_nav
+    @step_content_parser = StepContentParser.new
   end
 
   def render_for_publishing_api
@@ -9,7 +10,7 @@ class StepNavPresenter
 
 private
 
-  attr_reader :step_nav
+  attr_reader :step_nav, :step_content_parser
 
   def required_fields
     {
@@ -59,8 +60,6 @@ private
   end
 
   def steps
-    step_content_parser = StepContentParser.new
-
     step_nav.steps.map do |step|
       {
         title: step.title,
@@ -73,6 +72,16 @@ private
   end
 
   def edition_links
-    {}
+    {
+      "pages_part_of_step_nav": parsed_edition_links
+    }
+  end
+
+  def parsed_edition_links
+    StepNavPublisher.lookup_content_ids(parsed_base_paths).values
+  end
+
+  def parsed_base_paths
+    step_nav.steps.map { |step| step_content_parser.base_paths(step.contents) }.flatten.uniq
   end
 end

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -35,6 +35,11 @@ class StepContentParser
     end
   end
 
+  def base_paths(step_text)
+    step_text.scan(/\[.+\]\((.+)\)/).
+      reject { |href| href[0] =~ /https?:\/\//i if href.any? }.flatten
+  end
+
 private
 
   def standard_list?(section)

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -8,4 +8,8 @@ class StepNavPublisher
   def self.discard_draft(content_id)
     Services.publishing_api.discard_draft(content_id)
   end
+
+  def self.lookup_content_ids(base_paths)
+    Services.publishing_api.lookup_content_ids(base_paths: base_paths, with_drafts: true)
+  end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe StepNavPresenter do
 
     subject { described_class.new(step_nav) }
 
+    before do
+      allow(StepNavPublisher).to receive(:lookup_content_ids).and_return('/foo' => 'd6b1901d-b925-47c5-b1ca-1e52197097e2')
+    end
+
     it "presents a step by step page in the correct format" do
       presented = subject.render_for_publishing_api
       expect(presented).to be_valid_against_schema("step_by_step_nav")
@@ -33,7 +37,7 @@ RSpec.describe StepNavPresenter do
 
     it "presents edition links correctly" do
       presented = subject.render_for_publishing_api
-      expect(presented[:links]).to eq({})
+      expect(presented[:links]).to eq(pages_part_of_step_nav: ["d6b1901d-b925-47c5-b1ca-1e52197097e2"])
     end
   end
 end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -3,240 +3,343 @@ require 'rails_helper'
 RSpec.describe StepContentParser do
   subject { described_class.new }
 
-  context "paragraphs" do
-    it "a single line of text is parsed to an array with one paragraph section" do
+  context "#parse" do
+    context "paragraphs" do
+      it "a single line of text is parsed to an array with one paragraph section" do
+        step_text = "This is a paragraph."
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "paragraph",
+            "text": "This is a paragraph."
+          }
+        ])
+      end
+
+      it "generates multiple paragraphs if they are separated by blank lines" do
+        step_text = <<~HEREDOC
+          These are all the right notes
+
+          Just not necessarily in the right order
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "paragraph",
+            "text": "These are all the right notes"
+          },
+          {
+            "type": "paragraph",
+            "text": "Just not necessarily in the right order"
+          }
+        ])
+      end
+
+      it "copes with multiple blank lines and trailing blank lines" do
+        step_text = <<~HEREDOC
+          Ladies and gentlemen:
+
+
+          Grieg's piano concerto.
+
+
+          By Grieg
+
+          Conducted by Mr Andrew Preview
+
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "paragraph",
+            "text": "Ladies and gentlemen:"
+          },
+          {
+            "type": "paragraph",
+            "text": "Grieg's piano concerto."
+          },
+          {
+            "type": "paragraph",
+            "text": "By Grieg"
+          },
+          {
+            "type": "paragraph",
+            "text": "Conducted by Mr Andrew Preview"
+          }
+        ])
+      end
+    end
+
+    context "list of bulleted links" do
+      context 'and using "*" character for bullet points' do
+        it "is parsed to a 'choice' list of links" do
+          step_text = <<~HEREDOC
+            * [Apply for a provisional driving licence](/apply-provisional-licence)
+            * [Check that you can drive](/vehicles-can-drive)
+          HEREDOC
+
+          expect(subject.parse(step_text)).to eq([
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "text": "Apply for a provisional driving licence",
+                  "href": "/apply-provisional-licence"
+                },
+                {
+                  "text": "Check that you can drive",
+                  "href": "/vehicles-can-drive"
+                }
+              ]
+            }
+          ])
+        end
+
+        it "is parsed to a 'choice' list of links with optional context" do
+          step_text = <<~HEREDOC
+            * [A speed boat](/speed-boat)
+            * [Spending money](/spending-money)£5000 or so
+          HEREDOC
+
+          expect(subject.parse(step_text)).to eq([
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "text": "A speed boat",
+                  "href": "/speed-boat"
+                },
+                {
+                  "text": "Spending money",
+                  "href": "/spending-money",
+                  "context": "£5000 or so"
+                }
+              ]
+            }
+          ])
+        end
+      end
+
+      context 'and using "-" character for bullet points' do
+        it 'parses lists without links' do
+          step_text = <<~HEREDOC
+            - Apply for a provisional driving licence
+          HEREDOC
+
+          expect(subject.parse(step_text)).to eq([
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "text": "Apply for a provisional driving licence"
+                }
+              ]
+            }
+          ])
+        end
+
+        it "is parsed to a 'choice' list of links" do
+          step_text = <<~HEREDOC
+            - [Apply for a provisional driving licence](/apply-provisional-licence)
+            - [Check that you can drive](/vehicles-can-drive)
+          HEREDOC
+
+          expect(subject.parse(step_text)).to eq([
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "text": "Apply for a provisional driving licence",
+                  "href": "/apply-provisional-licence"
+                },
+                {
+                  "text": "Check that you can drive",
+                  "href": "/vehicles-can-drive"
+                }
+              ]
+            }
+          ])
+        end
+
+        it "is parsed to a 'choice' list of links with optional context" do
+          step_text = <<~HEREDOC
+            - [A speed boat](/speed-boat)
+            - [Spending money](/spending-money)£5000 or so
+          HEREDOC
+
+          expect(subject.parse(step_text)).to eq([
+            {
+              "type": "list",
+              "style": "choice",
+              "contents": [
+                {
+                  "text": "A speed boat",
+                  "href": "/speed-boat"
+                },
+                {
+                  "text": "Spending money",
+                  "href": "/spending-money",
+                  "context": "£5000 or so"
+                }
+              ]
+            }
+          ])
+        end
+      end
+    end
+
+    context "list of non-bulleted links" do
+      it "is parsed to a standard list of links" do
+        step_text = <<~HEREDOC
+          [Open the box](/open-the-box)
+          [Keep the money](/keep-the-money)
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "contents": [
+              {
+                "text": "Open the box",
+                "href": "/open-the-box"
+              },
+              {
+                "text": "Keep the money",
+                "href": "/keep-the-money"
+              }
+            ]
+          }
+        ])
+      end
+
+      it "is parsed to a standard list of links with optional context" do
+        step_text = <<~HEREDOC
+          [A cuddly toy](/cuddly-toy)
+          [Brucie bonus](/brucie-bonus)Mystery prize
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "list",
+            "contents": [
+              {
+                "text": "A cuddly toy",
+                "href": "/cuddly-toy"
+              },
+              {
+                "text": "Brucie bonus",
+                "href": "/brucie-bonus",
+                "context": "Mystery prize"
+              }
+            ]
+          }
+        ])
+      end
+    end
+
+    context "mixed content" do
+      it "is parsed as expected" do
+        step_text = <<~HEREDOC
+          There are several prizes on offer on today's Generation Game conveyor belt including:
+
+          [A cuddly toy](/cuddly-toy)
+          [Brucie bonus](/brucie-bonus)Mystery prize
+
+          If you get the mystery prize, this may be one of several things:
+
+          * A speed boat
+          - [A very expensive speed boat](/i-love-speed-boats)
+          * [Spending money](/spending-money)£5000 or so
+          - [A dishwasher](http://dishwashers.org/bargain-basement)
+          - And I'm a healthy bullet (although I eat ice cream everyday)
+
+          You have to remember them all!
+        HEREDOC
+
+        expect(subject.parse(step_text)).to eq([
+          {
+            "type": "paragraph",
+            "text": "There are several prizes on offer on today's Generation Game conveyor belt including:"
+          },
+          {
+            "type": "list",
+            "contents": [
+              {
+                "text": "A cuddly toy",
+                "href": "/cuddly-toy"
+              },
+              {
+                "text": "Brucie bonus",
+                "href": "/brucie-bonus",
+                "context": "Mystery prize"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "text": "If you get the mystery prize, this may be one of several things:"
+          },
+          {
+            "type": "list",
+            "style": "choice",
+            "contents": [
+              {
+                "text": "A speed boat"
+              },
+              {
+                "text": "A very expensive speed boat",
+                "href": "/i-love-speed-boats",
+              },
+              {
+                "text": "Spending money",
+                "href": "/spending-money",
+                "context": "£5000 or so"
+              },
+              {
+                "text": "A dishwasher",
+                "href": "http://dishwashers.org/bargain-basement"
+              },
+              {
+                "text": "And I'm a healthy bullet (although I eat ice cream everyday)"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "text": "You have to remember them all!"
+          }
+        ])
+      end
+    end
+  end
+
+  context "#base_paths" do
+    it "text with no links is parsed to an empty array" do
       step_text = "This is a paragraph."
 
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "paragraph",
-          "text": "This is a paragraph."
-        }
-      ])
+      expect(subject.base_paths(step_text)).to eq([])
     end
 
-    it "generates multiple paragraphs if they are separated by blank lines" do
+    it "rejects fully qualified urls" do
       step_text = <<~HEREDOC
-        These are all the right notes
-
-        Just not necessarily in the right order
+        [All the prizes](/all-the-prizes)
+        - [A gondola trip for two](https://gondolier-r-us.com/default.asp)
+        - [A very expensive speed boat](/i-love-speed-boats)
+        - [Spending money](/spending-money)£5000 or so
+        - [A dishwasher](HTTP://dishwashers.org/bargain-basement)
       HEREDOC
 
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "paragraph",
-          "text": "These are all the right notes"
-        },
-        {
-          "type": "paragraph",
-          "text": "Just not necessarily in the right order"
-        }
-      ])
-    end
-
-    it "copes with multiple blank lines and trailing blank lines" do
-      step_text = <<~HEREDOC
-        Ladies and gentlemen:
-
-
-        Grieg's piano concerto.
-
-
-        By Grieg
-
-        Conducted by Mr Andrew Preview
-
-      HEREDOC
-
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "paragraph",
-          "text": "Ladies and gentlemen:"
-        },
-        {
-          "type": "paragraph",
-          "text": "Grieg's piano concerto."
-        },
-        {
-          "type": "paragraph",
-          "text": "By Grieg"
-        },
-        {
-          "type": "paragraph",
-          "text": "Conducted by Mr Andrew Preview"
-        }
-      ])
-    end
-  end
-
-  context "list of bulleted links" do
-    context 'and using "*" character for bullet points' do
-      it "is parsed to a 'choice' list of links" do
-        step_text = <<~HEREDOC
-          * [Apply for a provisional driving licence](/apply-provisional-licence)
-          * [Check that you can drive](/vehicles-can-drive)
-        HEREDOC
-
-        expect(subject.parse(step_text)).to eq([
-          {
-            "type": "list",
-            "style": "choice",
-            "contents": [
-              {
-                "text": "Apply for a provisional driving licence",
-                "href": "/apply-provisional-licence"
-              },
-              {
-                "text": "Check that you can drive",
-                "href": "/vehicles-can-drive"
-              }
-            ]
-          }
-        ])
-      end
-
-      it "is parsed to a 'choice' list of links with optional context" do
-        step_text = <<~HEREDOC
-          * [A speed boat](/speed-boat)
-          * [Spending money](/spending-money)£5000 or so
-        HEREDOC
-
-        expect(subject.parse(step_text)).to eq([
-          {
-            "type": "list",
-            "style": "choice",
-            "contents": [
-              {
-                "text": "A speed boat",
-                "href": "/speed-boat"
-              },
-              {
-                "text": "Spending money",
-                "href": "/spending-money",
-                "context": "£5000 or so"
-              }
-            ]
-          }
-        ])
-      end
-    end
-
-    context 'and using "-" character for bullet points' do
-      it 'parses lists without links' do
-        step_text = <<~HEREDOC
-          - Apply for a provisional driving licence
-        HEREDOC
-
-        expect(subject.parse(step_text)).to eq([
-          {
-            "type": "list",
-            "style": "choice",
-            "contents": [
-              {
-                "text": "Apply for a provisional driving licence"
-              }
-            ]
-          }
-        ])
-      end
-
-      it "is parsed to a 'choice' list of links" do
-        step_text = <<~HEREDOC
-          - [Apply for a provisional driving licence](/apply-provisional-licence)
-          - [Check that you can drive](/vehicles-can-drive)
-        HEREDOC
-
-        expect(subject.parse(step_text)).to eq([
-          {
-            "type": "list",
-            "style": "choice",
-            "contents": [
-              {
-                "text": "Apply for a provisional driving licence",
-                "href": "/apply-provisional-licence"
-              },
-              {
-                "text": "Check that you can drive",
-                "href": "/vehicles-can-drive"
-              }
-            ]
-          }
-        ])
-      end
-
-      it "is parsed to a 'choice' list of links with optional context" do
-        step_text = <<~HEREDOC
-          - [A speed boat](/speed-boat)
-          - [Spending money](/spending-money)£5000 or so
-        HEREDOC
-
-        expect(subject.parse(step_text)).to eq([
-          {
-            "type": "list",
-            "style": "choice",
-            "contents": [
-              {
-                "text": "A speed boat",
-                "href": "/speed-boat"
-              },
-              {
-                "text": "Spending money",
-                "href": "/spending-money",
-                "context": "£5000 or so"
-              }
-            ]
-          }
-        ])
-      end
-    end
-  end
-
-  context "list of non-bulleted links" do
-    it "is parsed to a standard list of links" do
-      step_text = <<~HEREDOC
-        [Open the box](/open-the-box)
-        [Keep the money](/keep-the-money)
-      HEREDOC
-
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "list",
-          "contents": [
-            {
-              "text": "Open the box",
-              "href": "/open-the-box"
-            },
-            {
-              "text": "Keep the money",
-              "href": "/keep-the-money"
-            }
-          ]
-        }
-      ])
-    end
-
-    it "is parsed to a standard list of links with optional context" do
-      step_text = <<~HEREDOC
-        [A cuddly toy](/cuddly-toy)
-        [Brucie bonus](/brucie-bonus)Mystery prize
-      HEREDOC
-
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "list",
-          "contents": [
-            {
-              "text": "A cuddly toy",
-              "href": "/cuddly-toy"
-            },
-            {
-              "text": "Brucie bonus",
-              "href": "/brucie-bonus",
-              "context": "Mystery prize"
-            }
-          ]
-        }
-      ])
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /all-the-prizes
+          /i-love-speed-boats
+          /spending-money
+        )
+      )
     end
   end
 
@@ -293,77 +396,28 @@ RSpec.describe StepContentParser do
       ])
     end
 
-    it "is parsed as expected" do
+    it "extracts relative links from extended content" do
       step_text = <<~HEREDOC
         There are several prizes on offer on today's Generation Game conveyor belt including:
-
         [A cuddly toy](/cuddly-toy)
         [Brucie bonus](/brucie-bonus)Mystery prize
-
         If you get the mystery prize, this may be one of several things:
-
         * A speed boat
-        - [A very expensive speed boat](/i-love-speed-boats)
+        - [A very expensive speed boat](/i-love-speed-boats/big-ones)
         * [Spending money](/spending-money)£5000 or so
         - [A dishwasher](http://dishwashers.org/bargain-basement)
         - And I'm a healthy bullet (although I eat ice cream everyday)
-
         You have to remember them all!
       HEREDOC
 
-      expect(subject.parse(step_text)).to eq([
-        {
-          "type": "paragraph",
-          "text": "There are several prizes on offer on today's Generation Game conveyor belt including:"
-        },
-        {
-          "type": "list",
-          "contents": [
-            {
-              "text": "A cuddly toy",
-              "href": "/cuddly-toy"
-            },
-            {
-              "text": "Brucie bonus",
-              "href": "/brucie-bonus",
-              "context": "Mystery prize"
-            }
-          ]
-        },
-        {
-          "type": "paragraph",
-          "text": "If you get the mystery prize, this may be one of several things:"
-        },
-        {
-          "type": "list",
-          "style": "choice",
-          "contents": [
-            {
-              "text": "A speed boat"
-            },
-            {
-              "text": "A very expensive speed boat",
-              "href": "/i-love-speed-boats",
-            },
-            {
-              "text": "Spending money",
-              "href": "/spending-money",
-              "context": "£5000 or so"
-            },
-            {
-              "text": "A dishwasher",
-              "href": "http://dishwashers.org/bargain-basement"
-            },
-            {
-              "text": "And I'm a healthy bullet (although I eat ice cream everyday)"
-            }
-          ]
-        },
-        {
-          "type": "paragraph",
-          "text": "You have to remember them all!"
-        }
-      ])
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /cuddly-toy
+          /brucie-bonus
+          /i-love-speed-boats/big-ones
+          /spending-money
+        )
+      )
     end
   end
 end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -11,8 +11,18 @@ RSpec.describe StepNavPublisher do
 
   context ".update" do
     it "sends the rendered step nav to the publishing api" do
+      allow(StepNavPublisher).to receive(:lookup_content_ids).and_return('/foo' => 'a-content-id')
       StepNavPublisher.update(step_nav)
       expect(Services.publishing_api).to have_received(:put_content)
+    end
+  end
+
+  context ".lookup_content_ids" do
+    it "calls the publishing_api end point" do
+      allow(Services.publishing_api).to receive(:lookup_content_ids)
+      StepNavPublisher.lookup_content_ids(["/foo", "/bar"])
+
+      expect(Services.publishing_api).to have_received(:lookup_content_ids)
     end
   end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -3,6 +3,12 @@ module StepNavSteps
     allow(Services.publishing_api).to receive(:put_content)
     allow(Services.publishing_api).to receive(:discard_draft)
     allow(Services.publishing_api).to receive(:lookup_content_id)
+    allow(Services.publishing_api).to receive(:lookup_content_ids)
+    allow(StepNavPublisher).to receive(:lookup_content_ids).and_return(
+      '/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
+      '/also/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e2',
+      '/not/as/great' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e3'
+    )
   end
 
   def then_the_content_is_sent_to_publishing_api


### PR DESCRIPTION
This parses base_paths from step content, looks up content_ids using the
publishing-api endpoint, and then uses these to add pages_part_of_step_navs
edition links as part of the presenter.

We'll review the publishing api communication in due course, as I suspect we'll
need to move some of it to sidekiq workers.

https://trello.com/c/pKrmHkDr/551-handle-editionlinks