### PR TITLE
Remove the 'Delete' action from the Step by step list page (S)

### DIFF
--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -66,9 +66,6 @@
             <% if step_by_step_page.has_draft? %>
                 <li><%= link_to 'Preview', preview_url(step_by_step_page.slug, auth_bypass_id: step_by_step_page.auth_bypass_id) %></li>
             <% end %>
-            <% unless step_by_step_page.has_been_published? %>
-              <li><%= link_to 'Delete', step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' } %></li>
-            <% end %>
           </ul>
         </td>
         <td>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -45,14 +45,6 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_the_new_step_by_step_page
   end
 
-  scenario "User deletes a step by step page", js: true do
-    given_there_is_a_step_by_step_page_with_steps
-    and_I_visit_the_index_page
-    and_I_delete_the_step_by_step_page
-    then_the_draft_is_discarded
-    and_the_page_is_deleted
-  end
-
   scenario "User publishes a page" do
     given_there_is_a_step_by_step_page_with_steps
     and_I_visit_the_publish_page
@@ -121,12 +113,6 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Step by step page was successfully unpublished.")
   end
 
-  def and_I_delete_the_step_by_step_page
-    accept_confirm do
-      click_on "Delete"
-    end
-  end
-
   def when_I_view_the_step_by_step_page
     visit step_by_step_page_path(@step_by_step_page)
   end
@@ -184,10 +170,6 @@ RSpec.feature "Managing step by step pages" do
       expect(page).to_not have_css("a", text: "Publish")
       expect(page).to have_css("a", text: "Unpublish")
     end
-  end
-
-  def and_the_page_is_deleted
-    expect(page).to_not have_content("How to bake a cake")
   end
 
   def and_I_fill_in_the_form_with_invalid_data

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -16,10 +16,6 @@ module StepNavSteps
     assert_publishing_api_put_content(@step_by_step_page.content_id)
   end
 
-  def then_the_draft_is_discarded
-    assert_publishing_api_discard_draft(@step_by_step_page.content_id)
-  end
-
   def then_the_page_is_published
     payload = StepNavPresenter.new(@step_by_step_page).render_for_publishing_api
     stub_publishing_api_put_content_links_and_publish(payload, @step_by_step_page.content_id)


### PR DESCRIPTION
## What
We should remove the 'Delete' link from the list of actions on the Step by step list page: https://collections-publisher.integration.publishing.service.gov.uk/step-by-step-pages

## Why
Deleting a step by step could removes live content from the site, this is now handled in Publish tab.

## Changes
- Delete link removed from list page
- Tests for delete link removed

Ticket:
https://trello.com/c/kzy3S0gN/761-remove-the-delete-action-from-the-step-by-step-list-page-s