### PR TITLE
Add scheduling permission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,4 +39,8 @@ private
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
     end
   end
+
+  def require_scheduling_permissions!
+    authorise_user!("Scheduling")
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/i5BbBKPg

A new "Scheduling" permission has been added to collections-publisher.
This will allow us to "soft" deploy the features being added to implement scheduling and
hide them behind this special permission.
When scheduling is ready to go "live" this permission will be removed.