### PR TITLE
 Add publish functionality

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -23,8 +23,7 @@ class StepByStepPagesController < ApplicationController
         step.update_attribute(:position, step_data["position"])
       end
 
-      StepNavPublisher.update(@step_by_step_page)
-
+      update_draft
       redirect_to @step_by_step_page, notice: 'Steps were successfully reordered.'
     end
   end
@@ -35,6 +34,7 @@ class StepByStepPagesController < ApplicationController
     @step_by_step_page = StepByStepPage.new(step_by_step_page_params)
 
     if @step_by_step_page.save
+      update_draft
       redirect_to @step_by_step_page, notice: 'Step by step page was successfully created.'
     else
       render :new
@@ -43,8 +43,7 @@ class StepByStepPagesController < ApplicationController
 
   def update
     if @step_by_step_page.update(step_by_step_page_params)
-      StepNavPublisher.update(@step_by_step_page)
-
+      update_draft
       redirect_to step_by_step_page_path, notice: 'Step by step page was successfully updated.'
     else
       render :edit
@@ -52,16 +51,46 @@ class StepByStepPagesController < ApplicationController
   end
 
   def destroy
-    StepNavPublisher.discard_draft(@step_by_step_page.content_id)
-
     if @step_by_step_page.destroy
+      discard_draft
       redirect_to step_by_step_pages_path, notice: 'Step by step page was successfully deleted.'
     else
       render :edit
     end
   end
 
+  def publish
+    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
+
+    if request.post?
+      @publish_intent = PublishIntent.new(params)
+      if @publish_intent.valid?
+        publish_page(@publish_intent)
+        redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been published."
+      end
+    end
+  end
+
+  def unpublish; end
+
 private
+
+  def discard_draft
+    StepNavPublisher.discard_draft(@step_by_step_page.content_id)
+  rescue GdsApi::HTTPNotFound
+    nil
+  end
+
+  def update_draft
+    StepNavPublisher.update(@step_by_step_page)
+    @step_by_step_page.mark_draft_updated
+  end
+
+  def publish_page(publish_intent)
+    StepNavPublisher.update(@step_by_step_page, publish_intent)
+    StepNavPublisher.publish(@step_by_step_page)
+    @step_by_step_page.mark_as_published
+  end
 
   def set_step_by_step_page
     @step_by_step_page = StepByStepPage.find(params[:id])

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -53,6 +53,7 @@ private
 
   def update_publishing_api
     StepNavPublisher.update(step_by_step_page.reload)
+    step_by_step_page.mark_draft_updated
   end
 
   def step_by_step_page

--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -1,0 +1,28 @@
+class PublishIntent
+  include ActiveModel::Validations
+
+  attr_accessor :update_type, :change_note
+
+  validates :update_type, presence: true, inclusion: { in: %w(major minor), message: "%<value> must be either major or minor" }
+  validates :change_note, presence: true, if: :major_update?
+
+  def self.minor_update
+    new(update_type: "minor")
+  end
+
+  def initialize(params)
+    @update_type = params[:update_type]
+    @change_note = params[:change_note]
+  end
+
+  def major_update?
+    update_type == "major"
+  end
+
+  def present
+    {
+      update_type: update_type,
+      change_note: change_note || ""
+    }
+  end
+end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -12,7 +12,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def has_draft?
-    draft_updated_at.present?
+    draft_updated_at.present? && draft_updated_at != published_at
   end
 
   def mark_draft_updated
@@ -24,11 +24,14 @@ class StepByStepPage < ApplicationRecord
   end
 
   def mark_as_published
-    update_attribute(:published_at, Time.zone.now)
+    now = Time.zone.now
+    update_attribute(:published_at, now)
+    update_attribute(:draft_updated_at, now)
   end
 
   def mark_as_unpublished
     update_attribute(:published_at, nil)
+    update_attribute(:draft_updated_at, nil)
   end
 
 private

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -4,8 +4,9 @@ class StepNavPresenter
     @step_content_parser = StepContentParser.new
   end
 
-  def render_for_publishing_api
-    required_fields
+  def render_for_publishing_api(publish_intent = PublishIntent.minor_update)
+    payload = required_fields
+    payload.merge(publish_intent.present)
   end
 
 private
@@ -27,8 +28,7 @@ private
       rendering_app: "collections",
       routes: routes,
       schema_name: "step_by_step_nav",
-      title: step_nav.title,
-      update_type: "minor",
+      title: step_nav.title
     }
   end
 

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,7 +1,7 @@
 class StepNavPublisher
-  def self.update(step_nav)
+  def self.update(step_nav, publish_intent = PublishIntent.minor_update)
     presenter = StepNavPresenter.new(step_nav)
-    payload = presenter.render_for_publishing_api
+    payload = presenter.render_for_publishing_api(publish_intent)
     Services.publishing_api.put_content(step_nav.content_id, payload)
   end
 
@@ -11,5 +11,9 @@ class StepNavPublisher
 
   def self.lookup_content_ids(base_paths)
     Services.publishing_api.lookup_content_ids(base_paths: base_paths, with_drafts: true)
