### PR TITLE
Bypass changelog screen when first publishing step by steps

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -62,7 +62,7 @@ class StepByStepPagesController < ApplicationController
   def publish
     set_current_page_as_step_by_step
     if request.post?
-      @publish_intent = PublishIntent.new(params)
+      @publish_intent = PublishIntent.new(publish_intent_params)
       if @publish_intent.valid?
         publish_page(@publish_intent)
         custom_note = " with note: #{@publish_intent.change_note}" unless @publish_intent.change_note.empty?
@@ -167,6 +167,10 @@ private
 
   def update_downstream
     StepByStepDraftUpdateWorker.perform_async(@step_by_step_page.id, current_user.name)
+  end
+
+  def publish_intent_params
+    @step_by_step_page.has_been_published? ? params : { update_type: "minor" }
   end
 
   def publish_page(publish_intent)

--- a/app/models/publish_intent.rb
+++ b/app/models/publish_intent.rb
@@ -12,7 +12,7 @@ class PublishIntent
 
   def initialize(params)
     @update_type = params[:update_type]
-    @change_note = params[:change_note]
+    @change_note = params[:change_note] || ""
   end
 
   def major_update?
@@ -22,7 +22,7 @@ class PublishIntent
   def present
     {
       update_type: update_type,
-      change_note: change_note || ""
+      change_note: change_note
     }
   end
 end

--- a/app/views/step_by_step_pages/publish_or_delete.html.erb
+++ b/app/views/step_by_step_pages/publish_or_delete.html.erb
@@ -41,10 +41,16 @@
           <% elsif @step_by_step_page.can_be_published? %>
             <p class="govuk-body">Before publishing check for broken links.</p>
             <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
