### PR TITLE
Add primary publsihing organisation for Mainstream Browse Pages

### DIFF
--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -1,6 +1,8 @@
 class MainstreamBrowsePagePresenter < TagPresenter
 private # rubocop:disable Layout/IndentationWidth
 
+  GDS_CONTENT_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   def format
     'mainstream_browse_page'
   end
@@ -11,6 +13,7 @@ private # rubocop:disable Layout/IndentationWidth
       "active_top_level_browse_page" => active_top_level_browse_page_id,
       "top_level_browse_pages" => @tag.class.sorted_parents.map(&:content_id),
       "second_level_browse_pages" => second_level_browse_pages,
+      "primary_publishing_organisation" => [GDS_CONTENT_ID],
     )
   end
 

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -89,4 +89,16 @@ namespace :publishing_api do
       end
     end
   end
+
+  desc "Patch links for Mainstream Browse Pages"
+  task patch_links_for_mainstream_browse_pages: :environment do
+    MainstreamBrowsePage.all.each do |page|
+      Services.publishing_api.patch_links(
+        page.content_id,
+        MainstreamBrowsePagePresenter.new(page).render_links_for_publishing_api
+      )
+
+      puts "Patching links for #{page.content_id}..."
+    end
+  end
 end

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -97,6 +97,19 @@ RSpec.describe MainstreamBrowsePagePresenter do
       end
     end
 
+    describe "linking to primary publishing organisation" do
+      let!(:parent_browse_page) { create(:mainstream_browse_page) }
+      let(:rendered_links)      { presenter.render_links_for_publishing_api }
+      let(:organisation) { "af07d5a5-df63-4ddc-9383-6a666845ebe9" }
+
+      before :each do
+        browse_page.update_attributes!(:parent => parent_browse_page)
+      end
+
+      it "includes Government Digital Service content id" do
+        expect(rendered_links[:links]["primary_publishing_organisation"]).to eq([organisation])
+      end
+    end
 
     describe "linking to related pages" do
       let!(:top_level_page_1) { create(


### PR DESCRIPTION
The primary publishing organisation is Government Digital Service for all Mainstream Browse Pages.
This is because GDS owns these pages.