### PR TITLE
Show error message when secondary link slug doesn't exist

### DIFF
--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -10,7 +10,7 @@ class SecondaryContentLinksController < ApplicationController
 
       redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id), notice: 'Secondary content was successfully linked.'
     else
-      flash[:danger] = @error if @error
+      flash[:alert] = @error if @error
       redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id)
     end
   end

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SecondaryContentLinksController do
       allow(Services.publishing_api).to receive(:lookup_content_id).and_return(nil)
 
       post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
-      expect(flash[:danger]).to be_present
+      expect(flash[:alert]).to be_present
     end
 
     it "accepts a full url as the base_path" do

--- a/spec/features/secondary_content_for_step_by_steps_spec.rb
+++ b/spec/features/secondary_content_for_step_by_steps_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Managing secondary content for step by step pages" do
   end
 
   def then_I_see_a_failure_notice
-    "#{broken_base_path} doesn't exist on GOV.UK."
+    expect(page).to have_content("#{broken_base_path} doesn't exist on GOV.UK.")
   end
 
   def then_can_I_see_the_existing_secondary_content_listed


### PR DESCRIPTION
Fixes a regression whereby no error message is displayed if a
slug for a step by step's secondary link doesn't exist.
The error wasn't showing as it's outputting to flash[:danger],
which was no longer getting displayed in admin_layout.html.

The regression wasn't caught in tests as the test didn't assert
that the page contained content (it was missing an 'expect()').

Addresses https://trello.com/c/uZhLL67i/99-show-an-error-message-on-secondary-content-page-if-link-does-not-exist.

![Screen Shot 2019-08-08 at 15 30 02](https://user-images.githubusercontent.com/5111927/62712341-8a98ba80-b9f2-11e9-8b4c-d5f432d01eb3.png)

It's worth noting that the form error was probably intended to be displayed further down the page:

https://github.com/alphagov/collections-publisher/blob/87cc196cacb9a66ca1377f1b818a80ae2b25124b/app/views/secondary_content_links/index.html.erb#L47

^ That line currently doesn't appear to be doing anything. Worth revisiting in a future card (and if it's following the lead of Content Publisher, probably want to show the error twice - one at the top of the page, one inline in the erroring component). I think this is out of scope for this PR.
