### PR TITLE
Make reorder heading consistent with others

### DIFF
--- a/app/views/step_by_step_pages/reorder.html.erb
+++ b/app/views/step_by_step_pages/reorder.html.erb
@@ -18,10 +18,10 @@
 
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
-<h1>
-  <%= @step_by_step_page.title %><br />
-  <small>Reorder steps</small>
-</h1>
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Reorder steps'
+%>
 
 <div class="row">
   <div class="col-md-7">


### PR DESCRIPTION
#356 was using a heading structure on the reorder page that wasn't updated with the latest changes in #337. This uses the partial that ensures the headings among the pages are consistent.