### PR TITLE
Add link to Preview draft step by step pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,8 @@ module ApplicationHelper
   def content_tagger_url
     Plek.new.external_url_for('content-tagger')
   end
+
+  def preview_url(slug)
+    "#{Plek.new.external_url_for('draft-origin')}/#{slug}"
+  end
 end

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -35,7 +35,8 @@
         </th>
         <td>
           <ul class="list-inline">
-            <li><%= link_to 'Edit', step_by_step_page %></li>
+            <li><%= link_to 'Edit content', step_by_step_page %></li>
+            <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
             <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Are you sure?' } %></li>
           </ul>
         </td>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -21,6 +21,7 @@
 
 <ul class="list-inline step-actions">
   <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>
+  <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug), class: "btn btn-primary" %></li>
   <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-default" %></li>
 </ul>
 


### PR DESCRIPTION
This commit allows Content designers to preview new navigation before publication so that they can see how it will look when live and edit accordingly.

Trello: https://trello.com/c/fwUWX8tI/526-build-preview-functionality-into-the-publishing-tool


