### PR TITLE
Scheduling UI revamp - Design System

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
+//= require components/autocomplete.js
 //= require jquery-ui.sortable.min
 //= require jquery.clicktoggle
 //= require ./curated_lists

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -1,0 +1,63 @@
+//= require accessible-autocomplete/dist/accessible-autocomplete.min.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function Autocomplete () { }
+
+  Autocomplete.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    var $input = this.$module.querySelector('input')
+
+    if ($input) {
+      this.initAutoCompleteInput($input)
+    }
+  }
+
+  Autocomplete.prototype.initAutoCompleteInput = function ($input) {
+    var withoutNarrowingResults = this.$module.dataset.autocompleteWithoutNarrowingResults
+
+    var list = document.getElementById($input.getAttribute('list'))
+    var options = []
+
+    if (list) {
+      options = [].map.call(list.querySelectorAll('option'), function (option) {
+        return option.value
+      })
+    }
+
+    if (!options.length) {
+      return
+    }
+
+    new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
+      id: $input.id,
+      name: $input.name,
+      element: this.$module,
+      showAllValues: withoutNarrowingResults,
+      defaultValue: $input.value,
+      autoselect: !withoutNarrowingResults,
+      dropdownArrow: withoutNarrowingResults ? this.dropdownArrow : null,
+      source: function (query, syncResults) {
+        if (withoutNarrowingResults) {
+          syncResults(options)
+        } else {
+          syncResults(query
+            ? options.filter(function (option) {
+              return option.toLowerCase().indexOf(query.toLowerCase()) !== -1
+            }) : []
+          )
+        }
+      }
+    })
+
+    $input.parentNode.removeChild($input)
+  }
+
+  Autocomplete.prototype.dropdownArrow = function (config) {
+    return '<svg class="' + config.className + '" style="top: 8px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
+  }
+
+  Modules.Autocomplete = Autocomplete
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import "govuk_publishing_components/all_components";
+@import "./components/autocomplete";

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,0 +1,46 @@
+@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
+
+// TODO: Replace with $govuk-focus-colour when the new colour scheme is released
+$app-focus-colour: #ffdd00;
+
+.autocomplete__wrapper {
+  background: govuk-colour("white");
+}
+
+.autocomplete__input {
+  @include govuk-font(19);
+  z-index: 1;
+  color: $govuk-text-colour;
+}
+
+.autocomplete__dropdown-arrow-down {
+  z-index: 0;
+}
+
+.autocomplete__option,
+.autocomplete__selected-option {
+  @include govuk-font(19);
+  color: $govuk-text-colour;
+
+  mark {
+    border-bottom: 3px solid $govuk-focus-text-colour;
+    background: $app-focus-colour;
+  }
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  color: govuk-colour("white");
+
+  .autocomplete__option-hint {
+    color: govuk-colour("white");
+  }
+}
+
+.app-c-autocomplete--narrow {
+  max-width: 200px;
+
+  @include govuk-media-query($from: tablet) {
+    max-width: 230px;
+  }
+}

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -77,9 +77,12 @@ class StepByStepPagesController < ApplicationController
   def schedule
     set_current_page_as_step_by_step
     if request.post?
