### PR TITLE
Fix redirect from home page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  root to: redirect('/topics', status: 302)
+  root to: redirect('/specialist-sector-pages', status: 302)
 
   resources :step_by_step_pages, path: 'step-by-step-pages' do
     get 'navigation-rules', to: 'navigation_rules#edit'


### PR DESCRIPTION
When trying to visit the root of collections publisher, there is a redirect in place to take the user to `/topics`. The path `/topics` is now deprecated and the new route is
`/specialist-sector-pages`.