### PR TITLE
Change default page to Step by step pages

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  root to: redirect('/specialist-sector-pages', status: 302)
+  root to: redirect('/step-by-step-pages', status: 302)
 
   resources :step_by_step_pages, path: 'step-by-step-pages' do
     get 'navigation-rules', to: 'navigation_rules#edit'


### PR DESCRIPTION
The default page was Specialist sector pages, which is not used as often. We
are switch it to Step by step so its clear to users who are less familiar with
the tool.

[Trello card](https://trello.com/c/eA4r21sL/115-switch-the-default-tab-on-collections-publisher-to-be-step-by-step-pages)