### PR TITLE
Updates column name

### DIFF
--- a/db/migrate/20180921153838_change_column_name_to_assigned_to.rb
+++ b/db/migrate/20180921153838_change_column_name_to_assigned_to.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNameToAssignedTo < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :step_by_step_pages, :draft_created_by, :assigned_to
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_21_105035) do
+ActiveRecord::Schema.define(version: 2018_09_21_153838) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 2018_09_21_105035) do
     t.string "content_id", null: false
     t.datetime "published_at"
     t.datetime "draft_updated_at"
-    t.string "draft_created_by"
+    t.string "assigned_to"
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["slug"], name: "index_step_by_step_pages_on_slug", unique: true
   end


### PR DESCRIPTION
This commit updates step_by_step_pages.draft_created_by to step_by_step_pages.assigned_to

The original naming was made in #498 

This change is because further user research showed that users were interested in who was working on the guide right now, rather than just who created it. This change enables that future work.

[Ticket](https://trello.com/c/vJylutsp/874-change-the-column-name-to-assignedto)