### PR TITLE
Add unpublishing feature

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -34,6 +34,11 @@ class StepByStepPage < ApplicationRecord
     update_attribute(:draft_updated_at, nil)
   end
 
+  def self.validate_redirect(redirect_url)
+    regex = /\A\/([a-z0-9]+-)*[a-z0-9]+\z/
+    redirect_url =~ regex
+  end
+
 private
 
   def generate_content_id

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -16,4 +16,8 @@ class StepNavPublisher
   def self.publish(step_nav)
     Services.publishing_api.publish(step_nav.content_id)
   end
+
+  def self.unpublish(step_nav, redirect_url)
+    Services.publishing_api.unpublish(step_nav.content_id, type: "redirect", alternative_path: redirect_url)
+  end
 end

--- a/app/views/step_by_step_pages/publish.html.erb
+++ b/app/views/step_by_step_pages/publish.html.erb
@@ -24,35 +24,39 @@
 %>
 
 <% if @publish_intent %>
-    <%= render "shared/steps/form_errors", resource: @publish_intent %>
+  <%= render "shared/steps/form_errors", resource: @publish_intent %>
 <% end %>
 
-<%= form_tag do %>
-  <div class="form-group">
-    <%= label_tag :update_type, "Update type" %>
+<div class="row">
+  <div class="col-md-7">
+    <%= form_tag do %>
+      <div class="form-group">
+        <%= label_tag :update_type, "Update type" %>
 
-    <div class="radio">
-      <label>
-        <%= radio_button_tag :update_type, "minor", checked: true %>
-        minor
-      </label>
-    </div>
+        <div class="radio">
+          <label>
+            <%= radio_button_tag :update_type, "minor", checked: true %>
+            minor
+          </label>
+        </div>
 
-    <div class="radio">
-      <label>
-        <%= radio_button_tag :update_type, "major" %>
-        major
-      </label>
-    </div>
+        <div class="radio">
+          <label>
+            <%= radio_button_tag :update_type, "major" %>
+            major
+          </label>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= label_tag :change_note, "Change note" %>
+        <%= text_field_tag :change_note  %>
+      </div>
+
+      <div class="form-group">
+        <%= submit_tag "Publish", class: "btn btn-primary" %>
+        <%= link_to 'Cancel', @step_by_step_page %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="form-group">
-    <%= label_tag :change_note, "Change note" %>
-    <%= text_field_tag :change_note  %>
-  </div>
-
-  <div class="form-group">
-    <%= submit_tag "Publish", class: "btn btn-primary" %>
-    <%= link_to 'Cancel', @step_by_step_page %>
-  </div>
-<% end %>
+</div>

