### PR TITLE
Hide Reorder steps tab when the step by step is scheduled

### DIFF
--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -1,11 +1,11 @@
-<% 
+<%
   unless defined? active
     active = ''
   end
 %>
 
-<%= render "components/tabs", {
-  tabs: [
+<%
+  tabs = [
     {
       href: @step_by_step_page,
       label: "Edit steps",
@@ -42,4 +42,9 @@
       active: active == 'internal-change-notes'
     }
   ]
+  tabs.delete_at(1) unless @step_by_step_page.can_be_edited?
+%>
+
+<%= render "components/tabs", {
+  tabs: tabs
 } %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -487,6 +487,8 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_the_step_by_step_is_not_editable
+    then_there_should_be_no_reorder_steps_tab
+
     when_I_visit_the_secondary_content_page
     then_I_can_see_the_existing_secondary_links
     and_I_cannot_add_secondary_content_link
@@ -496,6 +498,10 @@ RSpec.feature "Managing step by step pages" do
     there_should_be_no_publish_button
     there_should_be_no_discard_changes_button
     there_should_be_no_unpublish_button
+  end
+
+  def then_there_should_be_no_reorder_steps_tab
+    expect(page).to_not have_link("Reorder steps", :href => step_by_step_page_reorder_path(@step_by_step_page))
   end
 
   def when_I_visit_the_secondary_content_page


### PR DESCRIPTION
## What
When a user has scheduled a step by step for publishing, they should not be able to make any further changes to that step by step.
- User _cannot_ see the Reorder steps tab and therefore change the order
- User _can_ still see the order in the steps Overview page

**Not scheduled**
<img width="971" alt="Screen Shot 2019-08-14 at 10 53 32" src="https://user-images.githubusercontent.com/38078064/63013405-15126b80-be84-11e9-8642-0b6d9ee49def.png">

**Scheduled for publishing**
<img width="972" alt="Screen Shot 2019-08-14 at 10 53 12" src="https://user-images.githubusercontent.com/38078064/63013372-0461f580-be84-11e9-89d0-f09bb9ec3c60.png">

_Note:_ No extra check implemented in the controller, as we trust content designers not to try to hack the url. 

## Why
This prevents any unexpected edits being published in error or too early.

[Trello card](https://trello.com/c/E4uqOWRy/82-lock-a-step-by-step-that-has-been-scheduled-for-publication-on-the-reorder-page-s)
