### PR TITLE
Add primary publishing organisation for Topics

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -1,7 +1,15 @@
 class TopicPresenter < TagPresenter
 private # rubocop:disable Layout/IndentationWidth
 
+  GDS_CONTENT_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   def format
     'topic'
+  end
+
+  def links
+    super.merge(
+      "primary_publishing_organisation" => [GDS_CONTENT_ID],
+    )
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -101,4 +101,16 @@ namespace :publishing_api do
       puts "Patching links for #{page.content_id}..."
     end
   end
+
+  desc "Patch links for Topics"
+  task patch_links_for_topics: :environment do
+    Topic.all.each do |page|
+      Services.publishing_api.patch_links(
+        page.content_id,
+        TopicPresenter.new(page).render_links_for_publishing_api
+      )
+
+      puts "Patching links for #{page.content_id}..."
+    end
+  end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe TopicPresenter do
           expect(rendered_links[:links]).to have_key("children")
           expect(rendered_links[:links]["children"]).to eq([alpha, bravo].map(&:content_id))
         end
+
+        it "includes links to primary publishing organisation" do
+          organisation = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+          expect(rendered_links[:links]).to have_key("primary_publishing_organisation")
+          expect(rendered_links[:links]["primary_publishing_organisation"]).to eq([organisation])
+        end
       end
     end
 


### PR DESCRIPTION
Currently Topics don't have primary publishing organisation set.
This PR sets Government Digital Service as the primary publishing organisation.
Government Digital Service is added as it is the organisation, which owns it.
It also adds a rake task to update links for all topics.