### PR TITLE
Change position of Publish, Delete and Preview buttons

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -24,6 +24,16 @@ pre.markdown-example {
   white-space: pre-wrap;
 }
 
+.nav.step-by-step-tabs {
+  margin-bottom: 2em;
+
+  @media screen and (min-width: 769px) and (max-width: 1000px) {
+    .step-by-step-tab-link {
+      min-height: 60px;
+    }
+  }
+}
+
 .table-stepnav-rules .checkbox,
 .table-stepnav-rules .checkbox label {
   margin-top: 0;

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -58,3 +58,16 @@ pre.markdown-example {
   border: 1px dashed #0B0C0C;
   border-radius: 4px;
 }
+
+.publish-or-delete .panel {
+  padding: 5px;
+  background-color: #f8f8f8;
+}
+
+.publish-or-delete .publish-button {
+  margin: 10px 0 10px;
+}
+
+.publish-or-delete .panel.delete-or-unpublish-panel {
+  border-left: 10px #b10e1e solid;
+}

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -6,6 +6,10 @@
   padding: 15px 0;
 }
 
+.step-by-step-actions .step-action {
+  margin-bottom: 15px;
+}
+
 pre.markdown-example {
   white-space: pre-wrap;
 }

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -88,6 +88,10 @@ class StepByStepPagesController < ApplicationController
     end
   end
 
+  def publish_or_delete
+    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
+  end
+
 private
 
   def discard_draft

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -25,6 +25,8 @@
   action: 'Choose on-page side navigation'
 %>
 
+<%= render 'step_by_step_pages/nav', step_by_step_page: @step_by_step_page, active: "choose-navigation" %>
+
 <%= form_for(step_by_step_page_navigation_rules_path(@step_by_step_page), method: :put) do |form| %>
 
   <table class="table table-striped table-stepnav-rules" data-module="filterable-table">

--- a/app/views/shared/steps/_form_notice.html.erb
+++ b/app/views/shared/steps/_form_notice.html.erb
@@ -4,7 +4,7 @@
 %>
 <% if message %>
   <div class="row">
-    <div class="col-md-7">
+    <div class="col-md-12">
       <div class="alert <%= status %>" role="alert">
         <%= message %>
       </div>

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -31,7 +31,7 @@
   </div>
 
   <div class="form-group">
-    <%= form.submit "Save and continue", class: "btn btn-primary" %>
+    <%= form.submit "Save", class: "btn btn-primary" %>
   </div>
   <div class="form-group">
     <%= link_to 'Cancel', @step_by_step_page %>

--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -19,4 +19,7 @@
   <li class="<%= "active" if active == 'choose-navigation' %>">
     <%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "step-by-step-tab-link" %>
   </li>
+  <li class="<%= "active" if active == 'publish-or-delete' %>">
+    <%= link_to 'Publish or delete', step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "step-by-step-tab-link" %>
+  </li>
 </ul>

--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -1,0 +1,22 @@
+<% 
+  unless defined? active
+    active = ''
+  end
+%>
+
+<ul class="nav nav-tabs nav-justified step-by-step-tabs">
+  <li class="<%= "active" if active == 'edit-steps' %>">
+    <%= link_to 'Edit steps', @step_by_step_page, class: "step-by-step-tab-link" %>
+  </li>
+  <% if @step_by_step_page.steps.length > 0 %>
+    <li class="<%= "active" if active == 'reorder-steps' %>">
+        <%= link_to "Reorder steps", step_by_step_page_reorder_path(@step_by_step_page), class: "step-by-step-tab-link" %>
+    </li>
+  <% end %>
+  <li class="<%= "active" if active == 'edit-title' %>">
+    <%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "step-by-step-tab-link" %>
+  </li>
+  <li class="<%= "active" if active == 'choose-navigation' %>">
+    <%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "step-by-step-tab-link" %>
+  </li>
+</ul>

--- a/app/views/step_by_step_pages/edit.html.erb
+++ b/app/views/step_by_step_pages/edit.html.erb
@@ -23,4 +23,6 @@
   action: 'Edit step by step navigation'
 %>
 
+<%= render 'nav', step_by_step_page: @step_by_step_page, active: "edit-title" %>
+
 <%= render 'form', step_by_step_page: @step_by_step_page %>

--- a/app/views/step_by_step_pages/edit.html.erb
+++ b/app/views/step_by_step_pages/edit.html.erb
@@ -9,7 +9,7 @@
       href: @step_by_step_page
     },
     {
-      text: 'Edit nav'
+      text: 'Edit title, intro or slug'
     }
   ]
 %>
