### PR TITLE
Move duplicated 'update_downstream' method into helper

### DIFF
--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -1,4 +1,6 @@
 class SecondaryContentLinksController < ApplicationController
+  include StepByStepHelper
+
   before_action :require_gds_editor_permissions!
 
   def create
@@ -37,10 +39,6 @@ private
 
   def secondary_content_link
     @secondary_content_link ||= step_by_step_page.secondary_content_links.find(params[:id])
-  end
-
-  def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id, current_user.name)
   end
 
   def content_item

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -1,5 +1,6 @@
 class StepByStepPagesController < ApplicationController
   include PublishingApiHelper
+  include StepByStepHelper
 
   before_action :require_gds_editor_permissions!
   before_action :set_step_by_step_page, only: %i[show edit update destroy]
@@ -115,10 +116,6 @@ private
     StepNavPublisher.discard_draft(@step_by_step_page)
   rescue GdsApi::HTTPNotFound
     Rails.logger.info "Discarding #{@step_by_step_page.content_id} failed"
-  end
-
-  def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(@step_by_step_page.id, current_user.name)
   end
 
   def publish_page(publish_intent)

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -1,4 +1,6 @@
 class StepsController < ApplicationController
+  include StepByStepHelper
+
   before_action :require_gds_editor_permissions!
 
   def new
@@ -40,10 +42,6 @@ class StepsController < ApplicationController
   end
 
 private
-
-  def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id, current_user.name)
-  end
 
   def step_by_step_page
     @step_by_step_page ||= StepByStepPage.find(params[:step_by_step_page_id])

--- a/app/helpers/step_by_step_helper.rb
+++ b/app/helpers/step_by_step_helper.rb
@@ -1,0 +1,5 @@
+module StepByStepHelper
+  def update_downstream
+    StepByStepDraftUpdateWorker.perform_async(@step_by_step_page.id, current_user.name)
+  end
+end


### PR DESCRIPTION
The definition of 'update_downstream' was repeated in three places.
Ideally we shouldn't have to update this in more than one place (DRY).