### PR TITLE
Make it possible to unpublish the organisation finder

### DIFF
--- a/app/services/finder_publisher.rb
+++ b/app/services/finder_publisher.rb
@@ -14,6 +14,10 @@ class FinderPublisher
     send_to_publishing_api
   end
 
+  def unpublish(options = {})
+    Services.publishing_api.unpublish(content_id, options)
+  end
+
 private
 
   def send_to_publishing_api

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -28,6 +28,25 @@ namespace :publishing_api do
     end
   end
 
+  desc 'Unpublish organisations content finder'
+  task unpublish_org_finder: :environment do
+    file_path = "#{Rails.root}/lib/finders/organisation_content.json"
+
+    content_item = JSON.parse(File.read(file_path))
+
+    puts "Unpublishing #{content_item['title']}..."
+
+    FinderPublisher.new(content_item).unpublish(
+      type: "redirect",
+      redirects: [{
+        segments_mode: "preserve",
+        destination: "/search/all",
+        type: "exact",
+        path: content_item["base_path"],
+      }],
+    )
+  end
+
   desc "Publish special routes"
   task publish_special_routes: :environment do
     publishing_api = GdsApi::PublishingApiV2.new(

--- a/spec/services/finder_publisher_spec.rb
+++ b/spec/services/finder_publisher_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe FinderPublisher do
   before do
     allow(Services.publishing_api).to receive(:put_content)
     allow(Services.publishing_api).to receive(:publish)
+    allow(Services.publishing_api).to receive(:unpublish)
   end
 
   it "publishes valid finders" do
@@ -24,5 +25,18 @@ RSpec.describe FinderPublisher do
 
     expect(Services.publishing_api).to have_received(:put_content).with(content_id, example_finder)
     expect(Services.publishing_api).to have_received(:publish).with(content_id)
+  end
+
+  describe "#unpublish" do
+    it "unpublishes the finder" do
+      file_path = "#{Rails.root}/lib/finders/organisation_content.json"
+      content_item = JSON.parse(File.read(file_path))
+      content_id = content_item['content_id']
+      options = { type: "gone" }
+
+      described_class.new(content_item).unpublish(options)
+
+      expect(Services.publishing_api).to have_received(:unpublish).with(content_id, options)
+    end
   end
 end


### PR DESCRIPTION
The finder at https://www.gov.uk/api/content/government/organisations/latest
will be unpublished, and will redirect to https://www.gov.uk/search/all.

The organisation param will be preserved. The brexit param will not.

The rake task to unpublish the content item must be run manually:

```
publishing_api:unpublish_org_finder
```

Trello: https://trello.com/c/dhMHTIOr/377