### PR TITLE
Allow publishers to view draft step-by-steps without signon

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,6 @@ module ApplicationHelper
   end
 
   def preview_url(slug)
-    "#{Plek.new.external_url_for('draft-origin')}/#{slug.sub(/^\//, '')}"
+    "#{Services.draft_origin}/#{slug.sub(/^\//, '')}"
   end
 end

--- a/app/helpers/jwt_helper.rb
+++ b/app/helpers/jwt_helper.rb
@@ -13,4 +13,19 @@ module JwtHelper
       "%08x-%04x-%04x-%04x-%04x%08x" % ary
     end
   end
+
+  def access_limited_preview_url(slug, auth_bypass_id)
+    token = jwt_token(auth_bypass_id)
+    "#{Services.draft_origin}/#{slug.sub(/^\//, '')}?token=#{token}"
+  end
+
+private
+
+  def jwt_token(auth_bypass_id)
+    JWT.encode({ 'sub' => auth_bypass_id }, jwt_auth_secret, 'HS256')
+  end
+
+  def jwt_auth_secret
+    ENV['JWT_AUTH_SECRET']
+  end
 end

--- a/app/helpers/jwt_helper.rb
+++ b/app/helpers/jwt_helper.rb
@@ -1,0 +1,16 @@
+module JwtHelper
+  # Create a deterministic, but unique token that will be used to give one-time
+  # access to a piece of draft content.
+  # This token is created by using an id that should be unique so that there is
+  # little chance of the same token being created to view another piece of content.
+  # The code to create the token has been "borrowed" from SecureRandom.uuid,
+  # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
+  def auth_bypass_token(id)
+    @_auth_bypass_id ||= begin
+      ary = Digest::SHA256.hexdigest(id.to_s).unpack('NnnnnN')
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    end
+  end
+end

--- a/app/helpers/jwt_helper.rb
+++ b/app/helpers/jwt_helper.rb
@@ -1,19 +1,4 @@
 module JwtHelper
-  # Create a deterministic, but unique token that will be used to give one-time
-  # access to a piece of draft content.
-  # This token is created by using an id that should be unique so that there is
-  # little chance of the same token being created to view another piece of content.
-  # The code to create the token has been "borrowed" from SecureRandom.uuid,
-  # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
-  def auth_bypass_token(id)
-    @_auth_bypass_id ||= begin
-      ary = Digest::SHA256.hexdigest(id.to_s).unpack('NnnnnN')
-      ary[2] = (ary[2] & 0x0fff) | 0x4000
-      ary[3] = (ary[3] & 0x3fff) | 0x8000
-      "%08x-%04x-%04x-%04x-%04x%08x" % ary
-    end
-  end
-
   def access_limited_preview_url(slug, auth_bypass_id)
     token = jwt_token(auth_bypass_id)
     "#{Services.draft_origin}/#{slug.sub(/^\//, '')}?token=#{token}"

--- a/app/lib/jwt_helper.rb
+++ b/app/lib/jwt_helper.rb
@@ -1,0 +1,16 @@
+class JwtHelper
+  def self.access_limited_preview_url(url, auth_bypass_id)
+    token = jwt_token(auth_bypass_id)
+    "#{url}?token=#{token}"
+  end
+
+private
+
+  def jwt_token(auth_bypass_id)
+    JWT.encode({ 'sub' => auth_bypass_id }, jwt_auth_secret, 'HS256')
+  end
+
+  def jwt_auth_secret
+    ENV['JWT_AUTH_SECRET']
+  end
+end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -16,4 +16,8 @@ module Services
       disable_cache: true
     )
   end
+
+  def self.draft_origin
+    @draft_origin ||= Plek.new.external_url_for('draft-origin')
+  end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,4 +1,6 @@
 class StepByStepPage < ApplicationRecord
+  include JwtHelper
+
   has_many :navigation_rules, -> { order(title: :asc) }, dependent: :destroy
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
@@ -39,6 +41,10 @@ class StepByStepPage < ApplicationRecord
   def self.validate_redirect(redirect_url)
     regex = /\A\/([a-z0-9]+-)*[a-z0-9]+\z/
     redirect_url =~ regex
+  end
+
+  def auth_bypass_id
+    @_auth_bypass_id ||= auth_bypass_token(content_id)
   end
 
 private

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,6 +1,4 @@
 class StepByStepPage < ApplicationRecord
-  include JwtHelper
-
   has_many :navigation_rules, -> { order(title: :asc) }, dependent: :destroy
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
 
@@ -43,8 +41,19 @@ class StepByStepPage < ApplicationRecord
     redirect_url =~ regex
   end
 
+  # Create a deterministic, but unique token that will be used to give one-time
+  # access to a piece of draft content.
+  # This token is created by using an id that should be unique so that there is
+  # little chance of the same token being created to view another piece of content.
+  # The code to create the token has been "borrowed" from SecureRandom.uuid,
+  # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
   def auth_bypass_id
-    @_auth_bypass_id ||= auth_bypass_token(content_id)
+    @_auth_bypass_id ||= begin
+      ary = Digest::SHA256.hexdigest(content_id.to_s).unpack('NnnnnN')
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    end
   end
 
 private

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -6,6 +6,7 @@ class StepNavPresenter
 
   def render_for_publishing_api(publish_intent = PublishIntent.minor_update)
     payload = required_fields
+    payload.merge!(optional_fields)
     payload.merge(publish_intent.present)
   end
 
@@ -29,6 +30,12 @@ private
       schema_name: "step_by_step_nav",
       title: step_nav.title
     }
