### PR TITLE
Create special route for campaign page

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -1,0 +1,33 @@
+require 'gds_api/publishing_api/special_route_publisher'
+
+class SpecialRoutePublisher
+  def initialize(publisher_options)
+    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
+  end
+
+  def publish(route_type, route)
+    @publisher.publish(
+      route.merge(
+        format: "special_route",
+        publishing_app: "collections-publisher",
+        rendering_app: "collections",
+        type: route_type,
+        public_updated_at: Time.zone.now.iso8601,
+        update_type: "major",
+      )
+    )
+  end
+
+  def self.routes
+    {
+      prefix: [
+        {
+          content_id: "ecb55f9d-0823-43bd-a116-dbfab2b76ef9",
+          base_path: "/prepare-uk-leaving-eu",
+          title: "Prepare for the UK leaving the EU",
+          description: "How to prepare for Brexit in March 2019 if you're a British citizen or have indefinite leave to remain in the UK.",
+        },
+      ]
+    }
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,4 +1,5 @@
 require_relative "../publish_organisations_api_route"
+require_relative "../special_route_publisher"
 
 namespace :publishing_api do
   desc "Send all tags to the publishing-api, skipping any marked as dirty"
@@ -24,6 +25,27 @@ namespace :publishing_api do
 
       content_item = JSON.parse(File.read(file_path))
       FinderPublisher.call(content_item)
+    end
+  end
+
+  desc "Publish special routes"
+  task publish_special_routes: :environment do
+    publishing_api = GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+
+    logger = Logger.new(STDOUT)
+
+    publisher = SpecialRoutePublisher.new(
+      logger: logger,
+      publishing_api: publishing_api
+    )
+
+    SpecialRoutePublisher.routes.each do |route_type, routes_for_type|
+      routes_for_type.each do |route|
+        publisher.publish(route_type, route)
+      end
     end
   end
 end


### PR DESCRIPTION
This creates the functionality to publish the [new campaign page](https://github.com/alphagov/collections/pull/952).

This has been tested by deploying this branch to integration and running the `publishing-api:publish_special_routes` rake task. The content item can be seen [here](https://www-origin.integration.publishing.service.gov.uk/api/content/prepare-uk-leaving-eu).