### PR TITLE
[Do not merge] SPIKE: Scheduling

### DIFF
--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -10,6 +10,14 @@ class StepNavPresenter
     payload.merge(publish_intent.present)
   end
 
+  def scheduling_payload
+    {
+      publish_time: Time.now + 2.minutes, # Placeholder, should be replaced with step_nav.scheduled_at
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+    }
+  end
+
 private
 
   attr_reader :step_nav, :step_content_parser

--- a/app/services/scheduled_publishing_job.rb
+++ b/app/services/scheduled_publishing_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ScheduledPublishingJob
+  include Sidekiq::Worker
+  sidekiq_options retry: 5
+
+  sidekiq_retries_exhausted do |msg, _e|
+    if msg["error_class"] == "StandardError"
+      Rails.logger.error(msg['error_message'])
+    end
+  end
+
+  def perform(id)
+    step_nav = nil
+
+    StepByStepPage.transaction do
+      step_nav = StepByStepPage.lock.find_by(id: id)
+      StepNavPublisher.publish(step_nav)
+      step_nav.mark_as_published
+    end
+
+    # TO DO: notify success
+  end
+end

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -21,4 +21,12 @@ class StepNavPublisher
   def self.unpublish(step_by_step_page, redirect_url)
     Services.publishing_api.unpublish(step_by_step_page.content_id, type: "redirect", alternative_path: redirect_url)
   end
+
+  def self.schedule_for_publishing(step_by_step_page)
+    presenter = StepNavPresenter.new(step_by_step_page)
+    payload = presenter.scheduling_payload
+    GdsApi.publishing_api.put_intent("/#{step_by_step_page.slug}", payload)
+
+    ScheduledPublishingJob.perform_at(payload[:publish_time], step_by_step_page.id)
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/C3O7swbp

Commands to test:

```
sbs = StepByStepPage.last
StepNavPublisher.update(sbs) # creates a new draft, otherwise publishing-api throws a conflict error.
StepNavPublisher.schedule_for_publishing(sbs)
```

publising-api receives the intent to publish:
```
172.19.0.7 - - [11/Jul/2019:11:14:25 UTC] "PUT /publish-intent/one HTTP/1.0" 200 119
- -> /publish-intent/one
```

and the draft is updated:

![Screen Shot 2019-07-11 at 12 24 34](https://user-images.githubusercontent.com/5793815/61047614-c9c5f280-a3d7-11e9-9b3a-fd93d3233201.png)

Two minutes later, the content-item is updated:

```
"publishing_scheduled_at": "2019-07-11T11:16:25.036+00:00
"updated_at": "2019-07-11T11:16:26.220Z",
```

![Screen Shot 2019-07-11 at 12 31 36](https://user-images.githubusercontent.com/5793815/61047758-1d384080-a3d8-11e9-81ef-d96cb91d88e4.png)

