### PR TITLE
Repopulate a StepByStepPage with content from publishing-api

### DIFF
--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -35,6 +35,7 @@ private
       Step.new(
         title: step[:title],
         logic: logic(step),
+        optional: step[:optional],
       )
     end
 

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -10,6 +10,7 @@ class StepByStepPageReverter
     step_by_step_page.title = payload_from_publishing_api[:title]
     step_by_step_page.slug = payload_from_publishing_api[:base_path].tr('/', '')
     step_by_step_page.introduction = introduction
+    step_by_step_page.description = payload_from_publishing_api[:description]
 
     step_by_step_page.save!
   end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -11,6 +11,7 @@ class StepByStepPageReverter
     step_by_step_page.slug = payload_from_publishing_api[:base_path].tr('/', '')
     step_by_step_page.introduction = introduction
     step_by_step_page.description = payload_from_publishing_api[:description]
+    step_by_step_page.draft_updated_at = step_by_step_page.published_at
 
     step_by_step_page.save!
   end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -16,6 +16,8 @@ class StepByStepPageReverter
     step_by_step_page.save!
 
     step_by_step_page.steps = steps
+
+    add_navigation_rules
   end
 
 private
@@ -93,5 +95,9 @@ private
 
   def context(content)
     content[:context].present? ? " #{content[:context]}" : ""
+  end
+
+  def add_navigation_rules
+    StepLinksForRules.update(step_by_step_page)
   end
 end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -31,11 +31,12 @@ private
 
   def steps
     steps_in_step_by_step = step_by_step_nav_details[:steps]
-    new_steps = steps_in_step_by_step.map do |step|
+    new_steps = steps_in_step_by_step.map.with_index do |step, index|
       Step.new(
         title: step[:title],
         logic: logic(step),
         optional: step[:optional],
+        position: index + 1,
       )
     end
 

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -77,7 +77,7 @@ private
 
   def list(contents)
     list = contents[:contents].map do |content|
-      link(content)
+      link(content) + context(content)
     end
 
     list.join("\r\n")
@@ -89,5 +89,9 @@ private
 
   def link(content)
     "[#{content[:text]}](#{content[:href]})"
+  end
+
+  def context(content)
+    content[:context].present? ? " #{content[:context]}" : ""
   end
 end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -64,7 +64,8 @@ private
 
   def bulleted_list(contents)
     list = contents[:contents].map do |content|
-      "- #{link(content)}"
+      next "- #{link(content)}" if link?(content)
+      "- #{content[:text]}"
     end
 
     list.join("\r\n")
@@ -80,6 +81,10 @@ private
     end
 
     list.join("\r\n")
+  end
+
+  def link?(content)
+    content[:href].present?
   end
 
   def link(content)

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -8,6 +8,7 @@ class StepByStepPageReverter
 
   def repopulate_from_publishing_api
     step_by_step_page.title = payload_from_publishing_api[:title]
+    step_by_step_page.slug = payload_from_publishing_api[:base_path].tr('/', '')
 
     step_by_step_page.save!
   end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -50,11 +50,24 @@ private
 
   def contents(step_contents)
     contents_list = step_contents.map do |content|
+      next bulleted_list(content) if bulleted_list?(content)
       next list(content) if list?(content[:type])
       content[:text]
     end
 
     contents_list.join("\r\n\r\n")
+  end
+
+  def bulleted_list?(content)
+    list?(content[:type]) && content[:style].present? && content[:style] == "choice"
+  end
+
+  def bulleted_list(contents)
+    list = contents[:contents].map do |content|
+      "- #{link(content)}"
+    end
+
+    list.join("\r\n")
   end
 
   def list?(type)

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -50,9 +50,26 @@ private
 
   def contents(step_contents)
     contents_list = step_contents.map do |content|
+      next list(content) if list?(content[:type])
       content[:text]
     end
 
     contents_list.join("\r\n\r\n")
+  end
+
+  def list?(type)
+    type == "list"
+  end
+
+  def list(contents)
+    list = contents[:contents].map do |content|
+      link(content)
+    end
+
+    list.join("\r\n")
+  end
+
+  def link(content)
+    "[#{content[:text]}](#{content[:href]})"
   end
 end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -1,0 +1,14 @@
