### PR TITLE
Add service done pages to part_of_step_nav_links

### DIFF
--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -98,14 +98,21 @@ private
 
   def done_page_content_ids
     base_paths = step_nav.navigation_rules.select(&:include_in_links).map do |rule|
-      rule.base_path + "/y" if rule.smartanswer?
+      done_page_base_path(rule)
     end
 
     content_ids = []
     if base_paths.any?
-      content_ids = StepNavPublisher.lookup_content_ids(base_paths).values
+      results = StepNavPublisher.lookup_content_ids(base_paths)
+      content_ids = results.values if results.any?
     end
 
     content_ids
+  end
+
+  def done_page_base_path(page)
+    return page.base_path + "/y" if page.smartanswer?
+
+    "/done" + page.base_path
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/WHtWvjCl

Follows on from: PR #458 

## What's changed
Adds the  content_id of the service done page to the `part_of_step_nav` links in the payload for
publishing-api if the content_id for service start page is already included. 

## Why
So that the step by step navigation displays on the service done page.

### Before
![screen shot 2018-08-22 at 10 35 30](https://user-images.githubusercontent.com/5793815/44455922-32a55000-a5f7-11e8-9b02-e8dbc1dad6c1.png)

### After
![screen shot 2018-08-22 at 10 35 11](https://user-images.githubusercontent.com/5793815/44455926-38029a80-a5f7-11e8-8466-4efbb2ccb454.png)
