### PR TITLE
Get prepare-eu-exit page into site search

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -9,7 +9,6 @@ class SpecialRoutePublisher
   def publish(route_type, route)
     @publisher.publish(
       route.merge(
-        format: "special_route",
         publishing_app: "collections-publisher",
         rendering_app: "collections",
         type: route_type,
@@ -27,6 +26,7 @@ class SpecialRoutePublisher
     {
       prefix: [
         {
+          document_type: "answer",
           content_id: "ecb55f9d-0823-43bd-a116-dbfab2b76ef9",
           base_path: "/prepare-eu-exit",
           title: "Prepare for EU Exit if you live in the UK",

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -30,7 +30,7 @@ class SpecialRoutePublisher
           content_id: "ecb55f9d-0823-43bd-a116-dbfab2b76ef9",
           base_path: "/prepare-eu-exit",
           title: "Prepare for EU Exit if you live in the UK",
-          description: "",
+          description: "How Brexit affects you - visiting Europe, buying things, studying, family law.",
         },
       ]
     }


### PR DESCRIPTION
We want to make the `/prepare-eu-exit` page appear in GOV.UK site search under the services supergroup.  I'm doing this by tagging it as an `answer` document type in the short term - we can change this _soon_.  

The page is not appearing in search at all at the moment which is a problem.

I've set the description to one concocted by the Bravigation teams' content specialists.

Related to: https://github.com/alphagov/collections/pull/1056

https://trello.com/c/5GLtZUxs/152-get-prepare-eu-exit-in-search