### PR TITLE
Fix organisations API publishing rake task

### DIFF
--- a/lib/publish_organisations_api_route.rb
+++ b/lib/publish_organisations_api_route.rb
@@ -1,3 +1,5 @@
+require_relative "../app/lib/services"
+
 class PublishOrganisationsApiRoute
   def publish
     payload = present_for_publishing_api
@@ -28,7 +30,7 @@ private
             type: "prefix",
           },
         ],
-        public_updated_at: Time.zone.now.iso8601,
+        public_updated_at: Time.now.iso8601,
         update_type: "minor",
       }
     }

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,3 +1,5 @@
+require_relative "../publish_organisations_api_route"
+
 namespace :publishing_api do
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
   task :send_all_tags => :environment do


### PR DESCRIPTION
This commit fixes the organisations API publishing rake task by requiring some files and removing the reliance on time zones.

Trello: https://trello.com/c/p7ywlbk1/130-migrate-organisations-api