### PR TITLE
Update change note history

### DIFF
--- a/app/assets/javascripts/steps.js
+++ b/app/assets/javascripts/steps.js
@@ -13,7 +13,6 @@
       this.initialiseDragAndDrop();
       this.setOrder(); // this is called so the order of the list is initalised
       this.bindStatusClicks();
-      this.bindCancelAddChangeNoteLink();
       this.bindOverviewTableFilter();
     },
 
@@ -138,14 +137,6 @@
       function escapeStringForRegexp(str) {
         return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
       }
-    },
-
-    bindCancelAddChangeNoteLink: function() {
-      $('.add-change-note-cancel--link').on('click', function(e){
-        e.preventDefault();
-        $('.add-change-note-description--textarea').val('');
-        $('.add-change-note--details').removeAttr('open');
-      });
     }
   };
 }());

--- a/app/assets/stylesheets/_steps.scss
+++ b/app/assets/stylesheets/_steps.scss
@@ -135,52 +135,6 @@ $dark-grey-2: #6f777b;
   margin: 20px 0 20px;
 }
 
-.add-change-note--details {
-  margin-bottom: 20px;
-
-  &[open] {
-    .add-change-note--summary {
-      display: none;
-    }
-  }
-
-  .add-change-note--summary::-webkit-details-marker {
-    display: none;
-  }
-}
-
-.change-note--details {
-  border: 1px solid $border-grey;
-  border-radius: 4px;
-  padding: 10px 10px 0;
-  margin-bottom: 10px;
-
-  &[open] {
-    padding: 10px;
-
-    .change-note--summary {
-      border-bottom: 1px solid $border-grey;
-      margin-bottom: 10px;
-    }
-  }
-
-  .change-note--summary {
-    font-weight: bold;
-    margin: -10px -10px 0;
-    padding: 10px;
-  }
-}
-
-.change-note--description {
-  white-space: pre-wrap;
-  display: block;
-  padding: 20px;
-  margin: 0 0 10px;
-  color: $black;
-  word-wrap: break-word;
-  background-color: $light-grey-2;
-}
-
 .last-saved-by--text {
   margin: 20px 0 20px;
   color: $dark-grey;

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,3 +1,4 @@
 @import "./tabs";
 @import "./panel";
 @import "./markdown-editor";
+@import "./timeline-entry";

--- a/app/assets/stylesheets/components/_timeline-entry.scss
+++ b/app/assets/stylesheets/components/_timeline-entry.scss
@@ -1,0 +1,28 @@
+.app-c-timeline-entry {
+  margin-bottom: govuk-spacing(6);
+}
+
+.app-c-timeline-entry__title {
+  @include govuk-font(24, $weight: bold);
+  margin-top: 0;
+  margin-bottom: govuk-spacing(4);
+}
+
+.app-c-timeline-entry__type {
+  @include govuk-font(19, $weight: bold);
+  margin-top: 0;
+  margin-bottom: govuk-spacing(1);
+}
+
+.app-c-timeline-entry__dateline {
+  @include govuk-font(19);
+  margin-top: 0;
+  margin-bottom: govuk-spacing(4);
+  color: $govuk-secondary-text-colour;
+}
+
+.app-c-timeline-entry__description {
+  @include govuk-font(16);
+  margin-top: 0;
+  white-space: pre-line;
+}

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -25,56 +25,45 @@
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active: "internal-change-notes" %>
 
-<%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
-  <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <details class="add-change-note--details">
-        <summary class="add-change-note--summary">
-          <span class="gem-c-button govuk-button">Add a change note</span>
-        </summary>
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/textarea", {
-            label: {
-              text: "Description"
-            },
-            name: "internal_change_note[description]",
-            rows: 8
-          } %>
-        </div>
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Save change note"
-          } %>
-        </div>
-        <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to 'Cancel', step_by_step_page_internal_change_notes_path, class: "govuk-link add-change-note-cancel--link" %>
-        </div>
-      </details>
-    </div>
-  </div>
-<% end %>
-
+<% displayed_edition_number = nil %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/accordion", {
-      items: @step_by_step_page.internal_change_notes.map.with_index do |note, index|
-        {
-          heading: {
-            text: "#{note.readable_created_date}"
-          },
-          summary: {
-            text: sanitize("#{note.edition_number ? "Edition #{note.edition_number}" : "Current version"} - Change made by <strong>#{note.author}</strong>")
-          },
-          content: {
-            html: sanitize("
-              <pre class=\"govuk-body change-note--description\">#{note.description}</pre>
-            ")
-          },
-          expanded: index == 0
-        }
-      end
-    } %>
+    <%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
+      <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Internal note",
+          bold: true
+        },
+        name: "internal_change_note[description]"
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Add internal note",
+        margin_bottom: true
+      } %>
+    <% end %>
+
+    <% @step_by_step_page.internal_change_notes.each do |entry| %>
+      <div class="app-c-timeline-entry">
+        <% if displayed_edition_number != entry.edition_number %>
+          <h3 class="app-c-timeline-entry__title"><%= "#{entry.edition_number.to_i.ordinalize} edition" %></h3>
+          <% displayed_edition_number = entry.edition_number %>
+        <% end %>
+
+        <h4 class="app-c-timeline-entry__type">
+          <%= "Internal note" %>
+        </h4>
+
+        <p class="app-c-timeline-entry__dateline">
+          <%= entry.readable_created_date %> by <%= entry.author %>
+        </p>
+
+        <div class="app-c-timeline-entry__description">
+          <%= entry.description %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -25,7 +25,6 @@
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active: "internal-change-notes" %>
 
