### PR TITLE
Add status to step by step index page

### DIFF
--- a/app/assets/javascripts/steps.js
+++ b/app/assets/javascripts/steps.js
@@ -12,6 +12,7 @@
       this.bindReorderButtonClicks();
       this.initialiseDragAndDrop();
       this.setOrder(); // this is called so the order of the list is initalised
+      this.bindStatusClicks();
     },
 
     addReorderButtons: function() {
@@ -87,6 +88,21 @@
       // so that user does not accidently select text
       // while trying to do drag and drop
       $('#js-reorder-group').disableSelection();
+    },
+
+    // handles the filtering of step navs based on their status
+    // e.g. 'published'
+    bindStatusClicks: function() {
+      $('#filterStatus a').on('click', function(e){
+        e.preventDefault();
+        var show = $(this).data('show');
+        if (show === 'all') {
+          $('tr[data-status]').show();
+        } else {
+          $('tr[data-status]').hide();
+          $('tr[data-status="' + show + '"').show();
+        }
+      });
     }
   };
 }());

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -2,8 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-p.step-actions,
-ul.step-actions {
+.step-actions {
   padding: 15px 0;
 }
 

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -41,6 +41,12 @@ class StepByStepPage < ApplicationRecord
     redirect_url =~ regex
   end
 
+  def status
+    return unpublished_status if has_draft? && has_been_published?
+    return live_status if has_been_published?
+    draft_status
+  end
+
   # Create a deterministic, but unique token that will be used to give one-time
   # access to a piece of draft content.
   # This token is created by using an id that should be unique so that there is
@@ -60,5 +66,29 @@ private
 
   def generate_content_id
     self.content_id ||= SecureRandom.uuid
+  end
+
+  def draft_status
+    {
+      name: "draft",
+      text: "Draft",
+      label_class: "label-default"
+    }
+  end
+
+  def live_status
+    {
+      name: "live",
+      text: "Live",
+      label_class: "label-success"
+    }
+  end
+
+  def unpublished_status
+    {
+      name: "unpublished_changes",
+      text: "Unpublished changes",
+      label_class: "label-primary"
+    }
   end
 end

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -14,17 +14,35 @@
 
 <h1>Step by step navigation publisher</h1>
 
-<p class="step-actions">
-  <%= link_to 'Create new', new_step_by_step_page_path, class: "btn btn-primary" %>
-</p>
+<div class="row step-actions">
+  <div class="col-xs-6 col-md-6">
+    <%= link_to 'Create new', new_step_by_step_page_path, class: "btn btn-primary" %>
+  </div>
+
+  <div class="col-xs-6 col-md-6">
+    <div class="dropdown pull-right">
+      <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Filter by status
+        <span class="caret"></span>
+      </button>
+
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="filterStatus">
+        <li><a href="#" data-show="all">All</a></li>
+        <li><a href="#" data-show="draft">Draft</a></li>
+        <li><a href="#" data-show="live">Live</a></li>
+        <li><a href="#" data-show="unpublished_changes">Unpublished changes</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
 
 <table class="table table-striped" data-module="filterable-table">
   <thead>
     <tr>
       <th colspan="4">
-      <div class='filter-control'>
-        <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a step by step page here' } %>
-      </div>
+        <div class='filter-control'>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a step by step page here' } %>
+        </div>
       </th>
     </tr>
     <tr>
@@ -37,7 +55,7 @@
 
   <tbody>
     <% @step_by_step_pages.each do |step_by_step_page| %>
-      <tr>
+      <tr data-status="<%= step_by_step_page.status[:name] %>">
         <th>
           <%= step_by_step_page.title %>
         </th>

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -21,7 +21,7 @@
 <table class="table table-striped" data-module="filterable-table">
   <thead>
     <tr>
-      <th colspan="3">
+      <th colspan="4">
       <div class='filter-control'>
         <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a step by step page here' } %>
       </div>
@@ -31,6 +31,7 @@
       <th>Title</th>
       <th>Actions</th>
       <th>Slug</th>
+      <th class="text-right">Status</th>
     </tr>
   </thead>
 
@@ -54,6 +55,11 @@
         </td>
         <td>
           <%= step_by_step_page.slug %>
+        </td>
+        <td class="text-right">
+          <span class="h4">
+            <span class="label <%= step_by_step_page.status[:label_class] %>" title="<%= step_by_step_page.status[:text] %>"><%= step_by_step_page.status[:text] %></span>
+          </span>
         </td>
       </tr>
     <% end %>

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -179,5 +179,14 @@ RSpec.describe StepByStepPage do
       step_by_step_with_custom_id = create(:step_by_step_page, content_id: 123, slug: 'slug')
       expect(step_by_step_with_custom_id.auth_bypass_id).to eq("61363635-6134-4539-b230-343232663964")
     end
+
+    it 'should have a status of unpublished if published and then changes are made' do
+      step_by_step_page.mark_as_published
+
+      Timecop.freeze(Date.today + 1) do
+        step_by_step_page.mark_draft_updated
+        expect(step_by_step_page.status[:name]).to eq('unpublished_changes')
+      end
+    end
   end
 end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe StepByStepPage do
 
         expect(step_by_step_page.draft_updated_at).to be_within(1.second).of nowish
         expect(step_by_step_page.has_draft?).to be true
+        expect(step_by_step_page.status[:name]).to eq('draft')
       end
     end
 
@@ -163,6 +164,7 @@ RSpec.describe StepByStepPage do
         expect(step_by_step_page.published_at).to eq(step_by_step_page.draft_updated_at)
         expect(step_by_step_page.has_been_published?).to be true
         expect(step_by_step_page.has_draft?).to be false
+        expect(step_by_step_page.status[:name]).to eq('live')
       end
     end
 


### PR DESCRIPTION
- adds a status for a step by step navigation to the step by step navigation publishing interface
- status can be draft, published, or unpublished changes (i.e. has been published and since edited)

![screen shot 2018-07-26 at 11 26 27](https://user-images.githubusercontent.com/861310/43257125-c624d512-90c6-11e8-97f1-0e96875d11f4.png)

Trello cards: 

- https://trello.com/c/lgxjhPT6/750-display-status-of-step-by-step-on-index-page
- https://trello.com/c/1hRIjqY9/578-improve-search-and-filtering-functionality
