### PR TITLE
Add navigation rules frontend

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -20,3 +20,8 @@ pre.markdown-example {
 pre.markdown-example {
   white-space: pre-wrap;
 }
+
+.table-stepnav-rules .checkbox,
+.table-stepnav-rules .checkbox label {
+  margin-top: 0;
+}

--- a/app/controllers/navigation_rules_controller.rb
+++ b/app/controllers/navigation_rules_controller.rb
@@ -22,6 +22,7 @@ class NavigationRulesController < ApplicationController
   end
 
 private
+
   def set_step_by_step_page
     @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
   end

--- a/app/controllers/navigation_rules_controller.rb
+++ b/app/controllers/navigation_rules_controller.rb
@@ -1,0 +1,28 @@
+class NavigationRulesController < ApplicationController
+  before_action :require_gds_editor_permissions!
+  before_action :set_step_by_step_page, only: %i(edit update)
+
+  def edit
+    @step_by_step_page.navigation_rules
+  end
+
+  def update
+    navigation_rules = params.delete(:navigation_rules)
+
+    navigation_rules.each_pair do |content_id, value|
+      value = %w(true false).include?(value) ? value : true
+
+      rule = @step_by_step_page.navigation_rules.find_by(content_id: content_id)
+      rule.update_attribute(:include_in_links, value) if rule
+    end
+
+    StepByStepDraftUpdateWorker.perform_async(@step_by_step_page.id)
+
+    redirect_to(@step_by_step_page, notice: 'Your navigation choices have been saved.')
+  end
+
+private
+  def set_step_by_step_page
+    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,6 @@ module ApplicationHelper
   end
 
   def preview_url(slug)
-    "#{Plek.new.external_url_for('draft-origin')}/#{slug}"
+    "#{Plek.new.external_url_for('draft-origin')}/#{slug.sub(/^\//, '')}"
   end
 end

--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -2,4 +2,7 @@ class NavigationRule < ActiveRecord::Base
   belongs_to :step_by_step_page
 
   validates :title, :base_path, :content_id, :step_by_step_page_id, presence: true
+
+  scope :part_of_content_ids, -> { where(include_in_links: true).pluck(:content_id) }
+  scope :related_content_ids, -> { where(include_in_links: false).pluck(:content_id) }
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,5 +1,5 @@
 class StepByStepPage < ApplicationRecord
-  has_many :navigation_rules, dependent: :destroy
+  has_many :navigation_rules, -> { order(title: :asc) }, dependent: :destroy
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
   validates :title, :slug, :introduction, :description, presence: true

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -72,16 +72,17 @@ private
   end
 
   def edition_links
-    {
-      "pages_part_of_step_nav": parsed_edition_links
-    }
+    links = {}
+    links[:pages_part_of_step_nav] = part_of_step_nav_links if part_of_step_nav_links.present?
+    links[:pages_related_to_step_nav] = related_to_step_nav_links if related_to_step_nav_links.present?
+    links
   end
 
-  def parsed_edition_links
-    StepNavPublisher.lookup_content_ids(parsed_base_paths).values
+  def part_of_step_nav_links
+    step_nav.navigation_rules.part_of_content_ids
   end
 
-  def parsed_base_paths
-    step_nav.steps.map { |step| step_content_parser.base_paths(step.contents) }.flatten.uniq
+  def related_to_step_nav_links
+    step_nav.navigation_rules.related_content_ids
   end
 end

--- a/app/services/step_links_for_rules.rb
+++ b/app/services/step_links_for_rules.rb
@@ -69,7 +69,21 @@ private
 
     results_from_lookup = lookup_content_ids(base_paths)
 
-    results_from_lookup.values.uniq
+    missing_paths = base_paths - results_from_lookup.keys
+
+    parent_results = lookup_parents(missing_paths)
+
+    (results_from_lookup.values + parent_results.values).uniq
+  end
+
+  # This will match guides where we've referenced a chapter, but not the base path
+  def lookup_parents(paths)
+    parent_paths = paths.map { |path| File.dirname(path) }
+
+    # we don't want to tag the homepage
+    filtered_parents = parent_paths.reject{ |path| path == "/" }
+
+    lookup_content_ids(filtered_parents)
   end
 
   def lookup_content_ids(base_paths)

--- a/app/services/step_links_for_rules.rb
+++ b/app/services/step_links_for_rules.rb
@@ -71,19 +71,21 @@ private
 
     missing_paths = base_paths - results_from_lookup.keys
 
-    parent_results = lookup_parents(missing_paths)
+    parent_content_ids = lookup_parent_ids(missing_paths)
 
-    (results_from_lookup.values + parent_results.values).uniq
+    (results_from_lookup.values + parent_content_ids).uniq
   end
 
   # This will match guides where we've referenced a chapter, but not the base path
-  def lookup_parents(paths)
+  def lookup_parent_ids(paths)
+    return [] if paths.empty?
+
     parent_paths = paths.map { |path| File.dirname(path) }
 
     # we don't want to tag the homepage
-    filtered_parents = parent_paths.reject{ |path| path == "/" }
+    filtered_parents = parent_paths.reject { |path| path == "/" }
 
-    lookup_content_ids(filtered_parents)
+    lookup_content_ids(filtered_parents).values
   end
 
   def lookup_content_ids(base_paths)

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -1,0 +1,71 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: 'Choose navigation',
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
+<%= render 'shared/steps/page_title', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Choose on-page side navigation'
+%>
+
+<%= form_for(step_by_step_page_navigation_rules_path(@step_by_step_page), method: :put) do |form| %>
+
+  <table class="table table-striped table-stepnav-rules" data-module="filterable-table">
+    <thead>
+      <tr>
+        <th colspan="3">
+        <div class='filter-control'>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a rule here' } %>
+        </div>
+        </th>
+      </tr>
+      <tr>
+        <th>Page title</th>
+        <th>Path</th>
+        <th>Sidebar content of page</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @step_by_step_page.navigation_rules.each do |navigation_rule| %>
+        <tr>
+          <td><%= link_to(navigation_rule.title, preview_url(navigation_rule.base_path)) %></td>
+          <td><%= navigation_rule.base_path %></td>
+          <td>
+            <div class="checkbox">
+              <label>
+                <%= hidden_field_tag("navigation_rules[#{navigation_rule.content_id}]", false)%>
+                <%= check_box_tag( "navigation_rules[#{navigation_rule.content_id}]", true, navigation_rule.include_in_links) %>
+                Show this navigation<span class="sr-only"> on '<%= navigation_rule.title %>'</span>
+              </label>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="form-group">
+    <%= form.submit "Save", class: "btn btn-primary" %>
+  </div>
+  <div class="form-group">
+    <%= link_to "Cancel", @step_page %>
+  </div>
+<% end %>

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -18,8 +18,15 @@
   <%= link_to 'Create new', new_step_by_step_page_path, class: "btn btn-primary" %>
 </p>
 
-<table class="table table-striped">
+<table class="table table-striped" data-module="filterable-table">
   <thead>
+    <tr>
+      <th colspan="3">
+      <div class='filter-control'>
+        <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a step by step page here' } %>
+      </div>
+      </th>
+    </tr>
     <tr>
       <th>Title</th>
       <th>Actions</th>
@@ -35,9 +42,10 @@
         </th>
         <td>
           <ul class="list-inline">
-            <li><%= link_to 'Edit content', step_by_step_page %></li>
+            <li><%= link_to 'Edit', step_by_step_page %></li>
+            <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(step_by_step_page) %></li>
             <% if step_by_step_page.has_draft? %>
-              <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
+                <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
             <% end %>
             <% unless step_by_step_page.has_been_published? %>
               <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' } %></li>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -23,6 +23,7 @@
   <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug), class: "btn btn-primary" %></li>
   <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-primary" %></li>
