### PR TITLE
Add link checking for step-by-step pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,7 @@ Metrics/BlockLength:
     - 'lib/tasks/**/*.rake'
     - 'spec/**/*_spec.rb'
     - 'spec/factories.rb'
+
+Style/ExpandPathArguments:
+  Exclude:
+    - spec/rails_helper.rb

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'govuk-content-schema-test-helpers'
-  gem 'govuk-lint'
+  gem 'govuk-lint', '~> 3.9.0'
   gem 'nokogiri'
   gem 'parser', '2.5.1.2'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,9 +112,9 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (3.8.0)
-      rubocop (~> 0.52.0)
-      rubocop-rspec (~> 1.19.0)
+    govuk-lint (3.9.0)
+      rubocop (~> 0.58)
+      rubocop-rspec (~> 1.28)
       scss_lint
     govuk_admin_template (6.6.0)
       bootstrap-sass (= 3.3.5.1)
@@ -139,6 +139,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -202,7 +203,7 @@ GEM
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -273,16 +274,17 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.52.1)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.19.0)
-      rubocop (>= 0.51.0)
-    ruby-progressbar (1.9.0)
+    rubocop-rspec (1.29.0)
+      rubocop (>= 0.58.0)
+    ruby-progressbar (1.10.0)
     safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
@@ -334,7 +336,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.4.0)
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -367,7 +369,7 @@ DEPENDENCIES
   gds-sso (~> 13.6)
   generic_form_builder (~> 0.13)
   govuk-content-schema-test-helpers
-  govuk-lint
+  govuk-lint (~> 3.9.0)
   govuk_admin_template (~> 6.6)
   govuk_app_config (~> 1.8)
   govuk_sidekiq (~> 3.0)
@@ -387,4 +389,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -87,7 +87,8 @@ $beige: #8a6d3b;
   text-decoration: none;
   color: $beige;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: none;
     color: $beige;
   }

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -6,6 +6,7 @@ $light-grey: #f5f5f5;
 $light-grey-2: #f8f8f8;
 $black: #0B0C0C;
 $red: #b10e1e;
+$grey: #eeeeee;
 $beige: #8a6d3b;
 
 .step-actions {
@@ -112,4 +113,10 @@ $beige: #8a6d3b;
   .broken-links-accordion__indicator--show {
     display: block;
   }
+}
+
+.broken-links-last-checked--summary {
+  border-left: 5px solid $grey;
+  padding: 10px 20px;
+  margin: 20px 0 20px;
 }

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -6,6 +6,7 @@ $light-grey: #f5f5f5;
 $light-grey-2: #f8f8f8;
 $black: #0B0C0C;
 $red: #b10e1e;
