### PR TITLE
Content improvements to step nav edit form

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -50,6 +50,6 @@ private
   end
 
   def step_params
-    params.require(:step).permit(:title, :logic, :optional, :contents, :optional_heading, :optional_contents)
+    params.require(:step).permit(:title, :logic, :optional, :contents)
   end
 end

--- a/app/helpers/step_helper.rb
+++ b/app/helpers/step_helper.rb
@@ -1,5 +1,0 @@
-module StepHelper
-  def has_help_section?(step)
-    !(step.optional_heading.blank? || step.optional_contents.blank?)
-  end
-end

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -41,6 +41,8 @@
 <div class="form-group">
   <%= form.label :optional, "Is this step optional?", default_builder: true %>
 
+  <div class="help-block">You must select one of these so that user activity is tracked correctly in Google Analytics.</div>
+
   <div class="radio">
     <label>
       <%= form.radio_button :optional, "false", default_builder: true, checked: true %>
@@ -59,7 +61,7 @@
 <div class="form-group">
   <div class="row">
     <div class="<%= left_col %>">
-      <%= form.text_area :contents, class: "form-control", label: "Content in this step", rows: 8 %>
+      <%= form.text_area :contents, class: "form-control", label: "Content, tasks and links in this step", rows: 8 %>
     </div>
 
     <div class="<%= right_col %>">

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -70,44 +70,6 @@
   </div>
 </div>
 
-<% unless has_help_section?(step) %>
-  <p class="checkbox">
-    <label>
-      <input type="checkbox" data-toggle="collapse" data-target="#help-section" aria-expanded="false" aria-controls="help-section" />
-      Include help section
-    </label>
-  </p>
-<% end %>
-
-<div class="<%= 'collapse' unless has_help_section?(step) %>" id="help-section">
-  <div class="<%= 'well' unless has_help_section?(step) %>">
-
-    <h3>"Get help completing this step" section</h3>
-
-    <div class="form-group">
-      <div class="row">
-        <div class="<%= left_col %>">
-          <%= form.label :optional_heading, "Section heading", default_builder: true %>
-          <%= form.text_field :optional_heading, default_builder: true  %>
-        </div>
-      </div>
-    </div>
-
-    <div class="form-group">
-      <div class="row">
-        <div class="<%= left_col %>">
-          <%= form.text_area :optional_contents, class: "form-control", label: "Tasks", rows: 8 %>
-        </div>
-
-        <div class="<%= right_col %>">
-          <%= render 'shared/steps/markdown_help' %>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</div>
-
 
 <div class="form-group">
   <%= form.submit "Save step", class: "btn btn-primary" %>

--- a/db/migrate/20180319152348_remove_optional_content_from_steps.rb
+++ b/db/migrate/20180319152348_remove_optional_content_from_steps.rb
@@ -1,0 +1,6 @@
+class RemoveOptionalContentFromSteps < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :steps, :optional_heading, :string
+    remove_column :steps, :optional_contents, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180302165039) do
+ActiveRecord::Schema.define(version: 20180319152348) do
 
   create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "base_path"
@@ -68,8 +68,6 @@ ActiveRecord::Schema.define(version: 20180302165039) do
     t.string "logic"
     t.boolean "optional"
     t.text "contents"
-    t.string "optional_heading"
-    t.text "optional_contents"
     t.integer "position"
     t.bigint "step_by_step_page_id"
     t.datetime "created_at", null: false

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Managing step by step pages" do
     fill_in "Step title", with: "Buy Mary Berry's 'Simple Cakes' book"
     choose "number"
     choose "essential"
-    fill_in "Content in this step", with: "* [Booky booky book book.com](http://bbbb.com)\n* [Words inside cardboard.com](http://wic.com)"
+    fill_in "Content, tasks and links in this step", with: "* [Booky booky book book.com](http://bbbb.com)\n* [Words inside cardboard.com](http://wic.com)"
     click_on "Save step"
   end
 


### PR DESCRIPTION
After our second round of user research, some elements in the step nav edit form were found to not be very clear.

* Make label for content clearer
* Explain why marking a step as optional (or not) is necessary
* Remove optional content as it's not used yet and needs more work to explain to users

[Trello card](https://trello.com/c/jq8eTn7O)