### PR TITLE
Ability to record and view change notes

### DIFF
--- a/app/assets/javascripts/steps.js
+++ b/app/assets/javascripts/steps.js
@@ -13,6 +13,7 @@
       this.initialiseDragAndDrop();
       this.setOrder(); // this is called so the order of the list is initalised
       this.bindStatusClicks();
+      this.bindCancelAddChangeNoteLink();
     },
 
     addReorderButtons: function() {
@@ -102,6 +103,14 @@
           $('tr[data-status]').hide();
           $('tr[data-status="' + show + '"').show();
         }
+      });
+    },
+
+    bindCancelAddChangeNoteLink: function() {
+      $('.add-change-note-cancel--link').on('click', function(e){
+        e.preventDefault();
+        $('.add-change-note-description--textarea').val('');
+        $('.add-change-note--details').removeAttr('open');
       });
     }
   };

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -8,6 +8,7 @@ $black: #0B0C0C;
 $red: #b10e1e;
 $grey: #eeeeee;
 $beige: #8a6d3b;
+$border-grey: #aaaaaa;
 
 .step-actions {
   padding: 15px 0;
@@ -120,4 +121,40 @@ $beige: #8a6d3b;
   border-left: 5px solid $grey;
   padding: 10px 20px;
   margin: 20px 0 20px;
+}
+
+.add-change-note--details {
+  margin-bottom: 20px;
+
+  &[open] {
+    .add-change-note--summary {
+      display: none;
+    }
+  }
+
+  .add-change-note--summary::-webkit-details-marker {
+    display: none;
+  }
+}
+
+.change-note--details {
+  border: 1px solid $border-grey;
+  border-radius: 4px;
+  padding: 10px 10px 0;
+  margin-bottom: 10px;
+
+  &[open] {
+    padding: 10px;
+
+    .change-note--summary {
+      border-bottom: 1px solid $border-grey;
+      margin-bottom: 10px;
+    }
+  }
+
+  .change-note--summary {
+    font-weight: bold;
+    margin: -10px -10px 0;
+    padding: 10px;
+  }
 }

--- a/app/controllers/internal_change_notes_controller.rb
+++ b/app/controllers/internal_change_notes_controller.rb
@@ -1,7 +1,7 @@
 class InternalChangeNotesController < ApplicationController
   def create
     InternalChangeNote.create(internal_change_note_params.merge(step_by_step_page_id: step_by_step_page.id, created_at: Time.now, author: current_user.name))
-    redirect_to step_by_step_page
+    redirect_to step_by_step_page_internal_change_notes_path, notice: 'Change note was successfully added.'
   end
 
 private

--- a/app/models/internal_change_note.rb
+++ b/app/models/internal_change_note.rb
@@ -1,4 +1,8 @@
 class InternalChangeNote < ApplicationRecord
   validates :author, :description, :created_at, presence: true
   belongs_to :step_by_step_page
+
+  def readable_created_date
+    created_at.strftime('%A, %d %B %Y at %H:%M %p')
+  end
 end

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -41,8 +41,9 @@
           <span class="btn btn-primary">Add a change note</span>
         </summary>      
         <div class="form-group">
-          <%= form.text_area :description, required: true, class: "form-control", rows: 8 %>
+          <%= form.text_area :description, required: true, class: "form-control add-change-note-description--textarea", rows: 8 %>
           <%= form.submit "Save change note", class: "btn btn-success" %>
+          <a href="<%= step_by_step_page_internal_change_notes_path %>" class="btn btn-link add-change-note-cancel--link">Cancel</a>
         </div>
       </details>
     </div>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -9,7 +9,7 @@
       href: @step_by_step_page
     },
     {
-      text: 'Record a new change note or review prior changes'
+      text: 'Change notes'
     }
   ]
 %>
@@ -18,30 +18,46 @@
 
 <%= render 'shared/steps/page_title', links: links %>
 
+<%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
-  action: 'Record a new change note or review prior changes'
+  action: 'Change notes'
 %>
 
-<%= render 'nav', step_by_step_page: @step_by_step_page, active: "change-notes" %>
+<%= render 'nav', step_by_step_page: @step_by_step_page, active: "internal-change-notes" %>
 
 <%
-  left_col = "col-md-7"
-  right_col = "col-md-5"
+  full_width = "col-md-12"
 %>
 
 <%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
   <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 
-  <div class="form-group row">
-    <div class="<%= left_col %>">
-      <%= form.text_area :description, required: true, class: "form-control", rows: 8 %>
+  <div class="row">
+    <div class="<%= full_width %>">
+      <details class="add-change-note--details">
+        <summary class="add-change-note--summary">
+          <span class="btn btn-primary">Add a change note</span>
+        </summary>      
+        <div class="form-group">
+          <%= form.text_area :description, required: true, class: "form-control", rows: 8 %>
+          <%= form.submit "Save change note", class: "btn btn-success" %>
+        </div>
+      </details>
     </div>
   </div>
-  <div class="form-group">
-    <%= form.submit "Save", class: "btn btn-primary" %>
-  </div>
-  <div class="form-group">
-    <%= link_to 'Cancel', @step_by_step_page %>
+  <div class="row">
+    <div class="<%= full_width %>">
+      <% @step_by_step_page.internal_change_notes.each_with_index do |note, index| %>
+        <details class="change-note--details" <%= "open" if index == 0 %>>
+          <summary class="change-note--summary">
+            <%= note.readable_created_date %>
+          </summary>
+          <p>Change made by <strong><%= note.author %></strong></p>
+          <pre><%= note.description %></pre>
+        </details>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -41,7 +41,7 @@
           <span class="btn btn-primary">Add a change note</span>
         </summary>      
         <div class="form-group">
-          <%= form.text_area :description, required: true, class: "form-control add-change-note-description--textarea", rows: 8 %>
+          <%= form.text_area :description, required: true, class: "form-control add-change-note-description--textarea", rows: 8, maxlength: 50000 %>
           <%= form.submit "Save change note", class: "btn btn-success" %>
           <a href="<%= step_by_step_page_internal_change_notes_path %>" class="btn btn-link add-change-note-cancel--link">Cancel</a>
         </div>


### PR DESCRIPTION
# User need
As a content designer creating step by steps
I want to be able to see previous versions of the step by step
So that I can know who made changes to it and find out why, and so that I can revert to those versions if there's an issue with the current version

# What
Mainstream Publisher has version history for each content item, so that you can see the changes that were made to it each time it was published. This would be very useful to have in the step by step publishing tool.

# Why
Explanation of why we're doing this work

# Epic
https://trello.com/c/xurzZOox

# Applications involved
Collections Publisher

# Ticket 
https://trello.com/c/iDT6zgEA

# Demo
![sep-10-2018 16-53-47](https://user-images.githubusercontent.com/4599889/45308769-2b98a000-b51a-11e8-933e-785cfe32ea1c.gif)

# Screenshot
![screen shot 2018-09-10 at 16 45 58](https://user-images.githubusercontent.com/4599889/45308569-a3b29600-b519-11e8-9f63-e2d96e511dac.png)
