### PR TITLE
Allow publishers to view draft step-by-steps without signon

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,24 @@ module ApplicationHelper
     Plek.new.external_url_for('content-tagger')
   end
 
-  def preview_url(slug)
-    "#{Plek.new.external_url_for('draft-origin')}/#{slug.sub(/^\//, '')}"
+  def preview_url(slug, auth_bypass_id: nil)
+    url = "#{Plek.new.external_url_for('draft-origin')}/#{slug.sub(/^\//, '')}"
+
+    if auth_bypass_id.present?
+      token = jwt_token(auth_bypass_id)
+      url << "?token=#{token}"
+    end
+
+    url
+  end
+
+private
+
+  def jwt_token(auth_bypass_id)
+    JWT.encode({ 'sub' => auth_bypass_id }, jwt_auth_secret, 'HS256')
+  end
+
+  def jwt_auth_secret
+    Rails.application.config.jwt_auth_secret
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -41,6 +41,21 @@ class StepByStepPage < ApplicationRecord
     redirect_url =~ regex
   end
 
+  # This function first generates a hash from the object id,
+  # then unpacks it to integers,
+  # and then finally interpolates them into a string.
+  # The purpose is to generate a deterministic hash
+  # It mostly rips off SecureRandom.uuid
+  # see http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
+  def auth_bypass_id
+    @_auth_bypass_id ||= begin
+      ary = Digest::SHA256.hexdigest(content_id.to_s).unpack('NnnnnN')
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    end
+  end
+
 private
 
   def generate_content_id

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -6,6 +6,7 @@ class StepNavPresenter
 
   def render_for_publishing_api(publish_intent = PublishIntent.minor_update)
     payload = required_fields
+    payload.merge!(optional_fields)
     payload.merge(publish_intent.present)
   end
 
@@ -29,6 +30,12 @@ private
       schema_name: "step_by_step_nav",
       title: step_nav.title
     }
+  end
+
+  def optional_fields
+    fields = {}
+    fields[:access_limited] = access_limited_tokens if step_nav.has_draft?
+    fields
   end
 
   def base_path
@@ -83,5 +90,9 @@ private
 
   def related_to_step_nav_links
     step_nav.navigation_rules.related_content_ids
+  end
+
+  def access_limited_tokens
+    { auth_bypass_ids: [step_nav.auth_bypass_id] }
   end
 end

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -45,7 +45,7 @@
             <li><%= link_to 'Edit', step_by_step_page %></li>
             <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(step_by_step_page) %></li>
             <% if step_by_step_page.has_draft? %>
-                <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
+                <li><%= link_to 'Preview', preview_url(step_by_step_page.slug, auth_bypass_id: step_by_step_page.auth_bypass_id) %></li>
             <% end %>
             <% unless step_by_step_page.has_been_published? %>
               <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' } %></li>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -21,7 +21,7 @@
 
 <ul class="list-inline step-actions">
   <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>
-  <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug), class: "btn btn-primary" %></li>
+  <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug, auth_bypass_id: @step_by_step_page.auth_bypass_id), class: "btn btn-primary" %></li>
   <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% if @step_by_step_page.steps.length > 0 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,7 @@ module CollectionsPublisher
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.jwt_auth_secret = ENV['JWT_AUTH_SECRET']
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.jwt_auth_secret = '123'
+
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,4 +33,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.jwt_auth_secret = '123'
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#preview_url" do
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
+    let(:step_nav) { create(:step_by_step_page) }
+
+    it "returns a link to the draft content" do
+      expected_url = "#{draft_origin_url}/#{step_nav.slug}"
+
+      expect(helper.preview_url(step_nav.slug)).to eq(expected_url)
+    end
+  end
+
+  def draft_origin_url
+    Plek.new.external_url_for('draft-origin')
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -9,10 +9,23 @@ RSpec.describe ApplicationHelper do
     let(:step_nav) { create(:step_by_step_page) }
 
     it "returns a link to the draft content" do
-      expected_url = "#{draft_origin_url}/#{step_nav.slug}"
-
-      expect(helper.preview_url(step_nav.slug)).to eq(expected_url)
+      expect(helper.preview_url(step_nav.slug)).to eq(expected_step_nav_preview_url)
     end
+
+    it "appends a valid JWT token in the querystring" do
+      allow(step_nav).to receive(:auth_bypass_id) { "123" }
+
+      expected_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.Y_oxQPu1nx1r_LKrdBglDCUo7HD455GdccUMfdEAFJk"
+      expected_url = "#{expected_step_nav_preview_url}?token=#{expected_token}"
+
+      expect(helper.preview_url(step_nav.slug, auth_bypass_id: step_nav.auth_bypass_id)).to eq(expected_url)
+    end
+  end
+
+private
+
+  def expected_step_nav_preview_url
+    "#{draft_origin_url}/#{step_nav.slug}"
   end
 
   def draft_origin_url

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -174,5 +174,10 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.draft_updated_at).to be nil
       expect(step_by_step_page.has_draft?).to be false
     end
+
+    it 'should have a deterministically generated hex string' do
+      step_by_step_with_custom_id = create(:step_by_step_page, content_id: 123, slug: 'slug')
+      expect(step_by_step_with_custom_id.auth_bypass_id).to eq("61363635-6134-4539-b230-343232663964")
+    end
   end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -65,5 +65,30 @@ RSpec.describe StepNavPresenter do
       expect(presented[:update_type]).to eq("major")
       expect(presented[:change_note]).to eq("All your update belong to us")
     end
+
+    describe "#access_limited" do
+      before do
+        allow(step_nav).to receive(:auth_bypass_id) { "123" }
+      end
+
+      it "adds an access limiting token to drafts" do
+        step_nav.mark_draft_updated
+
+        presented = subject.render_for_publishing_api
+        expected_access_limited_tokens = {
+          auth_bypass_ids: ["123"]
+        }
+
+        expect(presented[:access_limited]).to eq(expected_access_limited_tokens)
+      end
+
+      it "doesn't add an access limiting token when publishing" do
+        step_nav.mark_as_published
+
+        presented = subject.render_for_publishing_api
+
+        expect(presented[:access_limited]).to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/9ZMVHe0u

## Motivation
Nearly all of the step-by-steps that are created need to be reviewed by people in departments who don't have signon access.  Content designers have been getting around this limitation by following a complicated process to create a preview app to send to factcheckers, but this process will become harder to support as more and more step-by-steps are created.

There is already a pattern used by Mainstream and Whitehall publishers that allows a list of `auth_bypass_ids` to be passed into the payload sent to publishing-api. This id is used by [authenticating-proxy](https://github.com/alphagov/authenticating-proxy) to decode a query string passed into the URL of the draft step-by-step. If the ids match, the user can view the content, otherwise, they will be asked to sign in.

## Tech debt
The code used to create the auth_bypass_id and JWT token passed into the query string are duplicated from Publisher:

* https://github.com/alphagov/publisher/blob/master/app/helpers/paths_helper.rb#L30
* https://github.com/alphagov/publisher/blob/master/app/models/edition.rb

A [card](https://trello.com/c/GcmcoPY0) has been added to the backlog to address this.