### PR TITLE
Handle missing batch link reports

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -37,7 +37,7 @@ private
   def batch_link_report
     begin
       @batch_link_report ||= Services.link_checker_api.get_batch(batch_link_report_id)
-    rescue GdsApi::HTTPServerError
+    rescue GdsApi::HTTPServerError, GdsApi::HTTPNotFound
       nil
     end
   end


### PR DESCRIPTION
This commit adds an exception handler for 404 errors from link-checker-api. This can happen if the batch link report has been removed, which happens autmoatically on a schedule to prevent build-up of old reports. The app should handle this case.