### PR TITLE
Assign user and log change

### DIFF
--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -9,6 +9,7 @@ $red: #b10e1e;
 $grey: #eeeeee;
 $beige: #8a6d3b;
 $border-grey: #aaaaaa;
+$dark-grey: #999999;
 
 .step-actions {
   padding: 15px 0;
@@ -161,4 +162,9 @@ $border-grey: #aaaaaa;
   .change-note--description {
     white-space: pre-wrap;
   }
+}
+
+.last-saved-by--text {
+  margin: 20px 0 20px;
+  color: $dark-grey;
 }

--- a/app/views/shared/steps/_heading.html.erb
+++ b/app/views/shared/steps/_heading.html.erb
@@ -2,3 +2,7 @@
   <small><%= action %><span class="sr-only"> - </span></small><br />
   <%= step_nav %>
 </h1>
+
+<% if @step_by_step_page.assigned_to.present? %>
+  <%= render 'shared/steps/last-saved-by', assigned_to: @step_by_step_page.assigned_to %>
+<% end %>

--- a/app/views/shared/steps/_last-saved-by.html.erb
+++ b/app/views/shared/steps/_last-saved-by.html.erb
@@ -1,0 +1,3 @@
+<p class="last-saved-by--text">
+    Last saved by <%= assigned_to %>
+</p>

--- a/app/workers/step_by_step_draft_update_worker.rb
+++ b/app/workers/step_by_step_draft_update_worker.rb
@@ -23,18 +23,24 @@ class StepByStepDraftUpdateWorker
   end
 
   def update_assigned_to
-    unless step_by_step_page.has_draft?
-      generate_internal_change_note
+    unless assigned_to_current_user?
       step_by_step_page.assigned_to = @current_user
       step_by_step_page.save
+      generate_internal_change_note
     end
   end
 
   def generate_internal_change_note
     change_note = step_by_step_page.internal_change_notes.new(
       author: @current_user,
-      description: "Draft created by #{@current_user}",
+      description: "Draft saved by #{@current_user}",
     )
     change_note.save
+  end
+
+private
+
+  def assigned_to_current_user?
+    step_by_step_page.assigned_to == @current_user
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_visit_the_new_step_by_step_form
     and_I_fill_in_the_form
     and_I_see_a_page_created_success_notice
+    and_I_see_I_saved_it_last
     when_I_visit_the_step_by_step_pages_index
     then_I_see_the_new_step_by_step_page
   end
@@ -307,5 +308,9 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_a_page_reverted_success_notice
     expect(page).to have_content("Draft successfully discarded.")
+  end
+
+  def and_I_see_I_saved_it_last
+    expect(page).to have_content("Last saved by Test author")
   end
 end


### PR DESCRIPTION
# What
These changes:
* display the name of the user who most recently saved a guide
* generate a change note when a different user saves a guide

# Why
After discussing with our content designers we've made these changes to make it easier to track the history of a step by step guide. The automatically generated chain of custody, alongside user-written change notes, should give a rich history of the guide in question. 

[Ticket](https://trello.com/c/KC9JoEZM/845-display-the-name-of-the-user-who-initiated-the-current-draft-m-l)