### PR TITLE
Unassign the user when step by step is published

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -38,6 +38,7 @@ class StepByStepPage < ApplicationRecord
     update_attribute(:published_at, now)
     update_attribute(:draft_updated_at, now)
     update_attribute(:scheduled_at, nil)
+    update_attribute(:assigned_to, nil)
   end
 
   def mark_as_unpublished

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -124,6 +124,16 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_a_page_reverted_success_notice
   end
 
+  scenario "User publishes and then makes more changes to a step by step page" do
+    given_there_is_a_step_by_step_page_assigned_to_me
+    and_I_visit_the_publish_page
+    and_I_publish_the_page
+    then_there_should_be_a_change_note "Minor update published by #{stub_user.name}"
+    when_I_view_the_step_by_step_page
+    and_I_delete_the_first_step
+    then_there_should_be_a_change_note "Draft saved by #{stub_user.name}"
+  end
+
   scenario "User cannot see Schedule button without Scheduling permissions" do
     given_there_is_a_draft_step_by_step_page
     and_I_visit_the_publish_or_delete_page
@@ -414,6 +424,8 @@ RSpec.feature "Managing step by step pages" do
     visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
     expect(page).to have_content(change_note)
   end
+
+  alias_method :then_there_should_be_a_change_note, :and_there_should_be_a_change_note
 
   def then_I_see_an_unschedule_button
     within(".publish-or-delete") do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -236,6 +236,13 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.scheduled_for_publishing?).to be false
     end
 
+    it 'should unassign the user' do
+      step_by_step_page.assigned_to = "Test User"
+      step_by_step_page.mark_as_published
+
+      expect(step_by_step_page.assigned_to).to be nil
+    end
+
     it 'should reset published date' do
       step_by_step_page.mark_as_unpublished
 

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -84,6 +84,10 @@ module StepNavSteps
     expect(@step_by_step_page.status[:name]).to eq 'unpublished_changes'
   end
 
+  def given_there_is_a_step_by_step_page_assigned_to_me
+    @step_by_step_page = create(:step_by_step_page_with_navigation_rules, assigned_to: stub_user.name)
+  end
+
   def given_there_is_a_scheduled_step_by_step_page
     @step_by_step_page = create(:scheduled_step_by_step_page)
     expect(@step_by_step_page.status[:name]).to eq 'scheduled'


### PR DESCRIPTION
Trello: https://trello.com/c/KnzX5H6C

Change notes are only generated when a draft is saved by a "new user".
[This][1] was added to prevent a change note from being added every time the
user clicks the "save" button.

Unfortunately, this meant that a change note wasn't being added if the same
user who had previously published the step by step made new changes. To solve this
problem the user is being unassigned when the step by step is published.

[1]: https://github.com/alphagov/collections-publisher/blob/master/app/workers/step_by_step_draft_update_worker.rb#L27