### PR TITLE
Get version number of latest published edition

### DIFF
--- a/app/helpers/publishing_api_helper.rb
+++ b/app/helpers/publishing_api_helper.rb
@@ -1,8 +1,14 @@
 module PublishingApiHelper
   # state_history returns a hash like {"3"=>"draft", "2"=>"published", "1"=>"superseded"}
   # so we need to get the highest value for a key.
-  def latest_edition_number(content_id)
+  def latest_edition_number(content_id, publication_state: "")
     latest_content_item = content_item(content_id)
+
+    if publication_state.present?
+      version = latest_content_item[:state_history].select { |_, hash| hash[publication_state] }
+      return version.keys.first.to_i
+    end
+
     latest_content_item[:state_history].keys.max.to_i
   end
 

--- a/spec/helpers/publishing_api_helper_spec.rb
+++ b/spec/helpers/publishing_api_helper_spec.rb
@@ -2,16 +2,24 @@ require "rails_helper"
 
 RSpec.describe PublishingApiHelper do
   describe "#latest_edition_number" do
-    it "returns the most recent edition number for a content_item" do
-      content_id = "i-am-a-content-id"
-      allow(Services.publishing_api).to receive(:get_content).with(content_id).and_return(
+    before do
+      @content_id = "i-am-a-content-id"
+
+      allow(Services.publishing_api).to receive(:get_content).with(@content_id).and_return(
         state_history: {
           "3" => "draft",
           "2" => "published",
           "1" => "superseded",
         }
       )
-      expect(helper.latest_edition_number(content_id)).to eq(3)
+    end
+
+    it "returns the most recent edition number for a content_item" do
+      expect(helper.latest_edition_number(@content_id)).to eq(3)
+    end
+
+    it "returns the edition number of the published version of content_item" do
+      expect(helper.latest_edition_number(@content_id, publication_state: "published")).to eq(2)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/UQPB5Tam

## Motivation

Functionality is being added to allow publishers to discard drafts of previously published content.
When these drafts are discarded, the data in the step by step will be replaced with the content of
latest published version held in publishing api.

By default, `get_content` retrieves the latest version regardless of publication state. Though we will
be sending a discard-draft request to publishing-api, this request may not have completed by the
time we are ready to revert the step-by-step, so we should make sure that we are over-writing it with
the correct version of the content.

However, we can specify which version of content we want by passing in the `latest_edition_number` as
the `version` when we are ready to replace the data:

e.g. `Services.publishing_api.get_content(content_id, version: 6)`