### PR TITLE
Assign secondary content to step by step pages

### DIFF
--- a/app/assets/javascripts/steps.js
+++ b/app/assets/javascripts/steps.js
@@ -14,6 +14,7 @@
       this.setOrder(); // this is called so the order of the list is initalised
       this.bindStatusClicks();
       this.bindCancelAddChangeNoteLink();
+      this.bindCancelAddSecondaryLink();
     },
 
     addReorderButtons: function() {
@@ -111,6 +112,14 @@
         e.preventDefault();
         $('.add-change-note-description--textarea').val('');
         $('.add-change-note--details').removeAttr('open');
+      });
+    },
+
+    bindCancelAddSecondaryLink: function() {
+      $('.add-secondary-link-cancel--link').on('click', function(e){
+        e.preventDefault();
+        $('.add-secondary-link-input').val('');
+        $('.add-secondary-link--details').removeAttr('open');
       });
     }
   };

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -36,9 +36,15 @@ $dark-grey: #999999;
 .nav.step-by-step-tabs {
   margin-bottom: 2em;
 
+  @media screen and (min-width: 1001px) and (max-width: 1500px) {
+    .step-by-step-tab-link {
+      min-height: 65px;
+    }
+  }
+
   @media screen and (min-width: 769px) and (max-width: 1000px) {
     .step-by-step-tab-link {
-      min-height: 70px;
+      min-height: 85px;
     }
   }
 }

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -174,3 +174,21 @@ $dark-grey: #999999;
   margin: 20px 0 20px;
   color: $dark-grey;
 }
+
+.add-secondary-link--details {
+  margin-bottom: 20px;
+
+  &[open] {
+    .add-secondary-link--summary {
+      display: none;
+    }
+  }
+
+  .add-secondary-link--summary::-webkit-details-marker {
+    display: none;
+  }
+}
+
+.add-secondary-link--example-text {
+  margin: 10px 0;
+}

--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -34,10 +34,11 @@ private
   end
 
   def content_item
-    content_id = Services.publishing_api.lookup_content_id(base_path: params[:base_path], with_drafts: true)
+    base_path = URI.parse(params[:base_path]).path
+    content_id = Services.publishing_api.lookup_content_id(base_path: base_path, with_drafts: true)
 
     if content_id.nil?
-      @error = "#{params[:base_path]} doesn't exist on GOV.UK."
+      @error = "#{base_path} doesn't exist on GOV.UK."
       return {}
     end
 

--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -1,6 +1,18 @@
 class SecondaryContentLinksController < ApplicationController
   before_action :require_gds_editor_permissions!
 
+  def create
+    @secondary_content_link = step_by_step_page.secondary_content_links.new(content_item)
+
+    if @secondary_content_link.save
+      update_downstream
+
+      redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id), notice: 'Secondary content was successfully linked.'
+    else
+      redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id)
+    end
+  end
+
   def index
     @secondary_content_link = step_by_step_page.secondary_content_links.new
     @secondary_content_links = step_by_step_page.secondary_content_links.all
@@ -14,5 +26,22 @@ private
 
   def secondary_content_link
     @secondary_content_link ||= step_by_step_page.secondary_content_links.find(params[:id])
+  end
+
+  def update_downstream
+    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id, current_user.name)
+  end
+
+  def content_item
+    content_id = Services.publishing_api.lookup_content_id(base_path: params[:base_path], with_drafts: true)
+    content_item = Services.publishing_api.get_content(content_id)
+
+    {
+      base_path: content_item["base_path"],
+      title: content_item["title"],
+      content_id: content_id,
+      publishing_app: content_item["publishing_app"],
+      schema_name: content_item["schema_name"]
+    }
   end
 end

--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -1,0 +1,18 @@
+class SecondaryContentLinksController < ApplicationController
+  before_action :require_gds_editor_permissions!
+
+  def index
+    @secondary_content_link = step_by_step_page.secondary_content_links.new
+    @secondary_content_links = step_by_step_page.secondary_content_links.all
+  end
+
+private
+
+  def step_by_step_page
+    @step_by_step_page ||= StepByStepPage.find(params[:step_by_step_page_id])
+  end
+
+  def secondary_content_link
+    @secondary_content_link ||= step_by_step_page.secondary_content_links.find(params[:id])
+  end
+end

--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -9,6 +9,7 @@ class SecondaryContentLinksController < ApplicationController
 
       redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id), notice: 'Secondary content was successfully linked.'
     else
+      flash[:danger] = @error if @error
       redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id)
     end
   end
@@ -34,6 +35,12 @@ private
 
   def content_item
     content_id = Services.publishing_api.lookup_content_id(base_path: params[:base_path], with_drafts: true)
+
+    if content_id.nil?
+      @error = "#{params[:base_path]} doesn't exist on GOV.UK."
+      return {}
+    end
+
     content_item = Services.publishing_api.get_content(content_id)
 
     {

--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -14,6 +14,16 @@ class SecondaryContentLinksController < ApplicationController
     end
   end
 
+  def destroy
+    if secondary_content_link.destroy
+      update_downstream
+
+      redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id), notice: 'Secondary content link was successfully deleted.'
+    else
+      redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id)
+    end
+  end
+
   def index
     @secondary_content_link = step_by_step_page.secondary_content_links.new
     @secondary_content_links = step_by_step_page.secondary_content_links.all

