### PR TITLE
Adds broken links section to edit steps page

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -25,3 +25,39 @@ pre.markdown-example {
 .table-stepnav-rules .checkbox label {
   margin-top: 0;
 }
+
+.broken-links-accordion__title {
+  word-wrap: break-word;
+}
+
+.broken-links-accordion__collapsible-link {
+  text-decoration: none;
+  color: #8a6d3b;
+
+  &:hover, &:focus {
+    text-decoration: none;
+    color: #8a6d3b;
+  }
+}
+
+.broken-links-accordion__indicator, {
+  float: right;
+
+  .broken-links-accordion__indicator-text {
+    margin-left: 3px;
+  }
+}
+
+.broken-links-accordion__indicator--show {
+  display: none;
+}
+
+.collapsed {
+  .broken-links-accordion__indicator--hide {
+    display: none;
+  }
+
+  .broken-links-accordion__indicator--show {
+    display: block;
+  }
+}

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -102,7 +102,7 @@ private
 
   def tag_params
     params.require(:mainstream_browse_page)
-      .permit(:slug, :title, :description, :parent_id, :child_ordering, children_attributes: [:index, :id])
+      .permit(:slug, :title, :description, :parent_id, :child_ordering, children_attributes: %i[index id])
   end
 
   def protect_archived_browse_pages!

--- a/app/services/tag_republisher.rb
+++ b/app/services/tag_republisher.rb
@@ -8,7 +8,7 @@ class TagRepublisher
 
       done += 1
 
-      if done % 100 == 0
+      if (done % 100).zero?
         log "#{done} completed..."
       end
     end

--- a/app/views/shared/steps/_broken-links-summary.html.erb
+++ b/app/views/shared/steps/_broken-links-summary.html.erb
@@ -1,0 +1,2 @@
+<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+<strong><%= step.broken_links.count %></strong> broken link<%= "(s)" if step.broken_links.count > 1 %> found

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -57,6 +57,11 @@
 
             <th class="h4">
               <%= step.title %>
+              <% if step.broken_links %>
+                <span class="label label-warning">
+                  <%= render 'shared/steps/broken-links-summary', step: step %>
+                </span>
+              <% end %>
             </th>
 
             <td class="text-right text-nowrap">

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -59,11 +59,64 @@
 </div>
 
 <div class="form-group">
-  <div>
-    <p>
-      <%= step.broken_links %>
-    </p>
-  </div>
+  <% if step.broken_links && step.broken_links.count > 0 %>
+    <div class="broken-links">
+      <div class="panel panel-warning">
+        <div class="panel-heading" role="tab" id="brokenLinkHeading">
+          <a role="button" class="collapsed broken-links-accordion__collapsible-link" data-toggle="collapse" data-parent="#brokenLinksAccordion" href="#brokenLinkBody" aria-expanded="true" aria-controls="brokenLinkBody">
+            <p class="panel-title h4 broken-links-accordion__title">
+              <%= render 'shared/steps/broken-links-summary', step: step %>
+              
+              <button class="broken-links-accordion__indicator btn btn-success btn-xs">
+                <span class="broken-links-accordion__indicator--show">
+                  <span class="broken-links-accordion__indicator-text">Show</span>
+                  <i class="glyphicon glyphicon-plus"></i>
+                </span>
+
+                <span class="broken-links-accordion__indicator--hide">
+                  <span class="broken-links-accordion__indicator-text">Hide</span>
+                  <i class="glyphicon glyphicon-minus"></i>
+                </span>
+              </button>
+            </p>
+          </a>
+        </div>
+        <div id="brokenLinkBody" class="panel-collapse collapse" role="tabpanel" aria-labelledby="brokenLinkHeading">
+          <div class="list-group">
+            <% step.broken_links.each.with_index do |link, index| %>
+              <a href="<%= link['uri'] %>" class="list-group-item" target="_blank">
+                <h4 class="list-group-item-heading"><%= link['uri'] %></h4>
+                <p class="list-group-item-text">
+                  <dl class="dl">
+                    <dt>Last checked</dt>
+                    <dd><%= link['checked'].to_datetime.to_formatted_s(:rfc822) %></dd>
+                    
+                    <% if link['errors'] && link['errors'].count > 0 %>
+                      <dt>Errors</dt>
+                      <dd>
+                        <% link['errors'].each do |error| %>
+                          <%= error %> <br/>
+                        <% end %>
+                      </dd>
+                    <% end %>
+                    
+                    <% if link['warnings'] && link['warnings'].count > 0 %>
+                      <dt>Warnings</dt>
+                      <dd>
+                        <% link['warnings'].each do |warning| %>
+                          <%= warning %> <br/>
+                        <% end %>
+                      </dd>
+                    <% end %>
+                  </dl>
+                </p>
+              </a>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
   <div class="row">
     <div class="<%= left_col %>">
       <%= form.text_area :contents, class: "form-control", label: "Content, tasks and links in this step", rows: 8 %>

--- a/spec/features/navigating_browse_pages_spec.rb
+++ b/spec/features/navigating_browse_pages_spec.rb
@@ -25,13 +25,13 @@ RSpec.feature "Managing browse pages" do
     create(:mainstream_browse_page, parent: citizenship, title: "Voting")
     british_citizenship = create(:mainstream_browse_page, parent: citizenship, title: "British citizenship")
 
-    @linked_item_content_id_1 = "6896f0f3-9b79-4ec3-9f16-892f7f35e921"
-    @linked_item_content_id_2 = "f608313e-524a-478a-ae73-03cfdc920bdd"
+    @linked_item_content_id1 = "6896f0f3-9b79-4ec3-9f16-892f7f35e921"
+    @linked_item_content_id2 = "f608313e-524a-478a-ae73-03cfdc920bdd"
     publishing_api_has_linked_items(
       british_citizenship.content_id,
       items: [
-        { base_path: "/naturalisation", title: "Naturalisation", content_id: @linked_item_content_id_1 },
-        { base_path: "/marriage", title: "Marriage", content_id: @linked_item_content_id_2 },
+        { base_path: "/naturalisation", title: "Naturalisation", content_id: @linked_item_content_id1 },
+        { base_path: "/marriage", title: "Marriage", content_id: @linked_item_content_id2 },
       ]
     )
   end
@@ -66,7 +66,7 @@ RSpec.feature "Managing browse pages" do
       Naturalisation
       Marriage
     ))
