### PR TITLE
Wrap the text display text for change notes

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -157,4 +157,8 @@ $border-grey: #aaaaaa;
     margin: -10px -10px 0;
     padding: 10px;
   }
+
+  .change-note--description {
+    white-space: pre-wrap;
+  }
 }

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -56,7 +56,7 @@
             <%= note.readable_created_date %>
           </summary>
           <p>Change made by <strong><%= note.author %></strong></p>
-          <pre><%= note.description %></pre>
+          <pre class="change-note--description"><%= note.description %></pre>
         </details>
       <% end %>
     </div>


### PR DESCRIPTION
Ticket: https://trello.com/c/CUlJqwif/861-bug-wrap-the-text-display-text-for-change-notes

# Before
<img width="1295" alt="screen shot 2018-09-21 at 12 28 06" src="https://user-images.githubusercontent.com/4599889/45878694-ec7c1180-bd99-11e8-90b1-a4e701f418d5.png">

# After
<img width="1346" alt="screen shot 2018-09-21 at 12 27 55" src="https://user-images.githubusercontent.com/4599889/45878702-f0a82f00-bd99-11e8-84a7-1aa3b78b20c9.png">
