### PR TITLE
Add a "last checked" timestamp below the check for broken links button 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'govuk-content-schema-test-helpers'
-  gem 'govuk-lint'
+  gem 'govuk-lint', '~> 3.9.0'
   gem 'nokogiri'
   gem 'poltergeist'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,9 +112,9 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (3.8.0)
-      rubocop (~> 0.52.0)
-      rubocop-rspec (~> 1.19.0)
+    govuk-lint (3.9.0)
+      rubocop (~> 0.58)
+      rubocop-rspec (~> 1.28)
       scss_lint
     govuk_admin_template (6.6.0)
       bootstrap-sass (= 3.3.5.1)
@@ -139,6 +139,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -202,7 +203,7 @@ GEM
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -273,16 +274,17 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    rubocop (0.52.1)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.19.0)
-      rubocop (>= 0.51.0)
-    ruby-progressbar (1.9.0)
+    rubocop-rspec (1.29.0)
+      rubocop (>= 0.58.0)
+    ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -334,7 +336,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
     unicorn (5.4.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -367,7 +369,7 @@ DEPENDENCIES
   gds-sso (~> 13.6)
   generic_form_builder (~> 0.13)
   govuk-content-schema-test-helpers
-  govuk-lint
+  govuk-lint (~> 3.9.0)
   govuk_admin_template (~> 6.6)
   govuk_app_config (~> 1.7)
   govuk_sidekiq (~> 3.0)
@@ -387,4 +389,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -61,3 +61,9 @@ pre.markdown-example {
     display: block;
   }
 }
+
+.broken-links-last-checked--summary {
+  border-left: 5px solid #eee;
+  padding: 10px 20px;
+  margin: 20px 0 20px;
+} 

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -12,6 +12,10 @@ class Step < ApplicationRecord
     most_recent_batch.present?
   end
 
+  def links_last_checked_date
+    most_recent_batch.created_at if link_report?
+  end
+
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
   end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -56,6 +56,11 @@ class StepByStepPage < ApplicationRecord
     end
   end
 
+  def links_last_checked_date
+    date = steps.map(&:links_last_checked_date).reject(&:blank?).max
+    date.strftime('%A, %d %B %Y at %H:%M %p') if date
+  end
+
 private
 
   def generate_content_id

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -61,6 +61,10 @@ class StepByStepPage < ApplicationRecord
     date.strftime('%A, %d %B %Y at %H:%M %p') if date
   end
 
+  def links_checked?
+    steps.map(&:link_report?).any?
+  end
+
 private
 
   def generate_content_id

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -74,9 +74,9 @@
     </div>
 
     <% if @step_by_step_page.links_checked? %>
-      <div>
-        Links last checked
-        <br>on <%= @step_by_step_page.links_last_checked_date %>
+      <div class="broken-links-last-checked--summary">
+        Links last checked on:
+        <br><%= @step_by_step_page.links_last_checked_date %>
       </div>
     <% end %>
 

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -75,7 +75,7 @@
 
     <% if @step_by_step_page.links_checked? %>
       <div class="broken-links-last-checked--summary">
-        Links last checked on:
+        Last checked:
         <br><%= @step_by_step_page.links_last_checked_date %>
       </div>
     <% end %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -73,10 +73,12 @@
         <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, class: "btn btn-primary" %>
     </div>
 
-    <div>
-      Links last checked
-      on <%= @step_by_step_page.links_last_checked_date %>
-    </div>
+    <% if @step_by_step_page.links_checked? %>
+      <div>
+        Links last checked
+        <br>on <%= @step_by_step_page.links_last_checked_date %>
+      </div>
+    <% end %>
 
     <ul class="list-inline publish-actions">
       <% if @step_by_step_page.has_been_published? %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -72,6 +72,12 @@
     <div>
         <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, class: "btn btn-primary" %>
     </div>
+
+    <div>
+      Links last checked
+      on <%= @step_by_step_page.links_last_checked_date %>
+    </div>
+
     <ul class="list-inline publish-actions">
       <% if @step_by_step_page.has_been_published? %>
         <li><%= link_to 'Unpublish', step_by_step_page_unpublish_path(@step_by_step_page), class: "btn btn-danger" %></li>

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -134,6 +134,26 @@ RSpec.describe StepByStepPage do
     }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
+  describe '#links_last_checked_date' do
+    it 'gets the latest date that links were checked for any step' do
+      step_by_step_with_step = create(:step_by_step_page)
+
+      step1 = create(:step, step_by_step_page: step_by_step_with_step)
+      step2 = create(:step, step_by_step_page: step_by_step_with_step)
+
+      create(:link_report, batch_id: 1, step_id: step1.id, created_at: "2018-08-07 10:31:38")
+      create(:link_report, batch_id: 2, step_id: step2.id, created_at: "2018-08-07 10:30:38")
+
+      expect(step_by_step_with_step.links_last_checked_date).to eq("Tuesday, 07 August 2018 at 10:31 AM")
+    end
+
+    it 'does not fail if there are no link reports' do
+      step_by_step_with_step = create(:step_by_step_page)
+
+      expect(step_by_step_with_step.links_last_checked_date).to be nil
+    end
+  end
+
   describe 'publishing' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -154,6 +154,22 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe 'links_checked?' do
+    it 'returns true if links have been checked' do
+      step_by_step_with_step = create(:step_by_step_page)
+      step = create(:step, step_by_step_page: step_by_step_with_step)
+      create(:link_report, batch_id: 1, step_id: step.id)
+
+      expect(step_by_step_with_step.links_checked?).to be true
+    end
+
+    it 'returns false if links have not been checked' do
+      step_by_step_with_step = create(:step_by_step_page)
+
+      expect(step_by_step_with_step.links_checked?).to be false
+    end
+  end
+
   describe 'publishing' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -129,5 +129,10 @@ RSpec.describe Step do
       expect(step_item.broken_links.length).to eql 1
       expect(step_item.broken_links?).to be true
     end
+
+    it 'should return the last date the links where checked' do
+      create(:link_report, batch_id: 2, step_id: step_item.id, created_at: "2018-08-07 10:30:38")
+      expect(step_item.links_last_checked_date.utc).to eq(Time.new(2018, 8, 7, 10, 30, 38).utc)
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/qR9lA9GQ

Dependant on PR https://github.com/alphagov/govuk-lint/pull/103 to fix the lint issues addressed in Rubocop 0.52.1

## What's changed

Show the date and time for the last time that the links were checked, to give context to the link alert messages. Messages showing that the steps have no broken links are misleading if the links haven't been checked in a while.

![screenshot-collections-publisher dev gov uk-2018 08 29-16-01-03](https://user-images.githubusercontent.com/5793815/44796373-c69d8b80-aba4-11e8-8b93-1d72c0b9ae11.png)