-            <%= render "govuk_publishing_components/components/button", {
-              text: "Publish changes",
-              href: step_by_step_page_publish_path(@step_by_step_page)
-            } %>
+            <% if @step_by_step_page.has_been_published? %>
+              <%= render "govuk_publishing_components/components/button", {
+                text: "Publish changes",
+                href: step_by_step_page_publish_path(@step_by_step_page)
+              } %>
+            <% else %>
+              <%= form_for(@step_by_step_page, url: step_by_step_page_publish_path(@step_by_step_page), method: :post) do %>
+                <%= render "govuk_publishing_components/components/button", text: "Publish" %>
+              <% end %>
+            <% end %>
             <p class="govuk-body govuk-!-margin-top-5">Or</p>
             <%= render "govuk_publishing_components/components/button", {
               text: "Schedule publish",

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe StepByStepPagesController do
 
   describe "#publish" do
     context 'major updates' do
+      let(:step_by_step_page) { create(:published_step_by_step_page) }
+
       it "generates an internal change note with change note text" do
         stub_publishing_api
 
@@ -62,6 +64,8 @@ RSpec.describe StepByStepPagesController do
     end
 
     context 'minor updates' do
+      let(:step_by_step_page) { create(:published_step_by_step_page) }
+
       it "generates an internal change note with change note text" do
         stub_publishing_api
 

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe StepByStepPagesController do
   end
 
   describe "#publish" do
+    context 'first publish' do
+      it "generates an internal change note stating that this is the first publication" do
+        stub_publishing_api
+
+        post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor" }
+
+        expected_description = "First published by Name Surname"
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+      end
+    end
+
     context 'major updates' do
       let(:step_by_step_page) { create(:published_step_by_step_page) }
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -59,8 +59,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_visit_the_publish_or_delete_page
     and_I_visit_the_publish_page
     and_I_publish_the_page
-    then_the_page_is_published
-    and_I_am_told_that_it_is_published
+    then_I_am_told_that_it_is_published
     then_I_see_the_step_by_step_page
     and_I_visit_the_publish_or_delete_page
     and_I_see_an_unpublish_button
@@ -373,7 +372,7 @@ RSpec.feature "Managing step by step pages" do
     click_on "Publish step by step"
   end
 
-  def and_I_am_told_that_it_is_published
+  def then_I_am_told_that_it_is_published
     expect(page).to have_content("has been published")
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -123,6 +123,15 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_a_page_reverted_success_notice
   end
 
+  scenario "User publishes changes to a live step by step page" do
+    given_there_is_a_published_step_by_step_page_with_unpublished_changes
+    and_I_visit_the_publish_or_delete_page
+    and_I_click_button "Publish changes"
+    then_I_should_see_a_publish_form_with_changenotes
+    and_when_I_click_button "Publish step by step"
+    then_I_am_told_that_it_is_published
+  end
+
   scenario "User publishes and then makes more changes to a step by step page" do
     given_there_is_a_step_by_step_page_assigned_to_me
     and_I_visit_the_publish_page
@@ -402,6 +411,23 @@ RSpec.feature "Managing step by step pages" do
   end
 
   alias_method :when_I_visit_the_scheduling_page, :and_I_visit_the_scheduling_page
+
+  def and_I_click_button(button_text)
+    begin
+      click_button button_text, exact: true
+    rescue Capybara::ElementNotFound
+      # some button-like things are actually marked up as link
+      click_link button_text, exact: true
+    end
+  end
+
+  alias_method :and_when_I_click_button, :and_I_click_button
+
+  def then_I_should_see_a_publish_form_with_changenotes
+    expect(page).to have_content("Update type")
+    expect(page).to have_css('input[type="radio"][name="update_type"]', count: 2)
+    expect(page).to have_css('textarea[name="change_note"]')
+  end
 
   def and_I_fill_in_the_scheduling_form
     fill_in 'schedule[date][year]', with: "2030"

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -54,11 +54,9 @@ RSpec.feature "Managing step by step pages" do
   end
 
   scenario "User publishes a page" do
-    given_there_is_a_step_by_step_page_with_steps
-    when_I_view_the_step_by_step_page
+    given_there_is_a_draft_step_by_step_page
     and_I_visit_the_publish_or_delete_page
-    and_I_visit_the_publish_page
-    and_I_publish_the_page
+    and_I_click_button "Publish"
     then_I_am_told_that_it_is_published
     then_I_see_the_step_by_step_page
     and_I_visit_the_publish_or_delete_page

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -61,6 +61,7 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_the_step_by_step_page
     and_I_visit_the_publish_or_delete_page
     and_I_see_an_unpublish_button
+    and_there_should_be_a_change_note "First published by Test author"
   end
 
   scenario "User unpublishes a step by step page with a valid redirect url" do
@@ -131,7 +132,7 @@ RSpec.feature "Managing step by step pages" do
   end
 
   scenario "User publishes and then makes more changes to a step by step page" do
-    given_there_is_a_step_by_step_page_assigned_to_me
+    given_I_am_assigned_to_a_live_step_by_step_page_with_unpublished_changes
     and_I_visit_the_publish_page
     and_I_publish_the_page
     then_there_should_be_a_change_note "Minor update published by #{stub_user.name}"

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -79,8 +79,8 @@ module StepNavSteps
     expect(@step_by_step_page.status[:name]).to eq 'unpublished_changes'
   end
 
-  def given_there_is_a_step_by_step_page_assigned_to_me
-    @step_by_step_page = create(:step_by_step_page_with_navigation_rules, assigned_to: stub_user.name)
+  def given_I_am_assigned_to_a_live_step_by_step_page_with_unpublished_changes
+    @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: Time.zone.now, assigned_to: stub_user.name)
   end
 
   def given_there_is_a_scheduled_step_by_step_page

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -44,11 +44,6 @@ module StepNavSteps
     assert_publishing_api_put_content(@step_by_step_page.content_id)
   end
 
-  def then_the_page_is_published
-    payload = StepNavPresenter.new(@step_by_step_page).render_for_publishing_api
-    stub_publishing_api_put_content_links_and_publish(payload, @step_by_step_page.content_id)
-  end
-
   def then_the_page_is_unpublished
     assert_publishing_api_unpublish(@step_by_step_page.content_id)
   end


### PR DESCRIPTION
When first publishing a step by step, it makes little sense to provide a changenote or
to designate a change as Major or Minor.
This change makes the publish screen show a "Publish" button for draft step by steps,
which publishes immediately. Published step by steps will continue to have a "Publish
changes" button with an intermediary changenotes screen.

Trello: https://trello.com/c/VKLFfznn/120-update-the-publishing-flow-so-the-change-note-minor-major-only-shows-if-updating-a-live-version