### PR TITLE
Add edition badge to change notes

### DIFF
--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -54,6 +54,9 @@
         <details class="change-note--details" <%= "open" if index == 0 %>>
           <summary class="change-note--summary">
             <%= note.readable_created_date %>
+            <span class="badge pull-right">
+              <%= note.edition_number ? "Edition #{note.edition_number}" : "Current version" %>
+            </span>
           </summary>
           <p>Change made by <strong><%= note.author %></strong></p>
           <pre><%= note.description %></pre>


### PR DESCRIPTION
# User story

As a user I want to be able to see which edition a change note relates to so that I can distiguish which edition a change was made on.

Ticket: https://trello.com/c/kqQHs6wu/855-add-edition-badge-to-change-notes-s

# Screenshots
![screen shot 2018-09-10 at 16 23 03](https://user-images.githubusercontent.com/4599889/45878723-0d446700-bd9a-11e8-9cc9-17df6525b3d4.png)
