### PR TITLE
Batch links for api

### DIFF
--- a/app/controllers/link_report_controller.rb
+++ b/app/controllers/link_report_controller.rb
@@ -1,18 +1,15 @@
 class LinkReportController < ApplicationController
   before_action :set_link_report
+  skip_before_action :verify_authenticity_token
 
   def update
     unless set_link_report.nil?
-      @link_report.completed = link_report_params[:completed_at]
+      @link_report.completed = params[:completed_at]
       @link_report.save
     end
   end
 
 private
-
-  def link_report_params
-    params.permit(:id, :completed_at)
-  end
 
   def set_link_report
     @link_report = LinkReport.find_by(batch_id: params[:id])

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -13,16 +13,13 @@ class StepByStepPagesController < ApplicationController
   def show; end
 
   def reorder
-    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
-
+    set_current_page_as_step_by_step
     if request.post? && params.key?(:step_order_save)
       reordered_steps = JSON.parse(params[:step_order_save])
-
       reordered_steps.each do |step_data|
         step = @step_by_step_page.steps.find(step_data["id"])
         step.update_attribute(:position, step_data["position"])
       end
-
       update_downstream
       redirect_to @step_by_step_page, notice: 'Steps were successfully reordered.'
     end
@@ -32,10 +29,8 @@ class StepByStepPagesController < ApplicationController
 
   def create
     @step_by_step_page = StepByStepPage.new(step_by_step_page_params)
-
     if @step_by_step_page.save
       update_downstream
-
       redirect_to @step_by_step_page, notice: 'Step by step page was successfully created.'
     else
       render :new
@@ -45,7 +40,6 @@ class StepByStepPagesController < ApplicationController
   def update
     if @step_by_step_page.update(step_by_step_page_params)
       update_downstream
-
       redirect_to step_by_step_page_path, notice: 'Step by step page was successfully updated.'
     else
       render :edit
@@ -62,8 +56,7 @@ class StepByStepPagesController < ApplicationController
   end
 
   def publish
-    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
-
+    set_current_page_as_step_by_step
     if request.post?
       @publish_intent = PublishIntent.new(params)
       if @publish_intent.valid?
@@ -74,11 +67,9 @@ class StepByStepPagesController < ApplicationController
   end
 
   def unpublish
-    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
-
+    set_current_page_as_step_by_step
     if request.post?
       redirect_url = params.delete("redirect_url")
-
       if StepByStepPage.validate_redirect(redirect_url)
         unpublish_page(redirect_url)
         redirect_to @step_by_step_page, notice: 'Step by step page was successfully unpublished.'
@@ -121,5 +112,9 @@ private
 
   def step_by_step_page_params
     params.require(:step_by_step_page).permit(:title, :slug, :introduction, :description)
+  end
+
+  def set_current_page_as_step_by_step
+    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
   end
 end

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -79,6 +79,11 @@ class StepByStepPagesController < ApplicationController
     end
   end
 
+  def check_links
+    set_current_page_as_step_by_step
+    @step_by_step_page.steps.each(&:request_broken_links)
+  end
+
 private
 
   def discard_draft

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -19,6 +19,8 @@ module Services
   end
 
   def self.link_checker_api
-    @link_checker_api ||= GdsApi::LinkCheckerApi.new(Plek.new.find("link-checker-api"))
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(
+      Plek.new.find("link-checker-api")
+    )
   end
 end

--- a/app/models/link_report.rb
+++ b/app/models/link_report.rb
@@ -1,3 +1,26 @@
 class LinkReport < ApplicationRecord
   belongs_to :step
+
+  def create_record
+    batch_response = request_batch_of_links
+    if request_batch_of_links.present?
+      self.batch_id = batch_response.id
+      self.save
+    end
+  end
+
+private
+
+  def batch_of_links
+    StepContentParser.new.all_paths(self.step.contents)
+  end
+
+  def request_batch_of_links
+    if batch_of_links.any?
+      Services.link_checker_api.create_batch(
+        batch_of_links,
+        webhook_uri: Plek.new.external_url_for("collections-publisher") + "/link_report"
+      )
+    end
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,9 +2,14 @@ class Step < ApplicationRecord
   belongs_to :step_by_step_page
   validates_presence_of :step_by_step_page
   validates :title, :logic, presence: true
+  has_many :link_reports
 
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
+  end
+
+  def request_broken_links
+    LinkReport.new(step_id: self.id).create_record
   end
 
 private

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -45,10 +45,30 @@ class StepContentParser
     end
   end
 
+  def all_paths(step_text)
+    external_links(step_text) + internal_links(step_text)
+  end
+
 private
 
   def relative_paths(content)
