### PR TITLE
Show step by step navigation on smartanswer done pages

### DIFF
--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -5,4 +5,8 @@ class NavigationRule < ActiveRecord::Base
 
   scope :part_of_content_ids, -> { where(include_in_links: true).pluck(:content_id) }
   scope :related_content_ids, -> { where(include_in_links: false).pluck(:content_id) }
+
+  def smartanswer?
+    schema_name == "transaction" && publishing_app == "smartanswers"
+  end
 end

--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -1,7 +1,7 @@
 class NavigationRule < ActiveRecord::Base
   belongs_to :step_by_step_page
 
-  validates :title, :base_path, :content_id, :step_by_step_page_id, presence: true
+  validates :title, :base_path, :content_id, :step_by_step_page_id, :publishing_app, :schema_name, presence: true
 
   scope :part_of_content_ids, -> { where(include_in_links: true).pluck(:content_id) }
   scope :related_content_ids, -> { where(include_in_links: false).pluck(:content_id) }

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -85,7 +85,7 @@ private
   end
 
   def part_of_step_nav_links
-    step_nav.navigation_rules.part_of_content_ids
+    step_nav.navigation_rules.part_of_content_ids + done_page_content_ids
   end
 
   def related_to_step_nav_links
@@ -94,5 +94,18 @@ private
 
   def access_limited_tokens
     { auth_bypass_ids: [step_nav.auth_bypass_id] }
+  end
+
+  def done_page_content_ids
+    base_paths = step_nav.navigation_rules.select(&:include_in_links).map do |rule|
+      rule.base_path + "/y" if rule.smartanswer?
+    end
+
+    content_ids = []
+    if base_paths.any?
+      content_ids = StepNavPublisher.lookup_content_ids(base_paths).values
+    end
+
+    content_ids
   end
 end

--- a/app/services/step_links_for_rules.rb
+++ b/app/services/step_links_for_rules.rb
@@ -52,6 +52,8 @@ private
       content_id: content_item["content_id"],
       title: content_item["title"],
       base_path: content_item["base_path"],
+      publishing_app: content_item["publishing_app"],
+      schema_name: content_item["schema_name"],
       include_in_links: true
     }
   end

--- a/db/migrate/20180817100339_add_publishing_app_to_navigation_rules.rb
+++ b/db/migrate/20180817100339_add_publishing_app_to_navigation_rules.rb
@@ -1,0 +1,22 @@
+class AddPublishingAppToNavigationRules < ActiveRecord::Migration[5.2]
+  def up
+    add_column :navigation_rules, :publishing_app, :string
+    add_column :navigation_rules, :schema_name, :string
+
+    NavigationRule.reset_column_information
+    NavigationRule.all.each do |rule|
+      begin
+        content_item = Services.publishing_api.get_content(rule.content_id)
+        rule.publishing_app = content_item["publishing_app"]
+        rule.schema_name = content_item["schema_name"]
+        rule.save
+      rescue GdsApi::HTTPNotFound
+      end
+    end
+  end
+
+  def down
+    remove_column :navigation_rules, :publishing_app
+    remove_column :navigation_rules, :schema_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180326073415) do
+ActiveRecord::Schema.define(version: 2018_08_17_100339) do
 
   create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "base_path"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 20180326073415) do
     t.bigint "step_by_step_page_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "publishing_app"
+    t.string "schema_name"
     t.index ["step_by_step_page_id", "base_path"], name: "index_navigation_rules_on_step_by_step_page_id_and_base_path", unique: true
     t.index ["step_by_step_page_id", "content_id"], name: "index_navigation_rules_on_step_by_step_page_id_and_content_id", unique: true
     t.index ["step_by_step_page_id"], name: "index_navigation_rules_on_step_by_step_page_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,6 +26,14 @@ FactoryBot.define do
     end
   end
 
+  factory :step_by_step_page_with_smartanswer_navigation_rules, parent: :step_by_step_page do
+    after(:create) do |step_by_step_page|
+      create(:navigation_rule, step_by_step_page: step_by_step_page)
+      create(:smartanswer_step, step_by_step_page: step_by_step_page)
+      create(:smartanswer_navigation_rule, step_by_step_page: step_by_step_page)
+    end
+  end
+
   factory :step do
     title "Check how awesome you are"
     logic "number"
@@ -47,6 +55,18 @@ FactoryBot.define do
       logic "or"
       position 2
     end
+
+    factory :smartanswer_step do
+      title "This step has a smartanswer in it"
+      logic "number"
+      position 1
+      contents <<~CONTENT
+        This is a step with a smartanswer
+
+        [A smartanswer](/a-smartanswer)
+      CONTENT
+      step_by_step_page
+    end
   end
 
   factory :navigation_rule do
@@ -55,6 +75,14 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
     publishing_app "publisher"
     schema_name "guide"
+  end
+
+  factory :smartanswer_navigation_rule, parent: :navigation_rule do
+    title "A smartanswer"
+    base_path "/a-smartanswer"
+    content_id { SecureRandom.uuid }
+    publishing_app "smartanswers"
+    schema_name "transaction"
   end
 
   factory :redirect_item do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -53,6 +53,8 @@ FactoryBot.define do
     title "Good stuff"
     base_path "/good/stuff"
     content_id { SecureRandom.uuid }
