### PR TITLE
Add primary publishing organisation to root browse page

### DIFF
--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -1,4 +1,6 @@
 class RootBrowsePagePresenter
+  GDS_CONTENT_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   def initialize(options)
     @state = options['state']
   end
@@ -63,7 +65,8 @@ private
 
   def links
     {
-      "top_level_browse_pages" => top_level_browse_pages.map(&:content_id)
+      "top_level_browse_pages" => top_level_browse_pages.map(&:content_id),
+      "primary_publishing_organisation" => [GDS_CONTENT_ID]
     }
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -100,6 +100,13 @@ namespace :publishing_api do
 
       puts "Patching links for #{page.content_id}..."
     end
+
+    root_page = RootBrowsePagePresenter.new('state' => 'published')
+    Services.publishing_api.patch_links(
+      root_page.content_id,
+      root_page.render_links_for_publishing_api
+    )
+    puts "Links patched for root page..."
   end
 
   desc "Patch links for Topics"

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe RootBrowsePagePresenter do
         page2.content_id,
       ])
     end
+
+    it 'includes primary publishing organisation' do
+      organisation = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+
+      rendered = RootBrowsePagePresenter.new('state' => 'published').render_links_for_publishing_api
+
+      expect(rendered[:links]["primary_publishing_organisation"]).to eq([organisation])
+    end
   end
 
   describe '#draft?' do


### PR DESCRIPTION
Root browse page is a special case as it is separate from the rest of mainstream browse pages, therefore needs a separate way of adding an organisation