### PR TITLE
Require jquery_ujs after govuk_publishing_components/dependencies

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/dependencies
+//= require jquery_ujs
 //= require govuk_publishing_components/all_components
 //= require jquery-ui.sortable.min
 //= require jquery.clicktoggle


### PR DESCRIPTION
The first line pulls in jQuery, which overrides the jQuery loaded in
the header, which has been modified by jquery_ujs. This means that the
CSRF tokens aren't included in the request headers automatically when
using jQuery, breaking the drag and drop behaviour on the list pages.

Work around this by following some advice from Kevin and add a require
for jquery_ujs after loading jQuery as a dependency of
govuk_publishing_components.