### PR TITLE
Navigation rules migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'parser', '2.5.0.5'
   gem 'byebug'
   gem 'capybara'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     plek (2.1.1)
     poltergeist (1.17.0)
@@ -371,6 +371,7 @@ DEPENDENCIES
   govuk_sidekiq (~> 3.0)
   mysql2
   nokogiri
+  parser (= 2.5.0.5)
   plek (~> 2.1)
   poltergeist
   pry-byebug

--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -1,0 +1,5 @@
+class NavigationRule < ActiveRecord::Base
+  belongs_to :step_by_step_page
+
+  validates :title, :base_path, :content_id, :step_by_step_page_id, presence: true
+end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,4 +1,5 @@
 class StepByStepPage < ApplicationRecord
+  has_many :navigation_rules, dependent: :destroy
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, :slug, :introduction, :description, presence: true

--- a/db/migrate/20180319082643_add_table_navigation_rules.rb
+++ b/db/migrate/20180319082643_add_table_navigation_rules.rb
@@ -1,0 +1,16 @@
+class AddTableNavigationRules < ActiveRecord::Migration[5.1]
+  def change
+    create_table :navigation_rules do |t|
+      t.string "title",                null: false
+      t.string "base_path",            null: false
+      t.string "content_id",           null: false
+      t.boolean "include_in_links",    null: false, default: true
+      t.references :step_by_step_page, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :navigation_rules, [:step_by_step_page_id, :content_id], unique: true
+    add_index :navigation_rules, [:step_by_step_page_id, :base_path], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,19 @@ ActiveRecord::Schema.define(version: 20180319152348) do
     t.index ["tag_id"], name: "index_lists_on_tag_id"
   end
 
+  create_table "navigation_rules", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "title", null: false
+    t.string "base_path", null: false
+    t.string "content_id", null: false
+    t.boolean "include_in_links", default: true, null: false
+    t.bigint "step_by_step_page_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["step_by_step_page_id", "base_path"], name: "index_navigation_rules_on_step_by_step_page_id_and_base_path", unique: true
+    t.index ["step_by_step_page_id", "content_id"], name: "index_navigation_rules_on_step_by_step_page_id_and_content_id", unique: true
+    t.index ["step_by_step_page_id"], name: "index_navigation_rules_on_step_by_step_page_id"
+  end
+
   create_table "redirect_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "content_id", null: false
     t.string "from_base_path", null: false
@@ -117,6 +130,7 @@ ActiveRecord::Schema.define(version: 20180319152348) do
 
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
   add_foreign_key "lists", "tags", name: "lists_tag_id_fk", on_delete: :cascade
+  add_foreign_key "navigation_rules", "step_by_step_pages"
   add_foreign_key "redirect_routes", "tags"
   add_foreign_key "steps", "step_by_step_pages"
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade

--- a/spec/models/navigation_rule_spec.rb
+++ b/spec/models/navigation_rule_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe NavigationRule do
+  let(:step_page) { create(:step_by_step_page) }
+
+  it { belong_to :step_by_step_page }
+
+  describe '#valid?' do
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
+    context 'without a step_by_step_page' do
+      it 'is invalid' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+        )
+
+        expect(resource).to_not be_valid
+        expect(resource.errors).to have_key(:step_by_step_page_id)
+      end
+    end
+
+    context 'without a title' do
+      it 'is invalid' do
+        resource = described_class.new(
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          step_by_step_page: step_page,
+        )
+
+        expect(resource).to_not be_valid
+        expect(resource.errors).to have_key(:title)
+      end
+    end
+
+    context 'without a base_path' do
+      it 'is invalid' do
+        resource = described_class.new(
+          title: 'A Title',
+          content_id: 'A-CONTENT-ID-BOOM',
+          step_by_step_page: step_page,
+        )
+
+        expect(resource).to_not be_valid
+        expect(resource.errors).to have_key(:base_path)
+      end
+    end
+
+    context 'without a content_id' do
+      it 'is invalid' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          step_by_step_page: step_page,
+        )
+
+        expect(resource).to_not be_valid
+        expect(resource.errors).to have_key(:content_id)
+      end
+    end
+
+    context 'with valid attributes' do
+      it 'is valid' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          step_by_step_page: step_page,
+        )
+
+        expect(resource).to be_valid
+        expect(resource.errors).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR contains a migration that stores links that have been mentioned on a Step of a "Step by Step page".
We need this so that we can turn on or off the "Step by Step navigation sidebar"  for individual content item pages.

Extra note: The parser gem had to be updated given it was using a yanked version (which was making the end to end tests fail), more context: https://github.com/alphagov/whitehall/pull/3917

Trello: https://trello.com/c/VDKP6zpq