### PR TITLE
[DO NOT MERGE] Rules page frontend

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -20,3 +20,8 @@ pre.markdown-example {
 pre.markdown-example {
   white-space: pre-wrap;
 }
+
+.table-stepnav-rules .checkbox,
+.table-stepnav-rules .checkbox label {
+  margin-top: 0;
+}

--- a/app/controllers/navigation_rules_controller.rb
+++ b/app/controllers/navigation_rules_controller.rb
@@ -23,6 +23,7 @@ class NavigationRulesController < ApplicationController
   end
 
 private
+
   def set_step_by_step_page
     @step_page = StepByStepPage.find(params[:step_by_step_page_id])
   end

--- a/app/controllers/navigation_rules_controller.rb
+++ b/app/controllers/navigation_rules_controller.rb
@@ -1,0 +1,29 @@
+class NavigationRulesController < ApplicationController
+  before_action :require_gds_editor_permissions!
+  before_action :set_step_by_step_page, only: %i(edit update)
+
+  def edit
+    @step_page.navigation_rules
+  end
+
+  def update
+    navigation_rules = params.delete(:navigation_rules)
+
+    navigation_rules.each_pair do |content_id, value|
+      value = %w(true false).include?(value) ? value : false
+
+      rule = @step_page.navigation_rules.find_by(content_id: content_id)
+      rule.update_attribute(:include_in_links, value) if rule
+    end
+
+    redirect_to(
+      step_by_step_page_navigation_rules_path(@step_page),
+      notice: 'Your choices have been saved.'
+    )
+  end
+
+private
+  def set_step_by_step_page
+    @step_page = StepByStepPage.find(params[:step_by_step_page_id])
+  end
+end

--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -2,4 +2,7 @@ class NavigationRule < ActiveRecord::Base
   belongs_to :step_by_step_page
 
   validates :title, :base_path, :content_id, :step_by_step_page_id, presence: true
+
+  scope :base_paths_part_of_step_nav, -> { where(include_in_links: true).pluck(:base_path) }
+  scope :base_paths_related_to_step_nav, -> { where(include_in_links: false).pluck(:base_path) }
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,5 +1,5 @@
 class StepByStepPage < ApplicationRecord
-  has_many :navigation_rules, dependent: :destroy
+  has_many :navigation_rules, -> { order(title: :asc) }, dependent: :destroy
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, :slug, :introduction, :description, presence: true

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -73,15 +73,31 @@ private
 
   def edition_links
     {
-      "pages_part_of_step_nav": parsed_edition_links
+      "pages_part_of_step_nav": pages_part_of_step_nav,
+      "pages_related_to_step_nav": pages_related_to_step_nav,
     }
   end
 
-  def parsed_edition_links
-    StepNavPublisher.lookup_content_ids(parsed_base_paths).values
+  def base_paths_pages_part_of_step_nav
+    @base_paths_pages_part_of_step_nav ||=
+      parsed_base_paths - step_nav.navigation_rules.base_paths_part_of_step_nav
+  end
+
+  def base_paths_pages_related_to_step_nav
+    @base_paths_pages_related_to_step_nav ||=
+      (parsed_base_paths - step_nav.navigation_rules.base_paths_related_to_step_nav) - base_paths_pages_part_of_step_nav
+  end
+
+  def pages_part_of_step_nav
+    StepNavPublisher.lookup_content_ids(base_paths_pages_part_of_step_nav).values
+  end
+
+  def pages_related_to_step_nav
+    return [] if base_paths_pages_related_to_step_nav.empty?
+    StepNavPublisher.lookup_content_ids(base_paths_pages_related_to_step_nav).values
   end
 
   def parsed_base_paths
-    step_nav.steps.map { |step| step_content_parser.base_paths(step.contents) }.flatten.uniq
+    @parsed_base_paths ||= step_nav.steps.map { |step| step_content_parser.base_paths(step.contents) }.flatten.uniq
   end
 end

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -1,0 +1,62 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_page.title,
+      href: step_by_step_page_path(@step_page)
+    },
+    {
+      text: 'Choose navigation',
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
+<%= render 'shared/steps/page_title', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_page.title,
+  action: 'Choose on-page side navigation'
+%>
+
+<%= form_for(step_by_step_page_navigation_rules_path(@step_page), method: :put) do |form| %>
+
+  <table class="table table-striped table-stepnav-rules">
+    <thead>
+      <tr>
+        <th>Page title</th>
+        <th>Sidebar content of page</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @step_page.navigation_rules.each do |navigation_rule| %>
+        <tr>
+          <th><%= link_to(navigation_rule.title, navigation_rule.base_path) %></th>
+          <td>
+            <div class="checkbox">
+              <label>
+                <%= hidden_field_tag("navigation_rules[#{navigation_rule.content_id}]", false)%>
+                <%= check_box_tag( "navigation_rules[#{navigation_rule.content_id}]", true, navigation_rule.include_in_links) %>
+                Show this navigation<span class="sr-only"> on '<%= navigation_rule.title %>'</span>
+              </label>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="form-group">
+    <%= form.submit "Save", class: "btn btn-primary" %>
+  </div>
+  <div class="form-group">
+    <%= link_to "Cancel", @step_page %>
+  </div>
+<% end %>

--- a/app/views/shared/steps/_page_title.html.erb
+++ b/app/views/shared/steps/_page_title.html.erb
@@ -1,7 +1,5 @@
-<% page_title = '' %>
+<%
+  page_title = links.reverse.map { |link| link[:text] }.join(" | ")
 
-<% links.each do |link| %>
-  <% page_title = "#{link[:text]} | #{page_title}" %>
-<% end %>
-
-<% content_for :page_title, page_title %>
+  content_for :page_title, page_title
+%>

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -35,12 +35,13 @@
         </th>
         <td>
           <ul class="list-inline">
-            <li><%= link_to 'Edit content', step_by_step_page %></li>
+            <li><%= link_to 'Edit', step_by_step_page %></li>
+            <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(step_by_step_page) %></li>
             <% if step_by_step_page.has_draft? %>
-              <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
+                <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
             <% end %>
             <% unless step_by_step_page.has_been_published? %>
-              <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' } %></li>
+                <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Are you sure?' } %></li>
             <% end %>
           </ul>
         </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
     get :unpublish
     post :unpublish
 
+    get 'navigation-rules', to: 'navigation_rules#edit'
+    put 'navigation-rules', to: 'navigation_rules#update'
+
     resources :steps
   end
 

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe StepNavPresenter do
     subject { described_class.new(step_nav) }
 
     before do
-      allow(StepNavPublisher).to receive(:lookup_content_ids).and_return('/foo' => 'd6b1901d-b925-47c5-b1ca-1e52197097e2')
+      allow(StepNavPublisher).to receive(:lookup_content_ids).with(
+        ["/good/stuff", "/also/good/stuff", "/not/as/great"]
+      ).and_return('/foo' => 'd6b1901d-b925-47c5-b1ca-1e52197097e2')
     end
 
     it "presents a step by step page in the correct format" do
@@ -38,7 +40,10 @@ RSpec.describe StepNavPresenter do
 
     it "presents edition links correctly" do
       presented = subject.render_for_publishing_api
-      expect(presented[:links]).to eq(pages_part_of_step_nav: ["d6b1901d-b925-47c5-b1ca-1e52197097e2"])
+      expect(presented[:links]).to eq(
+        pages_part_of_step_nav: ["d6b1901d-b925-47c5-b1ca-1e52197097e2"],
+        pages_related_to_step_nav: []
+      )
     end
 
     it "shows the correct update type and change note" do

--- a/spec/services/step_links_for_rules_spec.rb
+++ b/spec/services/step_links_for_rules_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe StepLinksForRules do
 
       expect(navigation_rules.size).to eql(3)
 
-      expect(navigation_rules.first.title).to eq("Good Stuff")
-      expect(navigation_rules.second.title).to eq("Also Good Stuff")
+      # alphabetically orded
+      expect(navigation_rules.first.title).to eq("Also Good Stuff")
+      expect(navigation_rules.second.title).to eq("Good Stuff")
       expect(navigation_rules.third.title).to eq("Not as Great")
     end
   end


### PR DESCRIPTION
This commit saves the option of showing or not showing the step pages on
the sidebar of a content item.

- add routes for navigation-rules
- Improves readability of page_title shared component
- Add button for navigation rules
- Form for navigation rules
- Improve copy and design of step nav rules
- Saves navigation rules

The explanation for the hidden field with the same name as the check_box can be [read here in the rails documentation][rails-documentation].

Also the best way at the moment to bypass the "GenericFormBuilder" gem is to explicitly pass it as an option of `form_for` like so:

```
  form_for(..., builder: ActionView::Helpers::FormBuilder)
```
[rails-documentation]: https://github.com/rails/rails/blob/44a9aedd7b8d65517b15bbbb7729f3f16991e23f/actionpack/lib/action_view/helpers/form_helper.rb#L788

It sorts the content_items alphabetically in the navigation rules page.

Add two scopes into NavigationRule model
 - base_paths_part_of_step_nav
 - base_paths_related_to_step_nav

base_paths_related_to_step_nav: These are the content_items that are related to the StepByStepPage but are not showing it on the sidebar of their pages, it will show the related items instead.

base_paths_part_of_step_nav: These are the content_items that will have the StepByStepPage showing on the sidebar.

The reason to have both keys is to keep a relationship between the content_items and the StepByStepPage without having to affect the sidebar when not wanted.

Trello: https://trello.com/c/0DUVntqs