--- a/app/views/step_by_step_pages/unpublish.html.erb
+++ b/app/views/step_by_step_pages/unpublish.html.erb
@@ -1,0 +1,61 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: @step_by_step_page
+    },
+    {
+      text: 'Unpublish'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/page_title', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Unpublish step by step'
+%>
+
+<div class="callout callout-warning add-bottom-margin">
+  <div class="callout-title">
+    Warning
+  </div>
+  <div class="callout-body">
+    Unpublish a page from GOV.UK. This can’t be undone.
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-7">
+    <%= form_tag(step_by_step_page_unpublish_path(@step_by_step_page), method: :post) do %>
+      <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
+
+      <div class="form-group">
+        <label for="redirect_url">Redirect to</label>
+        <span class="normal">
+          For example: <code>/redirect-to-replacement-page</code>
+        </span>
+        <%= text_field_tag :redirect_url %>
+      </div>
+
+      <div class="form-group">
+        <%= button_tag 'Unpublish',
+          {
+            data: {
+              module: 'confirm',
+              message: "This will remove ‘#{@step_by_step_page.title}’ from the website.\n\n Are you sure?"
+            },
+            class: "btn btn-danger"
+          }
+        %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,11 @@ FactoryBot.define do
     end
   end
 
+  factory :published_step_by_step_page, parent: :step_by_step_page_with_steps do
+    draft_updated_at 3.hours.ago
+    published_at Time.zone.now
+  end
+
   factory :step do
     title "Check how awesome you are"
     logic "number"

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -64,12 +64,35 @@ RSpec.feature "Managing step by step pages" do
     and_I_see_an_unpublish_button
   end
 
+  scenario "User unpublishes a step by step page with a valid redirect url" do
+    given_there_is_a_published_step_by_step_page
+    when_I_view_the_step_by_step_page
+    when_I_want_to_unpublish_the_page
+    and_I_fill_in_the_form_with_a_valid_url
+    then_the_page_is_unpublished
+    and_I_see_a_success_notice
+  end
+
+  scenario "User unpublishes a step by step page with an invalid redirect url" do
+    given_there_is_a_published_step_by_step_page
+    when_I_view_the_step_by_step_page
+    when_I_want_to_unpublish_the_page
+    and_I_fill_in_the_form_with_an_invalid_url
+    then_I_see_that_the_url_isnt_valid
+    and_I_fill_in_the_form_with_an_empty_url
+    then_I_see_that_the_url_isnt_valid
+  end
+
   def given_there_is_a_step_by_step_page
     @step_by_step_page = create(:step_by_step_page)
   end
 
   def given_there_is_a_step_by_step_page_with_steps
     @step_by_step_page = create(:step_by_step_page_with_steps)
+  end
+
+  def given_there_is_a_published_step_by_step_page
+    @step_by_step_page = create(:published_step_by_step_page)
   end
 
   def and_I_visit_the_index_page
@@ -80,10 +103,41 @@ RSpec.feature "Managing step by step pages" do
     visit step_by_step_page_publish_path(@step_by_step_page)
   end
 
+  def when_I_want_to_unpublish_the_page
+    click_on "Unpublish"
+  end
+
+  def and_I_fill_in_the_form_with_a_valid_url
+    fill_in "Redirect to", with: "/micro-pigs-can-grow-to-the-size-of-godzilla"
+    click_on "Unpublish"
+  end
+
+  def and_I_fill_in_the_form_with_an_empty_url
+    fill_in "Redirect to", with: ""
+    click_on "Unpublish"
+  end
+
+  def and_I_fill_in_the_form_with_an_invalid_url
+    fill_in "Redirect to", with: "!"
+    click_on "Unpublish"
+  end
+
+  def then_I_see_that_the_url_isnt_valid
+    expect(page).to have_content("Redirect path is invalid. Step by step page has not been unpublished.")
+  end
+
+  def and_I_see_a_success_notice
+    expect(page).to have_content("Step by step page was successfully unpublished.")
+  end
+
   def and_I_delete_the_step_by_step_page
     accept_confirm do
       click_on "Delete"
     end
+  end
+
+  def when_I_view_the_step_by_step_page
+    visit step_by_step_page_path(@step_by_step_page)
   end
 
   def when_I_edit_the_step_by_step_page

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -9,6 +9,7 @@ module StepNavSteps
       '/not/as/great' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e3'
     )
     stub_any_publishing_api_publish
+    stub_any_publishing_api_unpublish
   end
 
   def then_the_content_is_sent_to_publishing_api
@@ -22,5 +23,9 @@ module StepNavSteps
   def then_the_page_is_published
     payload = StepNavPresenter.new(@step_by_step_page).render_for_publishing_api
     stub_publishing_api_put_content_links_and_publish(payload, @step_by_step_page.content_id)
+  end
+
+  def then_the_page_is_unpublished
+    assert_publishing_api_unpublish(@step_by_step_page.content_id)
   end
 end


### PR DESCRIPTION
This allows a step by step page to be unpublished from the content-store.

It does not delete it from the application, so once unpublished, it can be
resubmitted at a later point.