### PR TITLE
Lock 'Choose navigation' page when the step by step is scheduled 

### DIFF
--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -14,6 +14,11 @@ class NavigationRule < ActiveRecord::Base
     options.each { |item| item[:selected] = item[:value] == include_in_links }
   end
 
+  def selected_option_text
+    selected = options.select { |item| item[:value] == include_in_links }.first
+    selected[:text]
+  end
+
 private
 
   def options

--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -9,4 +9,36 @@ class NavigationRule < ActiveRecord::Base
   def smartanswer?
     schema_name == "transaction" && publishing_app == "smartanswers"
   end
+
+  def options_with_selected
+    options.each { |item| item[:selected] = item[:value] == include_in_links }
+  end
+
+private
+
+  def options
+    [always, conditionally, never]
+  end
+
+  def always
+    {
+      text: "Always show navigation",
+      value: "always",
+      selected: true
+    }
+  end
+
+  def conditionally
+    {
+      text: "Show navigation if user comes from a step-by-step",
+      value: "conditionally",
+    }
+  end
+
+  def never
+    {
+      text: "Never show navigation",
+      value: "never"
+    }
+  end
 end

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -45,11 +45,15 @@
                   <td class="govuk-table__cell"><%= link_to(navigation_rule.title, preview_url(navigation_rule.base_path), class: "govuk-link") %></td>
                   <td class="govuk-table__cell"><%= navigation_rule.base_path %></td>
                   <td class="govuk-table__cell">
-                    <%= render "govuk_publishing_components/components/select", {
-                      id: "navigation_rules[#{navigation_rule.content_id}]",
-                      label: "",
-                      options: navigation_rule.options_with_selected,
-                    } %>
+                    <% if @step_by_step_page.can_be_edited? %>
+                      <%= render "govuk_publishing_components/components/select", {
+                        id: "navigation_rules[#{navigation_rule.content_id}]",
+                        label: "",
+                        options: navigation_rule.options_with_selected
+                      } %>
+                    <% else %>
+                      <%= tag.p navigation_rule.selected_option_text, id: "navigation_rules[#{navigation_rule.content_id}]" %>
+                    <% end %>
                   </td>
                 </tr>
               <% end %>
@@ -63,7 +67,7 @@
           </tbody>
         </table>
       </div>
-      <% if @step_by_step_page.navigation_rules.present? %>
+      <% if @step_by_step_page.navigation_rules.present? && @step_by_step_page.can_be_edited? %>
         <div class="govuk-grid-column-full">
           <%= render "govuk_publishing_components/components/button", {
             text: "Save"

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -48,21 +48,7 @@
                     <%= render "govuk_publishing_components/components/select", {
                       id: "navigation_rules[#{navigation_rule.content_id}]",
                       label: "",
-                      options: [
-                        {
-                          text: "Always show navigation",
-                          value: "always",
-                          selected: true
-                        },
-                        {
-                          text: "Show navigation if user comes from a step-by-step",
-                          value: "conditionally",
-                        },
-                        {
-                          text: "Never show navigation",
-                          value: "never"
-                        }
-                      ].each{ |item| item[:selected] = item[:value] == navigation_rule.include_in_links }
+                      options: navigation_rule.options_with_selected,
                     } %>
                   </td>
                 </tr>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -54,6 +54,14 @@ FactoryBot.define do
     end
   end
 
+  factory :step_by_step_page_with_secondary_content_and_navigation_rules, parent: :step_by_step_page_with_steps do
+    after(:create) do |step_by_step_page|
+      create(:secondary_content_link, step_by_step_page: step_by_step_page)
+      create(:navigation_rule, step_by_step_page: step_by_step_page)
+      create(:navigation_rule, step_by_step_page: step_by_step_page, title: "Also good stuff", base_path: "/also/good/stuff")
+    end
+  end
+
   factory :step do
     title { "Check how awesome you are" }
     logic { "number" }

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -147,7 +147,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User schedules publishing" do
-      given_there_is_a_draft_step_by_step_page_with_secondary_content
+      given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
       and_I_visit_the_scheduling_page
       and_I_fill_in_the_scheduling_form
       when_I_submit_the_form
@@ -502,6 +502,10 @@ RSpec.feature "Managing step by step pages" do
     then_I_can_see_the_step_by_step_details
     and_I_cannot_edit_the_step_by_step_details
 
+    when_I_visit_the_navigation_rules_page
+    then_I_see_pages_included_in_navigation
+    but_there_is_no_select_component
+
     when_I_visit_the_secondary_content_page
     then_I_can_see_the_existing_secondary_links
     and_I_cannot_add_secondary_content_link
@@ -546,6 +550,19 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to_not have_field("step_by_step_page[introduction]")
     expect(page).to_not have_field("step_by_step_page[description]")
     expect(page).to_not have_css("button", text: "Save")
+  end
+
+  def when_I_visit_the_navigation_rules_page
+    visit step_by_step_page_navigation_rules_path(@step_by_step_page)
+  end
+
+  def then_I_see_pages_included_in_navigation
+    expect(page).to have_link("Also good stuff", href: "https://draft-origin.test.gov.uk/also/good/stuff")
+    expect(page).to have_content("Always show navigation")
+  end
+
+  def but_there_is_no_select_component
+    expect(page).not_to have_css("select")
   end
 
   def when_I_visit_the_secondary_content_page

--- a/spec/models/navigation_rule_spec.rb
+++ b/spec/models/navigation_rule_spec.rb
@@ -139,4 +139,93 @@ RSpec.describe NavigationRule do
       expect(resource.smartanswer?).to be false
     end
   end
+
+  describe '#options_with_selected' do
+    context "include_in_links is set to always" do
+      it 'returns an array of hashes, where selected is true for the always hash' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          include_in_links: 'always'
+        )
+        expected_options = [
+          {
+            text: "Always show navigation",
+            value: "always",
+            selected: true
+          },
+          {
+            text: "Show navigation if user comes from a step-by-step",
+            value: "conditionally",
+            selected: false
+          },
+          {
+            text: "Never show navigation",
+            value: "never",
+            selected: false
+          }
+        ]
+        expect(resource.options_with_selected).to eq(expected_options)
+      end
+    end
+
+    context "include_in_links is set to conditionally" do
+      it 'returns an array of hashes, where selected is true for the conditionally hash' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          include_in_links: 'conditionally'
+        )
+        expected_options = [
+          {
+            text: "Always show navigation",
+            value: "always",
+            selected: false
+          },
+          {
+            text: "Show navigation if user comes from a step-by-step",
+            value: "conditionally",
+            selected: true
+          },
+          {
+            text: "Never show navigation",
+            value: "never",
+            selected: false
+          }
+        ]
+        expect(resource.options_with_selected).to eq(expected_options)
+      end
+    end
+
+    context "include_in_links is set to never" do
+      it 'returns an array of hashes, where selected is true for the never hash' do
+        resource = described_class.new(
+          title: 'A Title',
+          base_path: '/a-base-path',
+          content_id: 'A-CONTENT-ID-BOOM',
+          include_in_links: 'never'
+        )
+        expected_options = [
+          {
+            text: "Always show navigation",
+            value: "always",
+            selected: false
+          },
+          {
+            text: "Show navigation if user comes from a step-by-step",
+            value: "conditionally",
+            selected: false
+          },
+          {
+            text: "Never show navigation",
+            value: "never",
+            selected: true
+          }
+        ]
+        expect(resource.options_with_selected).to eq(expected_options)
+      end
+    end
+  end
 end

