### PR TITLE
Format scheduled date on publish and delete page

### DIFF
--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -38,7 +38,7 @@
             <p class="govuk-body govuk-!-margin-top-5">Or</p>
             <% if @step_by_step_page.scheduled_for_publishing? %>
               <p class="govuk-body">
-                Scheduled to be published at <%= @step_by_step_page.scheduled_at %>
+                Scheduled to be published on <%= @step_by_step_page.scheduled_at.strftime('%A, %d %B %Y at %l:%M %P') %>
               </p>
               <%= form_tag step_by_step_page_unschedule_path(@step_by_step_page), method: :unschedule do %>
                 <%= render "govuk_publishing_components/components/button", {

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -158,7 +158,7 @@ RSpec.feature "Managing step by step pages" do
     scenario "User tries to schedule publishing for an already scheduled step by step" do
       given_there_is_a_scheduled_step_by_step_page
       when_I_visit_the_publish_or_delete_page
-      then_I_should_see "Scheduled to be published at"
+      then_I_should_see "Scheduled to be published on"
       and_there_should_be_no_schedule_button
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/UBOZ3bje

The date was being displayed as: 
"Scheduled to be published at 2019-12-10 16:35:00 UTC"

This formats the same date to read as: 
"Scheduled to be published on Tuesday, 10 December 2019 at 4:35 pm"

### Before
<img width="1007" alt="Screen Shot 2019-08-09 at 14 30 34" src="https://user-images.githubusercontent.com/5793815/62788321-8cc84b00-babe-11e9-9aad-72e43aa09bff.png">

### After
![Screen Shot 2019-08-09 at 15 58 55](https://user-images.githubusercontent.com/5793815/62788354-9c479400-babe-11e9-8234-60a7b9728def.png)
