### PR TITLE
Show information instead of inputs if step by step can not be edited

### DIFF
--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -3,61 +3,99 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title"
-        },
-        name: "step_by_step_page[title]",
-        value: step_by_step_page.title
-      } %>
+      <% if @step_by_step_page.can_be_edited? %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Title"
+          },
+          name: "step_by_step_page[title]",
+          value: step_by_step_page.title
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Title",
+          bold: true,
+          html_for: 'step_by_step_page_title'
+        } %>
+        <%= tag.p step_by_step_page.title, id: "step_by_step_page_title", class: "govuk-body" %>
+      <% end %>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Slug"
-        },
-        hint: "No slashes",
-        name: "step_by_step_page[slug]",
-        value: step_by_step_page.slug
-      } %>
+      <% if @step_by_step_page.can_be_edited? %>
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Slug"
+          },
+          hint: "No slashes",
+          name: "step_by_step_page[slug]",
+          value: step_by_step_page.slug
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Slug",
+          bold: true,
+          html_for: 'step_by_step_page_slug'
+        } %>
+        <%= tag.p step_by_step_page.slug, id: "step_by_step_page_slug", class: "govuk-body" %>
+      <% end %>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Introduction"
-        },
-        name: "step_by_step_page[introduction]",
-        value: step_by_step_page.introduction
-      } %>
+      <% if @step_by_step_page.can_be_edited? %>
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: "Introduction"
+          },
+          name: "step_by_step_page[introduction]",
+          value: step_by_step_page.introduction
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Introduction",
+          bold: true,
+          html_for: 'step_by_step_page_introduction'
+        } %>
+        <%= tag.p step_by_step_page.introduction, id: "step_by_step_page_introduction", class: "govuk-body" %>
+      <% end %>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Meta description"
-        },
-        name: "step_by_step_page[description]",
-        value: step_by_step_page.description
-      } %>
+      <% if @step_by_step_page.can_be_edited? %>
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: "Meta description"
+          },
+          name: "step_by_step_page[description]",
+          value: step_by_step_page.description
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/label", {
+          text: "Meta description",
+          bold: true,
+          html_for: 'step_by_step_page_description'
+        } %>
+        <%= tag.p step_by_step_page.description, id: "step_by_step_page_description", class: "govuk-body" %>
+      <% end %>
     </div>
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save"
-      } %>
-    </div>
-    <div class="govuk-grid-column-full govuk-!-margin-top-3">
-      <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link" %>
-    </div>
+    <% if @step_by_step_page.can_be_edited? %>
+      <div class="govuk-grid-column-full">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save"
+        } %>
+      </div>
+      <div class="govuk-grid-column-full govuk-!-margin-top-3">
+        <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link" %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -489,6 +489,10 @@ RSpec.feature "Managing step by step pages" do
   def and_the_step_by_step_is_not_editable
     then_there_should_be_no_reorder_steps_tab
 
+    when_I_edit_the_step_by_step_page
+    then_I_can_see_the_step_by_step_details
+    and_I_cannot_edit_the_step_by_step_details
+
     when_I_visit_the_secondary_content_page
     then_I_can_see_the_existing_secondary_links
     and_I_cannot_add_secondary_content_link
@@ -502,6 +506,21 @@ RSpec.feature "Managing step by step pages" do
 
   def then_there_should_be_no_reorder_steps_tab
     expect(page).to_not have_link("Reorder steps", :href => step_by_step_page_reorder_path(@step_by_step_page))
+  end
+
+  def then_I_can_see_the_step_by_step_details
+    expect(page).to have_content("How to be amazing")
+    expect(page).to have_content("how-to-be-the-amazing-1")
+    expect(page).to have_content("Find out the steps to become amazing")
+    expect(page).to have_content("How to be amazing - find out the steps to become amazing")
+  end
+
+  def and_I_cannot_edit_the_step_by_step_details
+    expect(page).to_not have_field("step_by_step_page[title]")
+    expect(page).to_not have_field("step_by_step_page[slug]")
+    expect(page).to_not have_field("step_by_step_page[introduction]")
+    expect(page).to_not have_field("step_by_step_page[description]")
+    expect(page).to_not have_css("button", text: "Save")
   end
 
   def when_I_visit_the_secondary_content_page


### PR DESCRIPTION
### What

When a user has scheduled a step by step for publishing, they should not be able to make any further changes to that step by step but they should still be allowed to check for broken links and view step content.

### Why
This prevent any unexpected edits being published too early.

[Trello card](https://trello.com/c/YMFbkQ13)