### PR TITLE
Update edition number of change notes on publish

### DIFF
--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api_v2'
 
 RSpec.describe StepByStepPagesController do
+  include GdsApi::TestHelpers::PublishingApiV2
+
   describe "GET Step by step index page" do
     it "can only be accessed by users with GDS editor permissions" do
       stub_user.permissions << "GDS Editor"
@@ -15,5 +18,53 @@ RSpec.describe StepByStepPagesController do
 
       expect(response.status).to eq(403)
     end
+  end
+
+  describe "#publish" do
+    it "sets the edition number of the change notes" do
+      stub_user.permissions << "GDS Editor"
+
+      allow(Services.publishing_api).to receive(:lookup_content_id).and_return(nil)
+
+      step_by_step_page = create(:step_by_step_page_with_steps)
+      create(:internal_change_note, step_by_step_page_id: step_by_step_page.id)
+
+      allow(Services.publishing_api).to receive(:lookup_content_ids).with(
+        base_paths: [base_path(step_by_step_page.slug)],
+        with_drafts: true
+      ).and_return({})
+
+      allow(Services.publishing_api).to receive(:get_content)
+        .with(step_by_step_page.content_id)
+        .and_return(content_item(step_by_step_page))
+
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_publish
+
+      post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor" }
+
+      expect(step_by_step_page.internal_change_notes.first.edition_number).to eq(3)
+    end
+  end
+
+  def content_item(step_by_step_page)
+    {
+      content_id: step_by_step_page.content_id,
+      base_path: base_path(step_by_step_page.slug),
+      title: step_by_step_page.title,
+      description: step_by_step_page.description,
+      schema_name: "step_by_step_nav",
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+      state_history: {
+        "3" => "draft",
+        "2" => "published",
+        "1" => "superseded",
+      }
+    }
+  end
+
+  def base_path(slug)
+    "/#{slug}"
   end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -10,6 +10,9 @@ module StepNavSteps
     )
     stub_any_publishing_api_publish
     stub_any_publishing_api_unpublish
+    allow(Services.publishing_api).to receive(:get_content).and_return(
+      state_history: { "1" => "published" }
+    )
   end
 
   def then_the_content_is_sent_to_publishing_api


### PR DESCRIPTION
Trello: https://trello.com/c/kSH4Bvak

After a step by step is published, get the latest user_facing_version from publishing-api and store it against the change notes.

This will allow us in the future, to use the user_facing_version stored in the change notes and it marry to the edition stored in publishing-api to allow publishers in the future to see what was changed and why.

For now though, if a change note has a edition number, we will assume it belongs to a previous edition. However, if a change note does not have an edition number, we’ll assume it belongs to the latest draft, and delete it if the draft is ever discarded.