### PR TITLE
Fix the delete step text

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -61,6 +61,12 @@ FactoryBot.define do
       optional { "true" }
       logic { "or" }
       position { 2 }
+      contents {
+        <<~CONTENT
+          This is another great step
+        CONTENT
+      }
+      step_by_step_page
     end
 
     factory :smartanswer_step do


### PR DESCRIPTION
Fixes an error introduced in this PR: #487 

The `User deletes a step` feature test was failing with the following error:

```
ActiveRecord::RecordInvalid:
       Validation failed: Title can't be blank, Base path can't be blank, Content can't be blank, Publishing app can't be blank, Schema name can't be blank
```

The factory being used created two steps, ` step` and an `or_step`. The `or_step` did not have any content, so when the first `step` was deleted and the navigation_rules were updated, they threw an error.

I have no idea why the test didn’t fail when it was first added.