+$beige: #8a6d3b;
 
 .step-actions {
   padding: 15px 0;
@@ -75,4 +76,40 @@ $red: #b10e1e;
 
 .publish-or-delete .panel.delete-or-unpublish-panel {
   border-left: 10px $red solid;
+}
+
+.broken-links-accordion__title {
+  word-wrap: break-word;
+}
+
+.broken-links-accordion__collapsible-link {
+  text-decoration: none;
+  color: $beige;
+
+  &:hover, &:focus {
+    text-decoration: none;
+    color: $beige;
+  }
+}
+
+.broken-links-accordion__indicator {
+  float: right;
+
+  .broken-links-accordion__indicator-text {
+    margin-left: 3px;
+  }
+}
+
+.broken-links-accordion__indicator--show {
+  display: none;
+}
+
+.collapsed {
+  .broken-links-accordion__indicator--hide {
+    display: none;
+  }
+
+  .broken-links-accordion__indicator--show {
+    display: block;
+  }
 }

--- a/app/controllers/link_report_controller.rb
+++ b/app/controllers/link_report_controller.rb
@@ -1,0 +1,20 @@
+class LinkReportController < ApplicationController
+  before_action :set_link_report
+
+  def update
+    unless set_link_report.nil?
+      @link_report.completed = link_report_params[:completed_at]
+      @link_report.save
+    end
+  end
+
+private
+
+  def link_report_params
+    params.permit(:id, :completed_at)
+  end
+
+  def set_link_report
+    @link_report = LinkReport.find_by(batch_id: params[:id])
+  end
+end

--- a/app/controllers/link_report_controller.rb
+++ b/app/controllers/link_report_controller.rb
@@ -1,18 +1,15 @@
 class LinkReportController < ApplicationController
   before_action :set_link_report
+  skip_before_action :verify_authenticity_token
 
   def update
     unless set_link_report.nil?
-      @link_report.completed = link_report_params[:completed_at]
+      @link_report.completed = params[:completed_at]
       @link_report.save
     end
   end
 
 private
-
-  def link_report_params
-    params.permit(:id, :completed_at)
-  end
 
   def set_link_report
     @link_report = LinkReport.find_by(batch_id: params[:id])

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -78,7 +78,7 @@ private
   end
 
   def find_browse_page
-    @_browse_page ||= MainstreamBrowsePage.find_by!(content_id: params[:id])
+    @find_browse_page ||= MainstreamBrowsePage.find_by!(content_id: params[:id])
   end
 
   def browse_page_params

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -13,16 +13,13 @@ class StepByStepPagesController < ApplicationController
   def show; end
 
   def reorder
-    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
-
+    set_current_page_as_step_by_step
     if request.post? && params.key?(:step_order_save)
       reordered_steps = JSON.parse(params[:step_order_save])
-
       reordered_steps.each do |step_data|
         step = @step_by_step_page.steps.find(step_data["id"])
         step.update_attribute(:position, step_data["position"])
       end
-
       update_downstream
       redirect_to @step_by_step_page, notice: 'Steps were successfully reordered.'
     end
@@ -32,10 +29,8 @@ class StepByStepPagesController < ApplicationController
 
   def create
     @step_by_step_page = StepByStepPage.new(step_by_step_page_params)
-
     if @step_by_step_page.save
       update_downstream
-
       redirect_to @step_by_step_page, notice: 'Step by step page was successfully created.'
     else
       render :new
@@ -45,7 +40,6 @@ class StepByStepPagesController < ApplicationController
   def update
     if @step_by_step_page.update(step_by_step_page_params)
       update_downstream
-
       redirect_to step_by_step_page_path, notice: 'Step by step page was successfully updated.'
     else
       render :edit
@@ -62,8 +56,7 @@ class StepByStepPagesController < ApplicationController
   end
 
   def publish
-    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
-
+    set_current_page_as_step_by_step
     if request.post?
       @publish_intent = PublishIntent.new(params)
       if @publish_intent.valid?
@@ -74,11 +67,9 @@ class StepByStepPagesController < ApplicationController
   end
 
   def unpublish
-    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
-
+    set_current_page_as_step_by_step
     if request.post?
       redirect_url = params.delete("redirect_url")
-
       if StepByStepPage.validate_redirect(redirect_url)
         unpublish_page(redirect_url)
         redirect_to @step_by_step_page, notice: 'Step by step page was successfully unpublished.'
@@ -125,5 +116,9 @@ private
 
   def step_by_step_page_params
     params.require(:step_by_step_page).permit(:title, :slug, :introduction, :description)
+  end
+
+  def set_current_page_as_step_by_step
+    @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
   end
 end

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -83,6 +83,11 @@ class StepByStepPagesController < ApplicationController
     @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
   end
 
+  def check_links
+    set_current_page_as_step_by_step
+    @step_by_step_page.steps.each(&:request_broken_links)
+  end
+
 private
 
   def discard_draft

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -79,7 +79,7 @@ private
   end
 
   def find_topic
-    @_topic ||= Topic.find_by!(content_id: params[:id])
+    @find_topic ||= Topic.find_by!(content_id: params[:id])
   end
 
   def protect_archived_tags!

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -19,6 +19,8 @@ module Services
   end
 
   def self.link_checker_api
-    @link_checker_api ||= GdsApi::LinkCheckerApi.new(Plek.new.find("link-checker-api"))
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(
+      Plek.new.find("link-checker-api")
+    )
   end
 end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,5 +1,6 @@
 require 'gds_api/publishing_api_v2'
 require 'gds_api/content_store'
+require 'gds_api/link_checker_api'
 
 module Services
   def self.publishing_api
@@ -15,5 +16,9 @@ module Services
       Plek.new.find('content-store'),
       disable_cache: true
     )
+  end
+
+  def self.link_checker_api
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(Plek.new.find("link-checker-api"))
   end
 end

--- a/app/models/link_report.rb
+++ b/app/models/link_report.rb
@@ -1,0 +1,3 @@
+class LinkReport < ApplicationRecord
+  belongs_to :step
+end

--- a/app/models/link_report.rb
+++ b/app/models/link_report.rb
@@ -1,3 +1,26 @@
 class LinkReport < ApplicationRecord
   belongs_to :step
+
+  def create_record
+    batch_response = request_batch_of_links
+    if request_batch_of_links.present?
+      self.batch_id = batch_response.id
+      self.save
+    end
+  end
+
+private
+
+  def batch_of_links
+    StepContentParser.new.all_paths(self.step.contents)
+  end
+
+  def request_batch_of_links
+    if batch_of_links.any?
+      Services.link_checker_api.create_batch(
+        batch_of_links,
+        webhook_uri: Plek.new.external_url_for("collections-publisher") + "/link_report"
+      )
+    end
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -4,6 +4,10 @@ class Step < ApplicationRecord
   validates :title, :logic, presence: true
   has_many :link_reports
 
