### PR TITLE
Adds edition_number column to internal_change_notes

### DIFF
--- a/db/migrate/20180907075324_add_edition_number_to_internal_change_notes.rb
+++ b/db/migrate/20180907075324_add_edition_number_to_internal_change_notes.rb
@@ -1,0 +1,5 @@
+class AddEditionNumberToInternalChangeNotes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :internal_change_notes, :edition_number, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_29_153755) do
+ActiveRecord::Schema.define(version: 2018_09_07_075324) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
     t.text "description"
     t.bigint "step_by_step_page_id"
     t.datetime "created_at"
+    t.integer "edition_number"
     t.index ["step_by_step_page_id"], name: "index_internal_change_notes_on_step_by_step_page_id"
   end
 


### PR DESCRIPTION
# Context
## The vision
If a step by step has been previously published and has a draft, add a "discard draft" button. When this button is clicked:

* a "discard draft" request is sent to publishing api.
* get the latest "published" content from publishing-api
* copy the latest content over the step by step. Basically, reverse engineer the "render for publishing api" presenter. Things to consider:
* Excluding "done" pages from the navigation rules.
* Use the "content_id" to find the step by step to update as the base_path may have changed.
* Make sure the number of steps matches as some could have been added or removed between versions

## Preparatory work:
* **[This PR]Add an edition id field to the change notes table. The default value should be nil.**
* Add a post publish task that:
* Gets the user_facing_version of the latest version from publishing api
* Populates every empty edition id in the change notes for a step by step with the user_facing_version

## The main feature:
* Add a "discard draft" button, most likely to the "publish or delete" page
* Send a discard draft request to publishing-api
* Get the last published version from publishing_api. The get_content call will return the latest version regardless of publishing state, so it might be an idea to check that the state is "published".
* Repopulate StepByStepPage with the latest published content.
* Drop Change notes for the discarded draft, i.e. where the edition id is empty

## Detail

This commit creates a new column on internal_change_notes with a default of nil. The column will be filled with the associated step by step guide's edition number when the step by step guide is published. This allows change notes to be associated with a particular edition. We're doing this because we've found that step by step guides may have many editions, and each edition may have many internal change notes. We think this is the best way of implementing this data hierarchy.

[Ticket](https://trello.com/c/skeoVNM7/836-add-an-editionid-column-to-the-internalchangenote-model)