-<% displayed_edition_number = nil %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
@@ -45,25 +44,27 @@
       } %>
     <% end %>
 
-    <% @step_by_step_page.internal_change_notes.each do |entry| %>
-      <div class="app-c-timeline-entry">
-        <% if displayed_edition_number != entry.edition_number %>
-          <h3 class="app-c-timeline-entry__title"><%= "#{entry.edition_number.to_i.ordinalize} edition" %></h3>
-          <% displayed_edition_number = entry.edition_number %>
-        <% end %>
-
-        <h4 class="app-c-timeline-entry__type">
-          <%= "Internal note" %>
-        </h4>
-
-        <p class="app-c-timeline-entry__dateline">
-          <%= entry.readable_created_date %> by <%= entry.author %>
-        </p>
-
-        <div class="app-c-timeline-entry__description">
-          <%= entry.description %>
-        </div>
-      </div>
-    <% end %>
+    <%= render "govuk_publishing_components/components/accordion", {
+      items: @step_by_step_page.internal_change_notes
+        .group_by { |edition| edition.edition_number }
+        .map { |_ , records|
+          {
+            heading: {
+              text: sanitize("#{records.first.edition_number ? "#{records.first.edition_number.to_i.ordinalize} edition" : "Current version"}")
+            },
+            content: {
+              html: sanitize(records.map { |note|
+                  "<div class='app-c-timeline-entry'>
+                    <h4 class='app-c-timeline-entry__type'>Internal note</h4>
+                    <p class='app-c-timeline-entry__dateline'>#{note.readable_created_date} by #{note.author}</p>
+                    <pre class='app-c-timeline-entry__description'>#{note.description}</pre>
+                  </div>"
+                }.join
+              )
+            },
+            expanded: !records.first.edition_number
+          }
+        }
+    } %>
   </div>
 </div>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -56,8 +56,8 @@
   </div>
 <% end %>
 
-<div class="govuk-grid-row govuk-!-margin-top-3">
-  <div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/accordion", {
       items: @step_by_step_page.internal_change_notes.map.with_index do |note, index|
         {

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -213,5 +213,10 @@ RSpec.feature "Managing step by step pages" do
 
   def then_the_change_note_should_be_saved
     expect(page).to have_content "Change note was successfully added."
+    expect(page).to have_css(".govuk-accordion", count: 1)
+    within(".govuk-accordion") do
+      expect(page).to have_css(".govuk-accordion__section-heading", text: "Current version", count: 1)
+      expect(page).to have_css(".govuk-accordion__section-content", text: "I've changed this step by step!", count: 1)
+    end
   end
 end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -203,12 +203,12 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_I_write_a_change_note
-    fill_in "Description", with: "I've changed this step by step!"
+    fill_in "Internal note", with: "I've changed this step by step!"
   end
 
   def and_I_complete_a_change_note
     and_I_write_a_change_note
-    click_on "Save"
+    click_on "Add internal note"
   end
 
   def then_the_change_note_should_be_saved


### PR DESCRIPTION
This PR:

- Updates the change notes layout to use a  2/3 column for the internal notes timeline
- Make internal notes permanently visible
- Replaces the accordion with a [timeline entry pattern used consistently with content-publisher](https://github.com/alphagov/content-publisher/blob/60fa3c2fd2b351b2ca3ad5d1bd39f3ea1527918a/app/views/documents/show/_history_tab.html.erb)
- Use the accordion at the edition level (rather then internal note entry level).

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![internal-notes-before](https://user-images.githubusercontent.com/788096/63172172-ff907380-c034-11e9-89a7-c1aef56f1376.png)

</td><td valign="top">

![collections-publisher dev gov uk_step-by-step-pages_1_internal-change-notes copy](https://user-images.githubusercontent.com/788096/63273522-0964e180-c296-11e9-98aa-ccf5727eb3e1.png)

</td></tr>
</table>

**Note**: I appreciate the history of this PR doesn't make much sense as there was a bit of a back and forth on it, so I'd suggesting file-based review and I can squash them before merging.

[Trello card](https://trello.com/c/pmUvssRI)