+  def broken_links?
+    broken_links.present? && broken_links.any?
+  end
+
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
   end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,9 +2,14 @@ class Step < ApplicationRecord
   belongs_to :step_by_step_page
   validates_presence_of :step_by_step_page
   validates :title, :logic, presence: true
+  has_many :link_reports
 
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
+  end
+
+  def request_broken_links
+    LinkReport.new(step_id: self.id).create_record
   end
 
 private

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,4 +2,28 @@ class Step < ApplicationRecord
   belongs_to :step_by_step_page
   validates_presence_of :step_by_step_page
   validates :title, :logic, presence: true
+
+  def broken_links
+    collect_broken_links unless most_recent_batch.nil?
+  end
+
+private
+
+  def collect_broken_links
+    batch_link_report.links.keep_if do |link|
+      link.fetch('status') == 'broken'
+    end
+  end
+
+  def batch_link_report
+    @batch_link_report ||= Services.link_checker_api.get_batch(batch_link_report_id)
+  end
+
+  def batch_link_report_id
+    most_recent_batch.batch_id
+  end
+
+  def most_recent_batch
+    LinkReport.where(step_id: self.id).last
+  end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -8,6 +8,10 @@ class Step < ApplicationRecord
     broken_links.present? && broken_links.any?
   end
 
+  def link_report?
+    most_recent_batch.present?
+  end
+
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
   end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -12,6 +12,10 @@ class Step < ApplicationRecord
     most_recent_batch.present?
   end
 
+  def links_last_checked_date
+    most_recent_batch.created_at if link_report?
+  end
+
   def broken_links
     collect_broken_links unless most_recent_batch.nil?
   end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -54,7 +54,7 @@ class StepByStepPage < ApplicationRecord
   # The code to create the token has been "borrowed" from SecureRandom.uuid,
   # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
   def auth_bypass_id
-    @_auth_bypass_id ||= begin
+    @auth_bypass_id ||= begin
       ary = Digest::SHA256.hexdigest(content_id.to_s).unpack('NnnnnN')
       ary[2] = (ary[2] & 0x0fff) | 0x4000
       ary[3] = (ary[3] & 0x3fff) | 0x8000

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -67,6 +67,10 @@ class StepByStepPage < ApplicationRecord
     date.strftime('%A, %d %B %Y at %H:%M %p') if date
   end
 
+  def links_checked?
+    steps.map(&:link_report?).any?
+  end
+
 private
 
   def generate_content_id

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -62,6 +62,11 @@ class StepByStepPage < ApplicationRecord
     end
   end
 
+  def links_last_checked_date
+    date = steps.map(&:links_last_checked_date).reject(&:blank?).max
+    date.strftime('%A, %d %B %Y at %H:%M %p') if date
+  end
+
 private
 
   def generate_content_id

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,7 +17,7 @@ class Tag < ApplicationRecord
   has_many :redirect_routes
 
   validates :slug, :title, :content_id, presence: true
-  validates :slug, uniqueness: { scope: ["parent_id"] }, format: { with: /\A[a-z0-9-]*\z/ }
+  validates :slug, uniqueness: { scope: %w(parent_id) }, format: { with: /\A[a-z0-9-]*\z/ }
   validates :child_ordering, inclusion: { in: ORDERING_TYPES }
   validate :parent_is_not_a_child
   validate :cannot_change_slug

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -109,7 +109,7 @@ class Tag < ApplicationRecord
   end
 
   def tagged_documents
-    @_tagged_documents ||= TaggedDocuments.new(self)
+    @tagged_documents ||= TaggedDocuments.new(self)
   end
 
   def tagged_document_for_base_path(base_path)

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -45,10 +45,30 @@ class StepContentParser
     end
   end
 
+  def all_paths(step_text)
+    external_links(step_text) + internal_links(step_text)
+  end
+
 private
 
   def relative_paths(content)
-    content.scan(LINK_REGEX).select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
+    all_links_in_content(content).select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
+  end
+
+  def external_links(content)
+    all_links_in_content(content).flatten - relative_paths(content)
+  end
+
+  def internal_links(content)
+    relative_paths(content).map { |path| prefix_govuk(path) }
+  end
+
+  def all_links_in_content(content)
+    content.scan(LINK_REGEX)
+  end
+
+  def prefix_govuk(path_to_prefix)
+    "https://www.gov.uk" + path_to_prefix
   end
 
   def standard_list?(section)
@@ -68,7 +88,6 @@ private
           "text": text,
           "href": href
         }
-
         payload[:context] = context.strip unless context.blank?
         payload
       end

--- a/app/services/step_links_for_rules.rb
+++ b/app/services/step_links_for_rules.rb
@@ -42,7 +42,7 @@ private
 
   # hash of rules payloads keyed by content_id
   def rules_from_step_content
