### PR TITLE
Lock 'Delete or publish' & 'Secondary links' pages when publishing is scheduled

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -63,19 +63,19 @@ class StepByStepPage < ApplicationRecord
   end
 
   def can_be_published?
-    has_draft?
+    has_draft? && !scheduled_for_publishing?
   end
 
   def can_be_unpublished?
-    has_been_published?
+    has_been_published? && !scheduled_for_publishing?
   end
 
   def can_discard_changes?
-    unpublished_changes?
+    unpublished_changes? && !scheduled_for_publishing?
   end
 
   def can_be_deleted?
-    !has_been_published?
+    !has_been_published? && !scheduled_for_publishing?
   end
 
   # Create a deterministic, but unique token that will be used to give one-time

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -62,6 +62,22 @@ class StepByStepPage < ApplicationRecord
     has_draft? && has_been_published?
   end
 
+  def can_be_published?
+    has_draft?
+  end
+
+  def can_be_unpublished?
+    has_been_published?
+  end
+
+  def can_discard_changes?
+    unpublished_changes?
+  end
+
+  def can_be_deleted?
+    !has_been_published?
+  end
+
   # Create a deterministic, but unique token that will be used to give one-time
   # access to a piece of draft content.
   # This token is created by using an id that should be unique so that there is

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -78,6 +78,10 @@ class StepByStepPage < ApplicationRecord
     !has_been_published? && !scheduled_for_publishing?
   end
 
+  def can_be_edited?
+    !scheduled_for_publishing?
+  end
+
   # Create a deterministic, but unique token that will be used to give one-time
   # access to a piece of draft content.
   # This token is created by using an id that should be unique so that there is

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -39,51 +39,51 @@
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-  <div class="govuk-grid-column-full">
-    <%= form_for(@secondary_content_link, url: step_by_step_page_secondary_content_links_path) do |form| %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+<% if @step_by_step_page.can_be_edited? %>
+  <div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-6">
+    <div class="govuk-grid-column-full">
+      <%= form_for(@secondary_content_link, url: step_by_step_page_secondary_content_links_path) do |form| %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Add new secondary link",
-            margin_bottom: 5
-          } %>
+            <%= render "govuk_publishing_components/components/heading", {
+              text: "Add new secondary link",
+              margin_bottom: 5
+            } %>
 
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Base Path"
-            },
-            hint: capture do %>
-              For example: 
-              <a href="https://www.gov.uk/pay-vat" target="_blank" class="govuk-link">https://www.gov.uk/pay-vat</a> 
-              or <a href="https://www.gov.uk/bank-holidays" class="govuk-link" target="_blank">/bank-holidays</a>
-            <% end,
-            name: "base_path"
-          } %>
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: "Base Path"
+              },
+              hint: capture do %>
+                For example:
+                <a href="https://www.gov.uk/pay-vat" target="_blank" class="govuk-link">https://www.gov.uk/pay-vat</a>
+                or <a href="https://www.gov.uk/bank-holidays" class="govuk-link" target="_blank">/bank-holidays</a>
+              <% end,
+              name: "base_path"
+            } %>
+          </div>
         </div>
-      </div>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Add secondary link"
-          } %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Add secondary link"
+            } %>
+          </div>
         </div>
-      </div>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to 'Cancel', step_by_step_page_secondary_content_links_path, class: "govuk-link add-secondary-link-cancel--link" %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full govuk-!-margin-top-3">
+            <%= link_to 'Cancel', step_by_step_page_secondary_content_links_path, class: "govuk-link add-secondary-link-cancel--link" %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+<% end %>
 
-<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-<div class="govuk-grid-row secondary-links">
+<div class="govuk-grid-row secondary-links govuk-!-margin-top-6">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/heading", {
       text: "Existing secondary links",
@@ -95,7 +95,9 @@
       <tr>
         <th class="govuk-table__header" scope="col">Page title</th>
         <th class="govuk-table__header" scope="col">Path</th>
-        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Action</th>
+        <% if @step_by_step_page.can_be_edited? %>
+          <th class="govuk-table__header govuk-table__header--numeric" scope="col">Action</th>
+        <% end %>
       </tr>
     </thead>
 
@@ -105,9 +107,11 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= link_to(link.title, preview_url(link.base_path), class: "govuk-link") %></td>
             <td class="govuk-table__cell"><%= link.base_path %></td>