-    expect(page).to have_link(nil, href: "#{Plek.new.external_url_for('content-tagger')}/taggings/#{@linked_item_content_id_1}")
-    expect(page).to have_link(nil, href: "#{Plek.new.external_url_for('content-tagger')}/taggings/#{@linked_item_content_id_2}")
+    expect(page).to have_link(nil, href: "#{Plek.new.external_url_for('content-tagger')}/taggings/#{@linked_item_content_id1}")
+    expect(page).to have_link(nil, href: "#{Plek.new.external_url_for('content-tagger')}/taggings/#{@linked_item_content_id2}")
   end
 end

--- a/spec/models/tagged_documents_spec.rb
+++ b/spec/models/tagged_documents_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TaggedDocuments do
 
       publishing_api_has_linked_items(
         topic.content_id,
-        items: [ { base_path: "/some-link", title: "The Title" }, { base_path: "/some-other-link", title: "Another Title" }]
+        items: [{ base_path: "/some-link", title: "The Title" }, { base_path: "/some-other-link", title: "Another Title" }]
       )
 
       documents = TaggedDocuments.new(topic).documents
@@ -33,7 +33,7 @@ RSpec.describe TaggedDocuments do
 
       publishing_api_has_linked_items(
         topic.content_id,
-        items: [ { base_path: "/some-link", title: "The Title" }, { base_path: "/some-other-link", title: "Another Title" }]
+        items: [{ base_path: "/some-link", title: "The Title" }, { base_path: "/some-other-link", title: "Another Title" }]
       )
 
       documents = TaggedDocuments.new(topic).documents
@@ -46,7 +46,7 @@ RSpec.describe TaggedDocuments do
 
       publishing_api_has_linked_items(
         topic.content_id,
-        items: [ { base_path: "/some-link", title: "The Title" }]
+        items: [{ base_path: "/some-link", title: "The Title" }]
       )
 
       document = TaggedDocuments.new(topic).documents.first

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ArchivedTagPresenter do
 
   describe '#render_for_publishing_api' do
     before(:each) do
-      %w{ child-1 child-1/latest child-1/email-signup }.each do |route|
+      %w{child-1 child-1/latest child-1/email-signup}.each do |route|
         child.redirect_routes.create!(from_base_path: "/topic/parent/#{route}", to_base_path: parent.base_path, tag_id: child.id)
       end
     end

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -17,17 +17,17 @@ RSpec.describe RootBrowsePagePresenter do
     end
 
     it ":public_updated_at equals the time of last browse page update" do
