### PR TITLE
Navigation Rules Backend

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -8,6 +8,8 @@ class StepsController < ApplicationController
     @step = step_by_step_page.steps.new(step_params)
 
     if @step.save
+      StepLinksForRulesWorker.perform_async(step.id)
+
       StepNavPublisher.update(step_by_step_page.reload)
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully created.'
     else
@@ -22,6 +24,7 @@ class StepsController < ApplicationController
   def update
     step_params = params.require(:step).permit!
 
+    StepLinksForRulesWorker.perform_async(step.id)
     if step.update(step_params)
       StepNavPublisher.update(step_by_step_page.reload)
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully updated.'

--- a/app/services/step_links_for_rules.rb
+++ b/app/services/step_links_for_rules.rb
@@ -1,0 +1,75 @@
+class StepLinksForRules
+  def initialize(step:, step_content_parser: StepContentParser.new)
+    @step = step
+    @step_page = step.step_by_step_page
+    @step_content_parser = step_content_parser
+  end
+
+  def call
+    step_page.navigation_rules.each do |rule|
+      rules_from_step_content[rule.content_id]["include_in_links"] = rule.include_in_links if rules_from_step_content[rule.content_id]
+    end
+
+    # clear out the existing rules
+    delete_rules
+
+    # replace with fresh rules
+    add_rules(rules: rules_from_step_content.values)
+  end
+
+private
+
+  attr_reader :step, :step_content_parser, :step_page
+
+  # hash of rules payloads keyed by content_id
+  def rules_from_step_content
+    @step_rules ||= content_items.each_with_object({}) do |content_item, items|
+      payload = {
+        content_id: content_item["content_id"],
+        title: content_item["title"],
+        base_path: content_item["base_path"],
+        include_in_links: true
+      }
+      items[content_item["content_id"]] = payload
+    end
+  end
+
+  def base_paths
+    @base_paths ||=
+      begin
+        all_contents = step_page.steps.map(&:contents).join
+        step_content_parser.base_paths(all_contents).uniq
+      end
+  end
+
+  def content_ids
+    return [] if base_paths.empty?
+
+    unvalidated_base_paths = (base_paths - navigation_rule_paths)
+
+    @content_ids ||= Services.publishing_api.lookup_content_ids(
+      base_paths: unvalidated_base_paths,
+      with_drafts: true,
+      ).values
+  end
+
+  def content_items
+    @content_items ||= content_ids.map do |content_id|
+      Services.publishing_api.get_content(content_id)
+    end
+  end
+
+  def navigation_rule_paths
+    step_page.navigation_rules.pluck(&:base_path)
+  end
+
+  def delete_rules
+    step_page.navigation_rules.delete_all
+  end
+
+  def add_rules(rules:)
+    rules.each do |rule|
+      step_page.navigation_rules.new(rule).save!
+    end
+  end
+end

--- a/app/workers/step_links_for_rules_worker.rb
+++ b/app/workers/step_links_for_rules_worker.rb
@@ -1,0 +1,10 @@
+class StepLinksForRulesWorker
+  include Sidekiq::Worker
+
+  def perform(step_id)
+    step = Step.find_by(id: step_id)
+    return unless step
+
+    StepLinksForRules.new(step: step).call
+  end
+end

