### PR TITLE
Fix delete guide when changenotes bug

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -7,6 +7,7 @@ class StepByStepPage < ApplicationRecord
   validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true
   validates :slug, slug: true, on: :create
   before_validation :generate_content_id, on: :create
+  before_destroy :discard_notes
 
   scope :by_title, -> { order(:title) }
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -95,8 +95,27 @@ RSpec.feature "Managing step by step pages" do
     and_I_see_a_step_deleted_success_notice
   end
 
+  scenario "User deletes a draft step by step guide without change notes" do
+    given_there_is_a_step_by_step_page
+    and_I_visit_the_publish_or_delete_page
+    and_I_delete_the_draft
+    then_I_see_a_step_by_step_deleted_success_notice
+  end
+
+  scenario "User deletes a draft step by step guide with change notes" do
+    given_there_is_a_step_by_step_page
+    and_it_has_change_notes
+    and_I_visit_the_publish_or_delete_page
+    and_I_delete_the_draft
+    then_I_see_a_step_by_step_deleted_success_notice
+  end
+
   def given_there_is_a_published_step_by_step_page
     @step_by_step_page = create(:published_step_by_step_page)
+  end
+
+  def and_it_has_change_notes
+    create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end
 
   def and_I_visit_the_index_page
@@ -124,6 +143,14 @@ RSpec.feature "Managing step by step pages" do
   def and_I_fill_in_the_form_with_an_invalid_url
     fill_in "Redirect to", with: "!"
     click_on "Unpublish"
+  end
+
+  def and_I_delete_the_draft
+    click_on "Delete"
+  end
+
+  def then_I_see_a_step_by_step_deleted_success_notice
+    expect(page).to have_content("Step by step page was successfully deleted.")
   end
 
   def then_I_see_that_the_url_isnt_valid


### PR DESCRIPTION
# What
This change adds a `before_destroy` action to delete a draft guide's changenotes before deleting the draft guide itself. It's a custom method, to avoid accidentally deleting all of the changenotes associated to that guide.

# Why
As it stands a foreign key violation is thrown if you try to destroy a draft step by step without first deleting all of the change notes. This is because the changenotes have a foreign key on `step_by_step_pages`, and once the guide is deleted, the changenotes would be orphaned.

https://sentry.io/govuk/app-collections-publisher/issues/695190304/?query=is:unresolved