+  <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% if @step_by_step_page.steps.length > 0 %>
     <li><%= link_to "Reorder steps", step_by_step_page_reorder_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   root to: redirect('/topics', status: 302)
 
   resources :step_by_step_pages, path: 'step-by-step-pages' do
+    get 'navigation-rules', to: 'navigation_rules#edit'
+    put 'navigation-rules', to: 'navigation_rules#update'
     get :publish
     post :publish
     get :reorder

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
       after(:create) do |step_by_step_page|
         create(:step, step_by_step_page: step_by_step_page)
         create(:or_step, step_by_step_page: step_by_step_page)
+        create(:navigation_rule, step_by_step_page: step_by_step_page)
+        create(:navigation_rule, step_by_step_page: step_by_step_page, title: "Also good stuff", base_path: "/also/good/stuff")
       end
     end
   end
@@ -40,6 +42,12 @@ FactoryBot.define do
       logic "or"
       position 2
     end
+  end
+
+  factory :navigation_rule do
+    title "Good stuff"
+    base_path "/good/stuff"
+    content_id { SecureRandom.uuid }
   end
 
   factory :redirect_item do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -10,8 +10,6 @@ FactoryBot.define do
       after(:create) do |step_by_step_page|
         create(:step, step_by_step_page: step_by_step_page)
         create(:or_step, step_by_step_page: step_by_step_page)
