### PR TITLE
Remove unneeded buttons from the markdown toolbar

### DIFF
--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -12,21 +12,9 @@
     <div class="app-c-markdown-editor__head">
       <div class="app-c-markdown-editor__toolbar">
         <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="<%= textarea[:id] %>">
-          <md-header-2 class="app-c-markdown-editor__toolbar-button" title="Heading level 2" aria-label="Heading level 2">
-            <%= render "components/markdown_editor/heading_two.svg" %>
-          </md-header-2>
-          <md-header-3 class="app-c-markdown-editor__toolbar-button" title="Heading level 3" aria-label="Heading level 3">
-            <%= render "components/markdown_editor/heading_three.svg" %>
-          </md-header-3>
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
-          <md-quote class="app-c-markdown-editor__toolbar-button" title="Blockquote" aria-label="Blockquote">
-            <%= render "components/markdown_editor/blockquote.svg" %>
-          </md-quote>
-          <md-ordered-list class="app-c-markdown-editor__toolbar-button" title="Numbered list" aria-label="Numbered list">
-            <%= render "components/markdown_editor/numbered_list.svg" %>
-          </md-ordered-list>
           <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
             <%= render "components/markdown_editor/bullets.svg" %>
           </md-unordered-list>


### PR DESCRIPTION
According to the guidance steps content should only need injectors for links and bullets.

### Before
<img width="636" alt="Screen Shot 2019-08-14 at 10 18 38" src="https://user-images.githubusercontent.com/788096/63011788-f2328800-be80-11e9-9770-a580b5b5bac5.png">

### After
<img width="636" alt="Screen Shot 2019-08-14 at 10 18 51" src="https://user-images.githubusercontent.com/788096/63011795-f494e200-be80-11e9-8fa7-8288cae70271.png">


[Trello card](https://trello.com/c/PiQCXSt0)