### PR TITLE
Add scheduled_at field to StepByStepPages

### DIFF
--- a/db/migrate/20190716152152_add_scheduled_at_to_step_by_step_pages.rb
+++ b/db/migrate/20190716152152_add_scheduled_at_to_step_by_step_pages.rb
@@ -1,0 +1,5 @@
+class AddScheduledAtToStepByStepPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :step_by_step_pages, :scheduled_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_162024) do
+ActiveRecord::Schema.define(version: 2019_07_16_152152) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_162024) do
     t.datetime "published_at"
     t.datetime "draft_updated_at"
     t.string "assigned_to"
+    t.datetime "scheduled_at"
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["slug"], name: "index_step_by_step_pages_on_slug", unique: true
   end


### PR DESCRIPTION
Trello: https://trello.com/c/5WNB5kgU

## What
Adds a field to record the date and time that the step by step is scheduled to be published.

## Why
The functionality to allow publishers to schedule step by steps is currently being added. Creating this migration separately allows, the different parts of the scheduling flow (Scheduling a step by step, sending scheduled jobs to publishing-api) to be worked on simultaneously.