+class StepByStepPageReverter
+  attr_reader :step_by_step_page, :payload_from_publishing_api
+
+  def initialize(step_by_step_page, payload_from_publishing_api)
+    @step_by_step_page = step_by_step_page
+    @payload_from_publishing_api = payload_from_publishing_api.with_indifferent_access
+  end
+
+  def repopulate_from_publishing_api
+    step_by_step_page.title = payload_from_publishing_api[:title]
+
+    step_by_step_page.save!
+  end
+end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -9,7 +9,19 @@ class StepByStepPageReverter
   def repopulate_from_publishing_api
     step_by_step_page.title = payload_from_publishing_api[:title]
     step_by_step_page.slug = payload_from_publishing_api[:base_path].tr('/', '')
+    step_by_step_page.introduction = introduction
 
     step_by_step_page.save!
+  end
+
+private
+
+  def step_by_step_nav_details
+    payload_from_publishing_api[:details][:step_by_step_nav]
+  end
+
+  def introduction
+    contents = step_by_step_nav_details[:introduction].map { |line| line[:content] }
+    contents.join(" ")
   end
 end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -14,6 +14,8 @@ class StepByStepPageReverter
     step_by_step_page.draft_updated_at = step_by_step_page.published_at
 
     step_by_step_page.save!
+
+    step_by_step_page.steps = steps
   end
 
 private
@@ -25,5 +27,21 @@ private
   def introduction
     contents = step_by_step_nav_details[:introduction].map { |line| line[:content] }
     contents.join(" ")
+  end
+
+  def steps
+    steps_in_step_by_step = step_by_step_nav_details[:steps]
+    new_steps = steps_in_step_by_step.map do |step|
+      Step.new(
+        title: step[:title],
+        logic: logic(step),
+      )
+    end
+
+    new_steps
+  end
+
+  def logic(step)
+    step[:logic] || "number"
   end
 end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -99,5 +99,17 @@ private
 
   def add_navigation_rules
     StepLinksForRules.update(step_by_step_page)
+
+    set_navigation_states
+  end
+
+  def set_navigation_states
+    step_by_step_page.navigation_rules.each do |rule|
+      rule.update_attribute(:include_in_links, false) if pages_related_to_step_nav.include?(rule.content_id)
+    end
+  end
+
+  def pages_related_to_step_nav
+    payload_from_publishing_api[:links][:pages_related_to_step_nav] || []
   end
 end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -64,7 +64,7 @@ private
 
   def bulleted_list(contents)
     list = contents[:contents].map do |content|
-      next "- #{link(content)}" if link?(content)
+      next "- #{link(content)}" + context(content) if link?(content)
       "- #{content[:text]}"
     end
 

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -37,6 +37,7 @@ private
         logic: logic(step),
         optional: step[:optional],
         position: index + 1,
+        contents: contents(step[:contents]),
       )
     end
 
@@ -45,5 +46,13 @@ private
 
   def logic(step)
     step[:logic] || "number"
+  end
+
+  def contents(step_contents)
+    contents_list = step_contents.map do |content|
+      content[:text]
+    end
+
+    contents_list.join("\r\n\r\n")
   end
 end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -1,0 +1,254 @@
