### PR TITLE
Fix ability to preview step by step on first attempt

### DIFF
--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,9 +1,9 @@
 class StepNavPublisher
   def self.update(step_by_step_page, publish_intent = PublishIntent.minor_update)
+    step_by_step_page.mark_draft_updated
     presenter = StepNavPresenter.new(step_by_step_page)
     payload = presenter.render_for_publishing_api(publish_intent)
     Services.publishing_api.put_content(step_by_step_page.content_id, payload)
-    step_by_step_page.mark_draft_updated
   end
 
   def self.discard_draft(step_by_step_page)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
 
   factory :published_step_by_step_page, parent: :step_by_step_page_with_steps do
     draft_updated_at { 3.hours.ago }
-    published_at { Time.zone.now }
+    published_at { 3.hours.ago }
   end
 
   factory :step_by_step_page_with_navigation_rules, parent: :step_by_step_page_with_steps do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -112,7 +112,7 @@ RSpec.feature "Managing step by step pages" do
   end
 
   scenario "User reverts a step by step page" do
-    given_there_is_a_published_step_by_step_page
+    given_there_is_a_published_step_by_step_page_with_unpublished_changes
     when_I_view_the_step_by_step_page
     and_I_visit_the_publish_or_delete_page
     when_I_want_to_revert_the_page
@@ -121,6 +121,10 @@ RSpec.feature "Managing step by step pages" do
 
   def given_there_is_a_published_step_by_step_page
     @step_by_step_page = create(:published_step_by_step_page)
+  end
+
+  def given_there_is_a_published_step_by_step_page_with_unpublished_changes
+    @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: Time.zone.now)
   end
 
   def and_it_has_change_notes

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe StepNavPublisher do
       StepNavPublisher.update(step_nav)
       expect(Services.publishing_api).to have_received(:put_content)
     end
+
+    context "live step by step having a step edited" do
+      let(:step_nav) { create(:published_step_by_step_page) }
+
+      it "defines :access_limited in the publishing-api payload" do
+        StepNavPublisher.update(step_nav)
+        content_id = /[0-9a-f]{5,40}/ # changes on each test run, as does Array value below
+        payload = hash_including(:access_limited => { :auth_bypass_ids => instance_of(Array) })
+        expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+      end
+    end
   end
 
   context ".lookup_content_ids" do


### PR DESCRIPTION
Sets `draft_updated_at` before sending payload to publishing-api.

This fixes a bug whereby live step-by-steps can't be previewed
if they have only been edited once since publish. If someone
added/removed/edited a step in a live step-by-step and then
clicked 'Preview', they would see the "Sorry, we're experiencing
technical difficulties page" normally only seen by users missing
an access token in the request URL. However, if they then made an
additional edit, they could preview the step-by-step as expected.

The bug arises from the fact that StepNavPresenter only sets the
`access_limited` field in the publishing-api payload if the
StepByStepPage `has_draft?` method returns `true`:

https://github.com/alphagov/collections-publisher/blob/909a35f7a688f12447579186d8f0eee48cd60afe/app/presenters/step_nav_presenter.rb#L37

But if the
StepByStepPage is already live, then `has_draft?` returns `false`
at this point, as we haven't made the edit yet!
On subsequent edits, the `has_draft?` method returns `true` because
the StepByStepPage is in draft/'Unpublished changes' state from
the previous edit, and therefore the `access_limited` field is now
set and the user can now preview their step-by-step.

By calling `mark_draft_updated` _before_ initialising the StepNavPresenter
and getting the payload to pass to publishing-api, we ensure that
the step-by-step is in draft mode by the time we call `has_draft?`
and we can therefore preview our change right away.

See https://trello.com/c/g1M754qO/