### PR TITLE
Fix latest edition number bug

### DIFF
--- a/app/helpers/publishing_api_helper.rb
+++ b/app/helpers/publishing_api_helper.rb
@@ -13,6 +13,6 @@ module PublishingApiHelper
   end
 
   def content_item(content_id)
-    Services.publishing_api.get_content(content_id)
+    Services.publishing_api.get_content(content_id).to_hash
   end
 end


### PR DESCRIPTION
The fix applied in PR #502 didn’t completely fix the problem.

We need to parse the content returned by GDS API before we can apply Hash methods (with_indifferent_access) to it.

Error in [sentry](https://sentry.io/govuk/app-collections-publisher/issues/696647763/?query=is:unresolved)