-    @step_rules ||= content_items.each_with_object({}) do |content_item, items|
+    @rules_from_step_content ||= content_items.each_with_object({}) do |content_item, items|
       items[content_item["content_id"]] = build_rule(content_item)
     end
   end

--- a/app/views/shared/steps/_broken-links-summary.html.erb
+++ b/app/views/shared/steps/_broken-links-summary.html.erb
@@ -1,0 +1,2 @@
+<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+<strong><%= step.broken_links.count %> broken link<%= "(s)" if step.broken_links.count > 1 %> found</strong>

--- a/app/views/shared/steps/_broken-links-summary.html.erb
+++ b/app/views/shared/steps/_broken-links-summary.html.erb
@@ -1,2 +1,11 @@
-<span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
-<strong><%= step.broken_links.count %> broken link<%= "(s)" if step.broken_links.count > 1 %> found</strong>
+<% if step.broken_links? %>
+  <span class="label label-warning">
+    <span class="glyphicon glyphicon-warning-sign" aria-hidden="true"></span>
+    <strong><%= step.broken_links.count %> broken link<%= "(s)" if step.broken_links.count > 1 %> found</strong>
+  </span>
+<% elsif step.link_report? %>
+  <span class="label label-success">
+    <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+    <strong>No broken links</strong>
+  </span>
+<% end %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -52,16 +52,7 @@
 
             <th class="h4">
               <%= step.title %>
-              <% if step.broken_links? %>
-                <span class="label label-warning">
-                  <%= render 'shared/steps/broken-links-summary', step: step %>
-                </span>
-              <% elsif step.link_report? %>
-                <span class="label label-success">
-                  <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-                  <strong>No broken links</strong>
-                </span>
-              <% end %>
+              <%= render 'shared/steps/broken-links-summary', step: step %>
             </th>
 
             <td class="text-right text-nowrap">

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -72,5 +72,10 @@
     <div>
       <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, class: "btn btn-primary" %>
     </div>
+
+    <div>
+      Links last checked
+      on <%= @step_by_step_page.links_last_checked_date %>
+    </div>
   </div>
 </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -73,9 +73,11 @@
       <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, class: "btn btn-primary" %>
     </div>
 
-    <div>
-      Links last checked
-      on <%= @step_by_step_page.links_last_checked_date %>
-    </div>
+    <% if @step_by_step_page.links_checked? %>
+      <div>
+        Links last checked
+        <br>on <%= @step_by_step_page.links_last_checked_date %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -75,7 +75,7 @@
 
     <% if @step_by_step_page.links_checked? %>
       <div class="broken-links-last-checked--summary">
-        Links last checked on:
+        Last checked:
         <br><%= @step_by_step_page.links_last_checked_date %>
       </div>
     <% end %>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -52,7 +52,7 @@
 
             <th class="h4">
               <%= step.title %>
-              <% if step.broken_links %>
+              <% if step.broken_links? %>
                 <span class="label label-warning">
                   <%= render 'shared/steps/broken-links-summary', step: step %>
                 </span>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -52,6 +52,11 @@
 
             <th class="h4">
               <%= step.title %>
+              <% if step.broken_links %>
+                <span class="label label-warning">
+                  <%= render 'shared/steps/broken-links-summary', step: step %>
+                </span>
+              <% end %>
             </th>
 
             <td class="text-right text-nowrap">

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -73,5 +73,8 @@
         <li><%= link_to 'Preview', preview_url(@step_by_step_page.slug, auth_bypass_id: @step_by_step_page.auth_bypass_id), class: "btn btn-success btn-block preview-button step-action" %></li>
       </ul>
     </div>
+    <div>
+      <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, class: "btn btn-primary" %>
+    </div>
   </div>
 </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -74,9 +74,9 @@
     </div>
 
     <% if @step_by_step_page.links_checked? %>
-      <div>
-        Links last checked
-        <br>on <%= @step_by_step_page.links_last_checked_date %>
+      <div class="broken-links-last-checked--summary">
+        Links last checked on:
+        <br><%= @step_by_step_page.links_last_checked_date %>
       </div>
     <% end %>
   </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -56,6 +56,11 @@
                 <span class="label label-warning">
                   <%= render 'shared/steps/broken-links-summary', step: step %>
                 </span>
+              <% elsif step.link_report? %>
+                <span class="label label-success">
+                  <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+                  <strong>No broken links</strong>
+                </span>
               <% end %>
             </th>
 

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -59,6 +59,11 @@
 </div>
 
 <div class="form-group">
+  <div>
+    <p>
+      <%= step.broken_links %>
+    </p>
+  </div>
   <div class="row">
     <div class="<%= left_col %>">
       <%= form.text_area :contents, class: "form-control", label: "Content, tasks and links in this step", rows: 8 %>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -59,11 +59,64 @@
 </div>
 
 <div class="form-group">