+    publishing_app "publisher"
+    schema_name "guide"
   end
 
   factory :redirect_item do

--- a/spec/models/navigation_rule_spec.rb
+++ b/spec/models/navigation_rule_spec.rb
@@ -62,6 +62,35 @@ RSpec.describe NavigationRule do
       end
     end
 
+    context 'without a publishing_app' do
+      it 'is invalid' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          step_by_step_page: step_by_step_page,
+        )
+
+        expect(resource).to_not be_valid
+        expect(resource.errors).to have_key(:publishing_app)
+      end
+    end
+
+    context 'without a schema_name' do
+      it 'is invalid' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          step_by_step_page: step_by_step_page,
+          publishing_app: 'transaction',
+        )
+
+        expect(resource).to_not be_valid
+        expect(resource.errors).to have_key(:schema_name)
+      end
+    end
+
     context 'with valid attributes' do
       it 'is valid' do
         resource = described_class.new(
@@ -69,6 +98,8 @@ RSpec.describe NavigationRule do
           base_path: '/a-base-path',
           content_id: 'A-CONTENT-ID-BOOM',
           step_by_step_page: step_by_step_page,
+          publishing_app: 'publisher',
+          schema_name: 'transaction'
         )
 
         expect(resource).to be_valid

--- a/spec/models/navigation_rule_spec.rb
+++ b/spec/models/navigation_rule_spec.rb
@@ -107,4 +107,36 @@ RSpec.describe NavigationRule do
       end
     end
   end
+
+  describe '#smartanswer?' do
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
+    it 'is a smartanswer start page' do
+      resource = described_class.new(
+        title: 'A Title',
+        base_path: '/a-base-path',
+        content_id: 'A-CONTENT-ID-BOOM',
+        step_by_step_page: step_by_step_page,
+        publishing_app: 'smartanswers',
+        schema_name: 'transaction'
+      )
+
+      expect(resource.smartanswer?).to be true
+    end
+
+    it 'is not a smartanswer start page' do
+      resource = described_class.new(
+        title: 'A Title',
+        base_path: '/a-base-path',
+        content_id: 'A-CONTENT-ID-BOOM',
+        step_by_step_page: step_by_step_page,
+        publishing_app: 'publisher',
+        schema_name: 'transaction'
+      )
+
+      expect(resource.smartanswer?).to be false
+    end
+  end
 end

--- a/spec/services/step_links_for_rules_spec.rb
+++ b/spec/services/step_links_for_rules_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe StepLinksForRules do
         amazing_content_item = basic_content_item(
           title: "An Amazing Magic Link",
           base_path: base_path_data.keys.first,
-          content_id: base_path_data.values.first
+          content_id: base_path_data.values.first,
+          publishing_app: "publisher",
+          schema_name: "guide",
         )
 
         publishing_api_receives_request_to_lookup_content_ids(
@@ -184,25 +186,33 @@ RSpec.describe StepLinksForRules do
         title: "Good Stuff",
         base_path: '/good/stuff',
         content_id: 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
+        publishing_app: "publisher",
+        schema_name: "guide",
       ),
       basic_content_item(
         title: "Also Good Stuff",
         base_path: '/also/good/stuff',
         content_id: 'fd6b1901d-b925-47c5-b1ca-1e52197097e2',
+        publishing_app: "publisher",
+        schema_name: "guide",
       ),
       basic_content_item(
         title: "Not as Great",
         base_path: '/not/as/great',
         content_id: 'fd6b1901d-b925-47c5-b1ca-1e52197097e3',
+        publishing_app: "publisher",
+        schema_name: "guide",
       ),
     ]
   end
 
-  def basic_content_item(title:, base_path:, content_id:)
+  def basic_content_item(title:, base_path:, content_id:, publishing_app:, schema_name:)
     {
       "title": title,
       "base_path": base_path,
       "content_id": content_id,
+      "publishing_app": publishing_app,
+      "schema_name": schema_name,
     }.with_indifferent_access
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/FJTvAlWq

Related to: https://github.com/alphagov/smart-answers/pull/3604

## Motivation

When smartanswers are published, two content items are created. One with a document type of "transaction" (start page) and the other with a document type of "smartanswer" (the main body of the smartanswer including the done page). 

When a step by step links to a smartanswer, only the start page is being linked to, therefore only the content_item for the start page contains the details of the step by step.

This means that when a user navigates to the end of a smartanswer they have no way of finding their way back to the step by step.

## What's changed

When a step by step is saved to the publishing-api add a check to determine whether the navigation rules contain any smartanswer start pages. 

If they do find the content id for the smartanswer done pages (`/{smart-answer-start-page-slug}/y`) and add them to payload for publishing-api. 

Publishing-api will do a reverse lookup of the links and add step by step details to the "other" smartanswer content item.

<img width="776" alt="screen shot 2018-08-20 at 18 21 09" src="https://user-images.githubusercontent.com/5793815/44356016-1940be80-a4a6-11e8-9fe8-b01090c34f27.png">

