### PR TITLE
Check steps have content before publishing

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -64,7 +64,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def can_be_published?
-    has_draft? && !scheduled_for_publishing? && steps.any?
+    has_draft? && !scheduled_for_publishing? && steps_have_content?
   end
 
   def can_be_unpublished?
@@ -147,5 +147,9 @@ private
       text: "Unpublished changes",
       label_class: "label-primary"
     }
+  end
+
+  def steps_have_content?
+    steps.any? && steps.map(&:contents).all?(&:present?)
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -83,6 +83,10 @@ class StepByStepPage < ApplicationRecord
     !scheduled_for_publishing?
   end
 
+  def steps_have_content?
+    steps.any? && steps.map(&:contents).all?(&:present?)
+  end
+
   # Create a deterministic, but unique token that will be used to give one-time
   # access to a piece of draft content.
   # This token is created by using an id that should be unique so that there is
@@ -147,9 +151,5 @@ private
       text: "Unpublished changes",
       label_class: "label-primary"
     }
-  end
-
-  def steps_have_content?
-    steps.any? && steps.map(&:contents).all?(&:present?)
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -64,7 +64,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def can_be_published?
-    has_draft? && !scheduled_for_publishing?
+    has_draft? && !scheduled_for_publishing? && steps.any?
   end
 
   def can_be_unpublished?

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -28,15 +28,6 @@
     <% if @step_by_step_page.can_be_published? || @step_by_step_page.can_discard_changes? ||  @step_by_step_page.scheduled_for_publishing?%>
       <div class="govuk-panel panel-default">
         <div class="panel-body">
-          <% if @step_by_step_page.can_be_published? %>
-            <p class="govuk-body">Before publishing check for broken links.</p>
-            <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
-            <%= render "govuk_publishing_components/components/button", {
-              text: "Publish changes",
-              href: step_by_step_page_publish_path(@step_by_step_page)
-            } %>
-          <% end %>
-
           <% if @step_by_step_page.scheduled_for_publishing? %>
             <p class="govuk-body">
               Scheduled to be published on <%= format_full_date_and_time(@step_by_step_page.scheduled_at) %>
@@ -47,7 +38,14 @@
                 destructive: true
               } %>
             <% end %>
-          <% else %>
+          <% end %>
+          <% if @step_by_step_page.can_be_published? %>
+            <p class="govuk-body">Before publishing check for broken links.</p>
+            <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Publish changes",
+              href: step_by_step_page_publish_path(@step_by_step_page)
+            } %>
             <p class="govuk-body govuk-!-margin-top-5">Or</p>
             <%= render "govuk_publishing_components/components/button", {
               text: "Schedule publish",
@@ -57,7 +55,9 @@
           <% end %>
 
           <% if @step_by_step_page.can_discard_changes? %>
-            <p class="govuk-body govuk-!-margin-top-5">Or</p>
+            <% if @step_by_step_page.can_be_published? %>
+              <p class="govuk-body govuk-!-margin-top-5">Or</p>
+            <% end %>
             <%= button_to 'Discard changes', { action: "revert", step_by_step_page_id: @step_by_step_page.id }, data: { confirm: 'This will delete your draft. Do you want to discard your changes?' }, class: "gem-c-button govuk-button govuk-button--warning" %>
           <% end %>
           </div>

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -25,7 +25,7 @@
 
 <div class="govuk-grid-row publish-or-delete">
   <div class="govuk-grid-column-full">
-    <% if @step_by_step_page.can_be_published? || @step_by_step_page.can_discard_changes? ||  @step_by_step_page.scheduled_for_publishing?%>
+    <% if @step_by_step_page.can_be_published? || @step_by_step_page.can_discard_changes? || @step_by_step_page.scheduled_for_publishing? || !@step_by_step_page.steps_have_content? %>
       <div class="govuk-panel panel-default">
         <div class="panel-body">
           <% if @step_by_step_page.scheduled_for_publishing? %>
@@ -38,8 +38,7 @@
                 destructive: true
               } %>
             <% end %>
