### PR TITLE
Adds column to StepByStepPage table

### DIFF
--- a/db/migrate/20180921105035_add_draft_created_by_to_step_by_step_pages.rb
+++ b/db/migrate/20180921105035_add_draft_created_by_to_step_by_step_pages.rb
@@ -1,0 +1,5 @@
+class AddDraftCreatedByToStepByStepPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :step_by_step_pages, :draft_created_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_075324) do
+ActiveRecord::Schema.define(version: 2018_09_21_105035) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_075324) do
     t.string "content_id", null: false
     t.datetime "published_at"
     t.datetime "draft_updated_at"
+    t.string "draft_created_by"
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["slug"], name: "index_step_by_step_pages_on_slug", unique: true
   end


### PR DESCRIPTION
# What
This is a database migration that creates a `draft_created_by` column on the `step_by_step_pages` table. It will store the name of the user that created the current draft.

# Why
This will enable work that will allow content designers to see who created the current draft. It's remedial work to prevent slowdowns when we scale SBS guide production up and start allowing more publishers to build them. 

[Specific ticket](https://trello.com/c/cnZkBnrq/871-add-a-column-to-stepbysteppage-to-store-the-current-user)