-            <td class="govuk-table__cell govuk-table__cell--numeric">
-              <%= link_to("Delete", step_by_step_page_secondary_content_link_path(@step_by_step_page.id, link.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "gem-c-button govuk-button govuk-button--warning") %>
-            </td>
+            <% if @step_by_step_page.can_be_edited? %>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <%= link_to("Delete", step_by_step_page_secondary_content_link_path(@step_by_step_page.id, link.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "gem-c-button govuk-button govuk-button--warning") %>
+              </td>
+            <% end %>
           </tr>
         <% end %>
       <% else %>

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -25,17 +25,19 @@
 
 <div class="govuk-grid-row publish-or-delete">
   <div class="govuk-grid-column-full">
-    <% if @step_by_step_page.has_draft? %>
+    <% if @step_by_step_page.can_be_published? || @step_by_step_page.can_discard_changes? ||  @step_by_step_page.scheduled_for_publishing?%>
       <div class="govuk-panel panel-default">
         <div class="panel-body">
-          <p class="govuk-body">Before publishing check for broken links.</p>
-          <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Publish changes",
-            href: step_by_step_page_publish_path(@step_by_step_page)
-          } %>
+          <% if @step_by_step_page.can_be_published? %>
+            <p class="govuk-body">Before publishing check for broken links.</p>
+            <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Publish changes",
+              href: step_by_step_page_publish_path(@step_by_step_page)
+            } %>
+          <% end %>
+
           <% if user_can_schedule? %>
-            <p class="govuk-body govuk-!-margin-top-5">Or</p>
             <% if @step_by_step_page.scheduled_for_publishing? %>
               <p class="govuk-body">
                 Scheduled to be published at <%= @step_by_step_page.scheduled_at %>
@@ -47,6 +49,7 @@
                 } %>
               <% end %>
             <% else %>
+              <p class="govuk-body govuk-!-margin-top-5">Or</p>
               <%= render "govuk_publishing_components/components/button", {
                 text: "Schedule publish",
                 href: step_by_step_page_schedule_path(@step_by_step_page),
@@ -55,27 +58,31 @@
             <% end %>
           <% end %>
 
-          <% if @step_by_step_page.unpublished_changes? %>
+          <% if @step_by_step_page.can_discard_changes? %>
             <p class="govuk-body govuk-!-margin-top-5">Or</p>
             <%= button_to 'Discard changes', { action: "revert", step_by_step_page_id: @step_by_step_page.id }, data: { confirm: 'This will delete your draft. Do you want to discard your changes?' }, class: "gem-c-button govuk-button govuk-button--warning" %>
           <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @step_by_step_page.can_be_unpublished? || @step_by_step_page.can_be_deleted? %>
+        <div class="govuk-panel panel-danger delete-or-unpublish-panel">
+          <div class="panel-body">
+            <% if @step_by_step_page.can_be_unpublished? %>
+              <%= render "govuk_publishing_components/components/button", {
+                text: "Unpublish step by step",
+                href: step_by_step_page_unpublish_path(@step_by_step_page),
+                destructive: true
+              } %>
+            <% end %>
+            <% if @step_by_step_page.can_be_deleted? %>
+              <p class="text-danger govuk-body"><strong>Warning</strong></p>
+              <p class="govuk-body">Deleted step by steps cannot be recovered.</p>
+              <%= button_to 'Delete step by step', @step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' }, class: "gem-c-button govuk-button govuk-button--warning" %>
+            <% end %>
         </div>
       </div>
     <% end %>
-    <div class="govuk-panel panel-danger delete-or-unpublish-panel">
-      <div class="panel-body">
-        <% if @step_by_step_page.has_been_published? %>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Unpublish step by step",
-            href: step_by_step_page_unpublish_path(@step_by_step_page),
-            destructive: true
-          } %>
-        <% else %>
-          <p class="text-danger govuk-body"><strong>Warning</strong></p>
-          <p class="govuk-body">Deleted step by steps cannot be recovered.</p>
-          <%= button_to 'Delete step by step', @step_by_step_page, method: :delete, data: { confirm: 'Delete this step by step page?' }, class: "gem-c-button govuk-button govuk-button--warning" %>
-        <% end %>
-      </div>
-    </div>
   </div>
 </div>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -144,6 +144,7 @@ RSpec.feature "Managing step by step pages" do
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
       and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at #{schedule_time}"
+      and_the_step_by_step_is_not_editable
     end
 
     scenario "User tries to schedule publishing for date in the past" do
@@ -424,5 +425,30 @@ RSpec.feature "Managing step by step pages" do
 
   def when_I_unschedule_publishing
     click_on 'Unschedule publishing'