-  <div>
-    <p>
-      <%= step.broken_links %>
-    </p>
-  </div>
+  <% if step.broken_links && step.broken_links.count > 0 %>
+    <div class="broken-links">
+      <div class="panel panel-warning">
+        <div class="panel-heading" role="tab" id="brokenLinkHeading">
+          <a role="button" class="collapsed broken-links-accordion__collapsible-link" data-toggle="collapse" data-parent="#brokenLinksAccordion" href="#brokenLinkBody" aria-expanded="true" aria-controls="brokenLinkBody">
+            <p class="panel-title h4 broken-links-accordion__title">
+              <%= render 'shared/steps/broken-links-summary', step: step %>
+              
+              <button class="broken-links-accordion__indicator btn btn-success btn-xs">
+                <span class="broken-links-accordion__indicator--show">
+                  <span class="broken-links-accordion__indicator-text">Show</span>
+                  <i class="glyphicon glyphicon-plus"></i>
+                </span>
+
+                <span class="broken-links-accordion__indicator--hide">
+                  <span class="broken-links-accordion__indicator-text">Hide</span>
+                  <i class="glyphicon glyphicon-minus"></i>
+                </span>
+              </button>
+            </p>
+          </a>
+        </div>
+        <div id="brokenLinkBody" class="panel-collapse collapse" role="tabpanel" aria-labelledby="brokenLinkHeading">
+          <div class="list-group">
+            <% step.broken_links.each.with_index do |link, index| %>
+              <a href="<%= link['uri'] %>" class="list-group-item" target="_blank">
+                <h4 class="list-group-item-heading"><%= link['uri'] %></h4>
+                <p class="list-group-item-text">
+                  <dl class="dl">
+                    <dt>Last checked</dt>
+                    <dd><%= link['checked'].to_datetime.to_formatted_s(:rfc822) %></dd>
+                    
+                    <% if link['errors'] && link['errors'].count > 0 %>
+                      <dt>Errors</dt>
+                      <dd>
+                        <% link['errors'].each do |error| %>
+                          <%= error %> <br/>
+                        <% end %>
+                      </dd>
+                    <% end %>
+                    
+                    <% if link['warnings'] && link['warnings'].count > 0 %>
+                      <dt>Warnings</dt>
+                      <dd>
+                        <% link['warnings'].each do |warning| %>
+                          <%= warning %> <br/>
+                        <% end %>
+                      </dd>
+                    <% end %>
+                  </dl>
+                </p>
+              </a>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
   <div class="row">
     <div class="<%= left_col %>">
       <%= form.text_area :contents, class: "form-control", label: "Content, tasks and links in this step", rows: 8 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     "/tags/#{params[:tag_id]}/lists"
   }
 
-  patch 'link_report/:id', to: 'link_report#update'
+  post '/link_report', to: 'link_report#update'
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,8 @@ Rails.application.routes.draw do
     "/tags/#{params[:tag_id]}/lists"
   }
 
+  patch 'link_report/:id', to: 'link_report#update'
+
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 
   class SidekiqAccessContraint

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     get :unpublish
     post :unpublish
     get  'publish-or-delete', to: 'publish_or_delete'
+    post :check_links
 
     resources :steps
   end

--- a/db/migrate/20180807103538_create_link_reports.rb
+++ b/db/migrate/20180807103538_create_link_reports.rb
@@ -1,0 +1,11 @@
+class CreateLinkReports < ActiveRecord::Migration[5.2]
+  def change
+    create_table :link_reports do |t|
+      t.integer :batch_id
+      t.datetime :completed
+      t.references :step, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,15 @@ ActiveRecord::Schema.define(version: 2018_08_29_153755) do
     t.index ["step_by_step_page_id"], name: "index_internal_change_notes_on_step_by_step_page_id"
   end
 
+  create_table "link_reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "batch_id"
+    t.datetime "completed"
+    t.bigint "step_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["step_id"], name: "index_link_reports_on_step_id"
+  end
+
   create_table "list_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "base_path"
     t.integer "index", default: 0, null: false
@@ -141,6 +150,7 @@ ActiveRecord::Schema.define(version: 2018_08_29_153755) do
   end
 
   add_foreign_key "internal_change_notes", "step_by_step_pages"
+  add_foreign_key "link_reports", "steps"
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
   add_foreign_key "lists", "tags", name: "lists_tag_id_fk", on_delete: :cascade
   add_foreign_key "navigation_rules", "step_by_step_pages"

