### PR TITLE
Allow publishers to discard a draft of previously published content 

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -99,6 +99,7 @@ class StepByStepPagesController < ApplicationController
 private
 
   def discard_draft
+    @step_by_step_page.discard_notes
     StepNavPublisher.discard_draft(@step_by_step_page)
   rescue GdsApi::HTTPNotFound
     Rails.logger.info "Discarding #{@step_by_step_page.content_id} failed"

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -44,9 +44,13 @@ class StepByStepPage < ApplicationRecord
   end
 
   def status
-    return unpublished_status if has_draft? && has_been_published?
+    return unpublished_status if unpublished_changes?
     return live_status if has_been_published?
     draft_status
+  end
+
+  def unpublished_changes?
+    has_draft? && has_been_published?
   end
 
   # Create a deterministic, but unique token that will be used to give one-time

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -31,6 +31,11 @@
           <p>Before publishing check for broken links.</p>
           <p>After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
           <%= link_to 'Publish changes', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary publish-button" %>
+
+          <% if @step_by_step_page.unpublished_changes? %>
+            <p>Or</p>
+            <%= button_to 'Discard changes', { action: "revert", step_by_step_page_id: @step_by_step_page.id }, data: { confirm: 'Discarding reverts content back to currently published version of the step by step. Do you want to discard your changes?' }, class: "btn btn-danger" %>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     post :reorder
     get :unpublish
     post :unpublish
+    post :revert
     get  'publish-or-delete', to: 'publish_or_delete'
     get 'internal-change-notes', to: 'interal_change_notes'
     post 'internal-change-notes', to: 'internal_change_notes#create'

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -110,6 +110,14 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_a_step_by_step_deleted_success_notice
   end
 
+  scenario "User reverts a step by step page" do
+    given_there_is_a_published_step_by_step_page
+    when_I_view_the_step_by_step_page
+    and_I_visit_the_publish_or_delete_page
+    when_I_want_to_revert_the_page
+    then_I_see_a_page_reverted_success_notice
+  end
+
   def given_there_is_a_published_step_by_step_page
     @step_by_step_page = create(:published_step_by_step_page)
   end
@@ -128,6 +136,28 @@ RSpec.feature "Managing step by step pages" do
 
   def when_I_want_to_unpublish_the_page
     click_on "Unpublish"
+  end
+
+  def when_I_want_to_revert_the_page
+    allow(Services.publishing_api).to receive(:get_content).and_return(
+      base_path: "/#{@step_by_step_page.slug}",
+      title: "A step by step",
+      description: "A description of a step by step",
+      details: {
+        step_by_step_nav: {
+          introduction: [
+            {
+              content_type: "text/govspeak",
+              content: "An introduction to the step by step journey."
+            }
+          ],
+          steps: []
+        }
+      },
+      state_history: { "1" => "published" }
+    )
+
+    click_on "Discard changes"
   end
 
   def and_I_fill_in_the_form_with_a_valid_url
@@ -273,5 +303,9 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_see_a_step_deleted_success_notice
     expect(page).to have_content("Step was successfully deleted.")
+  end
+
+  def then_I_see_a_page_reverted_success_notice
+    expect(page).to have_content("Draft successfully discarded.")
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/C8eFHFSz

Related to PRs #485 #493 

## What
Adds functionality to discard draft changes if the step by step has been previously published.

This functionality uses the new or existing functionality to:

1. Send a discard draft request to publishing-api
2. Drop the internal change notes for the discarded draft
3. Get the latest published content from publishing-api
4. Repopulate StepByStepPage with the latest published content
5. Display a "discard draft" button on the "Publish or delete" page

## Before

![screen shot 2018-09-21 at 17 56 30](https://user-images.githubusercontent.com/5793815/45894923-bbb2d100-bdc7-11e8-9d7a-8acb3b0790b5.png)

## After

![screen shot 2018-09-21 at 18 22 53](https://user-images.githubusercontent.com/5793815/45896231-62e53780-bdcb-11e8-818f-f7306f51df2c.png)

![screen shot 2018-09-24 at 12 14 29](https://user-images.githubusercontent.com/5793815/45949336-7a066e00-bff3-11e8-993f-2845525e4c11.png)