--- a/app/models/secondary_content_link.rb
+++ b/app/models/secondary_content_link.rb
@@ -1,0 +1,5 @@
+class SecondaryContentLink < ActiveRecord::Base
+  belongs_to :step_by_step_page
+
+  validates :title, :base_path, :content_id, :publishing_app, :schema_name, :step_by_step_page_id, presence: true
+end

--- a/app/models/secondary_content_link.rb
+++ b/app/models/secondary_content_link.rb
@@ -1,5 +1,7 @@
 class SecondaryContentLink < ActiveRecord::Base
   belongs_to :step_by_step_page
+  validates_presence_of :step_by_step_page
 
   validates :title, :base_path, :content_id, :publishing_app, :schema_name, :step_by_step_page_id, presence: true
+  validates_uniqueness_of :base_path, scope: :step_by_step_page_id
 end

--- a/app/models/secondary_content_link.rb
+++ b/app/models/secondary_content_link.rb
@@ -4,4 +4,8 @@ class SecondaryContentLink < ActiveRecord::Base
 
   validates :title, :base_path, :content_id, :publishing_app, :schema_name, :step_by_step_page_id, presence: true
   validates_uniqueness_of :base_path, scope: :step_by_step_page_id
+
+  def smartanswer?
+    schema_name == "transaction" && publishing_app == "smartanswers"
+  end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -2,6 +2,7 @@ class StepByStepPage < ApplicationRecord
   has_many :navigation_rules, -> { order(title: :asc) }, dependent: :destroy
   has_many :steps, -> { order(position: :asc) }, dependent: :destroy
   has_many :internal_change_notes, -> { order(created_at: :desc) }
+  has_many :secondary_content_links, -> { order(title: :asc) }, dependent: :destroy
 
   validates :title, :slug, :introduction, :description, presence: true
   validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -86,7 +86,7 @@ private
   end
 
   def part_of_step_nav_links
-    step_nav.navigation_rules.part_of_content_ids + done_page_content_ids
+    step_nav.navigation_rules.part_of_content_ids + done_page_content_ids(base_paths_for_navigation_rules)
   end
 
   def related_to_step_nav_links
@@ -94,32 +94,14 @@ private
   end
 
   def secondary_to_step_nav_links
-    step_nav.secondary_content_links.pluck(:content_id) + secondary_content_done_page_content_ids
+    step_nav.secondary_content_links.pluck(:content_id) + done_page_content_ids(base_paths_for_secondary_content_links)
   end
 
   def access_limited_tokens
     { auth_bypass_ids: [step_nav.auth_bypass_id] }
   end
 
-  def done_page_content_ids
-    base_paths = step_nav.navigation_rules.select { |rule| rule.include_in_links == 'always' }.map do |rule|
-      done_page_base_path(rule)
-    end
-
-    content_ids = []
-    if base_paths.any?
-      results = StepNavPublisher.lookup_content_ids(base_paths)
-      content_ids = results.values if results.any?
-    end
-
-    content_ids
-  end
-
-  def secondary_content_done_page_content_ids
-    base_paths = step_nav.secondary_content_links.map do |secondary_content_link|
-      done_page_base_path(secondary_content_link)
-    end
-
+  def done_page_content_ids(base_paths)
     content_ids = []
     if base_paths.any?
       results = StepNavPublisher.lookup_content_ids(base_paths)
@@ -133,5 +115,17 @@ private
     return page.base_path + "/y" if page.smartanswer?
 
     "/done" + page.base_path
+  end
+
+  def base_paths_for_navigation_rules
+    step_nav.navigation_rules.select { |rule| rule.include_in_links == 'always' }.map do |rule|
+      done_page_base_path(rule)
+    end
+  end
+
+  def base_paths_for_secondary_content_links
+    step_nav.secondary_content_links.map do |secondary_content_link|
+      done_page_base_path(secondary_content_link)
+    end
   end
 end

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -81,6 +81,7 @@ private
     links = {}
     links[:pages_part_of_step_nav] = part_of_step_nav_links if part_of_step_nav_links.present?
     links[:pages_related_to_step_nav] = related_to_step_nav_links if related_to_step_nav_links.present?
+    links[:pages_secondary_to_step_nav] = secondary_to_step_nav_links if secondary_to_step_nav_links.present?
     links
   end
 
@@ -90,6 +91,10 @@ private
 
   def related_to_step_nav_links
     step_nav.navigation_rules.related_content_ids
+  end
+
+  def secondary_to_step_nav_links
+    step_nav.secondary_content_links.pluck(:content_id)
   end
 
   def access_limited_tokens

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -94,7 +94,7 @@ private
   end
 
   def secondary_to_step_nav_links
-    step_nav.secondary_content_links.pluck(:content_id)
+    step_nav.secondary_content_links.pluck(:content_id) + secondary_content_done_page_content_ids
   end
 
   def access_limited_tokens
@@ -104,6 +104,20 @@ private
   def done_page_content_ids
     base_paths = step_nav.navigation_rules.select { |rule| rule.include_in_links == 'always' }.map do |rule|
       done_page_base_path(rule)