+  end
+
+  def self.publish(step_nav)
+    Services.publishing_api.publish(step_nav.content_id)
   end
 end

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -36,8 +36,12 @@
         <td>
           <ul class="list-inline">
             <li><%= link_to 'Edit content', step_by_step_page %></li>
-            <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
-            <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Are you sure?' } %></li>
+            <% if step_by_step_page.has_draft? %>
+              <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
+            <% end %>
+            <% unless step_by_step_page.has_been_published? %>
+              <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' } %></li>
+            <% end %>
           </ul>
         </td>
         <td>

--- a/app/views/step_by_step_pages/publish.html.erb
+++ b/app/views/step_by_step_pages/publish.html.erb
@@ -1,0 +1,58 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: 'Publish'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Publish step by step page'
+%>
+
+<% if @publish_intent %>
+    <%= render "shared/steps/form_errors", resource: @publish_intent %>
+<% end %>
+
+<%= form_tag do %>
+  <div class="form-group">
+    <%= label_tag :update_type, "Update type" %>
+
+    <div class="radio">
+      <label>
+        <%= radio_button_tag :update_type, "minor", checked: true %>
+        minor
+      </label>
+    </div>
+
+    <div class="radio">
+      <label>
+        <%= radio_button_tag :update_type, "major" %>
+        major
+      </label>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= label_tag :change_note, "Change note" %>
+    <%= text_field_tag :change_note  %>
+  </div>
+
+  <div class="form-group">
+    <%= submit_tag "Publish", class: "btn btn-primary" %>
+    <%= link_to 'Cancel', @step_by_step_page %>
+  </div>
+<% end %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -67,5 +67,15 @@
 
       </tbody>
     </table>
+    <ul class="list-inline publish-actions">
+      <% if @step_by_step_page.has_been_published? %>
+        <li><%= link_to 'Unpublish', step_by_step_page_unpublish_path(@step_by_step_page), class: "btn btn-danger" %></li>
+      <% else %>
+        <li><%= link_to 'Delete', @step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' }, class: "btn btn-danger" %></li>
+      <% end %>
+      <% if @step_by_step_page.has_draft? %>
+        <li><%= link_to 'Publish', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary" %></li>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -22,9 +22,9 @@
 <ul class="list-inline step-actions">
   <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug), class: "btn btn-primary" %></li>
-  <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-default" %></li>
+  <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% if @step_by_step_page.steps.length > 0 %>
-    <li><%= link_to("Reorder steps", step_by_step_page_reorder_path(@step_by_step_page), class: "btn btn-default") %></li>
+    <li><%= link_to "Reorder steps", step_by_step_page_reorder_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% end %>
 </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,12 @@ Rails.application.routes.draw do
   root to: redirect('/topics', status: 302)
 
   resources :step_by_step_pages, path: 'step-by-step-pages' do
-    get :reorder, to: 'step_by_step_pages#reorder'
-    post :reorder, to: 'step_by_step_pages#reorder'
+    get :publish
+    post :publish
+    get :reorder
+    post :reorder
+    get :unpublish
+    post :unpublish
 
     resources :steps
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature "Managing step by step pages" do
   scenario "User creates a new step by step page" do
     when_I_visit_the_new_step_by_step_form
     and_I_fill_in_the_form
+    then_I_see_delete_and_publish_buttons
     when_I_visit_the_step_by_step_pages_index
     then_I_see_the_new_step_by_step_page
   end
@@ -53,6 +54,16 @@ RSpec.feature "Managing step by step pages" do
     and_the_page_is_deleted
   end
 
+  scenario "User publishes a page" do
+    given_there_is_a_step_by_step_page_with_steps
+    and_I_visit_the_publish_page
+    and_I_publish_the_page
+    then_the_page_is_published
+    and_I_am_told_that_it_is_published
+    then_I_see_the_step_by_step_page
+    and_I_see_an_unpublish_button
+  end
+
   def given_there_is_a_step_by_step_page
     @step_by_step_page = create(:step_by_step_page)
   end
@@ -63,6 +74,10 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_visit_the_index_page
     when_I_visit_the_step_by_step_pages_index
+  end
+
+  def and_I_visit_the_publish_page
+    visit step_by_step_page_publish_path(@step_by_step_page)
   end
 
   def and_I_delete_the_step_by_step_page
@@ -109,6 +124,22 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("How to bake a cake")
   end
 
+  def then_I_see_delete_and_publish_buttons
+    within(".publish-actions") do
+      expect(page).to have_css("a", text: "Delete")
+      expect(page).to have_css("a", text: "Publish")
+      expect(page).to_not have_css("a", text: "Unpublish")
+    end
+  end
+
+  def and_I_see_an_unpublish_button
+    within(".publish-actions") do
+      expect(page).to_not have_css("a", text: "Delete")
+      expect(page).to_not have_css("a", text: "Publish")
+      expect(page).to have_css("a", text: "Unpublish")
+    end
+  end
+
   def and_the_page_is_deleted
     expect(page).to_not have_content("How to bake a cake")
   end