--- a/spec/controllers/link_report_controller_spec.rb
+++ b/spec/controllers/link_report_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/link_checker_api'
+
+RSpec.describe LinkReportController do
+  include GdsApi::TestHelpers::LinkCheckerApi
+  describe '.update' do
+    it 'should update an existing LinkReport' do
+      time = Time.now
+      create(:link_report, batch_id: 1234, completed: nil)
+      patch :update, params: { id: 1234, completed_at: time }
+      expect(LinkReport.find_by(batch_id: 1234).completed).to be_within(1.second).of time
+    end
+    context "when the batch_id doesn't exist" do
+      it 'should fail gracefully' do
+        time = Time.now
+        expect { patch :update, params: { id: 1234, completed_at: time } }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/controllers/link_report_controller_spec.rb
+++ b/spec/controllers/link_report_controller_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe LinkReportController do
     it 'should update an existing LinkReport' do
       time = Time.now
       create(:link_report, batch_id: 1234, completed: nil)
-      patch :update, params: { id: 1234, completed_at: time }
+      post :update, params: link_checker_api_batch_report_hash(id: 1234, completed_at: time)
       expect(LinkReport.find_by(batch_id: 1234).completed).to be_within(1.second).of time
     end
     context "when the batch_id doesn't exist" do
       it 'should fail gracefully' do
         time = Time.now
-        expect { patch :update, params: { id: 1234, completed_at: time } }.to_not raise_error
+        expect { post :update, params: link_checker_api_batch_report_hash(id: 1234, completed_at: time) }.to_not raise_error
       end
     end
   end

--- a/spec/controllers/mainstream_browse_pages_controller_spec.rb
+++ b/spec/controllers/mainstream_browse_pages_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MainstreamBrowsePagesController do
     let(:browse_page) { create(:mainstream_browse_page) }
 
     it 'does not allow users without GDS Editor permissions access' do
-      stub_user.permissions = ["signin"]
+      stub_user.permissions = %w(signin)
 
       get :new, params: { parent_id: browse_page.id }
 

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe StepByStepPagesController do
     end
 
     it "cannot be accessed by users without GDS editor permissions" do
-      stub_user.permissions = ["signin"]
+      stub_user.permissions = %w(signin)
       get :index
 
       expect(response.status).to eq(403)

--- a/spec/controllers/steps_controller_spec.rb
+++ b/spec/controllers/steps_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StepsController do
     end
 
     it "cannot be accessed by users without GDS editor permissions" do
-      stub_user.permissions = ["signin"]
+      stub_user.permissions = %w(signin)
       get :edit, params: { step_by_step_page_id: step_by_step_page.id, id: step.id }
 
       expect(response.status).to eq(403)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
+  factory :link_report do
+    batch_id 1
+    completed "2018-08-07 10:35:38"
+    step nil
+  end
   factory :step_by_step_page do
     title "How to be amazing"
     slug "how-to-be-the-amazing-1"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -103,7 +103,7 @@ FactoryBot.define do
 
   factory :user do
     uid { SecureRandom.hex }
-    permissions { ["signin"] }
+    permissions { %w(signin) }
   end
 
   factory :list do

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -314,9 +314,7 @@ RSpec.feature "Curating topic contents" do
 
       # Then the list should be deleted
       within '.curated-lists' do
-        expect(list_titles_on_page).to eq([
-          'Piping'
-        ])
+        expect(list_titles_on_page).to eq(%w(Piping))
       end
 
       # And the content from the list should appear in the uncategorized section

--- a/spec/features/sidekiq_monitoring_spec.rb
+++ b/spec/features/sidekiq_monitoring_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Sidekiq monitoring" do
   end
 
   it "does not allow users without permissions to monitor Sidekiq" do
-    user = create(:user, permissions: ["signin"])
+    user = create(:user, permissions: %w(signin))
     allow_any_instance_of(Warden::Proxy).to receive(:user).and_return(user)
 
     expect {

--- a/spec/features/tagging_browse_with_topics_spec.rb
+++ b/spec/features/tagging_browse_with_topics_spec.rb
@@ -63,6 +63,6 @@ RSpec.feature "Tagging browse pages with topics" do
 
   def then_I_my_browse_page_is_selected
     expect(page).to have_select("mainstream_browse_page_topics",
-      selected: ["Alpha"])
+      selected: %w(Alpha))
   end
 end

--- a/spec/models/link_report_spec.rb
+++ b/spec/models/link_report_spec.rb
@@ -1,5 +1,38 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/link_checker_api'
 
 RSpec.describe LinkReport, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include GdsApi::TestHelpers::LinkCheckerApi
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
+  describe '.create_record' do
+    context 'when the step content has links' do
+      it 'should create a record with the right batch_id' do
+        step = create(:step)
+        link_report = create(:link_report, step: step)
+        link_checker_api_create_batch(
+          uris: [
+            "http://example.com/good",
+            'https://www.gov.uk/good/stuff',
+            "https://www.gov.uk/also/good/stuff",
+            "https://www.gov.uk/not/as/great",
+          ],
+          webhook_uri: "https://collections-publisher.test.gov.uk/link_report"
+        )
+        link_report.create_record
+        expect(LinkReport.find_by(batch_id: 0)).to be
+      end
+    end
+
+    context 'when the step content does not have links' do
+      it 'should return delete itself' do
+        step = create(:step, contents: "Lorem ipsum")
+        link_report = create(:link_report, step: step)
+        link_report.create_record
+        expect(LinkReport.find_by(batch_id: 0)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/link_report_spec.rb
+++ b/spec/models/link_report_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LinkReport, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -134,6 +134,26 @@ RSpec.describe StepByStepPage do
     }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
