### PR TITLE
"Turn on" scheduling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,14 +11,10 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :user_can_schedule?, :active_navigation_item
+  helper_method :gds_editor?, :active_navigation_item
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
-  end
-
-  def user_can_schedule?
-    current_user.has_permission? "Scheduling"
   end
 
   # Can be overridden to allow controllers to choose the active menu item.
@@ -42,9 +38,5 @@ private
     if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
     end
-  end
-
-  def require_scheduling_permissions!
-    authorise_user!("Scheduling")
   end
 end

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -4,7 +4,6 @@ class StepByStepPagesController < ApplicationController
   layout 'admin_layout'
 
   before_action :require_gds_editor_permissions!
-  before_action :require_scheduling_permissions!, only: %i[schedule unschedule]
   before_action :set_step_by_step_page, only: %i[show edit update destroy]
 
   def index

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -37,25 +37,23 @@
             } %>
           <% end %>
 
-          <% if user_can_schedule? %>
-            <% if @step_by_step_page.scheduled_for_publishing? %>
-              <p class="govuk-body">
-                Scheduled to be published on <%= format_full_date_and_time(@step_by_step_page.scheduled_at) %>
-              </p>
-              <%= form_tag step_by_step_page_unschedule_path(@step_by_step_page), method: :unschedule do %>
-                <%= render "govuk_publishing_components/components/button", {
-                  text: "Unschedule publishing",
-                  destructive: true
-                } %>
-              <% end %>
-            <% else %>
-              <p class="govuk-body govuk-!-margin-top-5">Or</p>
+          <% if @step_by_step_page.scheduled_for_publishing? %>
+            <p class="govuk-body">
+              Scheduled to be published on <%= format_full_date_and_time(@step_by_step_page.scheduled_at) %>
+            </p>
+            <%= form_tag step_by_step_page_unschedule_path(@step_by_step_page), method: :unschedule do %>
               <%= render "govuk_publishing_components/components/button", {
-                text: "Schedule publish",
-                href: step_by_step_page_schedule_path(@step_by_step_page),
-                secondary: true
+                text: "Unschedule publishing",
+                destructive: true
               } %>
             <% end %>
+          <% else %>
+            <p class="govuk-body govuk-!-margin-top-5">Or</p>
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Schedule publish",
+              href: step_by_step_page_schedule_path(@step_by_step_page),
+              secondary: true
+            } %>
           <% end %>
 
           <% if @step_by_step_page.can_discard_changes? %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,6 @@ user_id = "026530a0-750f-41e6-8863-b539d1467145"
 User.create!(
   uid: user_id,
   name: "Test user",
-  permissions: ["signin", "GDS Editor", "Scheduling"],
+  permissions: ["signin", "GDS Editor"],
   organisation_content_id: gds_organisation_id,
 )

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe StepByStepPagesController do
   end
 
   describe "GET Step by step schedule page" do
-    it "can only be accessed by users with Scheduling permissions" do
-      stub_user.permissions << "Scheduling"
+    it "can only be accessed by users with GDS editor permissions" do
       get :schedule, params: { step_by_step_page_id: step_by_step_page.id }
 
       expect(response.status).to eq(200)
     end
 
-    it "cannot be accessed by users without Scheduling permissions" do
+    it "cannot be accessed by users without GDS editor permissions" do
+      stub_user.permissions = %w(signin)
       get :schedule, params: { step_by_step_page_id: step_by_step_page.id }
 
       expect(response.status).to eq(403)
@@ -95,7 +95,6 @@ RSpec.describe StepByStepPagesController do
     let(:step_by_step_page) { create(:draft_step_by_step_page) }
 
     before :each do
-      stub_scheduling_permissions
       stub_publishing_api_for_scheduling
       stub_default_publishing_api_put_intent
     end
@@ -127,7 +126,6 @@ RSpec.describe StepByStepPagesController do
 
   describe "#unschedule" do
     before :each do
-      stub_scheduling_permissions
       stub_publishing_api_for_scheduling
     end
 
@@ -206,10 +204,6 @@ RSpec.describe StepByStepPagesController do
 
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
-  end
-
-  def stub_scheduling_permissions
-    stub_user.permissions << "Scheduling"
   end
 
   def stub_publishing_api_for_scheduling

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -134,15 +134,8 @@ RSpec.feature "Managing step by step pages" do
     then_there_should_be_a_change_note "Draft saved by #{stub_user.name}"
   end
 
-  scenario "User cannot see Schedule button without Scheduling permissions" do
-    given_there_is_a_draft_step_by_step_page
-    and_I_visit_the_publish_or_delete_page
-    then_there_should_be_no_schedule_button
-  end
-
-  context "Given I have Scheduling permissions" do
+  context "Scheduling" do
     before do
-      given_I_have_scheduling_permissions
       stub_publishing_api_destroy_intent('/how-to-be-the-amazing-1')
     end
 
@@ -389,10 +382,6 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_see_I_saved_it_last
     expect(page).to have_content("Last saved by Test author")
-  end
-
-  def given_I_have_scheduling_permissions
-    stub_user.permissions << "Scheduling"
   end
 
   def and_I_visit_the_scheduling_page


### PR DESCRIPTION
Trello: https://trello.com/c/By0dGoA7

## What
Removes the "scheduling" special permission.

## Why
So anybody with GDS editor permissions can schedule a step by step for publication.