+    end
+
+    content_ids = []
+    if base_paths.any?
+      results = StepNavPublisher.lookup_content_ids(base_paths)
+      content_ids = results.values if results.any?
+    end
+
+    content_ids
+  end
+
+  def secondary_content_done_page_content_ids
+    base_paths = step_nav.secondary_content_links.map do |secondary_content_link|
+      done_page_base_path(secondary_content_link)
     end
 
     content_ids = []

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -16,6 +16,7 @@ class StepByStepPageReverter
     step_by_step_page.save!
 
     step_by_step_page.steps = steps
+    step_by_step_page.secondary_content_links = secondary_content_links
 
     add_navigation_rules
   end
@@ -112,6 +113,20 @@ private
     end
   end
 
+  def secondary_content_links
+    @secondary_content_links ||= pages_secondary_to_step_nav.map do |content_id|
+      content_item = Services.publishing_api.get_content(content_id)
+
+      SecondaryContentLink.new(
+        base_path: content_item["base_path"],
+        title: content_item["title"],
+        content_id: content_id,
+        publishing_app: content_item["publishing_app"],
+        schema_name: content_item["schema_name"],
+      )
+    end
+  end
+
   def pages_related_to_step_nav
     payload_from_publishing_api[:links][:pages_related_to_step_nav] || []
   end
@@ -119,5 +134,9 @@ private
   def pages_part_of_or_related_to_step_nav
     (payload_from_publishing_api[:links][:pages_part_of_step_nav] || []) +
       (payload_from_publishing_api[:links][:pages_related_to_step_nav] || [])
+  end
+
+  def pages_secondary_to_step_nav
+    payload_from_publishing_api[:links][:pages_secondary_to_step_nav] || []
   end
 end

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -24,6 +24,52 @@
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
 <%= render '/step_by_step_pages/nav', step_by_step_page: @step_by_step_page, active:"secondary-links" %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+          What is secondary content?
+        </h3>
+      </div>
+      <div class="panel-body">
+        <p>Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.</p>
+        <p>We use it for content which:
+          <ul>
+            <li>helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task</li>
+            <li>is optional and not useful enough to be included in the step by step</li>
+          </ul>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for(@secondary_content_link, url: step_by_step_page_secondary_content_links_path) do |form| %>
+      <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+
+      <details class="add-secondary-link--details">
+        <summary class="add-secondary-link--summary">
+          <span class="btn btn-primary">Add a secondary link</span>
+        </summary>
+        <div class="form-group">
+          <label for="base_path">Base Path</label>
+          <input type="text" name="base_path" required="true" class="form-control add-secondary-link--input">
+          <p class="add-secondary-link__example-text">For example: <a href="https://www.gov.uk/pay-vat">https://www.gov.uk/pay-vat</a> or <a href="https://www.gov.uk/bank-holidays">/bank-holidays</a></p>
+          <%= form.submit "Add secondary link", class: "btn btn-success" %>
+          <a href="<%= step_by_step_page_secondary_content_links_path %>" class="btn btn-link add-secondary-link-cancel--link">Cancel</a>
+        </div>
+      </details>
+    <% end %>
+  </div>
+</div>
+
+<hr />
+
 <div class="row secondary-links">
   <div class="col-md-12">
     <h2>Existing secondary links</h2>

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -1,1 +1,57 @@
-<p> Placeholder for secondary content </p>
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: 'Secondary links'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Secondary links'
+%>
+
+<%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
+<%= render '/step_by_step_pages/nav', step_by_step_page: @step_by_step_page, active:"secondary-links" %>
+<div class="row secondary-links">
+  <div class="col-md-12">
+    <h2>Existing secondary links</h2>
+    <table class="table table-striped table-stepnav-rules" data-module="filterable-table">
+    <thead>
+      <tr>
+        <th colspan="3">
+        <div class='filter-control'>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a rule here' } %>
+        </div>
+        </th>
+      </tr>
+      <tr>
+        <th>Page title</th>
+        <th>Path</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% if @secondary_content_links.present? %>
+        <% @secondary_content_links.each do |link| %>
+          <tr>
+            <td><%= link_to(link.title, preview_url(link.base_path)) %></td>
+            <td><%= link.base_path %></td>
+          </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+  </div>
+</div>

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -1,0 +1,1 @@
+<p> Placeholder for secondary content </p>

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -85,6 +85,7 @@
       <tr>
         <th>Page title</th>
         <th>Path</th>
+        <th>Action</th>
       </tr>
     </thead>
 
@@ -94,6 +95,9 @@
           <tr>
             <td><%= link_to(link.title, preview_url(link.base_path)) %></td>
             <td><%= link.base_path %></td>