+require 'rails_helper'
+
+RSpec.describe StepByStepPageReverter do
+  describe "#repopulate_from_publishing_api" do
+    let(:step_by_step_page) { create(:step_by_step_page_with_navigation_rules) }
+
+    subject { described_class.new(step_by_step_page, payload_from_publishing_api(step_by_step_page.content_id)) }
+
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return({})
+      subject.repopulate_from_publishing_api
+      step_by_step_page.reload
+    end
+
+    it "saves the title" do
+      expect(step_by_step_page.title).to eq("An existing step by step that has previously been published")
+    end
+  end
+
+  def payload_from_publishing_api(content_id)
+    {
+      "base_path": "/an-existing-step-by-step",
+      "content_store": "live",
+      "description": "A description of the step by step page from publishing-api",
+      "details": {
+        "step_by_step_nav": {
+          "title": "An existing step by step that has previously been published",
+          "introduction": [
+            {
+              "content_type": "text/govspeak",
+              "content": "An introduction to the step by step journey."
+            }
+          ],
+          "steps": [
+            {
+              "title": "Step one of the step by step",
+              "contents": [
+                {
+                  "type": "paragraph",
+                  "text": "A paragraph of text in the first step."
+                },
+                {
+                  "type": "paragraph",
+                  "text": "A second paragraph of text in the first step."
+                }
+              ],
+              "optional": false
+            },
+            {
+              "title": "Step two of the step by step",
+              "contents": [
+                {
+                  "type": "list",
+                  "contents": [
+                    {
+                      "text": "The first item in the list for step two",
+                      "href": "/first-item-in-list-of-step-two"
+                    }
+                  ]
+                }
+              ],
+              "optional": false
+            },
+            {
+              "title": "Step three of the step by step",
+              "contents": [
+                {
+                  "type": "list",
+                  "style": "choice",
+                  "contents": [
+                    {
+                      "text": "The first item in the bulleted list for step three",
+                      "href": "/guidance/first-item-in-bulleted-list-of-step-three"
+                    }
+                  ]
+                }
+              ],
+              "optional": true,
+              "logic": "or"
+            },
+            {
+              "title": "Step four of the step by step",
+              "contents": [
+                {
+                  "type": "list",
+                  "contents": [
+                    {
+                      "text": "The first item in the list for step four",
+                      "href": "/first-item-in-list-of-step-four"
+                    },
+                    {
+                      "text": "The second item in the list for step four",
+                      "href": "/second-item-in-list-of-step-four"
+                    },
+                    {
+                      "text": "The third item in the list for step four",
+                      "href": "https://www.external.link/third-item-in-list-of-step-four"
+                    }
+                  ]
+                }
+              ],
+              "optional": false,
+              "logic": "and"
+            },
+            {
+              "title": "Step five of the step by step",
+              "contents": [
+                {
+                  "type": "list",
+                  "style": "choice",
+                  "contents": [
+                    {
+                      "text": "A list of text in the fifth step."
+                    }
+                  ]
+                }
+              ],
+              "optional": false,
+            },
+            {
+              "title": "Step six of the step by step",
+              "contents": [
+                {
+                  "type": "list",
+                  "contents": [
+                    {
+                      "text": "The first item in the list for step six with context",
+                      "href": "/first-item-in-list-of-step-six-with-context",
+                      "context": "£23"
+                    }
+                  ]
+                }
+              ],
+              "optional": false
+            },
+            {
+              "title": "Step seven of the step by step",
+              "contents": [
+                {
+                  "type": "list",
+                  "style": "choice",
+                  "contents": [
+                    {
+                      "text": "The first item in the bulleted list for step seven with context",
+                      "href": "/first-item-in-list-of-step-seven-with-context",
+                      "context": "£62 to £75"
+                    }
+                  ]
+                }
+              ],
+              "optional": false
+            },
+            {
+              "title": "Step eight of the step by step",
+              "contents": [
+                {
+                  "type": "paragraph",
+                  "text": "A paragraph of text in the eighth step."
+                },
+                {
+                  "type": "paragraph",
+                  "text": "A second paragraph of text in the eighth step."
+                },
+                {
+                  "type": "list",
+                  "contents": [
+                    {
+                      "text": "The first item in the list for step eight with context",
+                      "href": "/first-item-in-list-of-step-eight-with-context",
+                      "context": "£100"
+                    },
+                    {
+                      "text": "The second item in the list for step eight",
+                      "href": "/second-item-in-list-of-step-eight"
+                    }
+                  ]
+                },
+                {
+                  "type": "paragraph",
+                  "text": "A third paragraph of text in the eighth step."
+                },
+                {
+                  "type": "list",
+                  "style": "choice",
+                  "contents": [
+                    {
+                      "text": "The first item in the bulleted list for step eight with context",
+                      "href": "/first-item-in-bulleted-list-of-step-eight-with-context",
+                      "context": "£100"
+                    },
+                    {
+                      "text": "The second item in the bulleted list for step eight",
+                      "href": "/second-item-in-bulleted-list-of-step-eight"
+                    }
+                  ]
+                },
+              ],
+              "optional": false
+            }
+          ]
+        }
+      },
+      "document_type": "step_by_step_nav",
+      "first_published_at": "2017-11-01T15:31:15Z",
+      "last_edited_at": "2018-08-31T11:07:06Z",
+      "phase": "live",
+      "public_updated_at": "2018-08-31T10:58:30Z",
+      "publishing_app": "collections-publisher",
+      "redirects": [],
+      "rendering_app": "collections",
+      "routes": [
+        {
+          "path": "/an-existing-step-by-step",
+          "type": "exact"
+        }
+      ],
+      "schema_name": "step_by_step_nav",
+      "title": "An existing step by step that has previously been published",
+      "user_facing_version": 7,
+      "update_type": "minor",
+      "publication_state": "published",
+      "content_id": content_id,
+      "locale": "en",
+      "lock_version": 20,
+      "updated_at": "2018-08-31 11:07:06.977105",
+      "state_history": {
+        "5": "superseded",
+        "6": "published",
+        "1": "superseded",
+        "2": "superseded",
+        "3": "superseded",
+        "4": "superseded"
+      },
+      "links": {
+        "pages_related_to_step_nav": [
+          "8d35443d-7bf1-4f51-b9b1-e398e1d44030",
+        ],
+        "pages_part_of_step_nav": [
+          "a1156b8f-2a46-4fe1-8871-652abce9c925",
+          "eca3f3dd-3296-4b86-8dc8-42f91fe0cb6e",
+          "45c23180-968a-47bb-adbc-25d5422015ff",
+          "d6b1901d-b925-47c5-b1ca-1e52197097e2",
+          "b5d8c773-3a31-45f2-838d-255afef5511a",
+          "bbf6c11a-7dc6-4fe6-8dd8-68c09bdbe562",
+          "1788c387-8680-4454-8923-71ad0f632cbb",
+          "2b422e36-85c4-40fb-a40b-5cd40c86c0f8",
+          "2148f116-f909-4976-bb05-cb4899f3272a"
+        ]
+      },
+      "warnings": {
+      }
+    }
+  end
+end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -31,11 +31,22 @@ RSpec.describe StepByStepPageReverter do
     it "does not overwrite the content_id" do
       expect(step_by_step_page.content_id).to eq("content-id-of-step-by-step_by_step_nav")
     end
