### PR TITLE
Change the tab to View steps when Step by step is scheduled

### DIFF
--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -8,7 +8,7 @@
   tabs = [
     {
       href: @step_by_step_page,
-      label: "Edit steps",
+      label: @step_by_step_page.can_be_edited? ? "Edit steps" : "View steps",
       active: active == 'edit-steps'
     },
     {

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -17,7 +17,7 @@
 
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
-  action: 'Edit steps'
+  action: @step_by_step_page.can_be_edited? ? "Edit steps" : "View steps"
 %>
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active:"edit-steps" %>


### PR DESCRIPTION
## What
Change the 'Edit steps' tab to 'View steps' when Step by step is scheduled

**Not scheduled**
<kbd><img width="971" alt="not_scheduled" src="https://user-images.githubusercontent.com/38078064/63332959-7462f680-c330-11e9-9463-2385604ea6d1.png">

</kbd>

**Scheduled for publishing**
<kbd>
<img width="971" alt="scheduled" src="https://user-images.githubusercontent.com/38078064/63332970-7a58d780-c330-11e9-8b28-c73aa1ee8607.png">
</kbd>

## Why
Once the step by step is scheduled it is not possible to edit steps but they can still be viewed. The text on the tab is changed not to confuse content designers by giving the impression that the steps are editable.

[Trello card](https://trello.com/c/y3j0hfRN/133-change-the-edit-steps-tab-to-view-steps-when-step-by-step-is-scheduled)