+  describe '#links_last_checked_date' do
+    it 'gets the latest date that links were checked for any step' do
+      step_by_step_with_step = create(:step_by_step_page)
+
+      step1 = create(:step, step_by_step_page: step_by_step_with_step)
+      step2 = create(:step, step_by_step_page: step_by_step_with_step)
+
+      create(:link_report, batch_id: 1, step_id: step1.id, created_at: "2018-08-07 10:31:38")
+      create(:link_report, batch_id: 2, step_id: step2.id, created_at: "2018-08-07 10:30:38")
+
+      expect(step_by_step_with_step.links_last_checked_date).to eq("Tuesday, 07 August 2018 at 10:31 AM")
+    end
+
+    it 'does not fail if there are no link reports' do
+      step_by_step_with_step = create(:step_by_step_page)
+
+      expect(step_by_step_with_step.links_last_checked_date).to be nil
+    end
+  end
+
   describe 'publishing' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -154,6 +154,22 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe 'links_checked?' do
+    it 'returns true if links have been checked' do
+      step_by_step_with_step = create(:step_by_step_page)
+      step = create(:step, step_by_step_page: step_by_step_with_step)
+      create(:link_report, batch_id: 1, step_id: step.id)
+
+      expect(step_by_step_with_step.links_checked?).to be true
+    end
+
+    it 'returns false if links have not been checked' do
+      step_by_step_with_step = create(:step_by_step_page)
+
+      expect(step_by_step_with_step.links_checked?).to be false
+    end
+  end
+
   describe 'publishing' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -129,5 +129,10 @@ RSpec.describe Step do
       expect(step_item.broken_links.length).to eql 1
       expect(step_item.broken_links?).to be true
     end
+
+    it 'should return the last date the links where checked' do
+      create(:link_report, batch_id: 2, step_id: step_item.id, created_at: "2018-08-07 10:30:38")
+      expect(step_item.links_last_checked_date.utc).to eq(Time.new(2018, 8, 7, 10, 30, 38).utc)
+    end
   end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Step do
     it 'should return nothing if there are no link reports yet' do
       expect(step_item.broken_links).to be_nil
       expect(step_item.broken_links?).to be false
+      expect(step_item.link_report?).to be false
     end
 
     it 'should return an empty array if there are link reports, but all the links work' do
@@ -64,6 +65,7 @@ RSpec.describe Step do
       )
       expect(step_item.broken_links).to eql []
       expect(step_item.broken_links?).to be false
+      expect(step_item.link_report?).to be true
     end
 
     it 'should return a batch report if there is one with a matching id and it contains a broken link' do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Step do
   describe 'broken_links' do
     it 'should return nothing if there are no link reports yet' do
       expect(step_item.broken_links).to be_nil
+      expect(step_item.broken_links?).to be false
     end
 
     it 'should return an empty array if there are link reports, but all the links work' do
@@ -62,6 +63,7 @@ RSpec.describe Step do
         ]
       )
       expect(step_item.broken_links).to eql []
+      expect(step_item.broken_links?).to be false
     end
 
     it 'should return a batch report if there is one with a matching id and it contains a broken link' do
@@ -92,6 +94,7 @@ RSpec.describe Step do
         )
       create(:link_report, batch_id: 2, step_id: step_item.id)
       expect(step_item.broken_links).to_not be_empty
+      expect(step_item.broken_links?).to be true
     end
 
     it 'should contain one item if there are link reports and at least one is broken' do
@@ -122,6 +125,7 @@ RSpec.describe Step do
         )
       create(:link_report, batch_id: 2, step_id: step_item.id)
       expect(step_item.broken_links.length).to eql 1
+      expect(step_item.broken_links?).to be true
     end
   end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/link_checker_api'
 
 RSpec.describe Step do
+  include GdsApi::TestHelpers::LinkCheckerApi
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
   end
@@ -36,6 +38,90 @@ RSpec.describe Step do
 
       expect(step_item).not_to be_valid
       expect(step_item.errors).to have_key(:logic)
