### PR TITLE
Add scheduled job worker

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -21,7 +21,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def scheduled_for_publishing?
-    has_draft? && scheduled_at.present? && scheduled_at.future?
+    has_draft? && scheduled_at.present?
   end
 
   def mark_draft_updated

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -36,6 +36,7 @@ class StepByStepPage < ApplicationRecord
     now = Time.zone.now
     update_attribute(:published_at, now)
     update_attribute(:draft_updated_at, now)
+    update_attribute(:scheduled_at, nil)
   end
 
   def mark_as_unpublished

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -10,6 +10,14 @@ class StepNavPresenter
     payload.merge(publish_intent.present)
   end
 
+  def scheduling_payload
+    {
+      publish_time: step_nav.scheduled_at,
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+    }
+  end
+
 private
 
   attr_reader :step_nav, :step_content_parser

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -21,4 +21,8 @@ class StepNavPublisher
   def self.unpublish(step_by_step_page, redirect_url)
     Services.publishing_api.unpublish(step_by_step_page.content_id, type: "redirect", alternative_path: redirect_url)
   end
+
+  def self.schedule_for_publishing(step_by_step_page)
+    StepByStepScheduledPublishWorker.perform_at(step_by_step_page.scheduled_at, step_by_step_page.id)
+  end
 end

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -23,11 +23,7 @@ class StepNavPublisher
   end
 
   def self.schedule_for_publishing(step_by_step_page)
-    payload = {
-      publish_time: step_by_step_page.scheduled_at,
-      publishing_app: "collections-publisher",
-      rendering_app: "collections",
-    }
+    payload = StepNavPresenter.new(step_by_step_page).scheduling_payload
     base_path = "/#{step_by_step_page.slug}"
 
     GdsApi.publishing_api.put_intent(base_path, payload)

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -23,6 +23,14 @@ class StepNavPublisher
   end
 
   def self.schedule_for_publishing(step_by_step_page)
+    payload = {
+      publish_time: step_by_step_page.scheduled_at,
+      publishing_app: "collections-publisher",
+      rendering_app: "collections",
+    }
+    base_path = "/#{step_by_step_page.slug}"
+
+    GdsApi.publishing_api.put_intent(base_path, payload)
     StepByStepScheduledPublishWorker.perform_at(step_by_step_page.scheduled_at, step_by_step_page.id)
   end
 end

--- a/app/workers/step_by_step_scheduled_publish_worker.rb
+++ b/app/workers/step_by_step_scheduled_publish_worker.rb
@@ -13,6 +13,15 @@ class StepByStepScheduledPublishWorker
       step_nav = StepByStepPage.lock.find_by(id: id)
       StepNavPublisher.publish(step_nav)
       step_nav.mark_as_published
+      generate_internal_change_note(step_nav)
     end
+  end
+
+  def generate_internal_change_note(step_nav)
+    change_note = step_nav.internal_change_notes.new(
+      author: "Scheduled publishing",
+      description: "Published on schedule",
+    )
+    change_note.save!
   end
 end

--- a/app/workers/step_by_step_scheduled_publish_worker.rb
+++ b/app/workers/step_by_step_scheduled_publish_worker.rb
@@ -29,6 +29,10 @@ class StepByStepScheduledPublishWorker
 private
 
   def publish_now?(step_nav)
-    step_nav.scheduled_for_publishing?
+    step_nav.scheduled_for_publishing? && !scheduled_in_future?(step_nav)
+  end
+
+  def scheduled_in_future?(step_nav)
+    step_nav.scheduled_at > Time.zone.now
   end
 end

--- a/app/workers/step_by_step_scheduled_publish_worker.rb
+++ b/app/workers/step_by_step_scheduled_publish_worker.rb
@@ -2,6 +2,10 @@ class StepByStepScheduledPublishWorker
   include Sidekiq::Worker
   sidekiq_options retry: 5
 
+  sidekiq_retries_exhausted do |msg, _e|
+    GovukError.notify(msg['error_message'])
+  end
+
   def perform(id)
     step_nav = nil
 

--- a/app/workers/step_by_step_scheduled_publish_worker.rb
+++ b/app/workers/step_by_step_scheduled_publish_worker.rb
@@ -1,0 +1,14 @@
+class StepByStepScheduledPublishWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: 5
+
+  def perform(id)
+    step_nav = nil
+
+    StepByStepPage.transaction do
+      step_nav = StepByStepPage.lock.find_by(id: id)
+      StepNavPublisher.publish(step_nav)
+      step_nav.mark_as_published
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
     published_at { 3.hours.ago }
   end
 
+  factory :draft_step_by_step_page, parent: :step_by_step_page_with_steps do
+    draft_updated_at { 1.day.ago }
+  end
+
   factory :step_by_step_page_with_navigation_rules, parent: :step_by_step_page_with_steps do
     after(:create) do |step_by_step_page|
       create(:navigation_rule, step_by_step_page: step_by_step_page)

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -204,6 +204,15 @@ RSpec.describe StepByStepPage do
       end
     end
 
+    it 'should reset scheduled date' do
+      step_by_step_page.scheduled_at = Date.today
+
+      step_by_step_page.mark_as_published
+
+      expect(step_by_step_page.scheduled_at).to be nil
+      expect(step_by_step_page.scheduled_for_publishing?).to be false
+    end
+
     it 'should reset published date' do
       step_by_step_page.mark_as_unpublished
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe StepByStepPage do
   describe 'scheduled publishing' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 
-    it 'is scheduled for publishing when it has a draft and scheduled_at is in the future' do
+    it 'is scheduled for publishing when it has a draft and has a scheduled_at date' do
       step_by_step_page.mark_draft_updated
       step_by_step_page.scheduled_at = Date.tomorrow
       expect(step_by_step_page.scheduled_for_publishing?).to be true
