### PR TITLE
Cope with trailing whitespace in step markdown

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -13,7 +13,7 @@ class StepContentParser
   LINK_REGEX = /\[[^\[\]]+\]\(([^)]+)/.freeze
 
   def parse(step_text)
-    sections = step_text.delete("\r").split("\n\n").map do |section|
+    sections = step_text.rstrip.delete("\r").split("\n\n").map do |section|
       section.lines.map(&:chomp)
     end
 

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe StepContentParser do
 
           Conducted by Mr Andrew Preview
 
+
         HEREDOC
 
         expect(subject.parse(step_text)).to eq([


### PR DESCRIPTION
At present, steps with multiple trailing lines will create an empty paragraph once parsed.

This breaks Google's [rich snippet parser](https://search.google.com/test/rich-results?id=sm1WcP0wSd_gSZ-3ZSSVUQ) for HowTo schemas, so we should fix it.

![Screenshot 2019-05-30 15 52 56](https://user-images.githubusercontent.com/773037/58642358-1b696080-82f5-11e9-8480-eeb9f63f1e0f.png)

Note that it doesn't have any visible effects on the page as we seem to defend against that in the step by step component.

https://collections-publisher.publishing.service.gov.uk/step-by-step-pages/66/internal-change-notes