+            <td>
+              <%= link_to("Delete", step_by_step_page_secondary_content_link_path(@step_by_step_page.id, link.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm") %>
+            </td>
           </tr>
         <% end %>
       <% end %>

--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -19,6 +19,9 @@
   <li class="<%= "active" if active == 'choose-navigation' %>">
     <%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "step-by-step-tab-link" %>
   </li>
+  <li class="<%= "active" if active == 'secondary-links' %>">
+    <%= link_to 'Secondary links', step_by_step_page_secondary_content_links_path(@step_by_step_page), class: "step-by-step-tab-link" %>
+  </li>
   <li class="<%= "active" if active == 'publish-or-delete' %>">
     <%= link_to 'Publish or delete', step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "step-by-step-tab-link" %>
   </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     post 'internal-change-notes', to: 'internal_change_notes#create'
     post :check_links
 
+    resources :secondary_content_links, path: 'secondary-content-links'
     resources :steps
   end
 

--- a/db/migrate/20190520162024_create_secondary_content_links.rb
+++ b/db/migrate/20190520162024_create_secondary_content_links.rb
@@ -1,0 +1,12 @@
+class CreateSecondaryContentLinks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :secondary_content_links do |t|
+      t.string :base_path
+      t.string :title
+      t.string :content_id
+      t.string :publishing_app
+      t.string :schema_name
+      t.references :step_by_step_page, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_11_094250) do
+ActiveRecord::Schema.define(version: 2019_05_20_162024) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -82,6 +82,16 @@ ActiveRecord::Schema.define(version: 2018_10_11_094250) do
     t.index ["from_base_path"], name: "index_redirect_routes_on_from_base_path", unique: true
     t.index ["redirect_id"], name: "index_redirect_routes_on_redirect_id"
     t.index ["tag_id"], name: "index_redirect_routes_on_tag_id"
+  end
+
+  create_table "secondary_content_links", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "base_path"
+    t.string "title"
+    t.string "content_id"
+    t.string "publishing_app"
+    t.string "schema_name"
+    t.bigint "step_by_step_page_id"
+    t.index ["step_by_step_page_id"], name: "index_secondary_content_links_on_step_by_step_page_id"
   end
 
   create_table "step_by_step_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -157,6 +167,7 @@ ActiveRecord::Schema.define(version: 2018_10_11_094250) do
   add_foreign_key "lists", "tags", name: "lists_tag_id_fk", on_delete: :cascade
   add_foreign_key "navigation_rules", "step_by_step_pages"
   add_foreign_key "redirect_routes", "tags"
+  add_foreign_key "secondary_content_links", "step_by_step_pages"
   add_foreign_key "steps", "step_by_step_pages"
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe SecondaryContentLinksController do
     end
   end
 
+  describe "#destroy" do
+    it "removes a secondary content link" do
+      stub_user.permissions << "GDS Editor"
+      allow(Services.publishing_api).to receive(:put_content)
+
+      create(:secondary_content_link, step_by_step_page: step_by_step_page)
+
+      post :destroy, params: { step_by_step_page_id: step_by_step_page.id, id: step_by_step_page.secondary_content_links.first.id }
+
+      expect(step_by_step_page.secondary_content_links.count).to eq(0)
+    end
+  end
+
   def create_step_by_step_page
     build(:step_by_step_page_with_secondary_content).tap do |step_page|
       step_page.save(validate: false)

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe SecondaryContentLinksController do
         .with("a-content-id")
         .and_return(content_item)
       allow(Services.publishing_api).to receive(:put_content)
+      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
 
       post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
 
@@ -53,6 +54,7 @@ RSpec.describe SecondaryContentLinksController do
       allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
       allow(Services.publishing_api).to receive(:get_content).and_return(content_item)
       allow(Services.publishing_api).to receive(:put_content)
+      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
 
       post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "http:/foo.com/base_path" }
 

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe SecondaryContentLinksController do
       post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
       expect(flash[:danger]).to be_present
     end
+
+    it "accepts a full url as the base_path" do
+      stub_user.permissions << "GDS Editor"
+
+      allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
+      allow(Services.publishing_api).to receive(:get_content).and_return(content_item)
+      allow(Services.publishing_api).to receive(:put_content)
+
+      post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "http:/foo.com/base_path" }
+
+      expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
+    end
   end
 
   def create_step_by_step_page

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe SecondaryContentLinksController do
       expect(step_by_step_page.secondary_content_links.first.content_id).to eq("a-content-id")
       expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
     end
+
+    it "returns an error if the base_path does not exist" do
+      stub_user.permissions << "GDS Editor"
+
+      allow(Services.publishing_api).to receive(:lookup_content_id).and_return(nil)
+
+      post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
+      expect(flash[:danger]).to be_present
+    end
   end
 
   def create_step_by_step_page

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe SecondaryContentLinksController do
+  describe "GET secondary content index page" do
+    let(:step_by_step_page) { create_step_by_step_page }
+    let(:secondary_content_link) { create(:secondary_content_link, step_by_step_page: step_by_step_page) }
+
+    it "can only be accessed by users with GDS editor permissions" do
+      stub_user.permissions << "GDS Editor"
+      get :index, params: { step_by_step_page_id: step_by_step_page.id }
+
+      expect(response.status).to eq(200)
+    end
+
+    it "cannot be accessed by users without GDS editor permissions" do
+      stub_user.permissions = %w(signin)
+      get :index, params: { step_by_step_page_id: step_by_step_page.id }
+
+      expect(response.status).to eq(403)
+    end
+  end
+
+  def create_step_by_step_page
+    build(:step_by_step_page_with_secondary_content).tap do |step_page|
+      step_page.save(validate: false)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,6 +39,12 @@ FactoryBot.define do
     end
   end
 
