### PR TITLE
Display summary of broken links on edit steps page

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,5 +1,6 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/content_store'
+require 'gds_api/link_checker_api'
 
 module Services
   def self.publishing_api
@@ -15,5 +16,9 @@ module Services
       Plek.new.find('content-store'),
       disable_cache: true
     )
+  end
+
+  def self.link_checker_api
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(Plek.new.find("link-checker-api"))
   end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,4 +2,28 @@ class Step < ApplicationRecord
   belongs_to :step_by_step_page
   validates_presence_of :step_by_step_page
   validates :title, :logic, presence: true
+
+  def broken_links
+    collect_broken_links unless most_recent_batch.nil?
+  end
+
+private
+
+  def collect_broken_links
+    batch_link_report.links.keep_if do |link|
+      link.fetch('status') == 'broken'
+    end
+  end
+
+  def batch_link_report
+    @batch_link_report ||= Services.link_checker_api.get_batch(batch_link_report_id)
+  end
+
+  def batch_link_report_id
+    most_recent_batch.batch_id
+  end
+
+  def most_recent_batch
+    LinkReport.where(step_id: self.id).last
+  end
 end

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -59,6 +59,11 @@
 </div>
 
 <div class="form-group">
+  <div>
+    <p>
+      <%= step.broken_links %>
+    </p>
+  </div>
   <div class="row">
     <div class="<%= left_col %>">
       <%= form.text_area :contents, class: "form-control", label: "Content, tasks and links in this step", rows: 8 %>

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/link_checker_api'
 
 RSpec.describe Step do
+  include GdsApi::TestHelpers::LinkCheckerApi
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
   end
@@ -36,6 +38,90 @@ RSpec.describe Step do
 
       expect(step_item).not_to be_valid
       expect(step_item.errors).to have_key(:logic)
+    end
+  end
+  describe 'broken_links' do
+    it 'should return nothing if there are no link reports yet' do
+      expect(step_item.broken_links).to be_nil
+    end
+
+    it 'should return an empty array if there are link reports, but all the links work' do
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+      link_checker_api_get_batch(
+        id: 2,
+        links: [
+          {
+            "uri": "https://www.gov.uk/",
+            "status": "ok",
+            "checked": "2017-04-12T18:47:16Z",
+            "errors": [],
+            "warnings": [],
+            "problem_summary": "null",
+            "suggested_fix": "null"
+          }
+        ]
+      )
+      expect(step_item.broken_links).to eql []
+    end
+
+    it 'should return a batch report if there is one with a matching id and it contains a broken link' do
+      link_checker_api_get_batch(
+        id: 2,
+        links: [
+          {
+            "uri": "https://www.gov.uk/",
+            "status": "ok",
+            "checked": "2017-04-12T18:47:16Z",
+            "errors": [],
+            "warnings": [],
+            "problem_summary": "null",
+            "suggested_fix": "null"
+          },
+          {
+            "uri": "https://www.gov.uk/404",
+            "status": "broken",
+            "checked": "2017-04-12T16:30:39Z",
+            "errors": [
+              "Received 404 response from the server."
+            ],
+            "warnings": [],
+            "problem_summary": "404 error (page not found)",
+            "suggested_fix": ""
+          }
+        ]
+        )
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+      expect(step_item.broken_links).to_not be_empty
+    end
+
+    it 'should contain one item if there are link reports and at least one is broken' do
+      link_checker_api_get_batch(
+        id: 2,
+        links: [
+          {
+            "uri": "https://www.gov.uk/",
+            "status": "ok",
+            "checked": "2017-04-12T18:47:16Z",
+            "errors": [],
+            "warnings": [],
+            "problem_summary": "null",
+            "suggested_fix": "null"
+          },
+          {
+            "uri": "https://www.gov.uk/404",
+            "status": "broken",
+            "checked": "2017-04-12T16:30:39Z",
+            "errors": [
+              "Received 404 response from the server."
+            ],
+            "warnings": [],
+            "problem_summary": "404 error (page not found)",
+            "suggested_fix": ""
+          }
+        ]
+        )
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+      expect(step_item.broken_links.length).to eql 1
     end
   end
 end


### PR DESCRIPTION
This commit adds a method to the Step model. It retrieves the most recent batch_id associated with the Step. Then it retrieves the full batch report from the link-checker-api service. Any broken links are returned to the frontend as an array of Hashes with the same structure as a [`BatchReport`](https://github.com/alphagov/link-checker-api/blob/master/docs/api.md#batchreport-entity)

We're only saving the batch_id for efficiency. There's a tradeoff between storing the whole batch locally against fetching it over the wire, but I've tried to keep the data in one place rather than replicating it in link-checker-api and in collections-publisher.

[Ticket](https://trello.com/c/yZLz7LTB/765-display-the-broken-link-report-in-the-edit-step-page)