### PR TITLE
Set the time zone to London

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,8 @@ module CollectionsPublisher
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    config.time_zone = "London"
+
     unless Rails.env.production?
       ENV['JWT_AUTH_SECRET'] = '123'
     end

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe StepByStepPagesController do
       schedule_for_future
 
       expect(step_by_step_page.scheduled_at.class.name).to eq 'Time'
-      expect(format_full_date_and_time(step_by_step_page.scheduled_at.in_time_zone("London"))).to eq 'Saturday, 20 April 2030 at 10:26 am'
+      expect(format_full_date_and_time(step_by_step_page.scheduled_at)).to eq 'Saturday, 20 April 2030 at 10:26 am'
     end
 
     it "sets the status to Scheduled" do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe Step do
     end
 
     it 'should return the last date the links where checked' do
-      create(:link_report, batch_id: 2, step_id: step_item.id, created_at: "2018-08-07 10:30:38")
-      expect(step_item.links_last_checked_date.utc).to eq(Time.new(2018, 8, 7, 10, 30, 38).utc)
+      create(:link_report, batch_id: 2, step_id: step_item.id, created_at: Time.zone.parse("2018-08-07 10:30:38"))
+      expect(step_item.links_last_checked_date).to eq(Time.zone.local(2018, 8, 7, 10, 30, 38))
     end
 
     it 'should not fail if the saved batch id does not match a batch in link-checker-api' do


### PR DESCRIPTION
Trello: https://trello.com/c/WrpUNtsn

Config taken from: https://github.com/alphagov/content-publisher/commit/4ae1c4ed683bf0b24eb11d135aebd3cdd1a8ffa6

We store dates in the database in UTC, which means that when we're displaying
dates and times in the views they're an hour out of date during daylight saving
time. This sets the app's time zone to 'London' so that ActiveRecord
automatically converts dates and times to the UK's current time zone, whether
it's GMT or BST.

Also updates a test that was trying to get around this problem by converting the dates checked to "UTC +00:00"

## Expected changes
### Before
![Screen Shot 2019-08-16 at 18 24 54](https://user-images.githubusercontent.com/5793815/63186702-07601000-c055-11e9-8ce6-ffb57161123c.png)
![Screen Shot 2019-08-16 at 18 25 08](https://user-images.githubusercontent.com/5793815/63186706-0b8c2d80-c055-11e9-9fc9-f52172eb0e23.png)

### After
![Screen Shot 2019-08-16 at 18 34 01](https://user-images.githubusercontent.com/5793815/63186726-18108600-c055-11e9-8db6-3e277d435e3e.png)
![Screen Shot 2019-08-16 at 18 34 25](https://user-images.githubusercontent.com/5793815/63186735-1c3ca380-c055-11e9-813b-bd3865b1f2a2.png)