+    end
+  end
+  describe 'broken_links' do
+    it 'should return nothing if there are no link reports yet' do
+      expect(step_item.broken_links).to be_nil
+    end
+
+    it 'should return an empty array if there are link reports, but all the links work' do
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+      link_checker_api_get_batch(
+        id: 2,
+        links: [
+          {
+            "uri": "https://www.gov.uk/",
+            "status": "ok",
+            "checked": "2017-04-12T18:47:16Z",
+            "errors": [],
+            "warnings": [],
+            "problem_summary": "null",
+            "suggested_fix": "null"
+          }
+        ]
+      )
+      expect(step_item.broken_links).to eql []
+    end
+
+    it 'should return a batch report if there is one with a matching id and it contains a broken link' do
+      link_checker_api_get_batch(
+        id: 2,
+        links: [
+          {
+            "uri": "https://www.gov.uk/",
+            "status": "ok",
+            "checked": "2017-04-12T18:47:16Z",
+            "errors": [],
+            "warnings": [],
+            "problem_summary": "null",
+            "suggested_fix": "null"
+          },
+          {
+            "uri": "https://www.gov.uk/404",
+            "status": "broken",
+            "checked": "2017-04-12T16:30:39Z",
+            "errors": [
+              "Received 404 response from the server."
+            ],
+            "warnings": [],
+            "problem_summary": "404 error (page not found)",
+            "suggested_fix": ""
+          }
+        ]
+        )
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+      expect(step_item.broken_links).to_not be_empty
+    end
+
+    it 'should contain one item if there are link reports and at least one is broken' do
+      link_checker_api_get_batch(
+        id: 2,
+        links: [
+          {
+            "uri": "https://www.gov.uk/",
+            "status": "ok",
+            "checked": "2017-04-12T18:47:16Z",
+            "errors": [],
+            "warnings": [],
+            "problem_summary": "null",
+            "suggested_fix": "null"
+          },
+          {
+            "uri": "https://www.gov.uk/404",
+            "status": "broken",
+            "checked": "2017-04-12T16:30:39Z",
+            "errors": [
+              "Received 404 response from the server."
+            ],
+            "warnings": [],
+            "problem_summary": "404 error (page not found)",
+            "suggested_fix": ""
+          }
+        ]
+        )
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+      expect(step_item.broken_links.length).to eql 1
     end
   end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe StepNavPresenter do
 
         presented = subject.render_for_publishing_api
         expected_access_limited_tokens = {
-          auth_bypass_ids: ["123"]
+          auth_bypass_ids: %w(123)
         }
 
         expect(presented[:access_limited]).to eq(expected_access_limited_tokens)

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -464,4 +464,24 @@ RSpec.describe StepContentParser do
       )
     end
   end
+
+  describe '.all_paths' do
+    context 'when there are no links in the text' do
+      test_text = 'Lorem ipsum dolores'
+      it 'should return an empty array' do
+        expect(subject.all_paths(test_text)).to be_empty
+      end
+    end
+    context 'when there is one relative and one absolute path' do
+      test_text = "[Learn to drive](/learn-to-drive)\n[Google it](https://www.google.com)"
+      it 'should return an array of URLs' do
+        links = subject.all_paths(test_text)
+        expect(links).to all(start_with("https:"))
+      end
+      it 'should have a length of two' do
+        links = subject.all_paths(test_text)
+        expect(links.length).to eql 2
+      end
+    end
+  end
 end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -9,7 +9,7 @@ module CommonFeatureSteps
   end
 
   def given_I_am_not_a_GDS_editor
-    stub_user.permissions = ['signin']
+    stub_user.permissions = %w(signin)
   end
 
   def and_I_submit_the_form


### PR DESCRIPTION
Trello: https://trello.com/c/F1S78A0L 

## What's changed

Give publishers the ability to check for broken links in a step by step page. The link error messages appear against each step so they know where to go to fix the broken link.

This change uses [link-checker-api](https://docs.publishing.service.gov.uk/apis/link-checker-api.html#content) to check links in a similar way to the Mainstream Publisher app.

### Overview page
<img width="1552" alt="screen shot 2018-08-30 at 08 44 36" src="https://user-images.githubusercontent.com/5793815/44837461-99e38580-ac31-11e8-980c-cf12f235d115.png">

<img width="1552" alt="screen shot 2018-08-30 at 08 45 09" src="https://user-images.githubusercontent.com/5793815/44837487-aec01900-ac31-11e8-95ab-66b7946d4926.png">

### Each step
#### Collapsed
<img width="1306" alt="44145144-53337b8c-a082-11e8-855a-cdc60c94340b" src="https://user-images.githubusercontent.com/5793815/44835772-16c03080-ac2d-11e8-8dbc-e8294ca7f2b3.png">

#### Open
<img width="1267" alt="44145148-57cb3c34-a082-11e8-8c78-f31b3afaed23" src="https://user-images.githubusercontent.com/5793815/44835820-335c6880-ac2d-11e8-885a-162171945ce3.png">