-      if @step_by_step_page.update_attributes(scheduled_at: params[:scheduled_at])
+      date_params = params[:schedule][:date].permit(:year, :month, :day)
+      parser = DatetimeParser.new(date: date_params, time: params[:schedule][:time])
+      scheduled_at = parser.parse
+      if scheduled_at && @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish
-        note_description = "Minor update scheduled by #{current_user.name} for publishing at #{params[:scheduled_at]}"
+        note_description = "Minor update scheduled by #{current_user.name} for publishing at #{scheduled_at}"
         generate_internal_change_note(note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been scheduled to publish."

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -1,5 +1,6 @@
 class StepByStepPagesController < ApplicationController
   include PublishingApiHelper
+  include TimeOptionsHelper
   layout 'admin_layout'
 
   before_action :require_gds_editor_permissions!
@@ -77,8 +78,10 @@ class StepByStepPagesController < ApplicationController
   def schedule
     set_current_page_as_step_by_step
     if request.post?
-      date_params = params[:schedule][:date].permit(:year, :month, :day)
-      parser = DatetimeParser.new(date: date_params, time: params[:schedule][:time])
+      date_params = params[:schedule][:date].permit(:year, :month, :day).to_h.symbolize_keys
+      time_param = params[:schedule][:time]
+      @schedule_placeholder = default_datetime_placeholder(date_params.merge(time: time_param))
+      parser = DatetimeParser.new(date: date_params, time: time_param)
       scheduled_at = parser.parse
       if scheduled_at && @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish
@@ -89,6 +92,8 @@ class StepByStepPagesController < ApplicationController
       else
         render :schedule
       end
+    else
+      @schedule_placeholder = default_datetime_placeholder
     end
   end
 

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -90,7 +90,7 @@ class StepByStepPagesController < ApplicationController
         render :schedule
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish
-        note_description = "Minor update scheduled by #{current_user.name} for publishing at #{scheduled_at}"
+        note_description = "Minor update scheduled by #{current_user.name} for publishing on #{format_full_date_and_time(scheduled_at)}"
         generate_internal_change_note(note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been scheduled to publish."

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -84,6 +84,9 @@ class StepByStepPagesController < ApplicationController
       @parser = DatetimeParser.new(date: date_params, time: time_param)
       scheduled_at = @parser.parse
       if @parser.issues.any?
+        @parser.issues.each do |issue|
+          @step_by_step_page.errors.add :base, issue.values.first
+        end
         render :schedule
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -16,6 +16,10 @@ module TimeOptionsHelper
     datetime.strftime("%-l:%M%P")
   end
 
+  def format_full_date_and_time(datetime)
+    datetime.strftime('%A, %d %B %Y at %-l:%M %P')
+  end
+
   def default_datetime_placeholder(
     year: 1.day.from_now.year,
     month: 1.day.from_now.month,

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module TimeOptionsHelper
+  def time_options
+    %w[am pm].flat_map do |period|
+      hours = [12] + (1..11).to_a
+      hours.flat_map do |hour|
+        next ["12:01am", "12:30am"] if hour == 12 && period == "am"
+
+        ["#{hour}:00#{period}", "#{hour}:30#{period}"]
+      end
+    end
+  end
+end

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -11,4 +11,22 @@ module TimeOptionsHelper
       end
     end
   end
+
+  def format_time_12_hour_clock(datetime)
+    datetime.strftime("%-l:%M%P")
+  end
+
+  def default_datetime_placeholder(
+    year: 1.day.from_now.year,
+    month: 1.day.from_now.month,
+    day: 1.day.from_now.day,
+    time: format_time_12_hour_clock(1.day.from_now.change(hour: 9))
+  )
+    {
+      year: year,
+      month: month,
+      day: day,
+      time: time,
+    }
+  end
 end

--- a/app/services/datetime_parser.rb
+++ b/app/services/datetime_parser.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class DatetimeParser
+  def initialize(date:, time:)
+    @raw_date = date.to_h
+    @raw_time = time.to_s
+  end
+
+  def parse
+    begin
+      check_date_is_valid
+      check_time_is_valid
+
+      Time.find_zone("London").local(
+        raw_date[:year].to_i,
+        raw_date[:month].to_i,
+        raw_date[:day].to_i,
+        time[:hour],
+        time[:minute]
+      )
+    rescue ArgumentError
+      nil
+    end
+  end
+
+private
+
+  attr_reader :raw_date, :raw_time
+
+  def check_date_is_valid
+    day, month, year = raw_date.values_at(:day, :month, :year)
+    Date.strptime("#{day}-#{month}-#{year}", "%d-%m-%Y")
+  end
+
+  def check_time_is_valid
+    raise ArgumentError unless parsed_time_values
+  end
+
+  def parsed_time_values
+    @parsed_time_values ||= raw_time.match(%r{
+      \A
+      (?<hour>(2[0-3]|1[0-9]|0?[0-9]))
+      :
+      (?<minute>[0-5][0-9])
+      (\s?(?<period>(am|pm)))?
+      \Z
+    }ix)
+  end
+
+  def time
+    @time ||= begin
+      hour = parsed_time_values[:hour].to_i
+      period = parsed_time_values[:period]&.downcase
+      minute = parsed_time_values[:minute].to_i
+
+      if period == "am" && hour == 12
+        hour = 0
+      elsif period == "pm" && hour < 12
+        hour += 12
+      end
+
+      { hour: hour, minute: minute }
+    end
+  end
+end

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -1,0 +1,51 @@
+<%
+  id ||= "autocomplete-#{SecureRandom.hex(4)}"
+  type ||= nil
+  error_id = "error-#{SecureRandom.hex(4)}"
+  error_items ||= []
+  width ||= nil
+  data_attributes ||= {}
+  input ||= {}
+  name ||= nil
+  label = label.symbolize_keys if label
+  aria = error_id if error_items.any?
+
+  root_classes = %w(app-c-autocomplete govuk-form-group)
+  root_classes << "app-c-autocomplete--#{width}" if width
+  root_classes << "govuk-form-group--error" if error_items.any?
+
+  if name && label
+%>
+  <%= tag.div class: root_classes,
+              data: data_attributes.merge(module: "autocomplete", "autocomplete-type": type) do %>
+    <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": aria do %>
+      <%= render "govuk_publishing_components/components/label", {
+        html_for: id
+      }.merge(label) %>
+
+      <% if error_items.any? %>
+        <%= render "govuk_publishing_components/components/error_message", {
+          id: error_id,
+          items: error_items,
+        } %>
+      <% end %>
+
+      <% options = Array(input[:options]) %>
+
+      <%= tag.input name: name,
+                    value: input[:value],
+                    class: "govuk-input",
+                    id: id,
+                    list: options.any? ? "#{id}-list" : nil,
+                    type: "text" %>
+
+      <% if options.any? %>
+        <%= tag.datalist id: "#{id}-list" do %>
+          <% options.each do |option| %>
+            <%= tag.option(value: option) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -1,0 +1,102 @@
+name: Autocomplete
+description: An autocomplete component, built to be accessible
+body: |
+  This component is build using [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete).
+  An enhancement to an input element. All options (provided by a datalist)
+  are shown whenever the input is focused. A user can enter a value outside
+  the list of options.
+part_of_admin_layout: true
+accessibility_criteria: |
+  [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
+examples:
+  default:
+    data:
+      id: autocomplete
+      name: autocomplete
+      label:
+        text: Select your country
+      input:
+        options:
+          -
+            -
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+
+  with_placeholder_value:
+    data:
+      id: autocomplete-placeholder
+      name: autocomplete-placeholder
+      label:
+        text: Select your country
+        bold: true
+      hint: Only a few countries are available
+      input:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+        value: de
+
+  with_error:
+    data:
+      name: autocomplete-with-error
+      label:
+        text: Autocomplete with error
+      input:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+      error_items:
+        - text: There is a problem with this input
+
+  autocomplete_narrow_width:
+    data:
+      id: autocomplete-narrow
+      name: autocomplete-narrow
+      label:
+        text: Status
+      width: narrow
+      input:
+        options:
+          -
+            - Draft
+          -
+            - Published
+          -
+            - Removed
+
+  autocomplete_without_narrowing_results:
+    data:
+      id: autocomplete-without-narrowing-results
+      name: autocomplete-without-narrowing-results
+      data_attributes:
+        autocomplete-without-narrowing-results: true
+      label:
+        text: Select your country
+        bold: true
+      input:
+        value: France
+        options:
+          - France
+          - United Arab Emirates
+          - United Kingdom

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -40,7 +40,7 @@
           <% if user_can_schedule? %>
             <% if @step_by_step_page.scheduled_for_publishing? %>
               <p class="govuk-body">
-                Scheduled to be published on <%= @step_by_step_page.scheduled_at.strftime('%A, %d %B %Y at %l:%M %P') %>
+                Scheduled to be published on <%= format_full_date_and_time(@step_by_step_page.scheduled_at) %>
               </p>
               <%= form_tag step_by_step_page_unschedule_path(@step_by_step_page), method: :unschedule do %>
                 <%= render "govuk_publishing_components/components/button", {

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -39,6 +39,7 @@
         name: "schedule[date]",
         hint: "For example, 01 08 2027",
         id: "date",
+        error_items: issues_for(:date),
         items: [
           {
             name: "day",
@@ -69,6 +70,7 @@
           options: time_options,
           value: @schedule_placeholder[:time],
         },
+        error_items: issues_for(:time),
         data_attributes: {
           "autocomplete-without-narrowing-results": true,
         },

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -42,15 +42,18 @@
         items: [
           {
             name: "day",
-            width: 2
+            width: 2,
+            value: @schedule_placeholder[:day]
           },
           {
             name: "month",
-            width: 2
+            width: 2,
+            value: @schedule_placeholder[:month]
           },
           {
             name: "year",
-            width: 4
+            width: 4,
+            value: @schedule_placeholder[:year]
           }
         ]
       } %>
@@ -64,6 +67,7 @@
         },
         input: {
           options: time_options,
+          value: @schedule_placeholder[:time],
         },
         data_attributes: {
           "autocomplete-without-narrowing-results": true,

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -84,7 +84,7 @@
           } %>
         </div>
         <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
+          <%= link_to "Cancel", step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "govuk-link" %>
         </div>
       </div>
     <% end %>

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -31,7 +31,7 @@
   <div class="col-md-7">
     <%= form_tag do %>
       <div class="form-group">
-        <%= label_tag :scheduled_at, 'Schedule datetime (e.g. "2020-04-20 10:26:51 UTC")' %>
+        <%= label_tag :scheduled_at, 'Schedule datetime (e.g. "2020-04-20 10:26:51 London")' %>
         <%= text_field_tag :scheduled_at, params[:scheduled_at]  %>
       </div>
 

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -62,6 +62,9 @@
           text: "Time",
           bold: true,
         },
+        input: {
+          options: time_options,
+        },
         data_attributes: {
           "autocomplete-without-narrowing-results": true,
         },

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -77,9 +77,15 @@
         width: "narrow",
       } %>
 
-      <div class="form-group">
-        <%= submit_tag "Schedule to publish", class: "btn btn-primary" %>
-        <%= link_to "Cancel", @step_by_step_page %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Schedule to publish",
+          } %>
+        </div>
+        <div class="govuk-grid-column-full govuk-!-margin-top-3">
+          <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -14,6 +14,10 @@
   ]
 %>
 
