### PR TITLE
Adds method to discard change notes without an edition

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -72,6 +72,10 @@ class StepByStepPage < ApplicationRecord
     steps.map(&:link_report?).any?
   end
 
+  def discard_notes
+    internal_change_notes.where(edition_number: nil).delete_all
+  end
+
 private
 
   def generate_content_id

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -245,4 +245,22 @@ RSpec.describe StepByStepPage do
       end
     end
   end
+
+  describe '.discard_notes' do
+    before(:each) do
+      @step_by_step_page = create(:step_by_step_page)
+      create(:internal_change_note, edition_number: 1, step_by_step_page_id: @step_by_step_page.id)
+      create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
+    end
+    context 'when there are existing change notes with a version and new change notes without a version' do
+      before(:each) do
+        @step_by_step_page.discard_notes
+        @step_by_step_page.reload
+      end
+      it 'should only delete the change notes without an edition' do
+        expect(@step_by_step_page.internal_change_notes.count).to eq 1
+        expect(@step_by_step_page.internal_change_notes.first[:edition_number]).to eql 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
Drop all change notes associated with a draft but without an associated edition when that draft is discarded. 

# Why
When a SBS guide is published, it gets an edition number. At that point, we tag all the change notes **without** an edition number to that edition. However, if the draft is discarded, we don't want the change notes to hang around. If we leave them in the table they'll be tagged to the next published edition of that SBS guide. This would result in change notes that refer to a discarded draft being associated with a published guide, and that would cause confusion. 

# How
This has been implemented with a method on the StepByStepPage that is called from the StepByStepPage controller. It drops all the changenotes associated to that StepByStepPage that don't have an edition.

[Ticket](https://trello.com/c/x0k2Fsc6/841-drop-change-notes-for-the-discarded-draft-s)

