### PR TITLE
Generate an internal change note when a step by step is published

### DIFF
--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe StepByStepPagesController do
   include GdsApi::TestHelpers::PublishingApiV2
 
   let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
+  let(:stub_user) { create(:user, name: "Name Surname", permissions: ["signin", "GDS Editor"]) }
 
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id).and_return(nil)
@@ -16,7 +17,6 @@ RSpec.describe StepByStepPagesController do
 
   describe "GET Step by step index page" do
     it "can only be accessed by users with GDS editor permissions" do
-      stub_user.permissions << "GDS Editor"
       get :index
 
       expect(response.status).to eq(200)
@@ -31,20 +31,43 @@ RSpec.describe StepByStepPagesController do
   end
 
   describe "#publish" do
-    it "sets the edition number of the change notes" do
-      stub_user.permissions << "GDS Editor"
+    context 'major updates' do
+      it "generates an internal change note with change note text" do
+        stub_publishing_api
 
+        change_note_text = "Testing major change note"
+        post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "major", change_note: change_note_text }
+
+        expected_description = "Major update published by Name Surname with note: #{change_note_text}"
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+      end
+    end
+
+    context 'minor updates' do
+      it "generates an internal change note with change note text" do
+        stub_publishing_api
+
+        change_note_text = "Corrected a typo"
+        post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: change_note_text }
+
+        expected_description = "Minor update published by Name Surname with note: #{change_note_text}"
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+      end
+
+      it "generates an internal change note without change note text" do
+        stub_publishing_api
+        post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: "" }
+
+        expected_description = "Minor update published by Name Surname"
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+      end
+    end
+
+    it "sets the edition number of the change notes" do
       create(:internal_change_note, step_by_step_page_id: step_by_step_page.id)
 
-      allow(Services.publishing_api).to receive(:lookup_content_ids).with(
-        base_paths: [base_path(step_by_step_page.slug)],
-        with_drafts: true
-      ).and_return({})
-
-      stub_any_publishing_api_put_content
-      stub_any_publishing_api_publish
-
-      post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor" }
+      stub_publishing_api
+      post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: "" }
 
       expect(step_by_step_page.internal_change_notes.first.edition_number).to eq(3)
     end
@@ -52,8 +75,6 @@ RSpec.describe StepByStepPagesController do
 
   describe "#revert" do
     it "reverts the step by step page to the published version" do
-      stub_user.permissions << "GDS Editor"
-
       allow(Services.publishing_api).to receive(:discard_draft)
 
       allow(Services.publishing_api).to receive(:get_content)
@@ -87,5 +108,15 @@ RSpec.describe StepByStepPagesController do
 
   def base_path(slug)
     "/#{slug}"
+  end
+
+  def stub_publishing_api
+    allow(Services.publishing_api).to receive(:lookup_content_ids).with(
+      base_paths: [base_path(step_by_step_page.slug)],
+      with_drafts: true
+    ).and_return({})
+
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
   end
 end


### PR DESCRIPTION
**What**
Automatically create a change note when a step by step is published that reads:
- "Major update published by <user_name> with note: <change_note>"
- "Minor update published by <user_name> with note: <change_note>"
- "Minor update published by <user_name>" _- when optional description is not provided_

**Why**
It gives the content designers more detailed history of the changes made.  It
will also save them time they would spend on creating change notes manually.

**Examples**
- __Major__
![major](https://user-images.githubusercontent.com/38078064/60984377-844fe980-a333-11e9-8ef6-1e25c14f6b40.gif)

- __Minor without note__
![minor](https://user-images.githubusercontent.com/38078064/60984843-43a4a000-a334-11e9-899a-57291daa884b.gif)

[Trello card](https://trello.com/c/5t0oXw2T/9-record-who-published-a-step-by-step-and-when-they-published-it)