+<% legend = capture do %>
+  <span class="govuk-heading-s govuk-!-margin-bottom-0">Date</span>
+<% end %>
+
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
 <%= render 'shared/steps/heading',
@@ -30,10 +34,39 @@
 <div class="row">
   <div class="col-md-7">
     <%= form_tag do %>
-      <div class="form-group">
-        <%= label_tag :scheduled_at, 'Schedule datetime (e.g. "2020-04-20 10:26:51 London")' %>
-        <%= text_field_tag :scheduled_at, params[:scheduled_at]  %>
-      </div>
+      <%= render "govuk_publishing_components/components/date_input", {
+        legend_text: legend,
+        name: "schedule[date]",
+        hint: "For example, 01 08 2027",
+        id: "date",
+        items: [
+          {
+            name: "day",
+            width: 2
+          },
+          {
+            name: "month",
+            width: 2
+          },
+          {
+            name: "year",
+            width: 4
+          }
+        ]
+      } %>
+
+      <%= render "components/autocomplete", {
+        id: "time",
+        name: "schedule[time]",
+        label: {
+          text: "Time",
+          bold: true,
+        },
+        data_attributes: {
+          "autocomplete-without-narrowing-results": true,
+        },
+        width: "narrow",
+      } %>
 
       <div class="form-group">
         <%= submit_tag "Schedule to publish", class: "btn btn-primary" %>

