### PR TITLE
Improve edit step page

### DIFF
--- a/app/assets/stylesheets/_steps.scss
+++ b/app/assets/stylesheets/_steps.scss
@@ -21,7 +21,7 @@ $dark-grey-2: #6f777b;
 }
 
 .markdown-example {
-  @include govuk-font(14);
+  @include govuk-font(16);
   white-space: pre-wrap;
   display: block;
   padding: govuk-spacing(4);

--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -1,9 +1,5 @@
 .gem-c-layout-for-admin {
   @include _govuk-font-face-nta;
-
-  .govuk-main-wrapper {
-    padding-top: 0;
-  }
 }
 
 .gem-c-phase-banner {

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -38,11 +38,11 @@
       app_name: "Collections Publisher",
       phase: "beta"
     } %>
-    <% if yield(:back_link).present? %>
-      <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
-    <% end %>
 
-    <main class="govuk-main-wrapper" id="main-content" role="main">
+    <%= yield(:back_link) %>
+    <%= yield(:breadcrumbs) %>
+
+    <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
       <% if flash["notice"].present? %>
         <%= render "govuk_publishing_components/components/success_alert", {
           message: flash["notice"]
@@ -55,7 +55,6 @@
         } %>
       <% end %>
 
-      <%= yield(:breadcrumbs) %>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/steps/_markdown_help.html.erb
+++ b/app/views/shared/steps/_markdown_help.html.erb
@@ -1,6 +1,7 @@
 <p class="govuk-body">
-  <%= link_to "Content design guide", 
-    "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4", 
+  <%= link_to "Content design guide",
+    "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4",
+    class: "govuk-link",
     target: "_blank" %> for step by step navigation.
 </p>
 

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -4,7 +4,8 @@
 
     <%= render "govuk_publishing_components/components/input", {
       label: {
-        text: "Step title"
+        text: "Step title",
+        bold: true
       },
       name: "step[title]",
       value: step.title

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-grid-row govuk-!-margin-top-7">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "shared/steps/form_errors", resource: step %>
 
@@ -53,14 +53,14 @@
   </div>
 </div>
 
-<div class="govuk-grid-row govuk-!-margin-bottom-5">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render 'shared/steps/broken-links-summary', step: step %>
   </div>
 </div>
 
 <% if step.broken_links && step.broken_links.count > 0 %>
-  <div class="govuk-grid-row govuk-!-margin-bottom-5">
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/details", {
         title: "View broken links"
@@ -140,7 +140,7 @@
       text: "Save step"
     } %>
   </div>
-  <div class="govuk-grid-column-full govuk-!-margin-top-3">
+  <div class="govuk-grid-column-full">
     <%= link_to 'Return to overview', @step_by_step_page, class: "govuk-link" %>
   </div>
 </div>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -137,10 +137,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/button", {
-      text: "Save step"
+      text: "Save step",
+      margin_bottom: true
     } %>
-  </div>
-  <div class="govuk-grid-column-full">
-    <%= link_to 'Return to overview', @step_by_step_page, class: "govuk-link" %>
+    <%= tag.p (link_to 'Return to overview', @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
   </div>
 </div>

--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -14,7 +14,7 @@
   ]
 %>
 
-<% content_for :breadcrumbs do %>
+<% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: @step_by_step_page
   } %>


### PR DESCRIPTION
This PR improves the overall layout of the edit step page and includes the following changes:
- Increases the font size for the markdown example code (we avoid using 14 pixels as it's too small)
- Update the markdown guidance link to use govuk styles
- Make the 'Step title' input label bold, for consistency with the other fields
- Remove arbitrary margin overwrites
- Remove redundant row grid wrapper on primary action/return link
- Correct the back link/breadcrumbs positioning as per [design system template](https://design-system.service.gov.uk/styles/page-template/) and remove main wrapper overwrite.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![edit-step-before](https://user-images.githubusercontent.com/788096/62960598-e13b3580-bdf2-11e9-821e-9e42107e48ec.png)

</td>
<td>

![edit-step-after](https://user-images.githubusercontent.com/788096/62960604-e6988000-bdf2-11e9-8d28-538971f04afe.png)

</td>
</tr>
</table>

[Trello card](https://trello.com/c/ousy4kjO)