### PR TITLE
Add a reminder to check for broken links before publishing

### DIFF
--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -28,8 +28,9 @@
     <% if @step_by_step_page.has_draft? %>
       <div class="panel panel-default">
         <div class="panel-body">
+          <p>Before publishing check for broken links.</p>
+          <p>After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
           <%= link_to 'Publish changes', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary publish-button" %>
-          <p>You will need to tag this step by step to a mainstream browse category and a taxonomy topic after publishing</p>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
# What
Add a reminder to check for broken links before publishing

# Why
To reduce the chances of step navs being published with broken links

# Considerations
This message can't be added until the link-checking feature has been rebased against master and the layout changes have been picked up.

This card should be played immediately after the link-checking feature has been merged into master.

# Applications involved

collections-publisher

# Ticket

https://trello.com/c/6xZxg4b0/808-add-a-reminder-to-check-for-broken-links-before-publishing-xs