### PR TITLE
[WIP] Only show error message if there is a broken link

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -4,6 +4,10 @@ class Step < ApplicationRecord
   validates :title, :logic, presence: true
   has_many :link_reports
 
+  def broken_links?
+    broken_links.present? && broken_links.any?
+  end
+
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
   end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -8,6 +8,10 @@ class Step < ApplicationRecord
     broken_links.present? && broken_links.any?
   end
 
+  def link_report?
+    most_recent_batch.present?
+  end
+
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
   end

--- a/app/views/shared/steps/_broken-links-summary.html.erb
+++ b/app/views/shared/steps/_broken-links-summary.html.erb
@@ -1,2 +1,11 @@
-<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-<strong><%= step.broken_links.count %></strong> broken link<%= "(s)" if step.broken_links.count > 1 %> found
+<% if step.broken_links? %>
+  <span class="label label-warning">
+    <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+    <strong><%= step.broken_links.count %></strong> broken link<%= "(s)" if step.broken_links.count > 1 %> found
+  </span>
+<% elsif step.link_report? %>
+  <span class="label label-success">
+    <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+    <strong>No broken links</strong>
+  </span>
+<% end %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -57,7 +57,7 @@
 
             <th class="h4">
               <%= step.title %>
-              <% if step.broken_links %>
+              <% if step.broken_links? %>
                 <span class="label label-warning">
                   <%= render 'shared/steps/broken-links-summary', step: step %>
                 </span>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -57,16 +57,7 @@
 
             <th class="h4">
               <%= step.title %>
-              <% if step.broken_links? %>
-                <span class="label label-warning">
-                  <%= render 'shared/steps/broken-links-summary', step: step %>
-                </span>
-              <% elsif step.link_report? %>
-                <span class="label label-success">
-                  <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-                  <strong>No broken links</strong>
-                </span>
-              <% end %>
+              <%= render 'shared/steps/broken-links-summary', step: step %>
             </th>
 
             <td class="text-right text-nowrap">

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -61,6 +61,11 @@
                 <span class="label label-warning">
                   <%= render 'shared/steps/broken-links-summary', step: step %>
                 </span>
+              <% elsif step.link_report? %>
+                <span class="label label-success">
+                  <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+                  <strong>No broken links</strong>
+                </span>
               <% end %>
             </th>
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Step do
     it 'should return nothing if there are no link reports yet' do
       expect(step_item.broken_links).to be_nil
       expect(step_item.broken_links?).to be false
+      expect(step_item.link_report?).to be false
     end
 
     it 'should return an empty array if there are link reports, but all the links work' do
@@ -64,6 +65,7 @@ RSpec.describe Step do
       )
       expect(step_item.broken_links).to eql []
       expect(step_item.broken_links?).to be false
+      expect(step_item.link_report?).to be true
     end
 
     it 'should return a batch report if there is one with a matching id and it contains a broken link' do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Step do
   describe 'broken_links' do
     it 'should return nothing if there are no link reports yet' do
       expect(step_item.broken_links).to be_nil
+      expect(step_item.broken_links?).to be false
     end
 
     it 'should return an empty array if there are link reports, but all the links work' do
@@ -62,6 +63,7 @@ RSpec.describe Step do
         ]
       )
       expect(step_item.broken_links).to eql []
+      expect(step_item.broken_links?).to be false
     end
 
     it 'should return a batch report if there is one with a matching id and it contains a broken link' do
@@ -92,6 +94,7 @@ RSpec.describe Step do
         )
       create(:link_report, batch_id: 2, step_id: step_item.id)
       expect(step_item.broken_links).to_not be_empty
+      expect(step_item.broken_links?).to be true
     end
 
     it 'should contain one item if there are link reports and at least one is broken' do
@@ -122,6 +125,7 @@ RSpec.describe Step do
         )
       create(:link_report, batch_id: 2, step_id: step_item.id)
       expect(step_item.broken_links.length).to eql 1
+      expect(step_item.broken_links?).to be true
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/VKiDCA1o

## What's a changed

Only show an error message for broken links on the step overview page if the step has broken links.

### Before
![screen shot 2018-08-22 at 12 20 05 copy](https://user-images.githubusercontent.com/5793815/44465973-0dc0d500-a617-11e8-9801-290e90643f82.png)

### After
![screenshot-collections-publisher dev gov uk-2018 08 28-10-00-26](https://user-images.githubusercontent.com/5793815/44712676-3e868b80-aaa9-11e8-8bcc-1341d94a295b.png)


