### PR TITLE
Exclude closing parentheses from being allowed in links

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -45,7 +45,7 @@ class StepContentParser
 private
 
   def relative_paths(content)
-    content.scan(/\[.+\]\((.+)\)/).
+    content.scan(/\[.+\]\(([^)]+)\)/).
       select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
   end
 

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -364,11 +364,13 @@ RSpec.describe StepContentParser do
         [All the prizes](\\all-the-prizes/#the-best-ones)
         - [A very expensive speed boat](//i-love-speed-boats)
         - [Spending money](spending-money?currency=sterling)£5000 or so
+        - [Other things](/apart-from-this-one) And some trailing text with a (set of parens) in it
       HEREDOC
 
       expect(subject.base_paths(step_text)).to eq(
         %w(
           /the-only/Server-Relative/path/in-here
+          /apart-from-this-one
         )
       )
     end


### PR DESCRIPTION
We weren't excluding parens from our regex which meant that on a line like:

`- [Other things](/apart-from-this-one) And some trailing text with a (set of parens) in it`

we were matching the text

`/apart-from-this-one) And some trailing text with a (set of parens`

which is clearly wrong.