+  factory :step_by_step_page_with_secondary_content, parent: :step_by_step_page_with_steps do
+    after(:create) do |step_by_step_page|
+      create(:secondary_content_link, step_by_step_page: step_by_step_page)
+    end
+  end
+
   factory :step do
     title { "Check how awesome you are" }
     logic { "number" }
@@ -100,6 +106,15 @@ FactoryBot.define do
     publishing_app { "smartanswers" }
     schema_name { "transaction" }
     include_in_links { "always" }
+  end
+
+  factory :secondary_content_link do
+    title { "Secondary Good stuff" }
+    base_path { "/secondary/good/stuff" }
+    content_id { SecureRandom.uuid }
+    publishing_app { "publisher" }
+    schema_name { "guide" }
+    step_by_step_page
   end
 
   factory :redirect_item do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -155,7 +155,8 @@ RSpec.feature "Managing step by step pages" do
           steps: []
         }
       },
-      state_history: { "1" => "published" }
+      state_history: { "1" => "published" },
+      links: {},
     )
 
     click_on "Discard changes"

--- a/spec/features/secondary_content_for_step_by_steps_spec.rb
+++ b/spec/features/secondary_content_for_step_by_steps_spec.rb
@@ -25,6 +25,14 @@ RSpec.feature "Managing secondary content for step by step pages" do
     and_can_I_see_the_new_secondary_content_listed
   end
 
+  scenario "User trys to add broken secondary link" do
+    given_there_is_a_step_by_step_page_with_secondary_content
+    when_I_visit_the_step_by_step_page
+    when_I_visit_the_secondary_content_page
+    when_I_try_to_add_secondary_content_with_a_broken_link
+    then_I_see_a_failure_notice
+  end
+
   def given_there_is_a_step_by_step_page_with_secondary_content
     @step_by_step_page = create(:step_by_step_page_with_secondary_content)
   end
@@ -39,6 +47,12 @@ RSpec.feature "Managing secondary content for step by step pages" do
 
     find('details').click
     fill_in "base_path", with: base_path
+    find('input[value="Add secondary link"]').click
+  end
+
+  def when_I_try_to_add_secondary_content_with_a_broken_link
+    find('details').click
+    fill_in "base_path", with: broken_base_path
     find('input[value="Add secondary link"]').click
   end
 
@@ -74,6 +88,10 @@ RSpec.feature "Managing secondary content for step by step pages" do
 
   def base_path
     "/secondary-content"
+  end
+
+  def broken_base_path
+    "/i-dont-exist"
   end
 
   def content_id

--- a/spec/features/secondary_content_for_step_by_steps_spec.rb
+++ b/spec/features/secondary_content_for_step_by_steps_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.feature "Managing secondary content for step by step pages" do
+  include CommonFeatureSteps
+  include StepNavSteps
+
+  before do
+    given_I_am_a_GDS_editor
+    setup_publishing_api
+  end
+
+  scenario "User views secondary content links" do
+    given_there_is_a_step_by_step_page_with_secondary_content
+    when_I_visit_the_step_by_step_page
+    when_I_visit_the_secondary_content_page
+    then_can_I_see_the_existing_secondary_content_listed
+  end
+
+  def given_there_is_a_step_by_step_page_with_secondary_content
+    @step_by_step_page = create(:step_by_step_page_with_secondary_content)
+  end
+
+  def when_I_visit_the_step_by_step_page
+    visit step_by_step_page_path(@step_by_step_page)
+  end
+
+  def when_I_visit_the_secondary_content_page
+    visit step_by_step_page_secondary_content_links_path(@step_by_step_page)
+  end
+
+  def then_can_I_see_the_existing_secondary_content_listed
+    expect(find('tbody')).to have_content(@step_by_step_page.secondary_content_links.first.title)
+  end
+end

--- a/spec/features/secondary_content_for_step_by_steps_spec.rb
+++ b/spec/features/secondary_content_for_step_by_steps_spec.rb
@@ -16,6 +16,15 @@ RSpec.feature "Managing secondary content for step by step pages" do
     then_can_I_see_the_existing_secondary_content_listed
   end
 
+  scenario "User adds new secondary content link" do
+    given_there_is_a_step_by_step_page_with_secondary_content
+    when_I_visit_the_step_by_step_page
+    when_I_visit_the_secondary_content_page
+    when_I_add_secondary_content
+    then_I_see_a_successfully_linked_notice
+    and_can_I_see_the_new_secondary_content_listed
+  end
+
   def given_there_is_a_step_by_step_page_with_secondary_content
     @step_by_step_page = create(:step_by_step_page_with_secondary_content)
   end
@@ -24,11 +33,60 @@ RSpec.feature "Managing secondary content for step by step pages" do
     visit step_by_step_page_path(@step_by_step_page)
   end
 
+  def when_I_add_secondary_content
+    setup_publishing_api_request_expectations
+    expect_update_worker
+
+    find('details').click
+    fill_in "base_path", with: base_path
+    find('input[value="Add secondary link"]').click
+  end
+
   def when_I_visit_the_secondary_content_page
     visit step_by_step_page_secondary_content_links_path(@step_by_step_page)
   end
 