+  end
+
+  def optional_fields
+    fields = {}
+    fields[:access_limited] = access_limited_tokens if step_nav.has_draft?
+    fields
   end
 
   def base_path
@@ -83,5 +90,9 @@ private
 
   def related_to_step_nav_links
     step_nav.navigation_rules.related_content_ids
+  end
+
+  def access_limited_tokens
+    { auth_bypass_ids: [step_nav.auth_bypass_id] }
   end
 end

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -45,7 +45,7 @@
             <li><%= link_to 'Edit', step_by_step_page %></li>
             <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(step_by_step_page) %></li>
             <% if step_by_step_page.has_draft? %>
-                <li><%= link_to 'Preview', preview_url(step_by_step_page.slug) %></li>
+                <li><%= link_to 'Preview', access_limited_preview_url(step_by_step_page.slug, step_by_step_page.auth_bypass_id) %></li>
             <% end %>
             <% unless step_by_step_page.has_been_published? %>
               <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' } %></li>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -21,7 +21,7 @@
 
 <ul class="list-inline step-actions">
   <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>
-  <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug), class: "btn btn-primary" %></li>
+  <li><%= link_to 'Preview', access_limited_preview_url(@step_by_step_page.slug, @step_by_step_page.auth_bypass_id), class: "btn btn-primary" %></li>
   <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% if @step_by_step_page.steps.length > 0 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,9 @@ module CollectionsPublisher
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    unless Rails.env.production?
+      ENV['JWT_AUTH_SECRET'] = '123'
+    end
   end
 end

--- a/spec/helpers/jwt_helper_spec.rb
+++ b/spec/helpers/jwt_helper_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe JwtHelper do
+  describe "#auth_bypass_token" do
+    it 'should create a predictable hex string based on the id' do
+      expect(auth_bypass_token(123)).to eq("61363635-6134-4539-b230-343232663964")
+    end
+  end
+end

--- a/spec/helpers/jwt_helper_spec.rb
+++ b/spec/helpers/jwt_helper_spec.rb
@@ -6,4 +6,15 @@ RSpec.describe JwtHelper do
       expect(auth_bypass_token(123)).to eq("61363635-6134-4539-b230-343232663964")
     end
   end
+
+  describe "#access_limited_preview_url" do
+    it "appends a valid JWT token in the querystring" do
+      slug = "step-nav-slug"
+
+      expected_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEyM30.xTbOwaYOmzgd16a-cMrkBIeB5lY7qneU66rqFTwTKPw"
+      expected_url = "#{Services.draft_origin}/#{slug}?token=#{expected_token}"
+
+      expect(access_limited_preview_url(slug, 123)).to eq(expected_url)
+    end
+  end
 end

--- a/spec/helpers/jwt_helper_spec.rb
+++ b/spec/helpers/jwt_helper_spec.rb
@@ -1,12 +1,6 @@
 require "rails_helper"
 
 RSpec.describe JwtHelper do
-  describe "#auth_bypass_token" do
-    it 'should create a predictable hex string based on the id' do
-      expect(auth_bypass_token(123)).to eq("61363635-6134-4539-b230-343232663964")
-    end
-  end
-
   describe "#access_limited_preview_url" do
     it "appends a valid JWT token in the querystring" do
       slug = "step-nav-slug"

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -174,5 +174,10 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.draft_updated_at).to be nil
       expect(step_by_step_page.has_draft?).to be false
     end
+
+    it 'should have a deterministically generated hex string' do
+      step_by_step_with_custom_id = create(:step_by_step_page, content_id: 123, slug: 'slug')
+      expect(step_by_step_with_custom_id.auth_bypass_id).to eq("61363635-6134-4539-b230-343232663964")
+    end
   end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -65,5 +65,30 @@ RSpec.describe StepNavPresenter do
       expect(presented[:update_type]).to eq("major")
       expect(presented[:change_note]).to eq("All your update belong to us")
     end
+
+    describe "#access_limited" do
+      before do
+        allow(step_nav).to receive(:auth_bypass_id) { "123" }
+      end
+
+      it "adds an access limiting token to drafts" do
+        step_nav.mark_draft_updated
+
+        presented = subject.render_for_publishing_api
+        expected_access_limited_tokens = {
+          auth_bypass_ids: ["123"]
+        }
+
+        expect(presented[:access_limited]).to eq(expected_access_limited_tokens)
+      end
+
+      it "doesn't add an access limiting token when publishing" do
+        step_nav.mark_as_published
+
+        presented = subject.render_for_publishing_api
+
+        expect(presented[:access_limited]).to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/9ZMVHe0u

## Motivation
Nearly all of the step-by-steps that are created need to be reviewed by people in departments who don't have signon access.  Content designers have been getting around this limitation by following a complicated process to create a preview app to send to factcheckers, but this process will become harder to support as more and more step-by-steps are created.

There is already a pattern used by Mainstream and Whitehall publishers that allows a list of `auth_bypass_ids` to be passed into the payload sent to publishing-api. This id is used by [authenticating-proxy](https://github.com/alphagov/authenticating-proxy) to decode a query string passed into the URL of the draft step-by-step. If the ids match, the user can view the content, otherwise, they will be asked to sign in.

## Tech debt
The code used to create the auth_bypass_id and JWT token passed into the query string are duplicated from Publisher:

* https://github.com/alphagov/publisher/blob/master/app/helpers/paths_helper.rb#L30
* https://github.com/alphagov/publisher/blob/master/app/models/edition.rb

A [card](https://trello.com/c/GcmcoPY0) has been added to the backlog to address this.