--- a/spec/services/step_links_for_rules_spec.rb
+++ b/spec/services/step_links_for_rules_spec.rb
@@ -1,0 +1,208 @@
+require 'rails_helper'
+
+RSpec.describe StepLinksForRules do
+  let(:step_page) { create(:step_by_step_page_with_steps) }
+  let(:first_step) { step_page.steps.first }
+  let(:base_paths) { ["/good/stuff", "/also/good/stuff", "/not/as/great"] }
+  let(:base_paths_return_data) do
+    {
+      '/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
+      '/also/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e2',
+      '/not/as/great' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e3'
+    }
+  end
+
+  before do
+    publishing_api_receives_request_to_lookup_content_id(
+      base_path: "/how-to-be-the-amazing-1"
+    )
+  end
+
+  context 'when a step page has no rules' do
+    it 'has no navigation rules' do
+      expect(step_page.navigation_rules.count).to eql(0)
+    end
+
+    it 'adds new navigation rules' do
+      setup_test_with_publishing_api_requests
+
+      described_class.new(step: first_step).call
+
+      navigation_rules = step_page.reload.navigation_rules
+
+      expect(navigation_rules.size).to eql(3)
+
+      expect(navigation_rules.first.title).to eq("Good Stuff")
+      expect(navigation_rules.second.title).to eq("Also Good Stuff")
+      expect(navigation_rules.third.title).to eq("Not as Great")
+    end
+  end
+
+  context 'when a step page has rules' do
+    before do
+      setup_test_with_publishing_api_requests
+      described_class.new(step: first_step).call
+    end
+
+    it "has 3 rules" do
+      expect(
+        step_page.navigation_rules.size
+      ).to eql(3)
+    end
+
+    context 'and there are new links added to the content' do
+      it 'adds the missing rules' do
+        first_step.contents << "\n[An Amazing Magic Link](/amazing-magic-link)"
+        first_step.save!
+
+        base_path_data = {
+          '/amazing-magic-link' => 'fd6b1901d-A747-47c5-b1ca-1e52197097e3'
+        }
+
+        amazing_content_item = basic_content_item(
+          title: "An Amazing Magic Link",
+          base_path: base_path_data.keys.first,
+          content_id: base_path_data.values.first
+        )
+
+        publishing_api_receives_request_to_lookup_content_ids(
+          base_paths: base_paths << base_path_data.keys.first,
+          return_data: base_paths_return_data.merge(base_path_data)
+        )
+
+        publishing_api_receives_get_content_id_request(
+          content_items: initial_content_items << amazing_content_item
+        )
+
+        described_class.new(step: first_step.reload).call
+
+        expect(
+          step_page.navigation_rules.size
+        ).to eql(4)
+      end
+
+      it 'keeps the state of the existing rules' do
+        rule = step_page.navigation_rules.first
+        rule_content_id = rule.content_id
+
+        rule.update_attribute(:include_in_links, false)
+        expect(rule.reload.include_in_links).to be false
+
+        publishing_api_receives_request_to_lookup_content_ids(
+          base_paths: base_paths,
+          return_data: base_paths_return_data
+        )
+
+        publishing_api_receives_get_content_id_request(
+          content_items: initial_content_items
+        )
+
+        described_class.new(step: first_step.reload).call
+
+        expect { rule.reload }.to raise_error ActiveRecord::RecordNotFound
+
+        new_rule = NavigationRule.find_by(content_id: rule_content_id)
+        expect(new_rule.include_in_links).to be false
+      end
+    end
+
+    context 'when the links are removed from the content' do
+      it 'removes the rules for those links' do
+        first_step.update_attribute(:contents, "Hello World")
+        second_step = step_page.steps.second
+
+        second_step.update_attribute(:contents, "This is a great step\n\n- [Good stuff](/good/stuff)")
+
+        publishing_api_receives_request_to_lookup_content_ids(
+          base_paths: [base_paths.first],
+          return_data: {
+            '/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
+          }
+        )
+
+        publishing_api_receives_get_content_id_request(
+          content_items: [initial_content_items.first]
+        )
+
+        expect(
+          step_page.navigation_rules.count
+        ).to eql(3)
+
+        described_class.new(step: first_step.reload).call
+
+        expect(
+          step_page.navigation_rules.count
+        ).to eql(1)
+      end
+    end
+  end
+
+  def setup_test_with_publishing_api_requests
+    publishing_api_receives_request_to_lookup_content_ids(
+      base_paths: base_paths,
+      return_data: base_paths_return_data
+    )
+
+    publishing_api_receives_get_content_id_request(
+      content_items: initial_content_items
+    )
+  end
+
+  def publishing_api_receives_request_to_lookup_content_id(base_path:)
+    allow(Services.publishing_api).to(
+      receive(:lookup_content_id).with(
+        base_path: base_path,
+        with_drafts: true
+      )
+    )
+  end
+
+  def publishing_api_receives_request_to_lookup_content_ids(base_paths:, return_data: nil)
+    expectation = expect(Services.publishing_api).to receive(:lookup_content_ids).with(
+      base_paths: base_paths,
+      with_drafts: true
+    )
+
+    if return_data
+      expectation.and_return(
+        return_data
+      )
+    end
+  end
+
+  def publishing_api_receives_get_content_id_request(content_items:)
+    content_items.each do |content_item|
+      expect(Services.publishing_api).to(
+        receive(:get_content).with(content_item[:content_id])
+      ).and_return(content_item)
+    end
+  end
+
+  def initial_content_items
+    [
+      basic_content_item(
+        title: "Good Stuff",
+        base_path: '/good/stuff',
+        content_id: 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
+      ),
+      basic_content_item(
+        title: "Also Good Stuff",
+        base_path: '/also/good/stuff',
+        content_id: 'fd6b1901d-b925-47c5-b1ca-1e52197097e2',
+      ),
+      basic_content_item(
+        title: "Not as Great",
+        base_path: '/not/as/great',
+        content_id: 'fd6b1901d-b925-47c5-b1ca-1e52197097e3',
+      ),
+    ]
+  end
+
+  def basic_content_item(title:, base_path:, content_id:)
+    {
+      "title": title,
+      "base_path": base_path,
+      "content_id": content_id,
+    }.with_indifferent_access
+  end
+end


### PR DESCRIPTION
StepLinksForRulesWorker is responsible to send data to run StepLinksForRules where the links are extracted from the step contents.

Once those links are found it runs a request to Publishing API to get the content_id of that link.

Once the content_ids are fetched from Publishing API it requests the content to save the title, content_id and base_path in NavigationRule.

We can build up the payload for rules covering all the base paths in the current steps.  We can then override the "include_in_links" property in the current rule set (if any).

Then we can clear out all the rules (to ensure that we've catered for rules that are no longer relevant), and then add in all the rules that are for existing linked content.

This is to be later seen in the Rules page (frontend, to be done in future commit).

Trello: https://trello.com/c/VDKP6zpq