### PR TITLE
Generate changenote when assigned

### DIFF
--- a/app/controllers/internal_change_notes_controller.rb
+++ b/app/controllers/internal_change_notes_controller.rb
@@ -19,7 +19,6 @@ private
   def other_fields
     fields = {
       step_by_step_page_id: step_by_step_page.id,
-      created_at: Time.now,
       author: current_user.name
     }
 

--- a/app/models/internal_change_note.rb
+++ b/app/models/internal_change_note.rb
@@ -1,5 +1,5 @@
 class InternalChangeNote < ApplicationRecord
-  validates :author, :description, :created_at, presence: true
+  validates :author, :description, presence: true
   belongs_to :step_by_step_page
 
   def readable_created_date

--- a/app/workers/step_by_step_draft_update_worker.rb
+++ b/app/workers/step_by_step_draft_update_worker.rb
@@ -24,8 +24,17 @@ class StepByStepDraftUpdateWorker
 
   def update_assigned_to
     unless step_by_step_page.has_draft?
+      generate_internal_change_note
       step_by_step_page.assigned_to = @current_user
       step_by_step_page.save
     end
+  end
+
+  def generate_internal_change_note
+    change_note = step_by_step_page.internal_change_notes.new(
+      author: @current_user,
+      description: "Draft created by #{@current_user}",
+    )
+    change_note.save
   end
 end

--- a/spec/workers/step_by_step_draft_update_worker_spec.rb
+++ b/spec/workers/step_by_step_draft_update_worker_spec.rb
@@ -38,4 +38,23 @@ RSpec.describe StepByStepDraftUpdateWorker do
       end
     end
   end
+
+  describe '#generate_internal_change_note' do
+    let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
+    context 'when the guide is a new draft' do
+      it 'generates a note that says "Draft created by New author"' do
+        described_class.new.perform(step_by_step_page.id, @current_user.name)
+        expect(step_by_step_page.internal_change_notes.first.description).to eql 'Draft created by New author'
+      end
+    end
+    context 'when the guide is a draft that has already been updated' do
+      before do
+        step_by_step_page.mark_draft_updated
+      end
+      it 'should not generate a change note' do
+        described_class.new.perform(step_by_step_page.id, @current_user.name)
+        expect(step_by_step_page.internal_change_notes.count).to eql 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
This PR is for a small function that runs when a step by step is going into draft. It generates an InternalChangeNote with the text `"Draft created by #{current_user.name}"`. 

# Why
We think that this will help users to keep track of who started the current draft and make communication and traceability easier.

[Ticket](https://trello.com/c/lsMQWc6u/875-add-a-change-note-when-the-draft-is-assigned-to-a-new-user)