### PR TITLE
Make slug on step-by-step editable

### DIFF
--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -14,7 +14,7 @@
 
   <div class="form-group row">
     <div class="<%= left_col %>">
-      <%= form.text_field :slug, label: "Slug (no slashes)", disabled: @step_by_step_page.persisted? %>
+      <%= form.text_field :slug, label: "Slug (no slashes)" %>
     </div>
   </div>
 


### PR DESCRIPTION
Currently you cannot edit the slug of an existing step-by-step
item.

This commit allows the slug to be edited.
I've tried this in integration and it seems to work fine.

Redirects are being set up for the old slug.