### PR TITLE
Destroy link reports when a step is deleted

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -2,7 +2,7 @@ class Step < ApplicationRecord
   belongs_to :step_by_step_page
   validates_presence_of :step_by_step_page
   validates :title, :logic, presence: true
-  has_many :link_reports
+  has_many :link_reports, :dependent => :destroy
 
   def broken_links?
     broken_links.present? && broken_links.any?

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -79,6 +79,13 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_that_the_url_isnt_valid
   end
 
+  scenario "User deletes a step" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_view_the_step_by_step_page
+    and_I_delete_the_first_step
+    and_I_see_a_step_deleted_success_notice
+  end
+
   def given_there_is_a_published_step_by_step_page
     @step_by_step_page = create(:published_step_by_step_page)
   end
@@ -220,5 +227,15 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_am_told_that_it_is_published
     expect(page).to have_content("has been published")
+  end
+
+  def and_I_delete_the_first_step
+    within(".table tbody tr:first-child td") do
+      click_on "Delete"
+    end
+  end
+
+  def and_I_see_a_step_deleted_success_notice
+    expect(page).to have_content("Step was successfully deleted.")
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
+require "gds_api/test_helpers/link_checker_api"
 
 RSpec.feature "Managing step by step pages" do
   include CommonFeatureSteps
   include NavigationSteps
   include StepNavSteps
+  include GdsApi::TestHelpers::LinkCheckerApi
 
   before do
     given_I_am_a_GDS_editor
@@ -81,6 +83,13 @@ RSpec.feature "Managing step by step pages" do
 
   scenario "User deletes a step" do
     given_there_is_a_step_by_step_page_with_steps
+    when_I_view_the_step_by_step_page
+    and_I_delete_the_first_step
+    and_I_see_a_step_deleted_success_notice
+  end
+
+  scenario "User deletes a step that has an existing link report" do
+    given_there_is_a_step_by_step_page_with_a_link_report
     when_I_view_the_step_by_step_page
     and_I_delete_the_first_step
     and_I_see_a_step_deleted_success_notice

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -61,4 +61,25 @@ module StepNavSteps
   def given_there_is_a_step_by_step_page
     @step_by_step_page = create(:step_by_step_page)
   end
+
+  def given_there_is_a_step_by_step_page_with_a_link_report
+    link_checker_api_get_batch(
+      id: 1,
+      links: [
+        {
+          "uri": "https://www.gov.uk/",
+          "status": "ok",
+          "checked": "2017-04-12T18:47:16Z",
+          "errors": [],
+          "warnings": [],
+          "problem_summary": "null",
+          "suggested_fix": "null"
+        }
+      ]
+    )
+
+    step = create(:step)
+    create(:link_report, step_id: step.id)
+    @step_by_step_page = create(:step_by_step_page, steps: [step], slug: "step-by-step-with-link-report")
+  end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -3,11 +3,36 @@ module StepNavSteps
     stub_any_publishing_api_put_content
     stub_any_publishing_api_discard_draft
     allow(Services.publishing_api).to receive(:lookup_content_id)
-    allow(StepNavPublisher).to receive(:lookup_content_ids).and_return(
+    allow(Services.publishing_api).to receive(:lookup_content_ids).and_return(
       '/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e1',
       '/also/good/stuff' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e2',
       '/not/as/great' => 'fd6b1901d-b925-47c5-b1ca-1e52197097e3'
     )
+    allow(Services.publishing_api).to receive(:get_content).with("fd6b1901d-b925-47c5-b1ca-1e52197097e1").and_return(
+      "base_path" => "/first-item-in-list-of-step-one",
+      "title" => "The first item in the list for step one",
+      "content_id" => "fd6b1901d-b925-47c5-b1ca-1e52197097e1",
+      "publishing_app" => "publisher",
+      "rendering_app" => "frontend",
+      "schema_name" => "transaction"
+    )
+    allow(Services.publishing_api).to receive(:get_content).with("fd6b1901d-b925-47c5-b1ca-1e52197097e2").and_return(
+      "base_path" => "/first-item-in-list-of-step-two",
+      "title" => "The first item in the list for step two",
+      "content_id" => "fd6b1901d-b925-47c5-b1ca-1e52197097e2",
+      "publishing_app" => "publisher",
+      "rendering_app" => "frontend",
+      "schema_name" => "transaction"
+    )
+    allow(Services.publishing_api).to receive(:get_content).with("fd6b1901d-b925-47c5-b1ca-1e52197097e3").and_return(
+      "base_path" => "/first-item-in-list-of-step-three",
+      "title" => "The first item in the list for step three",
+      "content_id" => "fd6b1901d-b925-47c5-b1ca-1e52197097e3",
+      "publishing_app" => "publisher",
+      "rendering_app" => "frontend",
+      "schema_name" => "transaction"
+    )
+
     stub_any_publishing_api_publish
     stub_any_publishing_api_unpublish
   end


### PR DESCRIPTION
Trello: https://trello.com/c/CcC66wRE

Link reports belong to a step.

Adding this dependancy fixes the Foreign Violation that occurs when you try to delete a step:

```
Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_development`.`link_check_reports`, CONSTRAINT `fk_rails_ae2309ed25` FOREIGN KEY (`step_id`) REFERENCES `steps` (`id`))
```

Error in [Sentry](https://sentry.io/govuk/app-collections-publisher/issues/681560042/?query=is:unresolved)