-    content.scan(LINK_REGEX).select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
+    all_links_in_content(content).select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
+  end
+
+  def external_links(content)
+    all_links_in_content(content).flatten - relative_paths(content)
+  end
+
+  def internal_links(content)
+    relative_paths(content).map { |path| prefix_govuk(path) }
+  end
+
+  def all_links_in_content(content)
+    content.scan(LINK_REGEX)
+  end
+
+  def prefix_govuk(path_to_prefix)
+    "https://www.gov.uk" + path_to_prefix
   end
 
   def standard_list?(section)
@@ -68,7 +88,6 @@ private
           "text": text,
           "href": href
         }
-
         payload[:context] = context.strip unless context.blank?
         payload
       end

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -73,6 +73,9 @@
 
       </tbody>
     </table>
+    <div>
+        <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, class: "btn btn-primary" %>
+    </div>
     <ul class="list-inline publish-actions">
       <% if @step_by_step_page.has_been_published? %>
         <li><%= link_to 'Unpublish', step_by_step_page_unpublish_path(@step_by_step_page), class: "btn btn-danger" %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     "/tags/#{params[:tag_id]}/lists"
   }
 
-  patch 'link_report/:id', to: 'link_report#update'
+  post '/link_report', to: 'link_report#update'
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     post :reorder
     get :unpublish
     post :unpublish
+    post :check_links
 
     resources :steps
   end

--- a/spec/controllers/link_report_controller_spec.rb
+++ b/spec/controllers/link_report_controller_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe LinkReportController do
     it 'should update an existing LinkReport' do
       time = Time.now
       create(:link_report, batch_id: 1234, completed: nil)
-      patch :update, params: { id: 1234, completed_at: time }
+      post :update, params: link_checker_api_batch_report_hash(id: 1234, completed_at: time)
       expect(LinkReport.find_by(batch_id: 1234).completed).to be_within(1.second).of time
     end
     context "when the batch_id doesn't exist" do
       it 'should fail gracefully' do
         time = Time.now
-        expect { patch :update, params: { id: 1234, completed_at: time } }.to_not raise_error
+        expect { post :update, params: link_checker_api_batch_report_hash(id: 1234, completed_at: time) }.to_not raise_error
       end
     end
   end

--- a/spec/models/link_report_spec.rb
+++ b/spec/models/link_report_spec.rb
@@ -1,5 +1,38 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/link_checker_api'
 
 RSpec.describe LinkReport, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include GdsApi::TestHelpers::LinkCheckerApi
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
+  describe '.create_record' do
+    context 'when the step content has links' do
+      it 'should create a record with the right batch_id' do
+        step = create(:step)
+        link_report = create(:link_report, step: step)
+        link_checker_api_create_batch(
+          uris: [
+            "http://example.com/good",
+            'https://www.gov.uk/good/stuff',
+            "https://www.gov.uk/also/good/stuff",
+            "https://www.gov.uk/not/as/great",
+          ],
+          webhook_uri: "https://collections-publisher.test.gov.uk/link_report"
+        )
+        link_report.create_record
+        expect(LinkReport.find_by(batch_id: 0)).to be
+      end
+    end
+
+    context 'when the step content does not have links' do
+      it 'should return delete itself' do
+        step = create(:step, contents: "Lorem ipsum")
+        link_report = create(:link_report, step: step)
+        link_report.create_record
+        expect(LinkReport.find_by(batch_id: 0)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -464,4 +464,24 @@ RSpec.describe StepContentParser do
       )
     end
   end
+
+  describe '.all_paths' do
+    context 'when there are no links in the text' do
+      test_text = 'Lorem ipsum dolores'
+      it 'should return an empty array' do
+        expect(subject.all_paths(test_text)).to be_empty
+      end
+    end
+    context 'when there is one relative and one absolute path' do
+      test_text = "[Learn to drive](/learn-to-drive)\n[Google it](https://www.google.com)"
+      it 'should return an array of URLs' do
+        links = subject.all_paths(test_text)
+        expect(links).to all(start_with("https:"))
+      end
+      it 'should have a length of two' do
+        links = subject.all_paths(test_text)
+        expect(links.length).to eql 2
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Ticket!](https://trello.com/c/nX8IgZ6z/766-request-a-broken-link-report-m)

This PR adds a number of methods to allow users to parse Step content for links, batch them, and then send them to link-checker-api. It includes a rogue commit that hotfixes an issue with the webhook. The issue only came to light when I tried it out for real, and [it's in this commit](https://github.com/alphagov/collections-publisher/commit/78cc154e95976785539c03144aafbd2d9b6f7137). 