-        create(:navigation_rule, step_by_step_page: step_by_step_page)
-        create(:navigation_rule, step_by_step_page: step_by_step_page, title: "Also good stuff", base_path: "/also/good/stuff")
       end
     end
   end
@@ -19,6 +17,13 @@ FactoryBot.define do
   factory :published_step_by_step_page, parent: :step_by_step_page_with_steps do
     draft_updated_at 3.hours.ago
     published_at Time.zone.now
+  end
+
+  factory :step_by_step_page_with_navigation_rules, parent: :step_by_step_page_with_steps do
+    after(:create) do |step_by_step_page|
+      create(:navigation_rule, step_by_step_page: step_by_step_page)
+      create(:navigation_rule, step_by_step_page: step_by_step_page, title: "Also good stuff", base_path: "/also/good/stuff")
+    end
   end
 
   factory :step do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -82,14 +82,6 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_that_the_url_isnt_valid
   end
 
-  def given_there_is_a_step_by_step_page
-    @step_by_step_page = create(:step_by_step_page)
-  end
-
-  def given_there_is_a_step_by_step_page_with_steps
-    @step_by_step_page = create(:step_by_step_page_with_steps)
-  end
-
   def given_there_is_a_published_step_by_step_page
     @step_by_step_page = create(:published_step_by_step_page)
   end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -65,15 +65,6 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-
-  def given_there_is_a_step_by_step_page_with_steps
-    @step_by_step_page = create(:step_by_step_page_with_steps)
-  end
-
-  def given_there_is_a_step_by_step_page
-    @step_by_step_page = create(:step_by_step_page)
-  end
-
   def when_I_visit_the_step_by_step_page
     visit step_by_step_page_path(@step_by_step_page)
   end

--- a/spec/features/step_by_step_navigation_spec.rb
+++ b/spec/features/step_by_step_navigation_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Managing step by step navigation" do
     end
 
     scenario "User configures navigation" do
-      given_there_is_a_step_by_step_page_with_steps
+      given_there_is_a_step_by_step_page_with_navigation_rules
       and_I_visit_the_navigation_rules_page
       and_I_see_all_pages_included_in_navigation
       and_I_set_some_navigation_preferences
@@ -20,6 +20,10 @@ RSpec.feature "Managing step by step navigation" do
       then_I_visit_the_navigation_steps_page_again
       and_I_see_my_selected_preferences
     end
+  end
+
+  def given_there_is_a_step_by_step_page_with_navigation_rules
+    @step_by_step_page = create(:step_by_step_page_with_navigation_rules)
   end
 
   def and_I_visit_the_navigation_rules_page
@@ -32,7 +36,7 @@ RSpec.feature "Managing step by step navigation" do
 
     expect(page).to have_link("Also good stuff", href: "https://draft-origin.test.gov.uk/also/good/stuff")
 
-    checked = page.all(:css, "input[type=checkbox]") { |check| check.checked? }
+    checked = page.all(:css, "input[type=checkbox]", &:checked?)
     expect(checked.count).to eq @step_by_step_page.navigation_rules.count
   end
 

