### PR TITLE
Adds InternalChangeNote model

### DIFF
--- a/app/models/internal_change_note.rb
+++ b/app/models/internal_change_note.rb
@@ -1,0 +1,4 @@
+class InternalChangeNote < ApplicationRecord
+  validates :author, :description, :created_at, presence: true
+  belongs_to :step_by_step_page
+end

--- a/db/migrate/20180829153755_create_internal_change_notes.rb
+++ b/db/migrate/20180829153755_create_internal_change_notes.rb
@@ -1,0 +1,10 @@
+class CreateInternalChangeNotes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :internal_change_notes do |t|
+      t.string :author
+      t.text :description
+      t.references :step_by_step_page, foreign_key: true
+      t.datetime :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_17_100339) do
+ActiveRecord::Schema.define(version: 2018_08_29_153755) do
 
-  create_table "list_items", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "author"
+    t.text "description"
+    t.bigint "step_by_step_page_id"
+    t.datetime "created_at"
+    t.index ["step_by_step_page_id"], name: "index_internal_change_notes_on_step_by_step_page_id"
+  end
+
+  create_table "list_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "base_path"
     t.integer "index", default: 0, null: false
     t.integer "list_id"
@@ -132,6 +140,7 @@ ActiveRecord::Schema.define(version: 2018_08_17_100339) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "internal_change_notes", "step_by_step_pages"
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
   add_foreign_key "lists", "tags", name: "lists_tag_id_fk", on_delete: :cascade
   add_foreign_key "navigation_rules", "step_by_step_pages"


### PR DESCRIPTION
This commit adds an InternalChangeNote model with a foreign key on the StepByStepPage model. This enables us to build new functionality to record the changes that content designers have made to a step-by-step.

[Ticket](https://trello.com/c/OvHzWmh0/814-change-database-schema-to-add-changenote-model) and [more context](https://trello.com/c/G0fchnmS/733-ability-to-record-change-notes-l)

## Why
Research with content designers revealed that they like being able to see the changes they've made to a step-by-step. Ultimately this will probably be similar to git versioning, but as an MVP we're just implementing change notes. They'll have an author, a timestamp, and some content, all of which are validated. This will allow content designers to track changes they're making and also externalise knowledge they have about a specific step by step.