### PR TITLE
Updates the organisations finder to include a brexit filter.

### DIFF
--- a/lib/finders/organisation_content.json
+++ b/lib/finders/organisation_content.json
@@ -15,6 +15,21 @@
     "default_order": "-public_timestamp",
     "facets": [
       {
+        "key": "part_of_taxonomy_tree",
+        "name": "Topic",
+        "short_name": "Topic",
+        "type": "text",
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "preposition": "about",
+        "allowed_values": [
+          {
+            "label": "Brexit",
+            "value": "d6c2de5d-ef90-45d1-82d4-5f2438369eea"
+          }
+        ]
+      },
+      {
         "name": "Organisation",
         "key": "organisations",
         "short_name": "From",
@@ -34,7 +49,9 @@
       }
     ],
     "reject": {
-      "content_purpose_supergroup": ["other"]
+      "content_purpose_supergroup": [
+        "other"
+      ]
     },
     "show_summaries": true
   },


### PR DESCRIPTION
The Organisations finder at https://www.gov.uk/government/organisations/latest
needs a filter to only display items associated with Brexit.

** updated screenshot **
![screenshot 2018-10-30 15 37 48](https://user-images.githubusercontent.com/773037/47730318-d5162b00-dc59-11e8-802b-a87bc501ec1e.png)

Trello: https://trello.com/c/Ci8Mst30/88-allowing-users-to-explore-brexit-content-related-to-a-department