+  def then_I_see_a_successfully_linked_notice
+    expect(page).to have_content("Secondary content was successfully linked.")
+  end
+
+  def then_I_see_a_failure_notice
+    "#{broken_base_path} doesn't exist on GOV.UK."
+  end
+
   def then_can_I_see_the_existing_secondary_content_listed
     expect(find('tbody')).to have_content(@step_by_step_page.secondary_content_links.first.title)
+  end
+
+  def and_can_I_see_the_new_secondary_content_listed
+    expect(find('tbody')).to have_content(base_path)
+  end
+
+  def setup_publishing_api_request_expectations
+    allow(Services.publishing_api).to(
+      receive(:lookup_content_id).and_return(content_id)
+    )
+
+    allow(Services.publishing_api).to(
+      receive(:get_content).with(content_id).and_return(content_item)
+    )
+  end
+
+  def base_path
+    "/secondary-content"
+  end
+
+  def content_id
+    "a-secondary-content-id"
+  end
+
+  def content_item
+    {
+      "content_id" => content_id,
+      "base_path" => base_path,
+      "title" => "A Secondary Content Link",
+      "publishing_app" => "publisher",
+      "schema_name" => "guide",
+    }
   end
 end

--- a/spec/features/secondary_content_for_step_by_steps_spec.rb
+++ b/spec/features/secondary_content_for_step_by_steps_spec.rb
@@ -33,6 +33,15 @@ RSpec.feature "Managing secondary content for step by step pages" do
     then_I_see_a_failure_notice
   end
 
+  scenario "User removes a secondary content link" do
+    given_there_is_a_step_by_step_page_with_secondary_content
+    when_I_visit_the_step_by_step_page
+    when_I_visit_the_secondary_content_page
+    when_I_delete_secondary_content
+    then_I_see_a_successfully_deleted_notice
+    and_I_cannot_see_any_secondary_content_listed
+  end
+
   def given_there_is_a_step_by_step_page_with_secondary_content
     @step_by_step_page = create(:step_by_step_page_with_secondary_content)
   end
@@ -56,12 +65,22 @@ RSpec.feature "Managing secondary content for step by step pages" do
     find('input[value="Add secondary link"]').click
   end
 
+  def when_I_delete_secondary_content
+    expect_update_worker
+
+    find('.btn-danger').click
+  end
+
   def when_I_visit_the_secondary_content_page
     visit step_by_step_page_secondary_content_links_path(@step_by_step_page)
   end
 
   def then_I_see_a_successfully_linked_notice
     expect(page).to have_content("Secondary content was successfully linked.")
+  end
+
+  def then_I_see_a_successfully_deleted_notice
+    expect(page).to have_content("Secondary content link was successfully deleted.")
   end
 
   def then_I_see_a_failure_notice
@@ -74,6 +93,10 @@ RSpec.feature "Managing secondary content for step by step pages" do
 
   def and_can_I_see_the_new_secondary_content_listed
     expect(find('tbody')).to have_content(base_path)
+  end
+
+  def and_I_cannot_see_any_secondary_content_listed
+    expect(find('tbody')).to have_no_css('*')
   end
 
   def setup_publishing_api_request_expectations

--- a/spec/models/secondary_content_link_spec.rb
+++ b/spec/models/secondary_content_link_spec.rb
@@ -19,12 +19,6 @@ RSpec.describe SecondaryContentLink do
       expect(secondary_content_link).not_to be_valid
     end
 
-    it 'is created with valid attributes' do
-      expect(secondary_content_link).to be_valid
-      expect(secondary_content_link.save).to eql true
-      expect(secondary_content_link).to be_persisted
-    end
-
     it 'requires a title' do
       secondary_content_link.title = ''
 
@@ -58,6 +52,24 @@ RSpec.describe SecondaryContentLink do
 
       expect(secondary_content_link).not_to be_valid
       expect(secondary_content_link.errors).to have_key(:schema_name)
+    end
+
+    describe '#base_path' do
+      it 'is created with valid attributes when the base_path is unique to the step_by_step_page' do
+        secondary_content_link = build(
+          :secondary_content_link,
+          step_by_step_page: step_by_step_page,
+          base_path: "/same-step-by-step/shiny-new-path"
+        )
+        expect(secondary_content_link).to be_valid
+        expect(secondary_content_link.save).to eql true
+        expect(secondary_content_link).to be_persisted
+      end
+
+      it 'returns an error when the base_path and step_by_step_page are not unique' do
+        expect(secondary_content_link.save).to be false
+        expect(secondary_content_link.errors.count).to eq(1)
+      end
     end
   end
 end

