### PR TITLE
Unschedule publishing of Step by step

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -101,7 +101,12 @@ class StepByStepPagesController < ApplicationController
     end
   end
 
-  def unschedule; end
+  def unschedule
+    set_current_page_as_step_by_step
+    @step_by_step_page.update(scheduled_at: nil)
+    unschedule_publishing
+    redirect_to @step_by_step_page, notice: "Publishing of '#{@step_by_step_page.title}' has been unscheduled."
+  end
 
   def revert
     set_current_page_as_step_by_step
@@ -158,6 +163,10 @@ private
       Rails.logger.info "Unpublishing #{@step_by_step_page.content_id} failed"
     end
     @step_by_step_page.mark_as_unpublished
+  end
+
+  def unschedule_publishing
+    StepNavPublisher.cancel_scheduling(@step_by_step_page)
   end
 
   def revert_page

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -2,7 +2,7 @@ class StepByStepPagesController < ApplicationController
   include PublishingApiHelper
 
   before_action :require_gds_editor_permissions!
-  before_action :require_scheduling_permissions!, only: %i[schedule]
+  before_action :require_scheduling_permissions!, only: %i[schedule unschedule]
   before_action :set_step_by_step_page, only: %i[show edit update destroy]
 
   def index

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -101,6 +101,8 @@ class StepByStepPagesController < ApplicationController
     end
   end
 
+  def unschedule; end
+
   def revert
     set_current_page_as_step_by_step
     if request.post?

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -105,6 +105,9 @@ class StepByStepPagesController < ApplicationController
     set_current_page_as_step_by_step
     @step_by_step_page.update(scheduled_at: nil)
     unschedule_publishing
+    note_description = "Publishing was unscheduled by #{current_user.name}."
+    generate_internal_change_note(note_description)
+    set_change_note_version
     redirect_to @step_by_step_page, notice: "Publishing of '#{@step_by_step_page.title}' has been unscheduled."
   end
 

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -32,13 +32,16 @@
           <p>After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
           <%= link_to 'Publish changes', step_by_step_page_publish_path(@step_by_step_page), class: "btn btn-primary publish-button" %>
           <% if user_can_schedule? %>
-            <p>Or</p>	
+            <p>Or</p>
             <% if @step_by_step_page.scheduled_for_publishing? %>
               <div class="alert alert-info">
                 Scheduled to be published at <%= @step_by_step_page.scheduled_at %>
               </div>
+              <%= form_tag step_by_step_page_unschedule_path(@step_by_step_page), method: :unschedule do %>
+                <button class="btn btn-danger">Unschedule publishing</button>
+              <% end %>
             <% else %>
-              <%= link_to 'Schedule publish', step_by_step_page_schedule_path(@step_by_step_page), class: "btn btn-info" %>	
+              <%= link_to 'Schedule publish', step_by_step_page_schedule_path(@step_by_step_page), class: "btn btn-info" %>
             <% end %>
           <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     post :reorder
     get :unpublish
     post :unpublish
+    post :unschedule
     post :revert
     get  'publish-or-delete', to: 'publish_or_delete'
     get 'internal-change-notes', to: 'interal_change_notes'

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -117,6 +117,15 @@ RSpec.describe StepByStepPagesController do
       expect(step_by_step_page.scheduled_for_publishing?).to be false
       expect(step_by_step_page.status[:name]).to eq 'unpublished_changes'
     end
+
+    it "creates and internal change note" do
+      step_by_step_page = create(:scheduled_step_by_step_page, slug: 'how-to-be-fantastic')
+
+      unschedule_publishing(step_by_step_page)
+
+      expected_description = "Publishing was unscheduled by Name Surname."
+      expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+    end
   end
 
   describe "#revert" do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -160,6 +160,12 @@ RSpec.feature "Managing step by step pages" do
       then_I_should_see "Scheduled to be published at"
       and_there_should_be_no_schedule_button
     end
+
+    scenario "User unschedules publishing" do
+      given_there_is_a_scheduled_step_by_step_page
+      and_I_visit_the_publish_or_delete_page
+      then_I_see_an_unschedule_button
+    end
   end
 
   def and_it_has_change_notes
@@ -402,5 +408,12 @@ RSpec.feature "Managing step by step pages" do
   def and_there_should_be_a_change_note(change_note)
     visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
     expect(page).to have_content(change_note)
+  end
+
+  def then_I_see_an_unschedule_button
+    within(".publish-or-delete") do
+      expect(page).to_not have_css("button", text: "Schedule to publish")
+      expect(page).to have_css("button", text: "Unschedule publishing")
+    end
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -169,6 +169,7 @@ RSpec.feature "Managing step by step pages" do
       when_I_unschedule_publishing
       then_I_should_see "has been unscheduled"
       and_the_step_by_step_should_have_the_status "Draft"
+      and_there_should_be_a_change_note "Publishing was unscheduled by Test author."
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -133,6 +133,7 @@ RSpec.feature "Managing step by step pages" do
   context "Given I have Scheduling permissions" do
     before do
       given_I_have_scheduling_permissions
+      stub_publishing_api_destroy_intent('/how-to-be-the-amazing-1')
     end
 
     scenario "User schedules publishing" do
@@ -165,6 +166,9 @@ RSpec.feature "Managing step by step pages" do
       given_there_is_a_scheduled_step_by_step_page
       and_I_visit_the_publish_or_delete_page
       then_I_see_an_unschedule_button
+      when_I_unschedule_publishing
+      then_I_should_see "has been unscheduled"
+      and_the_step_by_step_should_have_the_status "Draft"
     end
   end
 
@@ -415,5 +419,9 @@ RSpec.feature "Managing step by step pages" do
       expect(page).to_not have_css("button", text: "Schedule to publish")
       expect(page).to have_css("button", text: "Unschedule publishing")
     end
+  end
+
+  def when_I_unschedule_publishing
+    click_on 'Unschedule publishing'
   end
 end


### PR DESCRIPTION
**Why**
We have recently added the functionality to schedule publishing #652 and we should enable publishers to unschedule the publication of a step by step after it has been scheduled.

In the event that a scheduled publication date needs to change we should ensure that we have the functionality to unschedule a piece of content that has been scheduled for publication.

**What**
- users can see an option to unschedule a step by step, which is currently scheduled
- user can unschedule a publication of step by step
- `scheduled_at` datetime is cleared
- the status is updated on index page to 'Draft' or to 'Unpublished changes'
- internal change note is created when a step by step is unscheduled
- access to the feature is limited to users with 'Scheduling' permissions

_Note_
We have decided not to implement confirmation dialogue as it's easy to reschedule.

**Example**
![unscheduling-gif](https://user-images.githubusercontent.com/38078064/62118139-13a64800-b2b5-11e9-9c69-66497be9c0c5.gif)


[Trello card](https://trello.com/c/QvgBFTkJ/32-allow-publishers-to-unschedule-a-step-by-step-set-for-publication-m)

