### PR TITLE
Remove field name from validation message

### DIFF
--- a/app/validators/slug_validator.rb
+++ b/app/validators/slug_validator.rb
@@ -1,7 +1,7 @@
 class SlugValidator < ActiveModel::Validator
   def validate(record)
     unless Services.publishing_api.lookup_content_id(base_path: "/#{record.slug}", with_drafts: true).nil?
-      record.errors[:slug] << "Slug has already been taken."
+      record.errors[:slug] << "has already been taken."
     end
   end
 end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe StepByStepPage do
         step_by_step_page.save(validate: false)
       }.to raise_error(ActiveRecord::RecordNotUnique)
     end
+
+    it 'must not be present in publishing-api' do
+      allow(Services.publishing_api).to receive(:lookup_content_id).and_return("A_CONTENT_ID")
+      step_by_step_page.save
+
+      expect(step_by_step_page.errors.full_messages).to eq(["Slug has already been taken."])
+    end
   end
 
   describe 'steps association' do


### PR DESCRIPTION
Rails includes the field name by default so if we include it too we get "Slug Slug has already been taken" which is just weird

https://trello.com/c/KSK0Y2qu/538-check-and-fix-slug-validation-error-message