### PR TITLE
Adds method to assign current user to current draft

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -105,7 +105,7 @@ private
   end
 
   def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(@step_by_step_page.id)
+    StepByStepDraftUpdateWorker.perform_async(@step_by_step_page.id, current_user.name)
   end
 
   def publish_page(publish_intent)

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -42,7 +42,7 @@ class StepsController < ApplicationController
 private
 
   def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id)
+    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id, current_user.name)
   end
 
   def step_by_step_page

--- a/app/workers/step_by_step_draft_update_worker.rb
+++ b/app/workers/step_by_step_draft_update_worker.rb
@@ -1,11 +1,11 @@
 class StepByStepDraftUpdateWorker
   include Sidekiq::Worker
 
-  def perform(step_by_step_page_id)
+  def perform(step_by_step_page_id, name_of_current_user = "")
     @step_by_step_page_id = step_by_step_page_id
-
+    @current_user = name_of_current_user
     return unless step_by_step_page
-
+    update_assigned_to
     update_navigation_rules
     update_draft
   end
@@ -20,5 +20,12 @@ class StepByStepDraftUpdateWorker
 
   def update_draft
     StepNavPublisher.update(step_by_step_page)
+  end
+
+  def update_assigned_to
+    unless step_by_step_page.has_draft?
+      step_by_step_page.assigned_to = @current_user
+      step_by_step_page.save
+    end
   end
 end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -6,6 +6,7 @@ module CommonFeatureSteps
 
   def given_I_am_a_GDS_editor
     stub_user.permissions << "GDS Editor"
+    stub_user.name = "Test author"
   end
 
   def given_I_am_not_a_GDS_editor

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -54,7 +54,7 @@ module StepNavSteps
   end
 
   def expect_update_worker
-    allow(StepByStepDraftUpdateWorker).to receive(:perform_async).with(@step_by_step_page.id)
+    allow(StepByStepDraftUpdateWorker).to receive(:perform_async).with(@step_by_step_page.id, stub_user.name)
   end
 
   def given_there_is_a_step_by_step_page_with_steps

--- a/spec/workers/step_by_step_draft_update_worker_spec.rb
+++ b/spec/workers/step_by_step_draft_update_worker_spec.rb
@@ -5,16 +5,37 @@ RSpec.describe StepByStepDraftUpdateWorker do
     allow(Services.publishing_api).to receive(:lookup_content_id)
     allow(StepLinksForRules).to receive(:update)
     allow(StepNavPublisher).to receive(:update)
+    @current_user = create(:user, name: "New author")
   end
 
   context "step by step page exists" do
-    let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
+    let(:step_by_step_page) { create(:step_by_step_page_with_steps, assigned_to: "Original author") }
 
-    it "updates the navigation rules and updates the publishing API" do
-      described_class.new.perform(step_by_step_page.id)
+    it "updates the navigation rules, the publishing API, and the assignee" do
+      described_class.new.perform(step_by_step_page.id, @current_user.name)
 
       expect(StepLinksForRules).to have_received(:update).with(step_by_step_page)
       expect(StepNavPublisher).to have_received(:update).with(step_by_step_page)
+      expect(StepByStepPage.find(step_by_step_page.id).assigned_to).to eql "New author"
+    end
+  end
+
+  describe '#update_assigned_to' do
+    let(:step_by_step_page) { create(:step_by_step_page_with_steps, assigned_to: "Old author") }
+    context 'when a guide is a new draft' do
+      it 'should assign the draft to the current user' do
+        described_class.new.perform(step_by_step_page.id, @current_user.name)
+        expect(StepByStepPage.find(step_by_step_page.id).assigned_to).to eql "New author"
+      end
+    end
+    context 'when a guide is a draft that has already been updated' do
+      before do
+        step_by_step_page.mark_draft_updated
+      end
+      it 'should remain assigned to the old author' do
+        described_class.new.perform(step_by_step_page.id, @current_user.name)
+        expect(StepByStepPage.find(step_by_step_page.id).assigned_to).to eql "Old author"
+      end
     end
   end
 end


### PR DESCRIPTION
# What
This commit adds a small method that assigns whoever the current user is to the current draft when it is updated. This happens if a new guide is created or an existing guide is edited in any way. The meat of this commit is updating areas where this method is called and updating the tests as well.

# Why
It will allow users to see who is currently responsible for a draft.

I'm going to extend this in a future PR so that a change note is generated. This will create a "Chain of Custody" that describes who's been assigned the draft.