### PR TITLE
Fix the brakeman security errors

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -6,7 +6,6 @@ class StepsController < ApplicationController
   end
 
   def create
-    step_params = params.require(:step).permit!
     @step = step_by_step_page.steps.new(step_params)
 
     if @step.save
@@ -23,8 +22,6 @@ class StepsController < ApplicationController
   end
 
   def update
-    step_params = params.require(:step).permit!
-
     if step.update(step_params)
       update_downstream
 


### PR DESCRIPTION
## What's changed
This change is copied from the one already in the master branch. It uses the permitted step_params method to avoid permitting all parameters and instead only accepts the ones we need.

## Why
This PR: https://github.com/alphagov/collections-publisher/pull/437, enables brakeman security checking.

Unfortunately, the changes were merged after the "link-checker" feature branch was created, so now all of the branches for the link-checking feature are failing with: 

```
[build] Message: Parameters should be whitelisted for mass assignment
[build] Code: params.require(:step).permit!
[build] File: app/controllers/steps_controller.rb
[build] Line: 26
[build] 
[build] Confidence: Medium
[build] Category: Mass Assignment
[build] Check: MassAssignment
[build] Message: Parameters should be whitelisted for mass assignment
[build] Code: params.require(:step).permit!
[build] File: app/controllers/steps_controller.rb
[build] Line: 9
```