### PR TITLE
Prevent long titles in step nav wrapping buttons

### DIFF
--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -59,8 +59,8 @@
             </th>
 
             <td class="text-right text-nowrap">
-            <%= link_to("Edit", edit_step_by_step_page_step_path(@step_by_step_page.id, step.id), class: "btn btn-primary btn-sm") %>
-            <%= link_to("Delete", step_by_step_page_step_path(@step_by_step_page.id, step.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm") %>
+              <%= link_to("Edit", edit_step_by_step_page_step_path(@step_by_step_page.id, step.id), class: "btn btn-primary btn-sm") %>
+              <%= link_to("Delete", step_by_step_page_step_path(@step_by_step_page.id, step.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm") %>
             </td>
           </tr>
         <% end %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -58,7 +58,7 @@
               <%= step.title %>
             </th>
 
-            <td class="text-right">
+            <td class="text-right text-nowrap">
             <%= link_to("Edit", edit_step_by_step_page_step_path(@step_by_step_page.id, step.id), class: "btn btn-primary btn-sm") %>
             <%= link_to("Delete", step_by_step_page_step_path(@step_by_step_page.id, step.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm") %>
             </td>


### PR DESCRIPTION
Before: 
<img width="555" alt="screen shot 2018-03-27 at 12 07 19" src="https://user-images.githubusercontent.com/108893/37963884-8bb4e62e-31b7-11e8-8bd2-999ea64fddc4.png">

After: 
<img width="566" alt="screen shot 2018-03-27 at 12 07 39" src="https://user-images.githubusercontent.com/108893/37963896-91c022ae-31b7-11e8-9b98-2568c02a1d5e.png">

[Trello card](https://trello.com/c/pAa4JrrZ)