### PR TITLE
Changes Step edit to refresh page

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -24,11 +24,9 @@ class StepsController < ApplicationController
   def update
     if step.update(step_params)
       update_downstream
-
-      redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully updated.'
-    else
-      render :edit
+      flash.now[:notice] = 'Step was successfully updated.'
     end
+    render :edit
   end
 
   def destroy

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -14,6 +14,8 @@
   ]
 %>
 
+<%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
 <%= render 'shared/steps/page_title', links: links %>

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Managing step by step pages" do
         and_I_edit_the_first_step
         then_I_can_see_the_edit_page
         and_I_fill_the_edit_form_and_submit
-        and_I_see_the_step_on_the_step_by_step_details_page
+        then_I_can_see_the_edit_page
       end
 
       scenario "User deletes step", js: true do


### PR DESCRIPTION
## Why
Users of the step-by-step publishing tool were frustrated that after saving changes to a particular step they were booted back to the main edit view. This meant that if they were making a number of quick edits they spent a lot of time fruitlessly clicking back to get where they wanted to go.

## What
This commit changes that redirect and just refreshes the page. It still displays a flash to let users know that their changes have been saved.