-          <% end %>
-          <% if @step_by_step_page.can_be_published? %>
+          <% elsif @step_by_step_page.can_be_published? %>
             <p class="govuk-body">Before publishing check for broken links.</p>
             <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
             <%= render "govuk_publishing_components/components/button", {
@@ -52,6 +51,10 @@
               href: step_by_step_page_schedule_path(@step_by_step_page),
               secondary: true
             } %>
+          <% elsif !@step_by_step_page.steps_have_content? %>
+            <p class="govuk-body">
+              Step by steps cannot be published until all steps have content.
+            </p>
           <% end %>
 
           <% if @step_by_step_page.can_discard_changes? %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -193,6 +193,14 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
+  scenario "A step doesn't have any content" do
+    given_there_is_a_step_by_step_page_with_steps_missing_content
+    when_I_visit_the_publish_or_delete_page
+    then_I_should_see "Step by steps cannot be published until all steps have content."
+    and_there_should_be_no_publish_button
+    and_there_should_be_no_schedule_button
+  end
+
   def and_it_has_change_notes
     create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end
@@ -578,6 +586,8 @@ RSpec.feature "Managing step by step pages" do
       expect(page).to_not have_css("button", text: "Publish changes")
     end
   end
+
+  alias_method :and_there_should_be_no_publish_button, :then_there_should_be_no_publish_button
 
   def then_there_should_be_no_discard_changes_button
     within(".publish-or-delete") do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -292,7 +292,7 @@ RSpec.describe StepByStepPage do
   describe '#can_be_published?' do
     let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
 
-    it 'can be published if it has a draft and it is not scheduled for publishing' do
+    it 'can be published if it has a draft, is not scheduled for publishing and all steps have content' do
       step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be true
@@ -311,6 +311,13 @@ RSpec.describe StepByStepPage do
 
     it 'cannot be published if there are no steps' do
       step_by_step_page = create(:step_by_step_page, slug: "no-steps")
+      step_by_step_page.mark_draft_updated
+
+      expect(step_by_step_page.can_be_published?).to be false
+    end
+
+    it 'cannot be published if all steps do not have content' do
+      create(:step, step_by_step_page: step_by_step_page, contents: "")
       step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be false

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -290,7 +290,7 @@ RSpec.describe StepByStepPage do
   end
 
   describe '#can_be_published?' do
-    let(:step_by_step_page) { create(:step_by_step_page) }
+    let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
 
     it 'can be published if it has a draft and it is not scheduled for publishing' do
       step_by_step_page.mark_draft_updated
@@ -305,6 +305,13 @@ RSpec.describe StepByStepPage do
     it 'cannot be published if it is scheduled for publishing' do
       step_by_step_page.mark_draft_updated
       step_by_step_page.scheduled_at = Date.tomorrow
+
+      expect(step_by_step_page.can_be_published?).to be false
+    end
+
+    it 'cannot be published if there are no steps' do
+      step_by_step_page = create(:step_by_step_page, slug: "no-steps")
+      step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be false
     end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -118,4 +118,9 @@ module StepNavSteps
     @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules, draft_updated_at: 1.day.ago)
     expect(@step_by_step_page.status[:name]).to eq 'draft'
   end
+
+  def given_there_is_a_step_by_step_page_with_steps_missing_content
+    @step_by_step_page = create(:draft_step_by_step_page)
+    create(:step, step_by_step_page: @step_by_step_page, contents: "")
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/3qZiI22D

## What
Hides the "Publish" and "Schedule Publish" buttons if there are no steps, and if any steps don't have content.

## Why
Step by steps will still be able to be saved and previewed, but hiding the buttons will prevent any incomplete step by steps from being accidentally published.

## Expected changes
### Step by step with unpublished changes
![Screen Shot 2019-08-20 at 18 10 56](https://user-images.githubusercontent.com/5793815/63368794-8d8e9600-c376-11e9-9d53-6de619be494e.png)


### Draft step by step
![Screen Shot 2019-08-20 at 18 10 36](https://user-images.githubusercontent.com/5793815/63368772-8071a700-c376-11e9-97d9-1036c315fe64.png)