@@ -242,9 +242,8 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.scheduled_for_publishing?).to be false
     end
 
-    it 'is not scheduled for publishing if scheduled_at is in the past' do
+    it 'is not scheduled for publishing if scheduled_at is not present' do
       step_by_step_page.mark_draft_updated
-      step_by_step_page.scheduled_at = Date.yesterday
       expect(step_by_step_page.scheduled_for_publishing?).to be false
     end
   end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -193,4 +193,29 @@ RSpec.describe StepNavPresenter do
       end
     end
   end
+
+  describe "#scheduling_payload" do
+    let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
+
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
+    subject { described_class.new(step_nav) }
+
+    it "adds the scheduled_at time" do
+      presented = subject.scheduling_payload
+      expect(presented[:publish_time]).to eq(step_nav.scheduled_at)
+    end
+
+    it "adds the publishing app" do
+      presented = subject.scheduling_payload
+      expect(presented[:publishing_app]).to eq("collections-publisher")
+    end
+
+    it "adds the rendering_app" do
+      presented = subject.scheduling_payload
+      expect(presented[:rendering_app]).to eq("collections")
+    end
+  end
 end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -43,15 +43,8 @@ RSpec.describe StepNavPublisher do
   context ".schedule_for_publishing" do
     let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
 
-    let(:payload) do
-      {
-        publish_time: step_nav.scheduled_at,
-        publishing_app: "collections-publisher",
-        rendering_app: "collections"
-      }
-    end
-
     before do
+      payload = StepNavPresenter.new(step_nav).scheduling_payload
       @publishing_api_request = stub_publishing_api_put_intent("/#{step_nav.slug}", payload)
     end
 

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -36,4 +36,16 @@ RSpec.describe StepNavPublisher do
       expect(Services.publishing_api).to have_received(:lookup_content_ids)
     end
   end
+
+  context ".schedule_for_publishing" do
+    let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
+
+    it "adds a scheduled job to the queue" do
+      Sidekiq::Testing.fake! do
+        expect {
+          StepNavPublisher.schedule_for_publishing(step_nav)
+        }.to change(StepByStepScheduledPublishWorker.jobs, :size).by(1)
+      end
+    end
+  end
 end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/publishing_api'
 
 RSpec.describe StepNavPublisher do
+  include GdsApi::TestHelpers::PublishingApi
+
   let(:step_nav) { create(:step_by_step_page_with_steps) }
 
   before do
@@ -40,12 +43,29 @@ RSpec.describe StepNavPublisher do
   context ".schedule_for_publishing" do
     let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
 
+    let(:payload) do
+      {
+        publish_time: step_nav.scheduled_at,
+        publishing_app: "collections-publisher",
+        rendering_app: "collections"
+      }
+    end
+
+    before do
+      @publishing_api_request = stub_publishing_api_put_intent("/#{step_nav.slug}", payload)
+    end
+
     it "adds a scheduled job to the queue" do
       Sidekiq::Testing.fake! do
         expect {
           StepNavPublisher.schedule_for_publishing(step_nav)
         }.to change(StepByStepScheduledPublishWorker.jobs, :size).by(1)
       end
+    end
+
+    it "tells publishing-api to expect a scheduled job" do
+      StepNavPublisher.schedule_for_publishing(step_nav)
+      expect(@publishing_api_request).to have_been_requested
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,4 +89,8 @@ RSpec.configure do |config|
     # Set a referer header so `redirect_to :back` works in tests.
     request.env["HTTP_REFERER"] = ''
   end
+
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
 end

--- a/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
+++ b/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
@@ -32,4 +32,14 @@ RSpec.describe StepByStepScheduledPublishWorker do
     step_by_step_page.reload
     expect(step_by_step_page.has_been_published?).to be false
   end
+
+  it "doesn't publish a step by step scheduled in the future" do
+    step_by_step_page = create(:draft_step_by_step_page, scheduled_at: Time.now + 1.hour)
+    described_class.new.perform(step_by_step_page.id)
+
+    expect(StepNavPublisher).to_not have_received(:publish)
+
+    step_by_step_page.reload
+    expect(step_by_step_page.has_been_published?).to be false
+  end
 end

--- a/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
+++ b/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
@@ -16,4 +16,9 @@ RSpec.describe StepByStepScheduledPublishWorker do
     step_by_step_page.reload
     expect(step_by_step_page.has_been_published?).to be true
   end
+
+  it "generates a change note" do
+    described_class.new.perform(step_by_step_page.id)
+    expect(step_by_step_page.internal_change_notes.first.description).to eq("Published on schedule")
+  end
 end

--- a/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
+++ b/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe StepByStepScheduledPublishWorker do
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+    allow(StepNavPublisher).to receive(:publish)
+  end
+
+  let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
+
+  it "publishes the step by step" do
+    described_class.new.perform(step_by_step_page.id)
+
+    expect(StepNavPublisher).to have_received(:publish).with(step_by_step_page)
+
+    step_by_step_page.reload
+    expect(step_by_step_page.has_been_published?).to be true
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/ZDJTzOzG

## What

Creates a job to schedule publication of the step by step, and processes that job on the scheduled date/time.

Scheduling a job:
* Notifies publishing-api of the intent to publish on date/time
* Adds a job to `StepByStepScheduledPublishWorker`

Processing a job:
* Only publishes step by steps with a status of "Scheduled"
* Only publishes step by steps with a scheduled date that's in the past
* Clears the `scheduled_at` date & time when the publish request is sent to publishing-api, i.e. it sets the status to "Published"
* Generates an internal change note

New jobs can be created by calling:

```
StepNavPublisher.schedule_for_publishing(step_by_step_page)
```

Note: the UI for users will be created in a separate PR.