### PR TITLE
Link change notes to published editions of a step by step

### DIFF
--- a/app/controllers/internal_change_notes_controller.rb
+++ b/app/controllers/internal_change_notes_controller.rb
@@ -1,6 +1,6 @@
 class InternalChangeNotesController < ApplicationController
   def create
-    InternalChangeNote.create(internal_change_note_params.merge(step_by_step_page_id: step_by_step_page.id, created_at: Time.now, author: current_user.name))
+    InternalChangeNote.create(required_fields.merge(other_fields))
     redirect_to step_by_step_page_internal_change_notes_path, notice: 'Change note was successfully added.'
   end
 
@@ -10,7 +10,15 @@ private
     StepByStepPage.find(params[:step_by_step_page_id])
   end
 
-  def internal_change_note_params
+  def required_fields
     params.require(:internal_change_note).permit(:description)
+  end
+
+  def other_fields
+    {
+      step_by_step_page_id: step_by_step_page.id,
+      created_at: Time.now,
+      author: current_user.name
+    }
   end
 end

--- a/app/controllers/internal_change_notes_controller.rb
+++ b/app/controllers/internal_change_notes_controller.rb
@@ -15,10 +15,28 @@ private
   end
 
   def other_fields
-    {
+    fields = {
       step_by_step_page_id: step_by_step_page.id,
       created_at: Time.now,
       author: current_user.name
     }
+
+    fields[:edition_number] = latest_edition_number if save_edition_number?
+
+    fields
+  end
+
+  def save_edition_number?
+    step_by_step_page.has_been_published? && !step_by_step_page.has_draft?
+  end
+
+  # state_history returns a hash like {"3"=>"draft", "2"=>"published", "1"=>"superseded"}
+  # so we need to get the highest value for a key.
+  def latest_edition_number
+    @latest_edition_number ||= content_item[:state_history].keys.max
+  end
+
+  def content_item
+    Services.publishing_api.get_content(step_by_step_page.content_id)
   end
 end

--- a/spec/controllers/internal_change_notes_controller_spec.rb
+++ b/spec/controllers/internal_change_notes_controller_spec.rb
@@ -3,20 +3,43 @@ require 'rails_helper'
 RSpec.describe InternalChangeNotesController, type: :controller do
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
+    stub_user.name = "Test author"
   end
 
   describe "POST #create" do
     it "creates an InternalChangeNote" do
-      stub_user.name = "Test author"
       create(:step_by_step_page, id: 0)
       expect(InternalChangeNote).to receive(:create)
       post :create, params: { step_by_step_page_id: 0, internal_change_note: { description: "Test description" } }
     end
     it "saves it to the database" do
-      stub_user.name = "Test author"
       create(:step_by_step_page, id: 0)
       post :create, params: { step_by_step_page_id: 0, internal_change_note: { description: "Test description" } }
       expect(InternalChangeNote.first.author).to eql "Test author"
+      expect(InternalChangeNote.first.edition_number).to be nil
+    end
+
+    it "saves a change note with an edition_number for a published version" do
+      published_step_by_step_page = create(:published_step_by_step_page)
+      published_step_by_step_page.mark_as_published
+
+      allow(Services.publishing_api).to receive(:get_content).with(published_step_by_step_page.content_id).and_return(
+        state_history: {
+          "3" => "published",
+          "2" => "superseded",
+          "1" => "superseded",
+        }
+      )
+
+      post :create, params: {
+        step_by_step_page_id: published_step_by_step_page.id,
+        internal_change_note: {
+          description: "Another change note"
+        }
+      }
+
+      change_notes = published_step_by_step_page.internal_change_notes
+      expect(change_notes.last.edition_number).to eq(3)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/waPzTr08

## Motivation

Sometimes information can be missed from a changed note when it's published. Publishers should be able to add a change note to the most recently published version of step by step without having to create a new draft.

Also, change notes are a new feature of step by step pages. This change will allow content designers to go back and record a change note for the 18 currently published step by steps.