### PR TITLE
Cope with more path variants

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -36,11 +36,18 @@ class StepContentParser
   end
 
   def base_paths(step_text)
-    step_text.scan(/\[.+\]\((.+)\)/).
-      reject { |href| href[0] =~ /https?:\/\//i if href.any? }.flatten
+    relative_paths(step_text).map do |path|
+      uri = URI.parse(path)
+      uri.path
+    end
   end
 
 private
+
+  def relative_paths(content)
+    content.scan(/\[.+\]\((.+)\)/).
+      select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
+  end
 
   def standard_list?(section)
     section.all? { |line| line =~ LIST_REGEX }

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -341,6 +341,37 @@ RSpec.describe StepContentParser do
         )
       )
     end
+
+    it "strips query strings and segments" do
+      step_text = <<~HEREDOC
+        [All the prizes](/all-the-prizes#the-best-ones)
+        - [A very expensive speed boat](/i-love-speed-boats)
+        - [Spending money](/spending-money?currency=sterling)£5000 or so
+      HEREDOC
+
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /all-the-prizes
+          /i-love-speed-boats
+          /spending-money
+        )
+      )
+    end
+
+    it "can cope with weird things" do
+      step_text = <<~HEREDOC
+        Some text with a [link in the middle](/the-only/Server-Relative/path/in-here)
+        [All the prizes](\\all-the-prizes/#the-best-ones)
+        - [A very expensive speed boat](//i-love-speed-boats)
+        - [Spending money](spending-money?currency=sterling)£5000 or so
+      HEREDOC
+
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /the-only/Server-Relative/path/in-here
+        )
+      )
+    end
   end
 
   context "mixed content" do


### PR DESCRIPTION
We need to be able to cope with relative paths that are a number of different
styles:

- those with segments on the end
- those with query strings on the end

We need to strip these so that the base path lookup to publishing-api works for
more cases.

We also want to make this more robust so that typos are less likely to cause
a problem

https://trello.com/c/TDl0QL4k/576-why-doesnt-the-step-nav-show-on-my-page