### PR TITLE
Update latest orgs content finder

### DIFF
--- a/lib/finders/organisation_content.json
+++ b/lib/finders/organisation_content.json
@@ -10,7 +10,7 @@
   "rendering_app": "finder-frontend",
   "update_type": "minor",
   "details": {
-    "document_noun": "organisation",
+    "document_noun": "document",
     "default_order": "-public_timestamp",
     "facets": [
       {

--- a/lib/finders/organisation_content.json
+++ b/lib/finders/organisation_content.json
@@ -24,7 +24,7 @@
       }
     ],
     "reject": {
-      "email_document_supertype": ["other"]
+      "content_purpose_supergroup": ["other"]
     },
     "show_summaries": true
   },


### PR DESCRIPTION
This now matches the [latest documents section](https://github.com/alphagov/collections/blob/63bc6efd0dd673fbab9bef1e22ec6644b325f36f/app/presenters/organisations/documents_presenter.rb#L73) on org pages.

This needs https://github.com/alphagov/govuk-content-schemas/pull/795 to be deployed before it will pass