### PR TITLE
Bump gds-api-adapters to 57.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'select2-rails', '~> 3.5.9'
 gem 'uglifier', '~> 4.1'
 
 # GDS managed dependencies
-gem 'gds-api-adapters', '~> 55.0'
+gem 'gds-api-adapters', '~> 57.0'
 gem 'gds-sso', '~> 13.6'
 gem 'govuk_admin_template', '~> 6.6'
 gem 'govuk_app_config', '~> 1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
-    gds-api-adapters (55.0.2)
+    gds-api-adapters (57.0.0)
       addressable
       link_header
       null_logger
@@ -379,7 +379,7 @@ DEPENDENCIES
   byebug
   database_cleaner
   factory_bot_rails
-  gds-api-adapters (~> 55.0)
+  gds-api-adapters (~> 57.0)
   gds-sso (~> 13.6)
   generic_form_builder (~> 0.13)
   govuk-content-schema-test-helpers


### PR DESCRIPTION
Related to: https://trello.com/c/2IdzHdtp/26-add-authentication-to-link-checker-api