### PR TITLE
Remove cancel links

### DIFF
--- a/app/assets/javascripts/steps.js
+++ b/app/assets/javascripts/steps.js
@@ -14,7 +14,6 @@
       this.setOrder(); // this is called so the order of the list is initalised
       this.bindStatusClicks();
       this.bindCancelAddChangeNoteLink();
-      this.bindCancelAddSecondaryLink();
       this.bindOverviewTableFilter();
     },
 
@@ -108,7 +107,7 @@
       });
     },
 
-    // Ported over from: 
+    // Ported over from:
     // https://github.com/alphagov/govuk_admin_template/blob/master/app/assets/javascripts/govuk-admin-template/modules/filterable_table.js
     bindOverviewTableFilter: function() {
       var rows = $('.step-by-step-list__table').find('tbody tr'),
@@ -146,14 +145,6 @@
         e.preventDefault();
         $('.add-change-note-description--textarea').val('');
         $('.add-change-note--details').removeAttr('open');
-      });
-    },
-
-    bindCancelAddSecondaryLink: function() {
-      $('.add-secondary-link-cancel--link').on('click', function(e){
-        e.preventDefault();
-        $('.add-secondary-link-input').val('');
-        $('.add-secondary-link--details').removeAttr('open');
       });
     }
   };

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -83,9 +83,6 @@
             text: "Save"
           } %>
         </div>
-        <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to 'Cancel', step_by_step_page_secondary_content_links_path, class: "govuk-link add-secondary-link-cancel--link" %>
-        </div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -72,11 +72,6 @@
             } %>
           </div>
         </div>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full govuk-!-margin-top-3">
-            <%= link_to 'Cancel', step_by_step_page_secondary_content_links_path, class: "govuk-link add-secondary-link-cancel--link" %>
-          </div>
-        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Cancel links from navigation rules and secondary contents links do not have effect  at the moment and they should be removed.

These links were used to hide a container and reset the input value of the field. It turns out they weren't useful the way they were designed and after the UI update they don't have any effects anymore so it's been decided to remove them.

[Trello card](https://trello.com/c/Il5JA4d2)