### PR TITLE
Adds 'Scheduled' status

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -49,6 +49,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def status
+    return scheduled_status if scheduled_for_publishing?
     return unpublished_status if unpublished_changes?
     return live_status if has_been_published?
 
@@ -98,6 +99,14 @@ private
       name: "draft",
       text: "Draft",
       label_class: "label-default"
+    }
+  end
+
+  def scheduled_status
+    {
+      name: "scheduled",
+      text: "Scheduled",
+      label_class: "label-warning"
     }
   end
 


### PR DESCRIPTION
Builds on the work done in https://github.com/alphagov/collections-publisher/pull/654.

Having a 'scheduled' status is a pre-requisite for other pieces of work this sprint. By defining the 'scheduled' status, we also display schedule status on the index, like this:

<img width="750" alt="Screen Shot 2019-07-18 at 11 38 41" src="https://user-images.githubusercontent.com/5111927/61451133-a14a7500-a950-11e9-91bb-9499f7cb8789.png">

Trello: https://trello.com/c/oX0nn9NG/43-scheduled-status-should-appear-in-index-page