### PR TITLE
[WIP] secondary content links

### DIFF
--- a/app/assets/javascripts/steps.js
+++ b/app/assets/javascripts/steps.js
@@ -14,6 +14,7 @@
       this.setOrder(); // this is called so the order of the list is initalised
       this.bindStatusClicks();
       this.bindCancelAddChangeNoteLink();
+      this.bindCancelAddSecondaryLink();
     },
 
     addReorderButtons: function() {
@@ -111,6 +112,14 @@
         e.preventDefault();
         $('.add-change-note-description--textarea').val('');
         $('.add-change-note--details').removeAttr('open');
+      });
+    },
+
+    bindCancelAddSecondaryLink: function() {
+      $('.add-secondary-link-cancel--link').on('click', function(e){
+        e.preventDefault();
+        $('.add-secondary-link-input').val('');
+        $('.add-secondary-link--details').removeAttr('open');
       });
     }
   };

--- a/app/assets/stylesheets/steps.scss
+++ b/app/assets/stylesheets/steps.scss
@@ -36,9 +36,15 @@ $dark-grey: #999999;
 .nav.step-by-step-tabs {
   margin-bottom: 2em;
 
+  @media screen and (min-width: 1001px) and (max-width: 1500px) {
+    .step-by-step-tab-link {
+      min-height: 65px;
+    }
+  }
+
   @media screen and (min-width: 769px) and (max-width: 1000px) {
     .step-by-step-tab-link {
-      min-height: 70px;
+      min-height: 85px;
     }
   }
 }
@@ -167,4 +173,22 @@ $dark-grey: #999999;
 .last-saved-by--text {
   margin: 20px 0 20px;
   color: $dark-grey;
+}
+
+.add-secondary-link--details {
+  margin-bottom: 20px;
+
+  &[open] {
+    .add-secondary-link--summary {
+      display: none;
+    }
+  }
+
+  .add-secondary-link--summary::-webkit-details-marker {
+    display: none;
+  }
+}
+
+.add-secondary-link__exampleText {
+  margin: 10px 0;
 }

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -107,6 +107,11 @@ class StepByStepPagesController < ApplicationController
     @internal_change_note = InternalChangeNote.new
   end
 
+  def secondary_links
+    set_current_page_as_step_by_step
+    @secondary_links = StepByStepPage.find(params[:step_by_step_page_id])
+  end
+
 private
 
   def discard_draft

--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -19,6 +19,9 @@
   <li class="<%= "active" if active == 'choose-navigation' %>">
     <%= link_to 'Choose navigation', step_by_step_page_navigation_rules_path(@step_by_step_page), class: "step-by-step-tab-link" %>
   </li>
+  <li class="<%= "active" if active == 'secondary-links' %>">
+    <%= link_to 'Secondary links', step_by_step_page_secondary_links_path(@step_by_step_page), class: "step-by-step-tab-link" %>
+  </li>
   <li class="<%= "active" if active == 'publish-or-delete' %>">
     <%= link_to 'Publish or delete', step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "step-by-step-tab-link" %>
   </li>

--- a/app/views/step_by_step_pages/secondary_links.html.erb
+++ b/app/views/step_by_step_pages/secondary_links.html.erb
@@ -1,0 +1,103 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: 'Secondary links'
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Secondary links'
+%>
+
+<%= render 'nav', step_by_step_page: @step_by_step_page, active:"secondary-links" %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+          What is secondary content?
+        </h3>
+      </div>
+      <div class="panel-body">
+        <p>Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.</p>
+        <p>We use it for content which:
+          <ul>
+            <li>helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task</li>
+            <li>is optional and not useful enough to be included in the step by step</li>
+          </ul>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <%= form_for(@secondary_links, url: step_by_step_page_secondary_links_path) do |form| %>
+      <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+
+      <details class="add-secondary-link--details">
+        <summary class="add-secondary-link--summary">
+          <span class="btn btn-primary">Add a secondary link</span>
+        </summary>
+        <div class="form-group">
+          <label for="link">Link</label>
+          <input type="text" name="link" required="true" class="form-control add-secondary-link--input">
+          <p class="add-secondary-link__exampleText">For example: <a href="https://www.gov.uk/pay-vat">https://www.gov.uk/pay-vat</a> or <a href="https://www.gov.uk/bank-holidays">/bank-holidays</a></p>
+          <%= form.submit "Add secondary link", class: "btn btn-success" %>
+          <a href="<%= step_by_step_page_secondary_links_path %>" class="btn btn-link add-secondary-link-cancel--link">Cancel</a>
+        </div>
+      </details>
+    <% end %>
+  </div>
+</div>
+
+<hr />
+
+<div class="row secondary-links">
+  <div class="col-md-12">
+    <h2>Existing secondary links</h2>
+    <table class="table table-striped table-stepnav-rules" data-module="filterable-table">
+    <thead>
+      <tr>
+        <th colspan="3">
+        <div class='filter-control'>
+          <%= render partial: 'govuk_admin_template/table_filter_form', locals: { placeholder: 'Search for a rule here' } %>
+        </div>
+        </th>
+      </tr>
+      <tr>
+        <th>Page title</th>
+        <th>Path</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @step_by_step_page.navigation_rules.each do |navigation_rule| %>
+        <tr>
+          <td><%= link_to(navigation_rule.title, preview_url(navigation_rule.base_path)) %></td>
+          <td><%= navigation_rule.base_path %></td>
+          <td>
+            <%= link_to("Delete", "/fdsds", method: 'delete', data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-sm") %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     post :unpublish
     post :revert
     get  'publish-or-delete', to: 'publish_or_delete'
+    get  'secondary-links', to: 'secondary_links'
     get 'internal-change-notes', to: 'interal_change_notes'
     post 'internal-change-notes', to: 'internal_change_notes#create'
     post :check_links


### PR DESCRIPTION
## What
We want a new tab that allows users to :

- add base path to the page that you want the step by step navigation to show on
- remove the step by step side navigation from secondary content


## Why
We want to add a new feature to 'step by step publisher' that makes it possible to add step by step navigation to secondary content. (Secondary content = content that is about the service but is not useful enough to include in the step by step). 

**MVP = add the closed step by step to the side nav for these pages**

**Nice to have =  make is possible to assign a step in the step by step to open for that piece of secondary content, where relevant.** 

Screenshot
=========
![secondary-links](https://user-images.githubusercontent.com/4599889/58334912-60465080-7e38-11e9-84db-b652887cba23.gif)

### Trello: 
https://trello.com/c/iE60uYXs/124-step-by-step-create-interface-in-collections-publisher-for-secondary-content