### PR TITLE
Don't change the slug once the Step Page is saved

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -2,7 +2,8 @@ class StepByStepPage < ApplicationRecord
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, :slug, :introduction, :description, presence: true
-  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true, slug: true
+  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true
+  validates :slug, slug: true, on: :create
   before_validation :generate_content_id, on: :create
 
 private

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -14,7 +14,7 @@
 
   <div class="form-group row">
     <div class="<%= left_col %>">
-      <%= form.text_field :slug, label: "Slug (no slashes)" %>
+      <%= form.text_field :slug, label: "Slug (no slashes)", disabled: @step_by_step_page.persisted? %>
     </div>
   </div>
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Managing step by step pages" do
   scenario "User edits step by step information when there is a step" do
     given_there_is_a_step_by_step_page_with_steps
     when_I_edit_the_step_by_step_page
-    and_I_fill_in_the_form
+    and_I_fill_in_the_edit_form
     then_the_content_is_sent_to_publishing_api
     then_I_see_the_new_step_by_step_page
   end
@@ -82,6 +82,14 @@ RSpec.feature "Managing step by step pages" do
   def and_I_fill_in_the_form
     fill_in "Title", with: "How to bake a cake"
     fill_in "Slug", with: "how-to-bake-a-cake"
+    fill_in "Introduction", with: "Learn how you can bake a cake"
+    fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
+
+    click_on "Save and continue"
+  end
+
+  def and_I_fill_in_the_edit_form
+    fill_in "Title", with: "How to bake a cake"
     fill_in "Introduction", with: "Learn how you can bake a cake"
     fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
 


### PR DESCRIPTION
When the step by step page is saved and the editor goes back to edit it
it should not be able to edit the slug, neither the slug should be validated again
as the slug already exists.

Kinda part of this: https://trello.com/c/daxHC9M9/549-add-slugvalidator-in-collections-publisher