### PR TITLE
Add organisation finder

### DIFF
--- a/app/services/finder_publisher.rb
+++ b/app/services/finder_publisher.rb
@@ -1,0 +1,26 @@
+class FinderPublisher
+  attr_reader :content_id, :content_item
+
+  def initialize(content_item)
+    @content_id = content_item.delete("content_id")
+    @content_item = content_item
+  end
+
+  def self.call(content_item)
+    new(content_item).call
+  end
+
+  def call
+    send_to_publishing_api
+  end
+
+private
+
+  def send_to_publishing_api
+    Services.publishing_api.put_content(
+      content_id,
+      content_item
+    )
+    Services.publishing_api.publish(content_id)
+  end
+end

--- a/lib/finders/organisation_content.json
+++ b/lib/finders/organisation_content.json
@@ -1,0 +1,45 @@
+{
+  "content_id": "4eeafac0-3a6e-4c8c-967a-4f055845ff3e",
+  "base_path": "/government/organisations/latest",
+  "title": "Latest documents by organisation",
+  "description": "Documents published by organisations.",
+  "locale": "en",
+  "document_type": "finder",
+  "schema_name": "finder",
+  "publishing_app": "collections-publisher",
+  "rendering_app": "finder-frontend",
+  "update_type": "minor",
+  "details": {
+    "document_noun": "organisation",
+    "default_order": "-public_timestamp",
+    "facets": [
+      {
+        "name": "Organisation",
+        "key": "organisations",
+        "short_name": "From",
+        "type": "text",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "preposition": "from"
+      }
+    ],
+    "reject": {
+      "email_document_supertype": ["other"]
+    },
+    "show_summaries": true
+  },
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/government/organisations/latest"
+    },
+    {
+      "type": "exact",
+      "path": "/government/organisations/latest.atom"
+    },
+    {
+      "type": "exact",
+      "path": "/government/organisations/latest.json"
+    }
+  ]
+}

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -16,4 +16,14 @@ namespace :publishing_api do
   task :publish_organisations_api_route do
     PublishOrganisationsApiRoute.new.publish
   end
+
+  desc 'Publish finders to the publishing API'
+  task publish_finders: :environment do
+    Dir[Rails.root + "lib/finders/*.json"].each do |file_path|
+      puts "Publishing #{file_path}"
+
+      content_item = JSON.parse(File.read(file_path))
+      FinderPublisher.call(content_item)
+    end
+  end
 end

--- a/spec/services/finder_publisher_spec.rb
+++ b/spec/services/finder_publisher_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe FinderPublisher do
+  before do
+    allow(Services.publishing_api).to receive(:put_content)
+    allow(Services.publishing_api).to receive(:publish)
+  end
+
+  it "publishes valid finders" do
+    Dir[Rails.root + "lib/finders/*.json"].each do |file_path|
+      finder_item = JSON.parse(File.read(file_path))
+
+      subject = described_class.new(finder_item)
+
+      expect(subject.content_item).to be_valid_against_schema('finder')
+    end
+  end
+
+  it "publishes the finder" do
+    example_finder = JSON.parse(File.read("lib/finders/organisation_content.json"))
+    content_id = example_finder["content_id"]
+
+    described_class.call(example_finder)
+
+    expect(Services.publishing_api).to have_received(:put_content).with(content_id, example_finder)
+    expect(Services.publishing_api).to have_received(:publish).with(content_id)
+  end
+end


### PR DESCRIPTION
This is to replace the ["latest" page](https://www.gov.uk/government/latest?departments%5B%5D=department-for-work-pensions) for an organisation

It's not exactly a like for like because this finder will allow you to find latest content for all orgs using the facet, whereas the previous page would lock you to one org.

This finder doesn't currently have a subscribe to email link on it as it will subscribe users to all content for all orgs.  I've left it off until we can figure out how this might work.

The existing email subscription link on the org page will work as usual.

https://trello.com/c/fSv9RhjE/199-migrate-latest-pages-from-organisations