### PR TITLE
Explicitly pass the CSRF token in AJAX requests

### DIFF
--- a/app/assets/javascripts/curated_lists.js
+++ b/app/assets/javascripts/curated_lists.js
@@ -2,6 +2,7 @@
   "use strict";
   window.GOVUK = window.GOVUK || {};
   var $ = window.jQuery;
+  var csrfToken = $( 'meta[name="csrf-token"]' ).attr( 'content' );
 
   GOVUK.curatedLists = {
     init: function() {
@@ -58,6 +59,7 @@
         }),
         contentType: 'application/json',
         dataType: 'json',
+        headers: { 'X-CSRF-Token': csrfToken },
         success: function() {
           $row.removeClass('working');
           GOVUK.publishing.unlockPublishing();
@@ -81,6 +83,7 @@
         }),
         contentType: 'application/json',
         dataType: 'json',
+        headers: { 'X-CSRF-Token': csrfToken },
         success: function(data) {
           $row.removeClass('working');
           $row.data({ 'update-url': data['updateURL'] });
@@ -101,6 +104,7 @@
         type: 'DELETE',
         contentType: 'application/json',
         dataType: 'json',
+        headers: { 'X-CSRF-Token': csrfToken },
         success: function() {
           $row.removeClass('working');
           $row.remove();

--- a/app/assets/javascripts/ordered_lists.js
+++ b/app/assets/javascripts/ordered_lists.js
@@ -2,6 +2,7 @@
   "use strict";
   window.GOVUK = window.GOVUK || {};
   var $ = window.jQuery;
+  var csrfToken = $( 'meta[name="csrf-token"]' ).attr( 'content' );
 
   GOVUK.orderedLists = {
     init: function() {
@@ -54,7 +55,8 @@
           }
         }),
         contentType: 'application/json',
-        dataType: 'json'
+        dataType: 'json',
+        headers: { 'X-CSRF-Token': csrfToken }
       });
     }
   };


### PR DESCRIPTION
This avoids an issue where jQuery modified by jQuery UJS gets
overridden by the unmodified jQuery required by the
govuk_publishing_components. This stops the X-CSRF-Token being sent,
breaking re-ordering list items.

Explictly add the header in, so that this functionality isn't
dependant on jquery-ujs.