### PR TITLE
Rescue error raised from missing batch report

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -27,13 +27,19 @@ class Step < ApplicationRecord
 private
 
   def collect_broken_links
+    return [] if batch_link_report.blank?
+
     batch_link_report.links.keep_if do |link|
       link.fetch('status') == 'broken'
     end
   end
 
   def batch_link_report
-    @batch_link_report ||= Services.link_checker_api.get_batch(batch_link_report_id)
+    begin
+      @batch_link_report ||= Services.link_checker_api.get_batch(batch_link_report_id)
+    rescue GdsApi::HTTPServerError
+      nil
+    end
   end
 
   def batch_link_report_id

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -134,5 +134,14 @@ RSpec.describe Step do
       create(:link_report, batch_id: 2, step_id: step_item.id, created_at: "2018-08-07 10:30:38")
       expect(step_item.links_last_checked_date.utc).to eq(Time.new(2018, 8, 7, 10, 30, 38).utc)
     end
+
+    it 'should not fail if the saved batch id does not match a batch in link-checker-api' do
+      create(:link_report, batch_id: 2, step_id: step_item.id)
+
+      allow(Services.link_checker_api).to receive(:get_batch).and_raise(GdsApi::HTTPServerError.new(500))
+
+      expect(step_item.broken_links).to eq([])
+      expect(step_item.broken_links?).to be false
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/e1vAwREO

Link-checker-api throw a 5xx error if `get_batch` is called for a batch report that doesn’t exist.

This isn’t usually a problem in Production, but step by step pages, and their associated link reports are copied
to integration and staging each night. This means that if when you try to view the step by step in those environments, it’s
querying link-checker-api with a batch id that was created in (and probably only exists in) production. This causes link-checker-api to
fail with a 5xx.

We should update link-checker-api to fail more gracefully if it can’t find a requested batch, but until then, allow collections-publisher
to load step by steps even if the link report details cannot be found.

Error in [sentry](https://sentry.io/govuk/app-collections-publisher/issues/686572073/?query=is:unresolved)