### PR TITLE
Add primary publishing organisation to root topic page

### DIFF
--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -1,4 +1,6 @@
 class RootTopicPresenter
+  GDS_CONTENT_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   def initialize(options)
     @state = options['state']
   end
@@ -64,7 +66,8 @@ private
 
   def links
     {
-      "children" => topics.map(&:content_id)
+      "children" => topics.map(&:content_id),
+      "primary_publishing_organisation" => [GDS_CONTENT_ID]
     }
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -112,5 +112,12 @@ namespace :publishing_api do
 
       puts "Patching links for #{page.content_id}..."
     end
+
+    root_page = RootTopicPresenter.new('state' => 'published')
+    Services.publishing_api.patch_links(
+      root_page.content_id,
+      root_page.render_links_for_publishing_api
+    )
+    puts "Links patched for root page..."
   end
 end

--- a/spec/presenters/root_topic_presenter_spec.rb
+++ b/spec/presenters/root_topic_presenter_spec.rb
@@ -44,5 +44,13 @@ RSpec.describe RootTopicPresenter do
         page2.content_id,
       ])
     end
+
+    it 'includes primary publishing organisation' do
+      organisation = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+
+      rendered = RootTopicPresenter.new('state' => 'published').render_links_for_publishing_api
+
+      expect(rendered[:links]["primary_publishing_organisation"]).to eq([organisation])
+    end
   end
 end


### PR DESCRIPTION
Root topic page is a special case as it is separate from the rest of the topic pages, therefore needs a separate way of adding an organisation