### PR TITLE
[WIP] Add unpublish to step by step page

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -6,6 +6,11 @@ class StepByStepPage < ApplicationRecord
   validates :slug, slug: true, on: :create
   before_validation :generate_content_id, on: :create
 
+  def self.validate_redirect(redirect_url)
+    regex = /\A([a-z0-9]+-)*[a-z0-9]+\z/
+    redirect_url =~ regex
+  end
+
 private
 
   def generate_content_id

--- a/app/views/shared/steps/_form_notice.html.erb
+++ b/app/views/shared/steps/_form_notice.html.erb
@@ -2,6 +2,7 @@
   message ||= false
   status = "alert-#{status}" if ['success', 'info', 'warning', 'danger'].include? status
 %>
+
 <% if message %>
   <div class="row">
     <div class="col-md-7">

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -26,6 +26,7 @@
   <% if @step_by_step_page.steps.length > 0 %>
     <li><%= link_to("Reorder steps", step_by_step_page_reorder_path(@step_by_step_page), class: "btn btn-default") %></li>
   <% end %>
+  <li><%= link_to 'Unpublish', step_by_step_page_unpublish_path(@step_by_step_page), class: "btn btn-danger btn-primary" %></li>
 </ul>
 
 <div class="row">

--- a/app/views/step_by_step_pages/unpublish.html.erb
+++ b/app/views/step_by_step_pages/unpublish.html.erb
@@ -20,28 +20,29 @@
 
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
-  action: 'Unpublish step by step'
+  action: 'Unpublish step by step navigation'
 %>
 
-<div class="callout callout-warning add-bottom-margin">
-  <div class="callout-title">
-    Warning
-  </div>
-  <div class="callout-body">
+<% warning = capture do %>
+  <h2 class="h4">Warning</h2>
+  <p>
     Unpublish a page from GOV.UK. This can’t be undone.
-  </div>
-</div>
+  </p>
+<% end %>
+
+<%= render "shared/steps/form_notice",
+  status: "danger",
+  message: warning
+%>
 
 <div class="row">
   <div class="col-md-7">
     <%= form_tag(step_by_step_page_unpublish_path(@step_by_step_page), method: :post) do %>
-      <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
-
       <div class="form-group">
         <label for="redirect_url">Redirect to</label>
-        <span class="normal">
+        <div class="help-block">
           For example: <code>redirect-to-replacement-page</code>
-        </span>
+        </div>
         <%= text_field_tag :redirect_url %>
       </div>
 

--- a/app/views/step_by_step_pages/unpublish.html.erb
+++ b/app/views/step_by_step_pages/unpublish.html.erb
@@ -1,0 +1,61 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: @step_by_step_page
+    },
+    {
+      text: 'Unpublish'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/page_title', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Unpublish step by step'
+%>
+
+<div class="callout callout-warning add-bottom-margin">
+  <div class="callout-title">
+    Warning
+  </div>
+  <div class="callout-body">
+    Unpublish a page from GOV.UK. This can’t be undone.
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-7">
+    <%= form_tag(step_by_step_page_unpublish_path(@step_by_step_page), method: :post) do %>
+      <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
+
+      <div class="form-group">
+        <label for="redirect_url">Redirect to</label>
+        <span class="normal">
+          For example: <code>redirect-to-replacement-page</code>
+        </span>
+        <%= text_field_tag :redirect_url %>
+      </div>
+
+      <div class="form-group">
+        <%= button_tag 'Unpublish',
+          {
+            data: {
+              module: 'confirm',
+              message: "This will remove ‘#{@step_by_step_page.title}’ from the website.\n\n Are you sure?"
+            },
+            class: "btn btn-danger"
+          }
+        %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
     get :reorder, to: 'step_by_step_pages#reorder'
     post :reorder, to: 'step_by_step_pages#reorder'
 
+    get :unpublish, to: 'step_by_step_pages#unpublish'
+    post :unpublish, to: 'step_by_step_pages#unpublish'
+
     resources :steps
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -53,6 +53,26 @@ RSpec.feature "Managing step by step pages" do
     and_the_page_is_deleted
   end
 
+  scenario "User unpublishes a step by step page with a valid redirect url" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_visit_the_step_by_step_page
+    and_I_visit_the_unpublish_page
+    and_I_fill_in_the_form_with_a_valid_url
+    then_the_page_is_unpublished
+    and_I_am_taken_to_the_index_page
+    and_I_see_a_success_notice
+  end
+
+  scenario "User unpublishes a step by step page with an invalid redirect url" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_visit_the_step_by_step_page
+    and_I_visit_the_unpublish_page
+    and_I_fill_in_the_form_with_an_invalid_url
+    then_I_see_that_the_url_isnt_valid
+    and_I_fill_in_the_form_with_an_empty_url
+    then_I_see_that_the_url_isnt_valid
+  end
+
   def given_there_is_a_step_by_step_page
     @step_by_step_page = create(:step_by_step_page)
   end
@@ -63,6 +83,10 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_visit_the_index_page
     when_I_visit_the_step_by_step_pages_index
+  end
+
+  def when_I_visit_the_step_by_step_page
+    visit step_by_step_page_path(@step_by_step_page)
   end
 
   def and_I_delete_the_step_by_step_page
@@ -105,6 +129,28 @@ RSpec.feature "Managing step by step pages" do
     click_on "Save and continue"
   end
 
+  def and_I_fill_in_the_form_with_a_valid_url
+    fill_in "Redirect to", with: "how-to-be-the-amazing-1"
+
+    click_on "Unpublish"
+  end
+
+  def and_I_fill_in_the_form_with_an_empty_url
+    fill_in "Redirect to", with: ""
+
+    click_on "Unpublish"
+  end
+
+  def and_I_fill_in_the_form_with_an_invalid_url
+    fill_in "Redirect to", with: "!"
+
+    click_on "Unpublish"
+  end
+
+  def then_I_see_that_the_url_isnt_valid
+    expect(page).to have_content("Redirect path is invalid. Step by step page has not been unpublished.")
+  end
+
   def then_I_see_the_new_step_by_step_page
     expect(page).to have_content("How to bake a cake")
   end
@@ -140,5 +186,9 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_a_slug_already_taken_error
     expect(page).to have_content("Slug has already been taken")
+  end
+
+  def and_I_visit_the_unpublish_page
+    visit step_by_step_page_unpublish_path(@step_by_step_page)
   end
 end


### PR DESCRIPTION
One of the new functional tests I have added is currently failing. 

Trello card: [Unpublish the step by step page](https://trello.com/c/FHDmLa16/556-unpublish-the-step-by-step-page)

![screen shot 2018-03-26 at 18 00 09](https://user-images.githubusercontent.com/19667619/37920797-ba079bfe-311f-11e8-94d2-7e86b81cb2a9.png)
![screen shot 2018-03-26 at 18 00 23](https://user-images.githubusercontent.com/19667619/37920802-bd4086aa-311f-11e8-969f-01820c746880.png)
![screen shot 2018-03-26 at 18 00 28](https://user-images.githubusercontent.com/19667619/37920807-bf2fe2c6-311f-11e8-92dc-7dd3c7d69b99.png)