+
+    it "does not change the created_at time" do
+      created_at = Time.parse("2018-01-10T00:00:00Z")
+      step_by_step = create(:step_by_step_page, created_at: created_at)
+
+      updater = described_class.new(step_by_step, payload_from_publishing_api(step_by_step.content_id, base_path: "/base-path-1"))
+      updater.repopulate_from_publishing_api
+
+      step_by_step.reload
+      expect(step_by_step.created_at).to eq(created_at)
+    end
   end
 
-  def payload_from_publishing_api(content_id)
+  def payload_from_publishing_api(content_id, base_path: "/an-existing-step-by-step")
     {
-      "base_path": "/an-existing-step-by-step",
+      "base_path": base_path,
       "content_store": "live",
       "description": "A description of the step by step page from publishing-api",
       "details": {

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -223,6 +223,17 @@ RSpec.describe StepByStepPageReverter do
           expect(rule.publishing_app).to eq("publisher")
         end
       end
+
+      it "saves whether or not to display the step nav" do
+        navigation_rule1 = step_by_step_page.navigation_rules.find_by(base_path: "/first-item-in-list-of-step-two")
+        expect(navigation_rule1.include_in_links).to be true
+
+        navigation_rule2 = step_by_step_page.navigation_rules.find_by(base_path: "/guidance/first-item-in-bulleted-list-of-step-three")
+        expect(navigation_rule2.include_in_links).to be true
+
+        navigation_rule3 = step_by_step_page.navigation_rules.find_by(base_path: "/first-item-in-list-of-step-four")
+        expect(navigation_rule3.include_in_links).to be false
+      end
     end
   end
 

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -87,6 +87,12 @@ RSpec.describe StepByStepPageReverter do
         expect(step_by_step_page.steps[2].optional).to be true
         expect(step_by_step_page.steps[3].optional).to be false
       end
+
+      it "saves the position of the step" do
+        expect(step_by_step_page.steps[0].position).to eq(1)
+        expect(step_by_step_page.steps[1].position).to eq(2)
+        expect(step_by_step_page.steps[2].position).to eq(3)
+      end
     end
   end
 

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -81,6 +81,12 @@ RSpec.describe StepByStepPageReverter do
         expect(step_by_step_page.steps[2].logic).to eq("or")
         expect(step_by_step_page.steps[3].logic).to eq("and")
       end
+
+      it "saves whether the step is optional" do
+        expect(step_by_step_page.steps[1].optional).to be false
+        expect(step_by_step_page.steps[2].optional).to be true
+        expect(step_by_step_page.steps[3].optional).to be false
+      end
     end
   end
 

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe StepByStepPageReverter do
       step_by_step.reload
       expect(step_by_step.published_at).to eq(published_at)
     end
+
+    it "sets the draft_updated_at time to published_at time of the step by step" do
+      published_at = Time.parse("2018-01-10T10:00:00Z")
+      step_by_step = create(:published_step_by_step_page, published_at: published_at)
+
+      updater = described_class.new(step_by_step, payload_from_publishing_api(step_by_step.content_id, base_path: "/base-path-1"))
+      updater.repopulate_from_publishing_api
+
+      step_by_step.reload
+      expect(step_by_step.draft_updated_at).to eq(published_at)
+    end
   end
 
   def payload_from_publishing_api(content_id, base_path: "/an-existing-step-by-step")

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe StepByStepPageReverter do
     it "saves the slug" do
       expect(step_by_step_page.slug).to eq("an-existing-step-by-step")
     end
+
+    it "saves the introduction" do
+      expect(step_by_step_page.introduction).to eq("An introduction to the step by step journey.")
+    end
   end
 
   def payload_from_publishing_api(content_id)

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe StepByStepPageReverter do
             "[The first item in the list for step six with context](/first-item-in-list-of-step-six-with-context) £23"
           )
         end
+
+        it "saves the contents of a bulleted list with links and context" do
+          expect(step_by_step_page.steps[6].contents).to eq(
+            "- [The first item in the bulleted list for step seven with context](/first-item-in-list-of-step-seven-with-context) £62 to £75"
+          )
+        end
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -64,6 +64,24 @@ RSpec.describe StepByStepPageReverter do
       step_by_step.reload
       expect(step_by_step.draft_updated_at).to eq(published_at)
     end
+
+    describe "steps" do
+      it "saves the right number of steps" do
+        expect(step_by_step_page.steps.size).to eq(steps.size)
+      end
+
+      it 'saves the step title for each step' do
+        expect(step_by_step_page.steps[0].title).to eq("Step one of the step by step")
+        expect(step_by_step_page.steps[1].title).to eq("Step two of the step by step")
+        expect(step_by_step_page.steps[2].title).to eq("Step three of the step by step")
+      end
+
+      it 'saves the logic for each step' do
+        expect(step_by_step_page.steps[1].logic).to eq("number")
+        expect(step_by_step_page.steps[2].logic).to eq("or")
+        expect(step_by_step_page.steps[3].logic).to eq("and")
+      end
+    end
   end
 
   def payload_from_publishing_api(content_id, base_path: "/an-existing-step-by-step")
@@ -299,5 +317,10 @@ RSpec.describe StepByStepPageReverter do
       "warnings": {
       }
     }
