### PR TITLE
Add publishing fields to step by step page model

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -7,6 +7,30 @@ class StepByStepPage < ApplicationRecord
   validates :slug, slug: true, on: :create
   before_validation :generate_content_id, on: :create
 
+  def has_been_published?
+    published_at.present?
+  end
+
+  def has_draft?
+    draft_updated_at.present?
+  end
+
+  def mark_draft_updated
+    update_attribute(:draft_updated_at, Time.zone.now)
+  end
+
+  def mark_draft_deleted
+    update_attribute(:draft_updated_at, nil)
+  end
+
+  def mark_as_published
+    update_attribute(:published_at, Time.zone.now)
+  end
+
+  def mark_as_unpublished
+    update_attribute(:published_at, nil)
+  end
+
 private
 
   def generate_content_id

--- a/db/migrate/20180326073415_add_publish_and_draft_times_to_step_by_step_page.rb
+++ b/db/migrate/20180326073415_add_publish_and_draft_times_to_step_by_step_page.rb
@@ -1,0 +1,6 @@
+class AddPublishAndDraftTimesToStepByStepPage < ActiveRecord::Migration[5.1]
+  def change
+    add_column :step_by_step_pages, :published_at, :datetime
+    add_column :step_by_step_pages, :draft_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180319152348) do
+ActiveRecord::Schema.define(version: 20180326073415) do
 
   create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "base_path"
@@ -72,6 +72,8 @@ ActiveRecord::Schema.define(version: 20180319152348) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "content_id", null: false
+    t.datetime "published_at"
+    t.datetime "draft_updated_at"
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["slug"], name: "index_step_by_step_pages_on_slug", unique: true
   end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -114,4 +114,42 @@ RSpec.describe StepByStepPage do
       step_by_step_page.save(validate: false)
     }.to raise_error(ActiveRecord::RecordNotUnique)
   end
+
+  describe 'publishing' do
+    let(:step_by_step_page) { create(:step_by_step_page) }
+
+    it 'should update draft date' do
+      nowish = Time.zone.now
+      Timecop.freeze do
+        step_by_step_page.mark_draft_updated
+
+        expect(step_by_step_page.draft_updated_at).to be_within(1.second).of nowish
+        expect(step_by_step_page.has_draft?).to be true
+      end
+    end
+
+    it 'should reset draft date' do
+      step_by_step_page.mark_draft_deleted
+
+      expect(step_by_step_page.draft_updated_at).to be nil
+      expect(step_by_step_page.has_draft?).to be false
+    end
+
+    it 'should update published date' do
+      nowish = Time.zone.now
+      Timecop.freeze do
+        step_by_step_page.mark_as_published
+
+        expect(step_by_step_page.published_at).to be_within(1.second).of nowish
+        expect(step_by_step_page.has_been_published?).to be true
+      end
+    end
+
+    it 'should reset published date' do
+      step_by_step_page.mark_as_unpublished
+
+      expect(step_by_step_page.published_at).to be nil
+      expect(step_by_step_page.has_been_published?).to be false
+    end
+  end
 end


### PR DESCRIPTION
We'll use these date fields to track in the app when a draft/publish event
occurs.  This adds the fields to the model that we'll use in subsequent work.

Also fixing a small bug where deleting a step doesn't update the draft correctly.