--- a/spec/components/autocomplete_spec.rb
+++ b/spec/components/autocomplete_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe "Autocomplete component", type: :view do
+  it "should not render when no data is given" do
+    assert_empty render_component({})
+  end
+
+  it "should not render when only a name is provided" do
+    assert_empty render_component(name: "foo")
+  end
+
+  it "should not render when only a label is provided" do
+    assert_empty render_component(label: { text: "foo" })
+  end
+
+  it "should generate a randomised id if no id provided" do
+    render_component(name: "foo", label: { text: "bar" })
+
+    assert_select ".app-c-autocomplete", count: 1
+    random_id = nil
+    assert_select ".app-c-autocomplete label", count: 1, text: "bar" do |label|
+      random_id = label[0]['for']
+    end
+    assert_select ".app-c-autocomplete input[name='foo'][id='#{random_id}']", count: 1
+  end
+
+  it "should render text input when id, name & label provided" do
+    render_component(
+      name: "foo",
+      label: { text: "bar" },
+      id: "baz"
+    )
+
+    assert_select ".app-c-autocomplete", count: 1
+    assert_select ".app-c-autocomplete label[for='baz']", count: 1, text: "bar"
+    assert_select ".app-c-autocomplete input[name='foo'][id='baz']", count: 1
+  end
+
+  it "renders datalist element associated with text input when options provided" do
+    render_component(
+      id: "basic-autocomplete",
+      name: "foo",
+      label: { text: "Countries" },
+      input: {
+        options: ["United Kingdom", "United States"]
+      }
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select ".app-c-autocomplete input[name='foo'][id='basic-autocomplete'][list='basic-autocomplete-list']", count: 1
+    assert_select "datalist#basic-autocomplete-list", count: 1
+    assert_select "datalist#basic-autocomplete-list option[value='United Kingdom']", count: 1
+    assert_select "datalist#basic-autocomplete-list option[value='United States']", count: 1
+  end
+
+  it "renders a default value if provided" do
+    render_component(
+      id: "foo",
+      name: "foo",
+      label: { text: "Countries" },
+      input: {
+        options: ["United Kingdom", "United States"],
+        value: "Spain"
+      }
+    )
+
+    assert_select ".app-c-autocomplete input[value='Spain'][name='foo'][id='foo'][list='foo-list']", count: 1
+    assert_select "datalist#foo-list option[value='United Kingdom']", count: 1
+    assert_select "datalist#foo-list option[value='United States']", count: 1
+    assert_select "datalist#foo-list option[value='Spain']", count: 0
+  end
+
+  it "renders error messages if passed to the component" do
+    render_component(
+      id: "foo",
+      name: "foo",
+      label: { text: "Label" },
+      error_items: [
+        { text: "Something wrong with A" },
+        { text: "Also something wrong with B" }
+      ]
+    )
+
+    assert_select ".app-c-autocomplete .gem-c-error-message", count: 1 do |error|
+      error_message = error[0].text
+      expect(error_message).to include "Something wrong with A"
+      expect(error_message).to include "Also something wrong with B"
+    end
+  end
+
+  def render_component(arguments)
+    render partial: "components/autocomplete", locals: arguments
+  end
+end

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -5,6 +5,7 @@ require "gds_api/test_helpers/publishing_api"
 RSpec.describe StepByStepPagesController do
   include GdsApi::TestHelpers::PublishingApiV2
   include GdsApi::TestHelpers::PublishingApi
+  include TimeOptionsHelper
 
   let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
   let(:stub_user) { create(:user, name: "Name Surname", permissions: ["signin", "GDS Editor"]) }
@@ -114,7 +115,7 @@ RSpec.describe StepByStepPagesController do
       schedule_for_future
 
       expect(step_by_step_page.scheduled_at.class.name).to eq 'Time'
-      expect(step_by_step_page.scheduled_at.in_time_zone("London").strftime('%d/%m/%Y %H:%M:%S')).to eq '20/04/2030 10:26:00'
+      expect(format_full_date_and_time(step_by_step_page.scheduled_at.in_time_zone("London"))).to eq 'Saturday, 20 April 2030 at 10:26 am'
     end
 
     it "sets the status to Scheduled" do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -9,8 +9,6 @@ RSpec.feature "Managing step by step pages" do
   include GdsApi::TestHelpers::LinkCheckerApi
   include GdsApi::TestHelpers::PublishingApi
 
-  let(:schedule_time) { "2030-04-20 10:26:51 London" }
-
   before do
     given_I_am_a_GDS_editor
     setup_publishing_api
@@ -153,7 +151,7 @@ RSpec.feature "Managing step by step pages" do
       when_I_submit_the_form
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
-      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at #{schedule_time}"
+      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at 2030-04-20 10:26:00 +0100"
       and_the_step_by_step_is_not_editable
     end
 
@@ -393,11 +391,18 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_I_fill_in_the_scheduling_form
-    fill_in 'scheduled_at', with: schedule_time
+    fill_in 'schedule[date][year]', with: "2030"
+    fill_in 'schedule[date][month]', with: "04"
+    fill_in 'schedule[date][day]', with: "20"
+    fill_in 'schedule[time]', with: "10:26am"
   end
 
   def and_I_fill_in_the_scheduling_form_with_a_date_in_the_past
-    fill_in 'scheduled_at', with: '1937-04-20 10:26:51 London'
+    yesterday = Time.current - 1.day
+    fill_in 'schedule[date][year]', with: yesterday.year
+    fill_in 'schedule[date][month]', with: yesterday.month
+    fill_in 'schedule[date][day]', with: yesterday.day
+    fill_in 'schedule[time]', with: "10:26am"
   end
 
   def when_I_submit_the_form

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -9,6 +9,8 @@ RSpec.feature "Managing step by step pages" do
   include GdsApi::TestHelpers::LinkCheckerApi
   include GdsApi::TestHelpers::PublishingApi
 
+  let(:yesterday) { Time.current - 1.day }
+
   before do
     given_I_am_a_GDS_editor
     setup_publishing_api
@@ -158,9 +160,11 @@ RSpec.feature "Managing step by step pages" do
     scenario "User tries to schedule publishing for date in the past" do
       given_there_is_a_draft_step_by_step_page
       and_I_visit_the_scheduling_page
+      then_inputs_should_have_tomorrows_date
       and_I_fill_in_the_scheduling_form_with_a_date_in_the_past
       when_I_submit_the_form
       then_I_should_see "Scheduled at can't be in the past"
+      and_I_can_still_see_the_date_and_time_values_I_entered
       and_the_step_by_step_should_have_the_status "Draft"
     end
 
@@ -398,11 +402,23 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_I_fill_in_the_scheduling_form_with_a_date_in_the_past
-    yesterday = Time.current - 1.day
     fill_in 'schedule[date][year]', with: yesterday.year
     fill_in 'schedule[date][month]', with: yesterday.month
     fill_in 'schedule[date][day]', with: yesterday.day
     fill_in 'schedule[time]', with: "10:26am"
+  end
+
+  def then_inputs_should_have_tomorrows_date
+    tomorrow = Time.current.tomorrow
+    expect(find_field('schedule[date][year]').value).to eq tomorrow.year.to_s
+    expect(find_field('schedule[date][month]').value).to eq tomorrow.month.to_s
+    expect(find_field('schedule[date][day]').value).to eq tomorrow.day.to_s
+    expect(find_field('schedule[time]').value).to eq "9:00am"
+  end
+
+  def and_I_can_still_see_the_date_and_time_values_I_entered
+    expect(find_field('schedule[date][day]').value).to eq yesterday.day.to_s
+    expect(find_field('schedule[time]').value).to eq "10:26am"
   end
 
   def when_I_submit_the_form

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -153,7 +153,7 @@ RSpec.feature "Managing step by step pages" do
       when_I_submit_the_form
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
-      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at 2030-04-20 10:26:00 +0100"
+      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing on Saturday, 20 April 2030 at 10:26 am"
       and_the_step_by_step_is_not_editable
     end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -190,7 +190,9 @@ RSpec.feature "Managing step by step pages" do
       and_I_visit_the_scheduling_page
       and_I_fill_in_the_scheduling_form_with_nonsense_data
       when_I_submit_the_form
-      then_I_should_see "Enter a valid date", :within_the_date_component
+      then_I_should_see "Enter a valid date", :at_the_top_of_the_page
+      and_I_should_see "Enter a valid time", :at_the_top_of_the_page
+      and_I_should_see "Enter a valid date", :within_the_date_component
       and_I_should_see "Enter a valid time", :within_the_time_component
     end
   end
@@ -451,6 +453,8 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_should_see(content, scope = nil)
     scope_selector = case scope
+                     when :at_the_top_of_the_page
+                       '.gem-c-error-summary'
                      when :within_the_date_component
                        'form > .govuk-form-group:not(.app-c-autocomplete)'
                      when :within_the_time_component

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -287,9 +287,7 @@ RSpec.feature "Managing step by step pages" do
     visit step_by_step_page_publish_or_delete_path(@step_by_step_page)
   end
 
-  def when_I_visit_the_publish_or_delete_page
-    and_I_visit_the_publish_or_delete_page
-  end
+  alias_method :when_I_visit_the_publish_or_delete_page, :and_I_visit_the_publish_or_delete_page
 
   def and_I_fill_in_the_form
     fill_in "Title", with: "How to bake a cake"
@@ -401,9 +399,7 @@ RSpec.feature "Managing step by step pages" do
     visit step_by_step_page_schedule_path(@step_by_step_page)
   end
 
-  def when_I_visit_the_scheduling_page
-    and_I_visit_the_scheduling_page
-  end
+  alias_method :when_I_visit_the_scheduling_page, :and_I_visit_the_scheduling_page
 
   def and_I_fill_in_the_scheduling_form
     fill_in 'schedule[date][year]', with: "2030"
@@ -447,9 +443,7 @@ RSpec.feature "Managing step by step pages" do
     expect(page).not_to have_css("button", text: "Schedule to publish")
   end
 
-  def then_there_should_be_no_schedule_button
-    and_there_should_be_no_schedule_button
-  end
+  alias_method :then_there_should_be_no_schedule_button, :and_there_should_be_no_schedule_button
 
   def then_I_should_see(content, scope = nil)
     scope_selector = case scope

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Managing step by step pages" do
   include GdsApi::TestHelpers::LinkCheckerApi
   include GdsApi::TestHelpers::PublishingApi
 
-  let(:schedule_time) { "2030-04-20 10:26:51 UTC" }
+  let(:schedule_time) { "2030-04-20 10:26:51 London" }
 
   before do
     given_I_am_a_GDS_editor
@@ -397,7 +397,7 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_I_fill_in_the_scheduling_form_with_a_date_in_the_past
-    fill_in 'scheduled_at', with: '1937-04-20 10:26:51 UTC'
+    fill_in 'scheduled_at', with: '1937-04-20 10:26:51 London'
   end
 
   def when_I_submit_the_form

--- a/spec/helpers/time_options_helper_spec.rb
+++ b/spec/helpers/time_options_helper_spec.rb
@@ -35,4 +35,54 @@ RSpec.describe TimeOptionsHelper do
       end
     end
   end
+
+  describe "#format_time_12_hour_clock" do
+    it "formats the time correctly" do
+      expect(helper.format_time_12_hour_clock(Time.current.tomorrow.change(hour: 9))).to eq("9:00am")
+    end
+  end
+
+  describe "#default_datetime_placeholder" do
+    let(:default_day) { Time.current.tomorrow.day }
+    let(:default_month) { Time.current.tomorrow.month }
+    let(:default_year) { Time.current.tomorrow.year }
+    let(:default_time) { '9:00am' }
+
+    context "with no params" do
+      it "should fall back to default placeholder values" do
+        expect(default_datetime_placeholder[:day]).to eq default_day
+        expect(default_datetime_placeholder[:month]).to eq default_month
+        expect(default_datetime_placeholder[:year]).to eq default_year
+        expect(default_datetime_placeholder[:time]).to eq default_time
+      end
+    end
+
+    context "with all params" do
+      it "should override the default datetime" do
+        schedule_datetime = default_datetime_placeholder(
+          day: '30',
+          month: '12',
+          year: '2030',
+          time: '13:00'
+        )
+        expect(schedule_datetime[:day]).to eq '30'
+        expect(schedule_datetime[:month]).to eq '12'
+        expect(schedule_datetime[:year]).to eq '2030'
+        expect(schedule_datetime[:time]).to eq '13:00'
+      end
+    end
+
+    context "with some params" do
+      it "should override those params and fall back to defaults for others" do
+        schedule_datetime = default_datetime_placeholder(
+          day: '7',
+          time: '3:14pm'
+        )
+        expect(schedule_datetime[:day]).to eq '7'
+        expect(schedule_datetime[:month]).to eq default_month
+        expect(schedule_datetime[:year]).to eq default_year
+        expect(schedule_datetime[:time]).to eq '3:14pm'
+      end
+    end
+  end
 end

--- a/spec/helpers/time_options_helper_spec.rb
+++ b/spec/helpers/time_options_helper_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe TimeOptionsHelper do
+  describe "#time_options" do
+    subject { helper.time_options }
+
+    it "contains a 12:01am special case" do
+      expect(subject).to include "12:01am"
+    end
+
+    it "does not contain 12:00am special case" do
+      expect(subject).not_to include "12:00am"
+    end
+
+    it "returns 48 items (hourly - except 12am special case - and half-hourly)" do
+      expect(subject.count).to eq(48)
+    end
+
+    it "returns all the AM times before the PM times" do
+      index_of_last_am = subject.map.with_index { |time, index| index if time.end_with?("am") }.compact.last
+      index_of_first_pm = subject.index { |time| time.end_with?("pm") }
+      expect(index_of_last_am).to be < index_of_first_pm
+    end
+
+    it "should only contain time values in 12-hour clock format" do
+      subject.each do |time|
+        expect(time).to match(/
+          1[0-2]     # first portion of time can be two digits, e.g. 10am
+          |          # or
+          [1-9]      # could just be one digit, e.g. 1am
+          :          # colon
+          [0-5][0-9] # second number must be exactly 2 chars, and no more than 59
+          (am|pm)$   # can only end in am or pm
+        /x)
+      end
+    end
+  end
+end

--- a/spec/helpers/time_options_helper_spec.rb
+++ b/spec/helpers/time_options_helper_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe TimeOptionsHelper do
     end
   end
 
+  describe "#format_full_date_and_time" do
+    it "formats the date and time correctly" do
+      datetime = Time.new(2030, 4, 20, 10, 26, 0, '+01:00') # London timezone
+      expect(helper.format_full_date_and_time(datetime)).to eq("Saturday, 20 April 2030 at 10:26 am")
+    end
+  end
+
   describe "#default_datetime_placeholder" do
     let(:default_day) { Time.current.tomorrow.day }
     let(:default_month) { Time.current.tomorrow.month }

--- a/spec/services/datetime_parser_spec.rb
+++ b/spec/services/datetime_parser_spec.rb
@@ -88,4 +88,61 @@ RSpec.describe DatetimeParser do
       expect(DatetimeParser.new(params).parse).to be_nil
     end
   end
+
+  describe "#issues_for" do
+    context "an invalid time is provided" do
+      let(:parser) { DatetimeParser.new(date: valid_date, time: nil) }
+
+      it "finds issues for schedule_time" do
+        parser.parse
+        time_issues = parser.issues_for(:time)
+
+        expect(time_issues.count).to eq(1)
+        expect(time_issues.first).to eq("Enter a valid time")
+      end
+
+      it "doesn't report issues for date" do
+        parser.parse
+        date_issues = parser.issues_for(:date)
+
+        expect(date_issues.count).to eq(0)
+      end
+    end
+
+    context "an invalid date is provided" do
+      let(:parser) { DatetimeParser.new(date: nil, time: valid_time) }
+
+      it "finds issues for date" do
+        parser.parse
+        date_issues = parser.issues_for(:date)
+
+        expect(date_issues.count).to eq(1)
+        expect(date_issues.first).to eq("Enter a valid date")
+      end
+
+      it "doesn't report issues for time" do
+        parser.parse
+        time_issues = parser.issues_for(:time)
+
+        expect(time_issues.count).to eq(0)
+      end
+    end
+  end
+
+  describe "#issues" do
+    it "returns no issues when there are none" do
+      parser = DatetimeParser.new(date: valid_date, time: valid_time)
+      parser.parse
+
+      expect(parser.issues).to be_empty
+    end
+
+    it "returns both date and time issues" do
+      parser = DatetimeParser.new(date: nil, time: nil)
+      parser.parse
+
+      expect(parser.issues).to include(date: "Enter a valid date")
+      expect(parser.issues).to include(time: "Enter a valid time")
+    end
+  end
 end

--- a/spec/services/datetime_parser_spec.rb
+++ b/spec/services/datetime_parser_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatetimeParser do
+  let(:valid_date) { { day: "10", month: "01", year: "2019" } }
+  let(:valid_time) { "9:00am" }
+
+  describe "#parse" do
+    it "takes time in lowercase 12-hour clock format" do
+      parser = DatetimeParser.new(date: valid_date, time: "11:00am")
+      expect(parser.parse.hour).to eq 11
+    end
+
+    it "takes time in uppercase 12-hour clock format" do
+      parser = DatetimeParser.new(date: valid_date, time: "11:00AM")
+      expect(parser.parse.hour).to eq 11
+    end
+
+    it "defaults to morning if no period provided and time < 12" do
+      parser = DatetimeParser.new(date: valid_date, time: "9:34")
+      expect(parser.parse.hour).to eq 9
+      expect(parser.parse.min).to eq 34
+    end
+
+    it "treats 12:00 as midday" do
+      parser = DatetimeParser.new(date: valid_date, time: "12:00")
+      expect(parser.parse.hour).to eq 12
+    end
+
+    it "treats 12:00am as midnight at the beginning of the provided date" do
+      parser = DatetimeParser.new(date: valid_date, time: "12:00am")
+      expect(parser.parse.hour).to eq 0
+      expect(parser.parse.day).to eq valid_date[:day].to_i
+      expect(parser.parse.month).to eq valid_date[:month].to_i
+      expect(parser.parse.year).to eq valid_date[:year].to_i
+    end
+
+    it "allows spaces before the period" do
+      parser = DatetimeParser.new(date: valid_date, time: "6:00 pm")
+      expect(parser.parse.hour).to eq 18
+    end
+
+    it "allows leading zeros" do
+      parser = DatetimeParser.new(date: valid_date, time: "09:00am")
+      expect(parser.parse.hour).to eq 9
+    end
+
+    it "defaults to afternoon/evening if no period provided and time > 12" do
+      parser = DatetimeParser.new(date: valid_date, time: "23:32")
+      expect(parser.parse.hour).to eq 23
+      expect(parser.parse.min).to eq 32
+    end
+
+    it "treats 12:30pm as the afternoon of the provided date" do
+      parser = DatetimeParser.new(date: valid_date, time: "12:30pm")
+      expect(parser.parse.hour).to eq 12
+      expect(parser.parse.min).to eq 30
+    end
+
+    it "returns nil when the time is blank" do
+      parser = DatetimeParser.new(date: valid_date, time: nil)
+      expect(parser.parse).to be_nil
+    end
+
+    it "returns nil when the time format is invalid" do
+      parser = DatetimeParser.new(date: valid_date, time: "13421")
+      expect(parser.parse).to be_nil
+    end
+
+    it "returns nil when the minutes are invalid" do
+      parser = DatetimeParser.new(date: valid_date, time: "7:60am")
+      expect(parser.parse).to be_nil
+    end
+
+    it "returns nil when the hours are invalid" do
+      parser = DatetimeParser.new(date: valid_date, time: "30:00am")
+      expect(parser.parse).to be_nil
+    end
+
+    it "returns nil when the date is blank" do
+      parser = DatetimeParser.new(date: nil, time: valid_time)
+      expect(parser.parse).to be_nil
+    end
+
+    it "returns nil when the date is invalid" do
+      params = { date: { day: "10", month: "60", year: "11" }, time: valid_time }
+      expect(DatetimeParser.new(params).parse).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This PR splits up the datetime text field into [Date](https://govuk-publishing-components.herokuapp.com/component-guide/date_input) and time (the latter of which is based on the autocomplete component copied from [Content Publisher](https://github.com/alphagov/content-publisher/)). The time field now provides a dropdown list of half-hourly suggested times - and a special case of 12:01am - but can also take any arbitrary time. These fields' placeholder values default to '9am tomorrow'. It stores this schedule time in London timezone format, so that BST is accounted for.

In addition, this PR also swaps out the Bootstrap submit button with [GOV.UK submit button](https://govuk-publishing-components.herokuapp.com/component-guide/button), and changes the redirect value of the cancel button to a more appropriate location.

| Before | After |
|--------|------|
|<img width="679" alt="61949262-20b7f400-afa2-11e9-9103-9197a389c11f" src="https://user-images.githubusercontent.com/5111927/62122987-d941a880-b2be-11e9-841a-ce3670f63d25.png">|![Screen Shot 2019-08-08 at 12 17 25](https://user-images.githubusercontent.com/5111927/62699068-937b9300-b9d6-11e9-8b04-f69c60c146bc.png)|

This design uses Content Publisher for inspiration. Note that I've not changed the error title "There is a problem", purely because "You need to" may not apply to other form error messages outside of scheduling.

| Error message content publisher | Error message collections publisher |
|----------------------------------|-------------------------------------|
|![Screen Shot 2019-07-30 at 10 52 53](https://user-images.githubusercontent.com/5111927/62119839-5b7a9e80-b2b8-11e9-90e8-08c9ff807503.png)|![Screen Shot 2019-07-30 at 15 24 33](https://user-images.githubusercontent.com/5111927/62137634-2d0fba00-b2de-11e9-88a8-886997d4d8fa.png)|

https://trello.com/c/oFvkJGff/44-use-govuk-components-in-the-scheduling-interface