+  end
+
+  def steps
+    @payload ||= payload_from_publishing_api(step_by_step_page.content_id)
+    @payload[:details][:step_by_step_nav][:steps]
   end
 end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -119,6 +119,12 @@ RSpec.describe StepByStepPageReverter do
             "- A list of text in the fifth step."
           )
         end
+
+        it "saves the contents of a list with links and context" do
+          expect(step_by_step_page.steps[5].contents).to eq(
+            "[The first item in the list for step six with context](/first-item-in-list-of-step-six-with-context) £23"
+          )
+        end
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe StepByStepPageReverter do
         expect(step_by_step_page.steps[1].position).to eq(2)
         expect(step_by_step_page.steps[2].position).to eq(3)
       end
+
+      describe "#contents" do
+        it "saves the contents of a paragraph" do
+          expect(step_by_step_page.steps[0].contents).to eq(
+            "A paragraph of text in the first step.\r\n\r\n" \
+            "A second paragraph of text in the first step."
+          )
+        end
+      end
     end
   end
 

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe StepByStepPageReverter do
   describe "#repopulate_from_publishing_api" do
-    let(:step_by_step_page) { create(:step_by_step_page_with_navigation_rules) }
+    let(:step_by_step_page) { create(:step_by_step_page_with_navigation_rules, content_id: "content-id-of-step-by-step_by_step_nav") }
 
     subject { described_class.new(step_by_step_page, payload_from_publishing_api(step_by_step_page.content_id)) }
 
@@ -26,6 +26,10 @@ RSpec.describe StepByStepPageReverter do
 
     it "saves the description" do
       expect(step_by_step_page.description).to eq("A description of the step by step page from publishing-api")