-      page_1 = create(:mainstream_browse_page, title: "Top-Level Page 1")
-      page_2 = create(:mainstream_browse_page, title: "Top-Level Page 2")
+      page1 = create(:mainstream_browse_page, title: "Top-Level Page 1")
+      page2 = create(:mainstream_browse_page, title: "Top-Level Page 2")
 
       Timecop.travel 3.hours.ago do
-        page_1.touch
+        page1.touch
       end
-      page_2.touch
+      page2.touch
 
       rendered = RootBrowsePagePresenter.new('state' => 'draft').render_for_publishing_api
 
-      expect(rendered[:public_updated_at]).to eq(page_2.updated_at.iso8601)
+      expect(rendered[:public_updated_at]).to eq(page2.updated_at.iso8601)
     end
   end
 
@@ -39,14 +39,14 @@ RSpec.describe RootBrowsePagePresenter do
     end
 
     it "includes draft and published top-level browse pages" do
-      page_1 = create(:mainstream_browse_page, :published, title: "Top-Level Page 1")
-      page_2 = create(:mainstream_browse_page, :draft, title: "Top-Level Page 2")
+      page1 = create(:mainstream_browse_page, :published, title: "Top-Level Page 1")
+      page2 = create(:mainstream_browse_page, :draft, title: "Top-Level Page 2")
 
       rendered = RootBrowsePagePresenter.new('state' => 'draft').render_links_for_publishing_api
 
       expect(rendered[:links]["top_level_browse_pages"]).to eq([
-        page_1.content_id,
-        page_2.content_id,
+        page1.content_id,
+        page2.content_id,
       ])
     end
   end

--- a/spec/presenters/root_topic_presenter_spec.rb
+++ b/spec/presenters/root_topic_presenter_spec.rb
@@ -18,30 +18,30 @@ RSpec.describe RootTopicPresenter do
     end
 
     it ":public_updated_at equals the time of last browse page update" do
-      page_1 = create(:topic, title: "Top-Level Topic 1")
-      page_2 = create(:topic, title: "Top-Level Topic 2")
+      page1 = create(:topic, title: "Top-Level Topic 1")
+      page2 = create(:topic, title: "Top-Level Topic 2")
 
       Timecop.travel 3.hours.ago do
-        page_1.touch
+        page1.touch
       end
-      page_2.touch
+      page2.touch
 
       rendered = RootTopicPresenter.new('state' => 'published').render_for_publishing_api
 
-      expect(rendered[:public_updated_at]).to eq(page_2.updated_at.iso8601)
+      expect(rendered[:public_updated_at]).to eq(page2.updated_at.iso8601)
     end
   end
 
   describe '#render_links_for_publishing_api' do
     it "includes draft and published top-level browse pages" do
-      page_1 = create(:topic, :published, title: "Top-Level Page 1")
-      page_2 = create(:topic, :draft, title: "Top-Level Page 2")
+      page1 = create(:topic, :published, title: "Top-Level Page 1")
+      page2 = create(:topic, :draft, title: "Top-Level Page 2")
 
       rendered = RootTopicPresenter.new('state' => 'published').render_links_for_publishing_api
 
       expect(rendered[:links]["children"]).to eq([
-        page_1.content_id,
-        page_2.content_id,
+        page1.content_id,
+        page2.content_id,
       ])
     end
   end


### PR DESCRIPTION
It uses a panel and a collapse to display the information regarding the broken links.

Tickets: 
- https://trello.com/c/EPGwXv7z/768-add-styling-to-link-report-information-on-edit-steps-page-s
- https://trello.com/c/D5HDhtSx/767-display-a-summary-of-the-broken-link-report-on-the-step-overview-page-xs

Replaces https://github.com/alphagov/collections-publisher/pull/449

Collapsed:
<img width="1306" alt="screen shot 2018-08-15 at 11 56 23" src="https://user-images.githubusercontent.com/4599889/44145144-53337b8c-a082-11e8-855a-cdc60c94340b.png">


Open:
<img width="1267" alt="screen shot 2018-08-15 at 11 56 29" src="https://user-images.githubusercontent.com/4599889/44145148-57cb3c34-a082-11e8-8c78-f31b3afaed23.png">


Broken links:
<img width="898" alt="screen shot 2018-08-10 at 12 33 24" src="https://user-images.githubusercontent.com/4599889/43955792-987c9350-9c99-11e8-92a4-121dc7d50a52.png">