--- a/spec/models/navigation_rule_spec.rb
+++ b/spec/models/navigation_rule_spec.rb
@@ -228,4 +228,36 @@ RSpec.describe NavigationRule do
       end
     end
   end
+
+  describe '#selected_option_text' do
+    it 'returns correct text, when include_in_links is set to always' do
+      resource = described_class.new(
+        title: 'A Title',
+        base_path: '/a-base-path',
+        content_id: 'A-CONTENT-ID-BOOM',
+        include_in_links: 'always'
+      )
+      expect(resource.selected_option_text).to eq("Always show navigation")
+    end
+
+    it 'returns correct text, when include_in_links is set to conditionally' do
+      resource = described_class.new(
+        title: 'A Title',
+        base_path: '/a-base-path',
+        content_id: 'A-CONTENT-ID-BOOM',
+        include_in_links: 'conditionally'
+      )
+      expect(resource.selected_option_text).to eq("Show navigation if user comes from a step-by-step")
+    end
+
+    it 'returns correct text, when include_in_links is set to never' do
+      resource = described_class.new(
+        title: 'A Title',
+        base_path: '/a-base-path',
+        content_id: 'A-CONTENT-ID-BOOM',
+        include_in_links: 'never'
+      )
+      expect(resource.selected_option_text).to eq("Never show navigation")
+    end
+  end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -114,8 +114,8 @@ module StepNavSteps
     @step_by_step_page = create(:step_by_step_page, steps: [step], slug: "step-by-step-with-link-report")
   end
 
-  def given_there_is_a_draft_step_by_step_page_with_secondary_content
-    @step_by_step_page = create(:step_by_step_page_with_secondary_content, draft_updated_at: 1.day.ago)
+  def given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
+    @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules, draft_updated_at: 1.day.ago)
     expect(@step_by_step_page.status[:name]).to eq 'draft'
   end
 end


### PR DESCRIPTION
## What
When a user has scheduled a step by step for publishing, they should not be able to make any further changes to that step by step. 
- User _cannot_ change the navigation setting
- User _can_ view the navigation setting

**Not scheduled**
<img width="980" alt="not_scheduled" src="https://user-images.githubusercontent.com/38078064/63162513-a0be0080-c01a-11e9-99b2-0c777d99be10.png">

**Scheduled for publishing**
<img width="975" alt="locked" src="https://user-images.githubusercontent.com/38078064/63162524-a7e50e80-c01a-11e9-8903-5e71df3c178d.png">

## Why
This prevents any unexpected edits being published in error or too early.

[Trello card](https://trello.com/c/0yrygTBl/88-lock-a-step-by-step-that-has-been-scheduled-for-publication-on-the-choose-navigation-pages)