@@ -140,5 +171,13 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_a_slug_already_taken_error
     expect(page).to have_content("Slug has already been taken")
+  end
+
+  def and_I_publish_the_page
+    click_on "Publish"
+  end
+
+  def and_I_am_told_that_it_is_published
+    expect(page).to have_content("has been published")
   end
 end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -62,7 +62,6 @@ RSpec.feature "Managing step by step pages" do
         given_there_is_a_step_by_step_page_with_steps
         and_I_visit_the_reorder_steps_page
         and_I_reorder_the_steps
-        then_the_payload_contains_the_new_steps_order
         and_I_see_the_steps_updated_on_the_step_by_step_details_page
       end
     end
@@ -181,16 +180,6 @@ RSpec.feature "Managing step by step pages" do
   def and_I_see_the_step_on_the_step_by_step_details_page
     expect(page).to have_content("Add a new step")
     expect(page).to have_content("Buy Mary Berry's 'Simple Cakes' book")
-  end
-
-  def then_the_payload_contains_the_new_steps_order
-    presenter = StepNavPresenter.new(@step_by_step_page.reload)
-    payload = presenter.render_for_publishing_api
-
-    payload_steps = payload[:details][:step_by_step_nav][:steps]
-
-    expect(payload_steps[0][:title]).to eql("Dress like the Fonz")
-    expect(payload_steps[1][:title]).to eql("Check how awesome you are")
   end
 
   def and_I_see_the_steps_updated_on_the_step_by_step_details_page

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -141,7 +141,9 @@ RSpec.describe StepByStepPage do
         step_by_step_page.mark_as_published
 
         expect(step_by_step_page.published_at).to be_within(1.second).of nowish
+        expect(step_by_step_page.published_at).to eq(step_by_step_page.draft_updated_at)
         expect(step_by_step_page.has_been_published?).to be true
+        expect(step_by_step_page.has_draft?).to be false
       end
     end
 
@@ -150,6 +152,8 @@ RSpec.describe StepByStepPage do
 
       expect(step_by_step_page.published_at).to be nil
       expect(step_by_step_page.has_been_published?).to be false
+      expect(step_by_step_page.draft_updated_at).to be nil
+      expect(step_by_step_page.has_draft?).to be false
     end
   end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe StepNavPresenter do
       presented = subject.render_for_publishing_api
       expect(presented).to be_valid_against_schema("step_by_step_nav")
 
+      expect(presented[:update_type]).to eq("minor")
       expect(presented[:base_path]).to eq("/how-to-be-the-amazing-1")
       expect(presented[:routes]).to eq([{ path: "/how-to-be-the-amazing-1", type: "exact" }])
     end
@@ -38,6 +39,15 @@ RSpec.describe StepNavPresenter do
     it "presents edition links correctly" do
       presented = subject.render_for_publishing_api
       expect(presented[:links]).to eq(pages_part_of_step_nav: ["d6b1901d-b925-47c5-b1ca-1e52197097e2"])
+    end
+
+    it "shows the correct update type and change note" do
+      intent = PublishIntent.new(update_type: "major", change_note: "All your update belong to us")
+      presented = subject.render_for_publishing_api(intent)
+
+      expect(presented).to be_valid_against_schema("step_by_step_nav")
+      expect(presented[:update_type]).to eq("major")
+      expect(presented[:change_note]).to eq("All your update belong to us")
     end
   end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -1,20 +1,26 @@
 module StepNavSteps
   def setup_publishing_api
-    allow(Services.publishing_api).to receive(:put_content)
-    allow(Services.publishing_api).to receive(:discard_draft)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_discard_draft
     allow(Services.publishing_api).to receive(:lookup_content_id)
     allow(StepNavPublisher).to receive(:lookup_content_ids).and_return(
       '/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
       '/also/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e2',
       '/not/as/great' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e3'
     )
+    stub_any_publishing_api_publish
   end
 
   def then_the_content_is_sent_to_publishing_api
-    expect(Services.publishing_api).to have_received(:put_content)
+    assert_publishing_api_put_content(@step_by_step_page.content_id)
   end
 
   def then_the_draft_is_discarded
-    expect(Services.publishing_api).to have_received(:discard_draft)
+    assert_publishing_api_discard_draft(@step_by_step_page.content_id)
+  end
+
+  def then_the_page_is_published
+    payload = StepNavPresenter.new(@step_by_step_page).render_for_publishing_api
+    stub_publishing_api_put_content_links_and_publish(payload, @step_by_step_page.content_id)
   end
 end


### PR DESCRIPTION
We should only be able to publish something that has a draft
We should only be able to delete something that doesn't have a published version
I've added the skeleton of the unpublishing bits as it's coming directly next - we should only be able to unpublish a thing that has a published version

When you publish, you can add a change note for a minor version but it's not
mandatory.  It is mandatory for a major version.

I've started transferring to using gds-api-adapter test helpers rather than
stubbing the methods ourselves.