### PR TITLE
Adds webhook to receive batch

### DIFF
--- a/app/controllers/link_report_controller.rb
+++ b/app/controllers/link_report_controller.rb
@@ -1,0 +1,20 @@
+class LinkReportController < ApplicationController
+  before_action :set_link_report
+
+  def update
+    unless set_link_report.nil?
+      @link_report.completed = link_report_params[:completed_at]
+      @link_report.save
+    end
+  end
+
+private
+
+  def link_report_params
+    params.permit(:id, :completed_at)
+  end
+
+  def set_link_report
+    @link_report = LinkReport.find_by(batch_id: params[:id])
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
     "/tags/#{params[:tag_id]}/lists"
   }
 
+  patch 'link_report/:id', to: 'link_report#update'
+
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 
   class SidekiqAccessContraint

--- a/spec/controllers/link_report_controller_spec.rb
+++ b/spec/controllers/link_report_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/link_checker_api'
+
+RSpec.describe LinkReportController do
+  include GdsApi::TestHelpers::LinkCheckerApi
+  describe '.update' do
+    it 'should update an existing LinkReport' do
+      time = Time.now
+      create(:link_report, batch_id: 1234, completed: nil)
+      patch :update, params: { id: 1234, completed_at: time }
+      expect(LinkReport.find_by(batch_id: 1234).completed).to be_within(1.second).of time
+    end
+    context "when the batch_id doesn't exist" do
+      it 'should fail gracefully' do
+        time = Time.now
+        expect { patch :update, params: { id: 1234, completed_at: time } }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a webhook that receives a batch from the link-checker-api and updates that batch's completed time. This enables us to search for the most recent batch_id and retrieve that from the link-checker-api. We've implemented a webhook to avoid spamming the link-checker-api.

[Ticket](https://trello.com/c/eK2bYYNM/769-accept-responses-from-link-checker-api-about-the-status-of-a-link-report-s-m) 