### PR TITLE
Update heading and metadata on summary page

### DIFF
--- a/app/assets/stylesheets/_steps.scss
+++ b/app/assets/stylesheets/_steps.scss
@@ -162,15 +162,6 @@ $dark-grey-2: #6f777b;
   font-size: 16px;
 }
 
-.step-by-step-actions__list {
-  padding: govuk-spacing(3);
-  background: govuk-colour("grey-4");
-
-  .gem-c-button {
-    width: 100%;
-  }
-}
-
 .step-list {
   .step-list__title {
     max-width: 300px;

--- a/app/assets/stylesheets/admin_layout.scss
+++ b/app/assets/stylesheets/admin_layout.scss
@@ -1,4 +1,5 @@
 @import "govuk_publishing_components/all_components";
 @import "./components/all";
+@import "./objects/side";
 @import "./utilities/overrides";
 @import "./steps";

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -1,0 +1,18 @@
+.app-side {
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-clearfix;
+
+  padding: govuk-spacing(3);
+  background: govuk-colour("grey-4");
+}
+
+.app-side__actions {
+  .govuk-button {
+    width: 100%;
+    margin-bottom: govuk-spacing(3);
+  }
+
+  .govuk-button:last-child {
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -48,3 +48,34 @@
     margin-bottom: 10px;
   }
 }
+
+.gem-c-metadata {
+  @include govuk-font(19);
+  margin-bottom: 0;
+
+  dl {
+    margin: 0;
+  }
+
+  .gem-c-metadata__term {
+    width: auto;
+    max-width: inherit;
+    padding-right: 0;
+    float: none;
+    @include govuk-font($size: 19, $weight: bold);
+  }
+
+  .gem-c-metadata__definition {
+    width: auto;
+    margin: 0;
+    margin-bottom: govuk-spacing(3);
+    float: none;
+
+    &:last-child {
+      margin: 0;
+    }
+
+    @include govuk-clearfix;
+  }
+
+}

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -89,7 +89,7 @@ class StepByStepPagesController < ApplicationController
         render :schedule
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish
-        note_description = "Minor update scheduled by #{current_user.name} for publishing on #{format_full_date_and_time(scheduled_at)}"
+        note_description = "Minor update scheduled by #{current_user.name} for publishing at #{format_full_date_and_time(scheduled_at)}"
         generate_internal_change_note(note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been scheduled to publish."

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -17,7 +17,7 @@ module TimeOptionsHelper
   end
 
   def format_full_date_and_time(datetime)
-    datetime.strftime('%A, %d %B %Y at %-l:%M %P')
+    datetime.strftime('%-l:%M%P on %-d %B %Y')
   end
 
   def default_datetime_placeholder(

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -103,8 +103,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def links_last_checked_date
-    date = steps.map(&:links_last_checked_date).reject(&:blank?).max
-    date.strftime('%A, %d %B %Y at %H:%M %p') if date
+    steps.map(&:links_last_checked_date).reject(&:blank?).max
   end
 
   def links_checked?

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -42,7 +42,7 @@
     <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>
 
-    <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
+    <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank?%>" id="main-content" role="main">
       <% if flash["notice"].present? %>
         <%= render "govuk_publishing_components/components/success_alert", {
           message: flash["notice"]

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -30,7 +30,7 @@
         <div class="panel-body">
           <% if @step_by_step_page.scheduled_for_publishing? %>
             <p class="govuk-body">
-              Scheduled to be published on <%= format_full_date_and_time(@step_by_step_page.scheduled_at) %>
+              Scheduled to be published at <%= format_full_date_and_time(@step_by_step_page.scheduled_at) %>
             </p>
             <%= form_tag step_by_step_page_unschedule_path(@step_by_step_page), method: :unschedule do %>
               <%= render "govuk_publishing_components/components/button", {

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -1,8 +1,7 @@
-
 <%
   links = [
     {
-      text: 'Step by step publisher',
+      text: 'Step by steps',
       href: step_by_step_pages_path
     },
     {
@@ -11,14 +10,9 @@
   ]
 %>
 
-<%= render 'shared/steps/step_breadcrumb', links: links %>
-
-<%= render 'shared/steps/page_title', links: links %>
-
-<%= render 'shared/steps/heading',
-  step_nav: @step_by_step_page.title,
-  action: @step_by_step_page.can_be_edited? ? "Edit steps" : "View steps"
-%>
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, @step_by_step_page.title %>
+<% content_for :context, 'Step by step' %>
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active:"edit-steps" %>
 

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -72,35 +72,33 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <ul class="govuk-list step-by-step-actions__list">
-      <% if @step_by_step_page.can_be_edited? %>
-        <li>
+    <div class="app-side">
+      <div class="app-side__actions">
+        <% if @step_by_step_page.can_be_edited? %>
           <%= render "govuk_publishing_components/components/button", {
             text: "Add a new step",
             href: new_step_by_step_page_step_path(@step_by_step_page)
           } %>
-      </li>
-      <% end %>
-      <li class="govuk-!-margin-top-2">
+        <% end %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Preview",
           href: preview_url(@step_by_step_page.slug, auth_bypass_id: @step_by_step_page.auth_bypass_id),
           secondary: true
         } %>
-      </li>
-      <li class="govuk-!-margin-top-2">
         <%= button_to "Check for broken links", {action: "check_links", step_by_step_page_id: @step_by_step_page.id}, method: :post, class: "govuk-button gem-c-button gem-c-button--secondary-quiet" %>
-      </li>
-    </ul>
-  </div>
-</div>
+      </div>
+    </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <% if @step_by_step_page.links_checked? %>
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: sanitize("<strong>Links last checked:</strong> <br/>#{@step_by_step_page.links_last_checked_date}")
-      } %>
-    <% end %>
+    <div class="app-side">
+      <%
+        metadata = {}
+        metadata.store("Status", @step_by_step_page.status[:text])
+        metadata.store("Last updated", format_full_date_and_time(@step_by_step_page.updated_at))
+        metadata["Last updated"] = "#{metadata["Last updated"]} by #{@step_by_step_page.assigned_to}" if @step_by_step_page.assigned_to.present?
+        metadata.store("Created", format_full_date_and_time(@step_by_step_page.created_at))
+        metadata.store("Links checked", @step_by_step_page.links_last_checked_date) if @step_by_step_page.links_checked?
+      %>
+      <%= render "govuk_publishing_components/components/metadata", { other: metadata } %>
+    </div>
   </div>
 </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -96,7 +96,7 @@
         metadata.store("Last updated", format_full_date_and_time(@step_by_step_page.updated_at))
         metadata["Last updated"] = "#{metadata["Last updated"]} by #{@step_by_step_page.assigned_to}" if @step_by_step_page.assigned_to.present?
         metadata.store("Created", format_full_date_and_time(@step_by_step_page.created_at))
-        metadata.store("Links checked", @step_by_step_page.links_last_checked_date) if @step_by_step_page.links_checked?
+        metadata.store("Links checked", format_full_date_and_time(@step_by_step_page.links_last_checked_date)) if @step_by_step_page.links_checked?
       %>
       <%= render "govuk_publishing_components/components/metadata", { other: metadata } %>
     </div>

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe StepByStepPagesController do
       schedule_for_future
 
       expect(step_by_step_page.scheduled_at.class.name).to eq 'Time'
-      expect(format_full_date_and_time(step_by_step_page.scheduled_at)).to eq 'Saturday, 20 April 2030 at 10:26 am'
+      expect(format_full_date_and_time(step_by_step_page.scheduled_at)).to eq '10:26am on 20 April 2030'
     end
 
     it "sets the status to Scheduled" do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -392,7 +392,10 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_I_see_I_saved_it_last
-    expect(page).to have_content("Last saved by Test author")
+    within(".gem-c-metadata") do
+      expect(page).to have_content("Status: Draft")
+      expect(page).to have_content("by Test author")
+    end
   end
 
   def and_I_visit_the_scheduling_page

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -146,7 +146,7 @@ RSpec.feature "Managing step by step pages" do
       when_I_submit_the_form
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
-      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing on Saturday, 20 April 2030 at 10:26 am"
+      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at 10:26am on 20 April 2030"
       and_the_step_by_step_is_not_editable
       when_I_view_the_step_by_step_page
       then_I_can_preview_the_step_by_step
@@ -167,7 +167,7 @@ RSpec.feature "Managing step by step pages" do
     scenario "User tries to schedule publishing for an already scheduled step by step" do
       given_there_is_a_scheduled_step_by_step_page
       when_I_visit_the_publish_or_delete_page
-      then_I_should_see "Scheduled to be published on"
+      then_I_should_see "Scheduled to be published at"
       and_there_should_be_no_schedule_button
     end
 

--- a/spec/helpers/time_options_helper_spec.rb
+++ b/spec/helpers/time_options_helper_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe TimeOptionsHelper do
   describe "#format_full_date_and_time" do
     it "formats the date and time correctly" do
       datetime = Time.new(2030, 4, 20, 10, 26, 0, '+01:00') # London timezone
-      expect(helper.format_full_date_and_time(datetime)).to eq("Saturday, 20 April 2030 at 10:26 am")
+      expect(helper.format_full_date_and_time(datetime)).to eq("10:26am on 20 April 2030")
     end
   end
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe StepByStepPage do
       create(:link_report, batch_id: 1, step_id: step1.id, created_at: "2018-08-07 10:31:38")
       create(:link_report, batch_id: 2, step_id: step2.id, created_at: "2018-08-07 10:30:38")
 
-      expect(step_by_step_with_step.links_last_checked_date).to eq("Tuesday, 07 August 2018 at 10:31 AM")
+      expect(step_by_step_with_step.links_last_checked_date).to eq(Time.zone.local(2018, 8, 7, 10, 31, 38))
     end
 
     it 'does not fail if there are no link reports' do


### PR DESCRIPTION
This PR updates the summary page as follows:
- Updates the header of the page to use the admin_layout yield blocks
- Uses the metadata component to display information about the step-by-step

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![summary-heading-status-before](https://user-images.githubusercontent.com/788096/63358774-80b47700-c363-11e9-881e-dd14780d8c57.png)

</td><td valign="top">

![summary-heading-status-after](https://user-images.githubusercontent.com/788096/63358787-86aa5800-c363-11e9-922d-f2816d2f8b71.png)

</td></tr>
</table>


[Trello card](https://trello.com/c/arYq0tST)