--- a/spec/features/step_by_step_navigation_spec.rb
+++ b/spec/features/step_by_step_navigation_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.feature "Managing step by step navigation" do
+  include CommonFeatureSteps
+  include NavigationSteps
+  include StepNavSteps
+
+  context "Given I'm a GDS Editor" do
+    before do
+      given_I_am_a_GDS_editor
+      setup_publishing_api
+    end
+
+    scenario "User configures navigation" do
+      given_there_is_a_step_by_step_page_with_steps
+      and_I_visit_the_navigation_rules_page
+      and_I_see_all_pages_included_in_navigation
+      and_I_set_some_navigation_preferences
+      then_I_see_the_step_by_step_page
+      then_I_visit_the_navigation_steps_page_again
+      and_I_see_my_selected_preferences
+    end
+  end
+
+  def and_I_visit_the_navigation_rules_page
+    visit step_by_step_page_navigation_rules_path(@step_by_step_page)
+  end
+
+  def and_I_see_all_pages_included_in_navigation
+    expect(page).to have_css("h1 small", "Choose on-page side navigation")
+    expect(page).to have_css("h1", @step_by_step_page.title)
+
+    expect(page).to have_link("Also good stuff", href: "https://draft-origin.test.gov.uk/also/good/stuff")
+
+    checked = page.all(:css, "input[type=checkbox]") { |check| check.checked? }
+    expect(checked.count).to eq @step_by_step_page.navigation_rules.count
+  end
+
+  def and_I_set_some_navigation_preferences
+    uncheck("Show this navigation", match: :first)
+
+    allow(StepByStepDraftUpdateWorker).to receive(:perform_async)
+    click_on "Save"
+  end
+
+  def then_I_see_the_step_by_step_page
+    expect(page).to have_content("Your navigation choices have been saved")
+    expect(page).to have_link("Choose navigation")
+  end
+
+  def then_I_visit_the_navigation_steps_page_again
+    click_on("Choose navigation")
+  end
+
+  def and_I_see_my_selected_preferences
+    expect(page.find(:checkbox, match: :first)).to_not be_checked
+    expect(page.all(:checkbox)[1]).to be_checked
+  end
+end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StepNavPresenter do
       allow(Services.publishing_api).to receive(:lookup_content_id)
     end
 
-    let(:step_nav) { create(:step_by_step_page_with_steps) }
+    let(:step_nav) { create(:step_by_step_page_with_navigation_rules) }
 
     subject { described_class.new(step_nav) }
 
@@ -38,7 +38,23 @@ RSpec.describe StepNavPresenter do
 
     it "presents edition links correctly" do
       presented = subject.render_for_publishing_api
-      expect(presented[:links]).to eq(pages_part_of_step_nav: ["d6b1901d-b925-47c5-b1ca-1e52197097e2"])
+      expect(presented[:links][:pages_part_of_step_nav].count).to eq(2)
+      expect(presented[:links][:pages_related_to_step_nav]).to be nil
+    end
+
+    it "detects pages for navigation" do
+      step_nav_with_navigation = create(:step_by_step_page_with_navigation_rules)
+      rule1 = step_nav_with_navigation.navigation_rules.first
+      rule1.include_in_links = false
+      rule1.save
+
+      step_nav_with_navigation.reload
+
+      presenter = described_class.new(step_nav_with_navigation)
+      presented = presenter.render_for_publishing_api
+
+      expect(presented[:links][:pages_part_of_step_nav].count).to eq(1)
+      expect(presented[:links][:pages_related_to_step_nav].count).to eq(1)
     end
 
     it "shows the correct update type and change note" do

--- a/spec/services/step_links_for_rules_spec.rb
+++ b/spec/services/step_links_for_rules_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe StepLinksForRules do
       expect(step_page.navigation_rules.count).to eql(0)
     end
 
-    it 'adds new navigation rules' do
+    it 'adds new navigation rules alphabetically' do
       setup_test_with_publishing_api_requests
 
       described_class.new(step_by_step_page: step_page).call
@@ -32,8 +32,8 @@ RSpec.describe StepLinksForRules do
 
       expect(navigation_rules.size).to eql(3)
 
-      expect(navigation_rules.first.title).to eq("Good Stuff")
-      expect(navigation_rules.second.title).to eq("Also Good Stuff")
+      expect(navigation_rules.first.title).to eq("Also Good Stuff")
+      expect(navigation_rules.second.title).to eq("Good Stuff")
       expect(navigation_rules.third.title).to eq("Not as Great")
     end
   end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -32,4 +32,12 @@ module StepNavSteps
   def expect_update_worker
     allow(StepByStepDraftUpdateWorker).to receive(:perform_async).with(@step_by_step_page.id)
   end
+
+  def given_there_is_a_step_by_step_page_with_steps
+    @step_by_step_page = create(:step_by_step_page_with_steps)
+  end
+
+  def given_there_is_a_step_by_step_page
+    @step_by_step_page = create(:step_by_step_page)
+  end
 end


### PR DESCRIPTION
We add a page to select whether a linked content item appears in the `pages_part_of_step_nav` links (which will mean that it will be part of that page's navigation) or the `pages_related_to_step_nav` (which means that it won't be included in a page's navigation - yet)

The navigation rules backend has been largely added already

We can only do this if we've found the item in publishing api, so we try a parent path if we don't find the item initially (so we try `/foo` if we don't find `/foo/bar`).  This is a known problem with linking to guide chapters but not the default guide page.