### PR TITLE
Allow indifferent access for content item hash

### DIFF
--- a/app/helpers/publishing_api_helper.rb
+++ b/app/helpers/publishing_api_helper.rb
@@ -2,7 +2,7 @@ module PublishingApiHelper
   # state_history returns a hash like {"3"=>"draft", "2"=>"published", "1"=>"superseded"}
   # so we need to get the highest value for a key.
   def latest_edition_number(content_id, publication_state: "")
-    latest_content_item = content_item(content_id)
+    latest_content_item = content_item(content_id).with_indifferent_access
 
     if publication_state.present?
       version = latest_content_item[:state_history].select { |_, hash| hash[publication_state] }


### PR DESCRIPTION
Publishing api returns a content item hash with string keys.
Allow the hash to be accessed with label keys as well.

See https://api.rubyonrails.org/v4.2/classes/ActiveSupport/HashWithIndifferentAccess.html

Fixes a bug introduced in Pr #492