### PR TITLE
Internal changenotes controller

### DIFF
--- a/app/controllers/internal_change_notes_controller.rb
+++ b/app/controllers/internal_change_notes_controller.rb
@@ -1,0 +1,16 @@
+class InternalChangeNotesController < ApplicationController
+  def create
+    InternalChangeNote.create(internal_change_note_params.merge(step_by_step_page_id: step_by_step_page.id, created_at: Time.now, author: current_user.name))
+    redirect_to step_by_step_page
+  end
+
+private
+
+  def step_by_step_page
+    StepByStepPage.find(params[:step_by_step_page_id])
+  end
+
+  def internal_change_note_params
+    params.require(:internal_change_note).permit(:description)
+  end
+end

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -88,6 +88,11 @@ class StepByStepPagesController < ApplicationController
     @step_by_step_page.steps.each(&:request_broken_links)
   end
 
+  def internal_change_notes
+    set_current_page_as_step_by_step
+    @internal_change_note = InternalChangeNote.new
+  end
+
 private
 
   def discard_draft

--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -22,4 +22,7 @@
   <li class="<%= "active" if active == 'publish-or-delete' %>">
     <%= link_to 'Publish or delete', step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "step-by-step-tab-link" %>
   </li>
+  <li class="<%= "active" if active == 'internal-change-notes' %>">
+    <%= link_to 'Change notes', step_by_step_page_internal_change_notes_path(@step_by_step_page), class: "step-by-step-tab-link"%>
+  </li>
 </ul>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -1,0 +1,47 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: @step_by_step_page
+    },
+    {
+      text: 'Record a new change note or review prior changes'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/page_title', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Record a new change note or review prior changes'
+%>
+
+<%= render 'nav', step_by_step_page: @step_by_step_page, active: "change-notes" %>
+
+<%
+  left_col = "col-md-7"
+  right_col = "col-md-5"
+%>
+
+<%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
+  <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+
+  <div class="form-group row">
+    <div class="<%= left_col %>">
+      <%= form.text_area :description, required: true, class: "form-control", rows: 8 %>
+    </div>
+  </div>
+  <div class="form-group">
+    <%= form.submit "Save", class: "btn btn-primary" %>
+  </div>
+  <div class="form-group">
+    <%= link_to 'Cancel', @step_by_step_page %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     get :unpublish
     post :unpublish
     get  'publish-or-delete', to: 'publish_or_delete'
+    get 'internal-change-notes', to: 'interal_change_notes'
+    post 'internal-change-notes', to: 'internal_change_notes#create'
     post :check_links
 
     resources :steps

--- a/spec/controllers/internal_change_notes_controller_spec.rb
+++ b/spec/controllers/internal_change_notes_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe InternalChangeNotesController, type: :controller do
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
+  describe "POST #create" do
+    it "creates an InternalChangeNote" do
+      stub_user.name = "Test author"
+      create(:step_by_step_page, id: 0)
+      expect(InternalChangeNote).to receive(:create)
+      post :create, params: { step_by_step_page_id: 0, internal_change_note: { description: "Test description" } }
+    end
+    it "saves it to the database" do
+      stub_user.name = "Test author"
+      create(:step_by_step_page, id: 0)
+      post :create, params: { step_by_step_page_id: 0, internal_change_note: { description: "Test description" } }
+      expect(InternalChangeNote.first.author).to eql "Test author"
+    end
+  end
+end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -63,6 +63,15 @@ RSpec.feature "Managing step by step pages" do
         and_I_see_the_steps_updated_on_the_step_by_step_details_page
       end
     end
+
+    context "and I would like to leave a change note on a step by step page" do
+      scenario "User leaves a change note" do
+        given_there_is_a_step_by_step_page
+        and_I_visit_the_change_notes_tab
+        and_I_complete_a_change_note
+        then_I_can_see_the_main_page
+      end
+    end
   end
 
   def when_I_visit_the_step_by_step_page
@@ -71,6 +80,10 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_visit_the_reorder_steps_page
     visit step_by_step_page_reorder_path(@step_by_step_page)
+  end
+
+  def and_I_visit_the_change_notes_tab
+    visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
   end
 
   def and_I_create_a_new_step
@@ -180,5 +193,18 @@ RSpec.feature "Managing step by step pages" do
   def and_I_see_the_steps_updated_on_the_step_by_step_details_page
     expect(page).to have_css("table > tbody > tr:nth-child(1) > th:nth-child(2)", text: "Dress like the Fonz")
     expect(page).to have_css("table > tbody > tr:nth-child(2) > th:nth-child(2)", text: "Check how awesome you are")
+  end
+
+  def and_I_write_a_change_note
+    fill_in "Description", with: "I've changed this step by step!"
+  end
+
+  def and_I_complete_a_change_note
+    and_I_write_a_change_note
+    click_on "Save"
+  end
+
+  def then_I_can_see_the_main_page
+    expect(page).to have_content("How to be amazing")
   end
 end


### PR DESCRIPTION
This PR adds a controller and a form for publishers to add changenotes to their Step-By-Steps. It's a very rough MVP and does not contain a method to retrieve those notes. That method will be added in another PR.

## Context
[Ticket for this PR](https://trello.com/c/OqkwUwN3/818-create-changenote-controller-with-create-action) and [wider context](https://trello.com/c/G0fchnmS/733-ability-to-record-change-notes-l)

## Why
Publishers want a way to record changes they've made to a SBS, or leave notes for people on 2i to read. This is a small PR, because the team is currently working on pushing to master at least once a day as an experiment to find out if it gets value to users faster.