### PR TITLE
Notify publishing-api that scheduled publication has been cancelled

### DIFF
--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -18,6 +18,10 @@ class StepNavPresenter
     }
   end
 
+  def base_path
+    "/#{step_nav.slug}"
+  end
+
 private
 
   attr_reader :step_nav, :step_content_parser
@@ -44,10 +48,6 @@ private
     fields = {}
     fields[:access_limited] = access_limited_tokens if step_nav.has_draft?
     fields
-  end
-
-  def base_path
-    "/#{step_nav.slug}"
   end
 
   def public_updated_at

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -23,15 +23,13 @@ class StepNavPublisher
   end
 
   def self.schedule_for_publishing(step_by_step_page)
-    payload = StepNavPresenter.new(step_by_step_page).scheduling_payload
-    base_path = "/#{step_by_step_page.slug}"
-
-    GdsApi.publishing_api.put_intent(base_path, payload)
+    presenter = StepNavPresenter.new(step_by_step_page)
+    GdsApi.publishing_api.put_intent(presenter.base_path, presenter.scheduling_payload)
     StepByStepScheduledPublishWorker.perform_at(step_by_step_page.scheduled_at, step_by_step_page.id)
   end
 
   def self.cancel_scheduling(step_by_step_page)
-    base_path = "/#{step_by_step_page.slug}"
+    base_path = StepNavPresenter.new(step_by_step_page).base_path
     GdsApi.publishing_api.destroy_intent(base_path)
   end
 end

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -29,4 +29,9 @@ class StepNavPublisher
     GdsApi.publishing_api.put_intent(base_path, payload)
     StepByStepScheduledPublishWorker.perform_at(step_by_step_page.scheduled_at, step_by_step_page.id)
   end
+
+  def self.cancel_scheduling(step_by_step_page)
+    base_path = "/#{step_by_step_page.slug}"
+    GdsApi.publishing_api.destroy_intent(base_path)
+  end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -218,4 +218,18 @@ RSpec.describe StepNavPresenter do
       expect(presented[:rendering_app]).to eq("collections")
     end
   end
+
+  describe "#base_path" do
+    let(:step_nav) { create(:step_by_step_page) }
+
+    before do
+      allow(Services.publishing_api).to receive(:lookup_content_id)
+    end
+
+    subject { described_class.new(step_nav) }
+
+    it "gets the base_path" do
+      expect(subject.base_path).to eq("/how-to-be-the-amazing-1")
+    end
+  end
 end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -61,4 +61,17 @@ RSpec.describe StepNavPublisher do
       expect(@publishing_api_request).to have_been_requested
     end
   end
+
+  context ".cancel_scheduling" do
+    let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
+
+    before do
+      @publishing_api_request = stub_publishing_api_destroy_intent("/#{step_nav.slug}")
+    end
+
+    it "tells publishing-api a scheduled job has been cancelled" do
+      StepNavPublisher.cancel_scheduling(step_nav)
+      expect(@publishing_api_request).to have_been_requested
+    end
+  end
 end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe StepNavPublisher do
     let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
 
     before do
-      payload = StepNavPresenter.new(step_nav).scheduling_payload
-      @publishing_api_request = stub_publishing_api_put_intent("/#{step_nav.slug}", payload)
+      presenter = StepNavPresenter.new(step_nav)
+      @publishing_api_request = stub_publishing_api_put_intent(presenter.base_path, presenter.scheduling_payload)
     end
 
     it "adds a scheduled job to the queue" do
@@ -66,7 +66,8 @@ RSpec.describe StepNavPublisher do
     let(:step_nav) { create(:draft_step_by_step_page, scheduled_at: Date.tomorrow) }
 
     before do
-      @publishing_api_request = stub_publishing_api_destroy_intent("/#{step_nav.slug}")
+      base_path = StepNavPresenter.new(step_nav).base_path
+      @publishing_api_request = stub_publishing_api_destroy_intent(base_path)
     end
 
     it "tells publishing-api a scheduled job has been cancelled" do


### PR DESCRIPTION
Trello: https://trello.com/c/lxL03mid

Informs publishing-api that the scheduled job has been cancelled.

This should remove the header set by content-store to clear the cache at the scheduled time.

Note: This doesn't remove the job from the sidekiq queue. To do that we would have to store the job id of the schedule job, and loop through all of the jobs on the queue to find the right one to delete. Rather than do this, and run the risk of the wrong job being removed, we are instead [checking whether the job is still valid](https://github.com/alphagov/collections-publisher/blob/master/app/workers/step_by_step_scheduled_publish_worker.rb#L12) before processing it.