@@ -20,7 +20,7 @@
 
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
-  action: 'Edit step by step navigation'
+  action: 'Edit title, intro or slug'
 %>
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active: "edit-title" %>

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -1,0 +1,48 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: 'Publish or delete'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Publish or delete'
+%>
+
+<%= render 'nav', step_by_step_page: @step_by_step_page, active:"publish-or-delete" %>
+
+<div class="row publish-or-delete">
+  <div class="col-md-12">
+    <% if @step_by_step_page.has_draft? %>
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <%= link_to 'Publish changes', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary publish-button" %>
+          <p>You will need to tag this step by step to a mainstream browse category and a taxonomy topic after publishing</p>
+        </div>
+      </div>
+    <% end %>
+    <div class="panel panel-danger delete-or-unpublish-panel">
+      <div class="panel-body">
+        <% if @step_by_step_page.has_been_published? %>
+          <%= link_to 'Unpublish step by step', step_by_step_page_unpublish_path(@step_by_step_page), class: "btn btn-danger" %>
+        <% else %>
+          <p class="text-danger"><strong>Warning</strong></p>
+          <p>Deleted step by steps cannot be recovered.</p>
+          <%= link_to 'Delete step by step', @step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' }, class: "btn btn-danger" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/step_by_step_pages/reorder.html.erb
+++ b/app/views/step_by_step_pages/reorder.html.erb
@@ -23,6 +23,8 @@
   action: 'Reorder steps'
 %>
 
+<%= render 'nav', step_by_step_page: @step_by_step_page, active: "reorder-steps" %>
+
 <div class="row">
   <div class="col-md-7">
     <p>Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.</p>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -60,19 +60,8 @@
             </td>
           </tr>
         <% end %>
-
       </tbody>
     </table>
-    <ul class="list-inline publish-actions">
-      <% if @step_by_step_page.has_been_published? %>
-        <li><%= link_to 'Unpublish', step_by_step_page_unpublish_path(@step_by_step_page), class: "btn btn-danger" %></li>
-      <% else %>
-        <li><%= link_to 'Delete', @step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' }, class: "btn btn-danger" %></li>
-      <% end %>
-      <% if @step_by_step_page.has_draft? %>
-        <li><%= link_to 'Publish', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary" %></li>
-      <% end %>
-    </ul>
     <div class="col-md-2 col-md-offset-10">
       <ul class="list-unstyled step-by-step-actions text-right">
         <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary btn-block step-action" %></li>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -25,7 +25,7 @@
 <%= render 'nav', step_by_step_page: @step_by_step_page, active:"edit-steps" %>
 
 <div class="row">
-  <div class="col-md-7">
+  <div class="col-md-12">
     <table class="table">
       <thead>
         <tr>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -17,7 +17,10 @@
 
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
-<h1><%= @step_by_step_page.title %></h1>
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Edit steps'
+%>
 
 <ul class="list-inline step-actions">
   <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -22,13 +22,7 @@
   action: 'Edit steps'
 %>
 
-<ul class="list-inline step-actions">
-  <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-primary" %></li>
-  <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "btn btn-primary" %></li>
-  <% if @step_by_step_page.steps.length > 0 %>
-    <li><%= link_to "Reorder steps", step_by_step_page_reorder_path(@step_by_step_page), class: "btn btn-primary" %></li>
-  <% end %>
-</ul>
+<%= render 'nav', step_by_step_page: @step_by_step_page, active:"edit-steps" %>
 
 <div class="row">
   <div class="col-md-7">

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -23,8 +23,6 @@
 %>
 
 <ul class="list-inline step-actions">
-  <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary" %></li>
-  <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug, auth_bypass_id: @step_by_step_page.auth_bypass_id), class: "btn btn-primary" %></li>
   <li><%= link_to 'Edit title, intro or slug', edit_step_by_step_page_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <li><%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "btn btn-primary" %></li>
   <% if @step_by_step_page.steps.length > 0 %>
@@ -81,5 +79,11 @@
         <li><%= link_to 'Publish', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary" %></li>
       <% end %>
     </ul>
+    <div class="col-md-2 col-md-offset-10">
+      <ul class="list-unstyled step-by-step-actions text-right">
+        <li><%= link_to 'Add a new step', new_step_by_step_page_step_path(@step_by_step_page), class: "btn btn-primary btn-block step-action" %></li>
+        <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug, auth_bypass_id: @step_by_step_page.auth_bypass_id), class: "btn btn-success btn-block preview-button step-action" %></li>
+      </ul>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     post :reorder
     get :unpublish
     post :unpublish
+    get  'publish-or-delete', to: 'publish_or_delete'
 
     resources :steps
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature "Managing step by step pages" do
     fill_in "Introduction", with: "Learn how you can bake a cake"
     fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
 
-    click_on "Save and continue"
+    click_on "Save"
   end
 
   def and_I_fill_in_the_edit_form
