### PR TITLE
Change discard draft confirmation dialogue message

### DIFF
--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -34,7 +34,7 @@
 
           <% if @step_by_step_page.unpublished_changes? %>
             <p>Or</p>
-            <%= button_to 'Discard changes', { action: "revert", step_by_step_page_id: @step_by_step_page.id }, data: { confirm: 'Discarding reverts content back to currently published version of the step by step. Do you want to discard your changes?' }, class: "btn btn-danger" %>
+            <%= button_to 'Discard changes', { action: "revert", step_by_step_page_id: @step_by_step_page.id }, data: { confirm: 'This will delete your draft. Do you want to discard your changes?' }, class: "btn btn-danger" %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
Trello: https://trello.com/c/C8eFHFSz

# Before
Confirmation text reads: "Discarding reverts content back to currently published version of the step by step. Do you want to discard your changes?"

![screen shot 2018-09-24 at 12 14 29](https://user-images.githubusercontent.com/5793815/45957143-3cfaa580-c00c-11e8-8514-26ba6d27ce94.png)


# After
Confirmation text reads: "This will delete your draft. Do you want to discard your changes?"

![screen shot 2018-09-24 at 16 26 26](https://user-images.githubusercontent.com/5793815/45961638-eb0b4d00-c016-11e8-9c73-89f80f77ea70.png)