+  end
+
+  def and_the_step_by_step_is_not_editable
+    when_I_visit_the_publish_or_delete_page
+    there_should_be_no_publish_button
+    there_should_be_no_discard_changes_button
+    there_should_be_no_unpublish_button
+  end
+
+  def there_should_be_no_publish_button
+    within(".publish-or-delete") do
+      expect(page).to_not have_css("button", text: "Publish changes")
+    end
+  end
+
+  def there_should_be_no_discard_changes_button
+    within(".publish-or-delete") do
+      expect(page).to_not have_css("button", text: "Discard changes")
+    end
+  end
+
+  def there_should_be_no_unpublish_button
+    within(".publish-or-delete") do
+      expect(page).to_not have_css("button", text: "Unpublish step by step")
+    end
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User schedules publishing" do
-      given_there_is_a_draft_step_by_step_page
+      given_there_is_a_draft_step_by_step_page_with_secondary_content
       and_I_visit_the_scheduling_page
       and_I_fill_in_the_scheduling_form
       when_I_submit_the_form
@@ -428,10 +428,34 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_the_step_by_step_is_not_editable
+    when_I_visit_the_secondary_content_page
+    then_I_can_see_the_existing_secondary_links
+    and_I_cannot_add_secondary_content_link
+    and_I_cannot_delete_secondary_content_links
+
     when_I_visit_the_publish_or_delete_page
     there_should_be_no_publish_button
     there_should_be_no_discard_changes_button
     there_should_be_no_unpublish_button
+  end
+
+  def when_I_visit_the_secondary_content_page
+    visit step_by_step_page_secondary_content_links_path(@step_by_step_page)
+  end
+
+  def then_I_can_see_the_existing_secondary_links
+    expect(find('tbody')).to have_content(@step_by_step_page.secondary_content_links.first.title)
+  end
+
+  def and_I_cannot_add_secondary_content_link
+    expect(page).to_not have_css("h2", text: "Add new secondary link")
+    expect(page).to_not have_css("button", text: "Add secondary link")
+  end
+
+  def and_I_cannot_delete_secondary_content_links
+    within("tbody") do
+      expect(page).to_not have_css("button", text: "Delete")
+    end
   end
 
   def there_should_be_no_publish_button

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe StepByStepPage do
   describe '#can_be_published?' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 
-    it 'can be published if it has a draft' do
+    it 'can be published if it has a draft and it is not scheduled for publishing' do
       step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be true
@@ -294,15 +294,29 @@ RSpec.describe StepByStepPage do
     it 'cannot be published if it does not have a draft' do
       expect(step_by_step_page.can_be_published?).to be false
     end
+
+    it 'cannot be published if it is scheduled for publishing' do
+      step_by_step_page.mark_draft_updated
+      step_by_step_page.scheduled_at = Date.tomorrow
+
+      expect(step_by_step_page.can_be_published?).to be false
+    end
   end
 
   describe '#can_be_unpublished?' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 
-    it 'can be unpublished if it has been published' do
+    it 'can be unpublished if it has been published and it is not scheduled for publishing' do
       step_by_step_page.mark_as_published
 
       expect(step_by_step_page.can_be_unpublished?).to be true
+    end
+
+    it 'cannot be unpublished if it is scheduled for publishing' do
+      step_by_step_page.mark_draft_updated
+      step_by_step_page.scheduled_at = Date.tomorrow
+
+      expect(step_by_step_page.can_be_unpublished?).to be false
     end
 
     it 'cannot be unpublished if it has not been published' do
@@ -313,7 +327,7 @@ RSpec.describe StepByStepPage do
   describe '#can_discard_changes?' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 
-    it 'can discard changes if it has unpublished changes' do
+    it 'can discard changes if it has unpublished changes and it is not scheduled for publishing' do
       step_by_step_page.published_at = Time.zone.now - 1.hour
       step_by_step_page.mark_draft_updated
 
@@ -323,13 +337,27 @@ RSpec.describe StepByStepPage do
     it 'cannot discard changes if it does not have unpublished changes' do
       expect(step_by_step_page.can_discard_changes?).to be false
     end
+
+    it 'cannot discard changes if it is scheduled for publishing' do
+      step_by_step_page.mark_draft_updated
+      step_by_step_page.scheduled_at = Date.tomorrow
+
+      expect(step_by_step_page.can_discard_changes?).to be false
+    end
   end
 
   describe '#can_be_deleted?' do
     let(:step_by_step_page) { create(:step_by_step_page) }
 
-    it 'can be deleted if it has not been published' do
+    it 'can be deleted if it has not been published and it is not scheduled for publishing' do
       expect(step_by_step_page.can_be_deleted?).to be true