+    end
+
+    it "does not overwrite the content_id" do
+      expect(step_by_step_page.content_id).to eq("content-id-of-step-by-step_by_step_nav")
     end
   end
 

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe StepByStepPageReverter do
       step_by_step.reload
       expect(step_by_step.created_at).to eq(created_at)
     end
+
+    it "does not change the published at time" do
+      published_at = Time.parse("2018-01-10T00:00:00Z")
+      step_by_step = create(:published_step_by_step_page, published_at: published_at)
+
+      updater = described_class.new(step_by_step, payload_from_publishing_api(step_by_step.content_id, base_path: "/base-path-1"))
+      updater.repopulate_from_publishing_api
+
+      step_by_step.reload
+      expect(step_by_step.published_at).to eq(published_at)
+    end
   end
 
   def payload_from_publishing_api(content_id, base_path: "/an-existing-step-by-step")

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -101,6 +101,12 @@ RSpec.describe StepByStepPageReverter do
             "A second paragraph of text in the first step."
           )
         end
+
+        it "saves the contents of a list with links" do
+          expect(step_by_step_page.steps[1].contents).to eq(
+            "[The first item in the list for step two](/first-item-in-list-of-step-two)"
+          )
+        end
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -113,6 +113,12 @@ RSpec.describe StepByStepPageReverter do
             "- [The first item in the bulleted list for step three](/guidance/first-item-in-bulleted-list-of-step-three)"
           )
         end
+
+        it "saves the contents of a bulleted list with just text" do
+          expect(step_by_step_page.steps[4].contents).to eq(
+            "- A list of text in the fifth step."
+          )
+        end
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe StepByStepPageReverter do
             "- [The first item in the bulleted list for step seven with context](/first-item-in-list-of-step-seven-with-context) £62 to £75"
           )
         end
+
+        it "saves a combination of links and paragraphs with context" do
+          expect(step_by_step_page.steps[7].contents).to eq(
+            "A paragraph of text in the eighth step.\r\n\r\n" \
+            "A second paragraph of text in the eighth step.\r\n\r\n" \
+            "[The first item in the list for step eight with context](/first-item-in-list-of-step-eight-with-context) £100\r\n" \
+            "[The second item in the list for step eight](/second-item-in-list-of-step-eight)\r\n\r\n" \
+            "A third paragraph of text in the eighth step.\r\n\r\n" \
+            "- [The first item in the bulleted list for step eight with context](/first-item-in-bulleted-list-of-step-eight-with-context) £100\r\n" \
+            "- [The second item in the bulleted list for step eight](/second-item-in-bulleted-list-of-step-eight)"
+          )
+        end
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe StepByStepPageReverter do
     it "saves the title" do
       expect(step_by_step_page.title).to eq("An existing step by step that has previously been published")
     end
+
+    it "saves the slug" do
+      expect(step_by_step_page.slug).to eq("an-existing-step-by-step")
+    end
   end
 
   def payload_from_publishing_api(content_id)

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe StepByStepPageReverter do
             "[The first item in the list for step two](/first-item-in-list-of-step-two)"
           )
         end
+
+        it "saves the contents of a bulleted list with links" do
+          expect(step_by_step_page.steps[2].contents).to eq(
+            "- [The first item in the bulleted list for step three](/guidance/first-item-in-bulleted-list-of-step-three)"
+          )
+        end
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe StepByStepPageReverter do
     it "saves the introduction" do
       expect(step_by_step_page.introduction).to eq("An introduction to the step by step journey.")
     end
+
+    it "saves the description" do
+      expect(step_by_step_page.description).to eq("A description of the step by step page from publishing-api")
+    end
   end
 
   def payload_from_publishing_api(content_id)


### PR DESCRIPTION
Trello: https://trello.com/c/c4z7hAxs

Dependant on PR #487

## Motivation

When draft changes are made to a published step by step in collections publisher, there is no way to discard those draft changes without manually unpicking them.

However, all of the previous editions are being stored in Publishing API.

We should give publishers the ability to discard a draft in collections-publisher by getting the latest published version of the step by step from the publishing-api and using that to repopulate the data for the step by step in collections-publisher.

In other words, programmatically unpicking the changes so that the publisher doesn't have to.

## What's changed

This is the first step in the ability to overwrite step by step data in collections-publisher with a version of the step by step held by publishing-api. The service takes any step by step payload from publishing-api and uses it to update the step by step in the database.