### PR TITLE
Publish organisations API route

### DIFF
--- a/lib/publish_organisations_api_route.rb
+++ b/lib/publish_organisations_api_route.rb
@@ -1,0 +1,36 @@
+class PublishOrganisationsApiRoute
+  def publish
+    payload = present_for_publishing_api
+    Services.publishing_api.put_content(payload[:content_id], payload[:content])
+    Services.publishing_api.publish(payload[:content_id], nil, locale: "en")
+  end
+
+private
+
+  BASE_PATH = "/api/organisations".freeze
+  CONTENT_ID = "6848a0b0-8cd0-4641-ac3f-5e70379be309".freeze
+
+  def present_for_publishing_api
+    {
+      content_id: CONTENT_ID,
+      content: {
+        title: "Organisations API",
+        description: "API exposing all organisations on GOV.UK.",
+        document_type: "special_route",
+        schema_name: "special_route",
+        locale: "en",
+        base_path: BASE_PATH,
+        publishing_app: "collections-publisher",
+        rendering_app: "collections",
+        routes: [
+          {
+            path: BASE_PATH,
+            type: "prefix",
+          },
+        ],
+        public_updated_at: Time.zone.now.iso8601,
+        update_type: "minor",
+      }
+    }
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -9,4 +9,9 @@ namespace :publishing_api do
   task :send_published_tags => :environment do
     TagRepublisher.new.republish_tags(Tag.published)
   end
+
+  desc "Publish the /api/organisations prefix route"
+  task :publish_organisations_api_route do
+    PublishOrganisationsApiRoute.new.publish
+  end
 end


### PR DESCRIPTION
This commit adds a rake task to publish the `/api/organisations` route used by collections to serve the organisations API. This is a prefix route since the route can be appended with an organisation slug to get details of a single organisation.

Trello: https://trello.com/c/p7ywlbk1/130-migrate-organisations-api