+    end
+
+    it 'cannot be deleted if it is scheduled for publishing' do
+      step_by_step_page.mark_draft_updated
+      step_by_step_page.scheduled_at = Date.tomorrow
+
+      expect(step_by_step_page.can_be_deleted?).to be false
     end
 
     it 'cannot be deleted if it has been published' do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -282,6 +282,63 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe '#can_be_published?' do
+    let(:step_by_step_page) { create(:step_by_step_page) }
+
+    it 'can be published if it has a draft' do
+      step_by_step_page.mark_draft_updated
+
+      expect(step_by_step_page.can_be_published?).to be true
+    end
+
+    it 'cannot be published if it does not have a draft' do
+      expect(step_by_step_page.can_be_published?).to be false
+    end
+  end
+
+  describe '#can_be_unpublished?' do
+    let(:step_by_step_page) { create(:step_by_step_page) }
+
+    it 'can be unpublished if it has been published' do
+      step_by_step_page.mark_as_published
+
+      expect(step_by_step_page.can_be_unpublished?).to be true
+    end
+
+    it 'cannot be unpublished if it has not been published' do
+      expect(step_by_step_page.can_be_unpublished?).to be false
+    end
+  end
+
+  describe '#can_discard_changes?' do
+    let(:step_by_step_page) { create(:step_by_step_page) }
+
+    it 'can discard changes if it has unpublished changes' do
+      step_by_step_page.published_at = Time.zone.now - 1.hour
+      step_by_step_page.mark_draft_updated
+
+      expect(step_by_step_page.can_discard_changes?).to be true
+    end
+
+    it 'cannot discard changes if it does not have unpublished changes' do
+      expect(step_by_step_page.can_discard_changes?).to be false
+    end
+  end
+
+  describe '#can_be_deleted?' do
+    let(:step_by_step_page) { create(:step_by_step_page) }
+
+    it 'can be deleted if it has not been published' do
+      expect(step_by_step_page.can_be_deleted?).to be true
+    end
+
+    it 'cannot be deleted if it has been published' do
+      step_by_step_page.mark_as_published
+
+      expect(step_by_step_page.can_be_deleted?).to be false
+    end
+  end
+
   describe '.internal_change_notes' do
     context 'when there are changenotes' do
       it 'returns an array of changenotes in chronological order' do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -367,6 +367,21 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe '#can_be_edited?' do
+    let(:step_by_step_page) { create(:step_by_step_page) }
+
+    it 'can be edited if it is not scheduled for publishing' do
+      expect(step_by_step_page.can_be_edited?).to be true
+    end
+
+    it 'cannot be edited if it is scheduled for publishing' do
+      step_by_step_page.mark_draft_updated
+      step_by_step_page.scheduled_at = Date.tomorrow
+
+      expect(step_by_step_page.can_be_edited?).to be false
+    end
+  end
+
   describe '.internal_change_notes' do
     context 'when there are changenotes' do
       it 'returns an array of changenotes in chronological order' do

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -109,4 +109,9 @@ module StepNavSteps
     create(:link_report, step_id: step.id)
     @step_by_step_page = create(:step_by_step_page, steps: [step], slug: "step-by-step-with-link-report")
   end
+
+  def given_there_is_a_draft_step_by_step_page_with_secondary_content
+    @step_by_step_page = create(:step_by_step_page_with_secondary_content, draft_updated_at: 1.day.ago)
+    expect(@step_by_step_page.status[:name]).to eq 'draft'
+  end
 end


### PR DESCRIPTION
## What
When a user has scheduled a step by step for publishing, they should not be able to make any further changes to that step by step.

**'Delete or publish' page**
User _cannot_ publish unpublish, delete a step by step page or discard draft.
User _can_ unschedule.
<kbd><img width="972" alt="delete_publish_locked" src="https://user-images.githubusercontent.com/38078064/62711901-bff0d880-b9f1-11e9-93e9-b8cba317d296.png"></kbd>

**'Secondary links' page**
User _cannot_ add new secondary content links or delete existing secondary content links.
User _can_ view existing secondary content links.
<kbd><img width="972" alt="secondary_content_locked" src="https://user-images.githubusercontent.com/38078064/62711923-c5e6b980-b9f1-11e9-9d4a-cd72b889d988.png"></kbd>

## Why
This prevents any unexpected edits being published in error or too early.

[Trello card: Delete or publish](https://trello.com/c/sLY5dXxq/84-lock-a-step-by-step-that-has-been-scheduled-for-publication-on-the-publish-and-delete-page-s)
[Trello card: Secondary links](https://trello.com/c/pSlr7lT7/87-lock-a-step-by-step-that-has-been-scheduled-for-publication-on-the-secondary-links-page-s)