--- a/spec/models/secondary_content_link_spec.rb
+++ b/spec/models/secondary_content_link_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe SecondaryContentLink do
+  describe "validations" do
+    let(:step_by_step_page) { create(:step_by_step_page_with_secondary_content) }
+    let(:secondary_content_link) { build(:secondary_content_link, step_by_step_page: step_by_step_page) }
+
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
+    it 'should belong to a step_by_step_page' do
+      should validate_presence_of(:step_by_step_page)
+    end
+
+    it 'fails if step_by_step_page does not exist' do
+      secondary_content_link.step_by_step_page = nil
+
+      expect(secondary_content_link).not_to be_valid
+    end
+
+    it 'is created with valid attributes' do
+      expect(secondary_content_link).to be_valid
+      expect(secondary_content_link.save).to eql true
+      expect(secondary_content_link).to be_persisted
+    end
+
+    it 'requires a title' do
+      secondary_content_link.title = ''
+
+      expect(secondary_content_link).not_to be_valid
+      expect(secondary_content_link.errors).to have_key(:title)
+    end
+
+    it 'requires a base_path' do
+      secondary_content_link.base_path = ''
+
+      expect(secondary_content_link).not_to be_valid
+      expect(secondary_content_link.errors).to have_key(:base_path)
+    end
+
+    it 'requires a content_id' do
+      secondary_content_link.content_id = ''
+
+      expect(secondary_content_link).not_to be_valid
+      expect(secondary_content_link.errors).to have_key(:content_id)
+    end
+
+    it 'requires a publishing_app' do
+      secondary_content_link.publishing_app = ''
+
+      expect(secondary_content_link).not_to be_valid
+      expect(secondary_content_link.errors).to have_key(:publishing_app)
+    end
+
+    it 'requires a schema_name' do
+      secondary_content_link.schema_name = ''
+
+      expect(secondary_content_link).not_to be_valid
+      expect(secondary_content_link.errors).to have_key(:schema_name)
+    end
+  end
+end

--- a/spec/models/secondary_content_link_spec.rb
+++ b/spec/models/secondary_content_link_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe SecondaryContentLink do
+  let(:step_by_step_page) { create(:step_by_step_page_with_secondary_content) }
+  let(:secondary_content_link) { build(:secondary_content_link, step_by_step_page: step_by_step_page) }
+
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
   describe "validations" do
-    let(:step_by_step_page) { create(:step_by_step_page_with_secondary_content) }
-    let(:secondary_content_link) { build(:secondary_content_link, step_by_step_page: step_by_step_page) }
-
-    before do
-      allow(Services.publishing_api).to receive(:lookup_content_id)
-    end
-
     it 'should belong to a step_by_step_page' do
       should validate_presence_of(:step_by_step_page)
     end
@@ -70,6 +70,23 @@ RSpec.describe SecondaryContentLink do
         expect(secondary_content_link.save).to be false
         expect(secondary_content_link.errors.count).to eq(1)
       end
+    end
+  end
+
+  describe '#smartanswer?' do
+    it 'is not a smartanswer start page' do
+      expect(secondary_content_link.smartanswer?).to be false
+    end
+
+    it 'is a smartanswer start page' do
+      secondary_content_link = build(
+        :secondary_content_link,
+        step_by_step_page: step_by_step_page,
+        publishing_app: "smartanswers",
+        schema_name: "transaction",
+      )
+
+      expect(secondary_content_link.smartanswer?).to be true
     end
   end
 end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -263,4 +263,19 @@ RSpec.describe StepByStepPage do
       end
     end
   end