@@ -140,7 +140,7 @@ RSpec.feature "Managing step by step pages" do
     fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
 
     expect_update_worker
-    click_on "Save and continue"
+    click_on "Save"
   end
 
   def and_I_fill_in_the_form_with_a_taken_slug
@@ -149,7 +149,7 @@ RSpec.feature "Managing step by step pages" do
     fill_in "Introduction", with: "Learn how you can bake a cake"
     fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
 
-    click_on "Save and continue"
+    click_on "Save"
   end
 
   def then_I_see_the_new_step_by_step_page
@@ -177,7 +177,7 @@ RSpec.feature "Managing step by step pages" do
     fill_in "Slug", with: ""
     fill_in "Introduction", with: ""
     fill_in "Meta description", with: ""
-    click_on "Save and continue"
+    click_on "Save"
   end
 
   def then_I_see_a_validation_error

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Managing step by step pages" do
   scenario "User creates a new step by step page" do
     when_I_visit_the_new_step_by_step_form
     and_I_fill_in_the_form
-    then_I_see_delete_and_publish_buttons
+    and_I_see_a_page_created_success_notice
     when_I_visit_the_step_by_step_pages_index
     then_I_see_the_new_step_by_step_page
   end
@@ -47,17 +47,21 @@ RSpec.feature "Managing step by step pages" do
 
   scenario "User publishes a page" do
     given_there_is_a_step_by_step_page_with_steps
+    when_I_view_the_step_by_step_page
+    and_I_visit_the_publish_or_delete_page
     and_I_visit_the_publish_page
     and_I_publish_the_page
     then_the_page_is_published
     and_I_am_told_that_it_is_published
     then_I_see_the_step_by_step_page
+    and_I_visit_the_publish_or_delete_page
     and_I_see_an_unpublish_button
   end
 
   scenario "User unpublishes a step by step page with a valid redirect url" do
     given_there_is_a_published_step_by_step_page
     when_I_view_the_step_by_step_page
+    and_I_visit_the_publish_or_delete_page
     when_I_want_to_unpublish_the_page
     and_I_fill_in_the_form_with_a_valid_url
     then_the_page_is_unpublished
@@ -67,6 +71,7 @@ RSpec.feature "Managing step by step pages" do
   scenario "User unpublishes a step by step page with an invalid redirect url" do
     given_there_is_a_published_step_by_step_page
     when_I_view_the_step_by_step_page
+    and_I_visit_the_publish_or_delete_page
     when_I_want_to_unpublish_the_page
     and_I_fill_in_the_form_with_an_invalid_url
     then_I_see_that_the_url_isnt_valid
@@ -113,6 +118,10 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Step by step page was successfully unpublished.")
   end
 
+  def and_I_see_a_page_created_success_notice
+    expect(page).to have_content("Step by step page was successfully created.")
+  end
+
   def when_I_view_the_step_by_step_page
     visit step_by_step_page_path(@step_by_step_page)
   end
@@ -123,6 +132,10 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_the_step_by_step_page
     expect(page).to have_content("How to be amazing")
+  end
+
+  def and_I_visit_the_publish_or_delete_page
+    visit step_by_step_page_publish_or_delete_path(@step_by_step_page)
   end
 
   def and_I_fill_in_the_form
@@ -157,17 +170,17 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def then_I_see_delete_and_publish_buttons
-    within(".publish-actions") do
-      expect(page).to have_css("a", text: "Delete")
-      expect(page).to have_css("a", text: "Publish")
+    within(".publish-or-delete") do
+      expect(page).to have_css("a", text: "Delete step by step")
+      expect(page).to have_css("a", text: "Publish changes")
       expect(page).to_not have_css("a", text: "Unpublish")
     end
   end
 
   def and_I_see_an_unpublish_button
-    within(".publish-actions") do
-      expect(page).to_not have_css("a", text: "Delete")
-      expect(page).to_not have_css("a", text: "Publish")
+    within(".publish-or-delete") do
+      expect(page).to_not have_css("a", text: "Delete step by step")
+      expect(page).to_not have_css("a", text: "Publish changes")
       expect(page).to have_css("a", text: "Unpublish")
     end
   end


### PR DESCRIPTION
## Changes
- Changes the position of the publish, delete and preview buttons

The position of the "Delete" Button on the Step by step overview page makes it feel like the default button to click.

We should reorder the buttons so that publishers don't keep clicking on Delete by accident.

## Preview
![jul-30-2018 16-36-23](https://user-images.githubusercontent.com/4599889/43407763-7fbcb4f6-9417-11e8-8f32-b107b93284b8.gif)



Ticket: https://trello.com/c/3HrLsnG4/728-change-position-of-publish-delete-and-preview-buttons
