### PR TITLE
Remove edit options from overview page for scheduled step by steps

### DIFF
--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -79,12 +79,14 @@
 
   <div class="govuk-grid-column-one-third">
     <ul class="govuk-list step-by-step-actions__list">
-      <li>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Add a new step",
-          href: new_step_by_step_page_step_path(@step_by_step_page)
-        } %>
+      <% if @step_by_step_page.can_be_edited? %>
+        <li>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Add a new step",
+            href: new_step_by_step_page_step_path(@step_by_step_page)
+          } %>
       </li>
+      <% end %>
       <li class="govuk-!-margin-top-2">
         <%= render "govuk_publishing_components/components/button", {
           text: "Preview",

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -29,7 +29,9 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Step</th>
           <th class="govuk-table__header" scope="col">Title</th>
-          <th class="govuk-table__header govuk-table__header--numeric" scope="col">Actions</th>
+          <% if @step_by_step_page.can_be_edited? %>
+            <th class="govuk-table__header govuk-table__header--numeric" scope="col">Actions</th>
+          <% end %>
         </tr>
       </thead>
 
@@ -56,10 +58,12 @@
                 </div>
               </th>
 
-              <td class="govuk-table__cell govuk-table__cell--numeric">
-                <%= link_to("Edit", edit_step_by_step_page_step_path(@step_by_step_page.id, step.id), class: "gem-c-button govuk-button gem-c-button--inline") %>
-                <%= link_to("Delete", step_by_step_page_step_path(@step_by_step_page.id, step.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "gem-c-button govuk-button govuk-button--warning gem-c-button--inline") %>
-              </td>
+              <% if @step_by_step_page.can_be_edited? %>
+                <td class="govuk-table__cell govuk-table__cell--numeric">
+                  <%= link_to("Edit", edit_step_by_step_page_step_path(@step_by_step_page.id, step.id), class: "gem-c-button govuk-button gem-c-button--inline") %>
+                  <%= link_to("Delete", step_by_step_page_step_path(@step_by_step_page.id, step.id), method: 'delete', data: { confirm: "Are you sure?" }, class: "gem-c-button govuk-button govuk-button--warning gem-c-button--inline") %>
+                </td>
+              <% end %>
             </tr>
           <% end %>
         <% else %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -489,6 +489,9 @@ RSpec.feature "Managing step by step pages" do
   def and_the_step_by_step_is_not_editable
     then_there_should_be_no_reorder_steps_tab
 
+    when_I_view_the_step_by_step_page
+    then_I_can_see_the_steps
+
     when_I_edit_the_step_by_step_page
     then_I_can_see_the_step_by_step_details
     and_I_cannot_edit_the_step_by_step_details
@@ -506,6 +509,10 @@ RSpec.feature "Managing step by step pages" do
 
   def then_there_should_be_no_reorder_steps_tab
     expect(page).to_not have_link("Reorder steps", :href => step_by_step_page_reorder_path(@step_by_step_page))
+  end
+
+  def then_I_can_see_the_steps
+    expect(find('tbody')).to have_content(@step_by_step_page.steps.first.title)
   end
 
   def then_I_can_see_the_step_by_step_details

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -157,6 +157,7 @@ RSpec.feature "Managing step by step pages" do
       and_the_step_by_step_is_not_editable
       when_I_view_the_step_by_step_page
       then_I_can_preview_the_step_by_step
+      and_the_steps_can_be_checked_for_broken_links
     end
 
     scenario "User tries to schedule publishing for date in the past" do
@@ -586,5 +587,9 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_can_preview_the_step_by_step
     expect(page).to have_link("Preview")
+  end
+
+  def and_the_steps_can_be_checked_for_broken_links
+    expect(page).to have_button("Check for broken links")
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -155,6 +155,8 @@ RSpec.feature "Managing step by step pages" do
       and_the_step_by_step_should_have_the_status "Scheduled"
       and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing on Saturday, 20 April 2030 at 10:26 am"
       and_the_step_by_step_is_not_editable
+      when_I_view_the_step_by_step_page
+      then_I_can_preview_the_step_by_step
     end
 
     scenario "User tries to schedule publishing for date in the past" do
@@ -580,5 +582,9 @@ RSpec.feature "Managing step by step pages" do
     within(".publish-or-delete") do
       expect(page).to_not have_css("button", text: "Unpublish step by step")
     end
+  end
+
+  def then_I_can_preview_the_step_by_step
+    expect(page).to have_link("Preview")
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -508,9 +508,9 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_delete_secondary_content_links
 
     when_I_visit_the_publish_or_delete_page
-    there_should_be_no_publish_button
-    there_should_be_no_discard_changes_button
-    there_should_be_no_unpublish_button
+    then_there_should_be_no_publish_button
+    then_there_should_be_no_discard_changes_button
+    then_there_should_be_no_unpublish_button
   end
 
   def then_there_should_be_no_reorder_steps_tab
@@ -567,19 +567,19 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  def there_should_be_no_publish_button
+  def then_there_should_be_no_publish_button
     within(".publish-or-delete") do
       expect(page).to_not have_css("button", text: "Publish changes")
     end
   end
 
-  def there_should_be_no_discard_changes_button
+  def then_there_should_be_no_discard_changes_button
     within(".publish-or-delete") do
       expect(page).to_not have_css("button", text: "Discard changes")
     end
   end
 
-  def there_should_be_no_unpublish_button
+  def then_there_should_be_no_unpublish_button
     within(".publish-or-delete") do
       expect(page).to_not have_css("button", text: "Unpublish step by step")
     end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -493,6 +493,7 @@ RSpec.feature "Managing step by step pages" do
     then_I_can_see_the_steps
     and_I_cannot_edit_any_steps
     and_I_cannot_delete_any_steps
+    and_I_cannot_add_new_steps
 
     when_I_edit_the_step_by_step_page
     then_I_can_see_the_step_by_step_details
@@ -523,6 +524,10 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_cannot_delete_any_steps
     expect(page).to_not have_button("Delete")
+  end
+
+  def and_I_cannot_add_new_steps
+    expect(page).to_not have_button("Add a new step")
   end
 
   def then_I_can_see_the_step_by_step_details

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -491,6 +491,8 @@ RSpec.feature "Managing step by step pages" do
 
     when_I_view_the_step_by_step_page
     then_I_can_see_the_steps
+    and_I_cannot_edit_any_steps
+    and_I_cannot_delete_any_steps
 
     when_I_edit_the_step_by_step_page
     then_I_can_see_the_step_by_step_details
@@ -513,6 +515,14 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_can_see_the_steps
     expect(find('tbody')).to have_content(@step_by_step_page.steps.first.title)
+  end
+
+  def and_I_cannot_edit_any_steps
+    expect(page).to_not have_button("Edit")
+  end
+
+  def and_I_cannot_delete_any_steps
+    expect(page).to_not have_button("Delete")
   end
 
   def then_I_can_see_the_step_by_step_details


### PR DESCRIPTION
Trello: https://trello.com/c/ltbNPIGz

## Motivation

When a user has scheduled a step by step for publishing, they should not be able to make any further changes to that step by step

BUT they should still be allowed to add internal changenotes, check for broken links and preview changes.

## Expected changes

### Before
<img width="1532" alt="Screen Shot 2019-08-15 at 13 52 19" src="https://user-images.githubusercontent.com/5793815/63095852-3054a800-bf64-11e9-8beb-d13a8763ac7a.png">

### After
<img width="1532" alt="Screen Shot 2019-08-15 at 13 52 44" src="https://user-images.githubusercontent.com/5793815/63095878-3fd3f100-bf64-11e9-8360-5a27413c72f0.png">
