### PR TITLE
Change legacy notation from topics to specialist sectors

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -20,7 +20,7 @@ class TopicsController < ApplicationController
 
     if topic.update_attributes(topic_params)
       TagBroadcaster.broadcast(topic)
-      redirect_to topic, success: "Topic updated"
+      redirect_to topic, success: "Specialist sector updated"
     else
       @topic = topic
       render 'edit'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 
   <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
-    <%= link_to 'Topics', topics_path %>
+    <%= link_to 'Specialist sector pages', topics_path %>
   </li>
 
   <% if gds_editor? %>

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -30,7 +30,7 @@
 <% if @browse_page.topics.any? %>
   <section class="children">
     <header class="heading-with-actions">
-      <h2>Topics</h2>
+      <h2>Specialist sector pages</h2>
     </header>
 
     <%= render 'shared/tags/table',

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,11 +1,11 @@
-<%= header 'Topics', breadcrumbs: ['Topics'] do %>
+<%= header 'Specialist sector pages', breadcrumbs: ['Specialist sector pages'] do %>
   <% if gds_editor? %>
     <%= link_to new_topic_path, class: 'new' do %>
-      <%= icon :add %> Add a topic
+      <%= icon :add %> Add a specialist sector page
     <% end %>
   <% end %>
 <% end %>
 
 <%= render 'shared/tags/table',
       resources: @topics,
-      empty_message: "No topics exist yet" %>
+      empty_message: "No specialist sector pages exist yet" %>

--- a/app/views/topics/new.html.erb
+++ b/app/views/topics/new.html.erb
@@ -1,4 +1,4 @@
-<%= header "New topic",
+<%= header "New specialist sector page",
   breadcrumbs: [:topics, @topic.parent, "New"] %>
 
 <%= form_for @topic, html: { class: 'topic' } do |f| %>
@@ -6,7 +6,7 @@
       Topic.sorted_parents.map { |topic| [topic.title, topic.id] },
       { include_blank: true },
       { class: 'select2',
-        data: { placeholder: "Choose a parent topic (optional)" } } %>
+        data: { placeholder: "Choose a parent specialist sector (optional)" } } %>
 
   <%= f.text_field :slug %>
   <%= f.text_field :title %>

--- a/app/views/topics/propose_archive.html.erb
+++ b/app/views/topics/propose_archive.html.erb
@@ -1,4 +1,4 @@
-<%= tag_header @archival.tag, 'Archive topic' %>
+<%= tag_header @archival.tag, 'Archive' %>
 
 <% if @archival.errors[:base].any? %>
   <div class="alert alert-danger">
@@ -9,10 +9,10 @@
 <%= form_for @archival, url: archive_topic_path(@archival.tag) do |f| %>
   <%= f.select :successor,
     options_from_collection_for_select(@archival.topics, :id, :title_including_parent),
-    { label: 'Choose a topic to redirect to:' },
+    { label: 'Choose a specialist sector to redirect to:' },
     { class: 'select2' } %>
 
-  <%= f.submit 'Archive and redirect to a topic', class: 'btn-submit btn-danger' %>
+  <%= f.submit 'Archive and redirect to a specialist sector', class: 'btn-submit btn-danger' %>
 <% end %>
 
 <%= form_for @archival, url: archive_topic_path(@archival.tag) do |f| %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,17 +1,17 @@
 <%= tag_header @topic do %>
   <% if gds_editor? %>
-    <%= link_to 'Edit topic',
+    <%= link_to 'Edit',
       edit_topic_path(@topic) %>
 
     <% if @topic.may_publish? %>
-      <%= link_to 'Publish topic', publish_topic_path(@topic), method: :post %>
+      <%= link_to 'Publish', publish_topic_path(@topic), method: :post %>
     <% end %>
 
     <% if @topic.child? %>
       <% if @topic.published? %>
-        <%= link_to 'Archive topic', propose_archive_topic_path(@topic) %>
+        <%= link_to 'Archive', propose_archive_topic_path(@topic) %>
       <% else %>
-        <%= link_to 'Remove topic', archive_topic_path(@topic),
+        <%= link_to 'Remove', archive_topic_path(@topic),
           method: 'post',
           data: { confirm: 'Are you sure?' } %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :topics, except: :destroy do
+  resources :topics, path: 'specialist-sector-pages', except: :destroy do
     member do
       post :publish
       get :propose_archive

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Archiving topic tags" do
 
   def when_I_redirect_the_topic_to_a_successor_topic
     select 'The Successor Topic', from: "topic_archival_form_successor"
-    click_button 'Archive and redirect to a topic'
+    click_button 'Archive and redirect to a specialist sector'
   end
 
   def when_I_visit_the_topic_edit_page
@@ -85,11 +85,11 @@ RSpec.feature "Archiving topic tags" do
   end
 
   def when_I_click_the_remove_button
-    click_link 'Remove topic'
+    click_link 'Remove'
   end
 
   def and_I_go_to_the_archive_page
-    click_link 'Archive topic'
+    click_link 'Archive'
   end
 
   def then_the_tag_is_archived

--- a/spec/features/managing_topic_pages_spec.rb
+++ b/spec/features/managing_topic_pages_spec.rb
@@ -62,11 +62,11 @@ RSpec.feature "Managing topics" do
   end
 
   def when_I_click_on_the_publish_button
-    click_on "Publish topic"
+    click_on "Publish"
   end
 
   def when_I_navigate_to_the_edit_page
-    click_on "Edit topic"
+    click_on "Edit"
   end
 
   def and_I_submit_a_changed_description


### PR DESCRIPTION
Update the name for a legacy taxonomy. The user facing interface now uses `specialist sectors` instead of `topics` as `topics` is used by a lot of different things, and we're trying to ensure that the only thing that is considered a topic is the topic taxonomy.

Trello:
https://trello.com/c/uHNW4dZb/189-change-instances-of-topics-in-collections-publisher-to-specialist-sectors