+
+  describe 'secondary content association' do
+    let(:step_by_step) { create(:step_by_step_page_with_secondary_content) }
+
+    it 'is created with a secondary content link' do
+      expect(step_by_step.secondary_content_links.length).to eql(1)
+    end
+
+    it 'deletes secondary content when the StepByStepPage is deleted' do
+      step_by_step.destroy
+
+      expect { step_by_step.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(step_by_step.secondary_content_links.length).to eql(0)
+    end
+  end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -144,5 +144,21 @@ RSpec.describe StepNavPresenter do
         expect(presented[:links][:pages_related_to_step_nav].count).to eq(1)
       end
     end
+
+    describe "secondary content" do
+      let(:step_nav_with_secondary_content) { create(:step_by_step_page_with_secondary_content) }
+
+      subject { described_class.new(step_nav_with_secondary_content) }
+
+      before do
+        allow(StepNavPublisher).to receive(:lookup_content_ids).and_return([])
+      end
+
+      it "adds the content_id of secondary content to pages_secondary_to_step_nav" do
+        presented = subject.render_for_publishing_api
+
+        expect(presented[:links][:pages_secondary_to_step_nav].count).to eq(1)
+      end
+    end
   end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe StepNavPresenter do
     end
 
     describe "secondary content" do
-      let(:step_nav_with_secondary_content) { create(:step_by_step_page_with_secondary_content) }
+      let(:step_nav_with_secondary_content) { create(:step_by_step_page_with_secondary_content, slug: "step-nav-with-secondary-content") }
 
       subject { described_class.new(step_nav_with_secondary_content) }
 
@@ -158,6 +158,38 @@ RSpec.describe StepNavPresenter do
         presented = subject.render_for_publishing_api
 
         expect(presented[:links][:pages_secondary_to_step_nav].count).to eq(1)
+      end
+
+      it "adds the content id of the smartanswer done page to pages_secondary_to_step_nav" do
+        allow(StepNavPublisher).to receive(:lookup_content_ids).and_return('/a-smartanswer/y' => '2fcc4688-89b5-4e71-802d-d95c69fe458a')
+
+        build(
+          :secondary_content_link,
+          step_by_step_page: step_nav,
+          base_path: "/a-smartanswer",
+          publishing_app: "smartanswers",
+          schema_name: "transaction",
+        )
+
+        presented = subject.render_for_publishing_api
+        expect(presented[:links][:pages_secondary_to_step_nav].count).to eq(2)
+        expect(presented[:links][:pages_secondary_to_step_nav]).to include('2fcc4688-89b5-4e71-802d-d95c69fe458a')
+      end
+
+      it "adds the content id of a service done page to pages_secondary_to_step_nav" do
+        allow(StepNavPublisher).to receive(:lookup_content_ids).and_return('/done/service-start-page' => '2fcc4688-89b5-4e71-802d-d95c69fe458a')
+
+        build(
+          :secondary_content_link,
+          step_by_step_page: step_nav,
+          base_path: "/service-start-page",
+          publishing_app: "publisher",
+          schema_name: "transaction",
+        )
+
+        presented = subject.render_for_publishing_api
+        expect(presented[:links][:pages_secondary_to_step_nav].count).to eq(2)
+        expect(presented[:links][:pages_secondary_to_step_nav]).to include('2fcc4688-89b5-4e71-802d-d95c69fe458a')
       end
     end
   end

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe StepByStepPageReverter do
 
     before do
       allow(Services.publishing_api).to receive(:lookup_content_ids).and_return({})
+      allow(Services.publishing_api).to receive(:get_content).with("42ce66de-04f3-4192-bf31-8394538e0734").and_return(
+        secondary_content_item
+      )
       subject.repopulate_from_publishing_api
       step_by_step_page.reload
     end
@@ -233,6 +236,32 @@ RSpec.describe StepByStepPageReverter do
 
         navigation_rule3 = step_by_step_page.navigation_rules.find_by(base_path: "/first-item-in-list-of-step-four")
         expect(navigation_rule3.include_in_links).to eq("conditionally")
+      end
+    end
+
+    describe "#secondary_content" do
+      it "saves the right number of secondary content" do
+        expect(step_by_step_page.secondary_content_links.size).to eq(1)
+      end
+
+      it "saves the title of the secondary content" do
+        title = step_by_step_page.secondary_content_links.first[:title]
+        expect(title).to eq(secondary_content_item["title"])
+      end
+
+      it "saves the base_path of the secondary content" do
+        base_path = step_by_step_page.secondary_content_links.first[:base_path]
+        expect(base_path).to eq(secondary_content_item["base_path"])
+      end
+
+      it "saves the publishing_app of the secondary content" do
+        publishing_app = step_by_step_page.secondary_content_links.first[:publishing_app]
+        expect(publishing_app).to eq(secondary_content_item["publishing_app"])
+      end
+
+      it "saves the schema_name of the secondary content" do
+        schema_name = step_by_step_page.secondary_content_links.first[:schema_name]
+        expect(schema_name).to eq(secondary_content_item["schema_name"])
       end
     end
   end
@@ -464,7 +493,10 @@ RSpec.describe StepByStepPageReverter do
           "1788c387-8680-4454-8923-71ad0f632cbb",
           "2b422e36-85c4-40fb-a40b-5cd40c86c0f8",
           "2148f116-f909-4976-bb05-cb4899f3272a"
-        ]
+        ],
+        "pages_secondary_to_step_nav": [
+          "42ce66de-04f3-4192-bf31-8394538e0734",
+        ],
       },
       "warnings": {
       }
@@ -474,5 +506,16 @@ RSpec.describe StepByStepPageReverter do
   def steps
     @payload ||= payload_from_publishing_api(step_by_step_page.content_id)
     @payload[:details][:step_by_step_nav][:steps]
+  end
+
+  def secondary_content_item
+    {
+      "base_path" => "/guidance/thats-sort-or-relevant",
+      "title" => "Guidance that's sort of relevant",
+      "content_id" => "42ce66de-04f3-4192-bf31-8394538e0734",
+      "publishing_app" => "publisher",
+      "rendering_app" => "frontend",
+      "schema_name" => "transaction"
+    }
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/iE60uYXs

Related to:
* https://github.com/alphagov/govuk_publishing_components/pull/900
* https://github.com/alphagov/publishing-api/pull/1501
* https://github.com/alphagov/govuk-content-schemas/pull/896

## Motivation

Secondary content is content that is about the service, but not needed by enough users to be included in the step by step. An example of this is internal links in content that is part of the step by step.

At the moment, if users click on internal links, they lose sight of the step by step journey they are on.

This PR allows content designers to assign content on GOV.UK as secondary content on a step by step.

## Expected changes

A new tab in collections-publisher to assign secondary content to a step by step page in its links.

Secondary content behaves in the same way as all other attributes of a step by step. When secondary content is added, it is either added to the existing draft, or a new draft is created. Secondary content does not appear on live until the draft is published. If the draft is discarded, the secondary content links will be reverted to the previous version's.

<img width="766" alt="Screen Shot 2019-06-06 at 12 48 44" src="https://user-images.githubusercontent.com/5793815/59030692-9385d800-8859-11e9-8c65-6078becd93c8.png">
<img width="766" alt="Screen Shot 2019-06-06 at 12 49 03" src="https://user-images.githubusercontent.com/5793815/59030697-97b1f580-8859-11e9-9dd2-3e7a46207380.png">

There is a [PR in review](https://github.com/alphagov/govuk_publishing_components/pull/900) to display the step by step breadcrumb and side bar on secondary content.