### PR TITLE
Upgrade govuk_publishing_components (19.0.0) & use summary_list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'gds-api-adapters', '~> 60.0'
 gem 'gds-sso', '~> 14.1'
 gem 'govuk_admin_template', '~> 6.7'
 gem 'govuk_app_config', '~> 2.0'
-gem 'govuk_publishing_components', '~> 17.19'
+gem 'govuk_publishing_components', '~> 19.0'
 gem 'govuk_sidekiq', '~> 3.0'
 gem 'plek', '~> 3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,10 +127,10 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (8.2.0)
+    govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (17.19.1)
+    govuk_publishing_components (19.0.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -284,7 +284,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.7.0)
+    rouge (3.9.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -418,7 +418,7 @@ DEPENDENCIES
   govuk-lint (~> 3.11.5)
   govuk_admin_template (~> 6.7)
   govuk_app_config (~> 2.0)
-  govuk_publishing_components (~> 17.19)
+  govuk_publishing_components (~> 19.0)
   govuk_sidekiq (~> 3.0)
   govuk_test
   jasmine (~> 3.4)

--- a/app/assets/stylesheets/_steps.scss
+++ b/app/assets/stylesheets/_steps.scss
@@ -28,7 +28,7 @@ $dark-grey-2: #6f777b;
   margin: 0 0 govuk-spacing(2);
   color: $black;
   word-wrap: break-word;
-  background-color: govuk-colour('grey-4');
+  background-color: govuk-colour("light-grey", $legacy: "grey-4");
 }
 
 // hide up button in first row and down button in last row
@@ -172,7 +172,7 @@ $dark-grey-2: #6f777b;
   .js-reorder {
     padding: 20px;
     border: 1px solid $dark-grey-2;
-    background-color: govuk-colour('white');
+    background-color: govuk-colour("white", $legacy: "white");
   }
 
   .step-by-step-reorder__step-title {

--- a/app/assets/stylesheets/admin_layout.scss
+++ b/app/assets/stylesheets/admin_layout.scss
@@ -1,3 +1,5 @@
+$govuk-use-legacy-palette: true;
+
 @import "govuk_publishing_components/all_components";
 @import "./components/all";
 @import "./objects/side";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,4 @@
+$govuk-compatibility-govuktemplate: true;
+
 @import "govuk_publishing_components/all_components";
 @import "./components/autocomplete";

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -4,7 +4,7 @@
 $app-focus-colour: #ffdd00;
 
 .autocomplete__wrapper {
-  background: govuk-colour("white");
+  background: govuk-colour("white", $legacy: "white");
 }
 
 .autocomplete__input {
@@ -30,10 +30,10 @@ $app-focus-colour: #ffdd00;
 
 .autocomplete__option--focused,
 .autocomplete__option:hover {
-  color: govuk-colour("white");
+  color: govuk-colour("white", $legacy: "white");
 
   .autocomplete__option-hint {
-    color: govuk-colour("white");
+    color: govuk-colour("white", $legacy: "white");
   }
 }
 

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -21,13 +21,13 @@ $app-toolbar-button-size: 50px;
   display: block;
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   border-bottom: 0;
-  background-color: govuk-colour("white");
+  background-color: govuk-colour("white", $legacy: "white");
 }
 
 .app-c-markdown-editor__preview-toggle {
   width: 100%;
   border-bottom: $govuk-border-width-form-element solid $govuk-border-colour;
-  background-color: govuk-colour("grey-3");
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
 }
 
 .app-c-markdown-editor__button {
@@ -54,11 +54,11 @@ $app-toolbar-button-size: 50px;
   border-right: $govuk-border-width-form-element solid $govuk-border-colour;
   border-left: $govuk-border-width-form-element solid $govuk-border-colour;
   color: $govuk-text-colour;
-  background: govuk-colour("grey-4");
+  background: govuk-colour("light-grey", $legacy: "grey-4");
   text-decoration: none;
 
   &:focus {
-    background-color: govuk-colour("grey-4");
+    background-color: govuk-colour("light-grey", $legacy: "grey-4");
   }
 
   &:first-child {
@@ -78,7 +78,7 @@ $app-toolbar-button-size: 50px;
   .govuk-textarea {
     padding: govuk-spacing(6);
     overflow: scroll;
-    background-color: govuk-colour("grey-4");
+    background-color: govuk-colour("light-grey", $legacy: "grey-4");
   }
 
   .govuk-govspeak {
@@ -89,7 +89,7 @@ $app-toolbar-button-size: 50px;
 }
 
 .app-c-markdown-editor__toolbar {
-  background-color: govuk-colour("grey-4");
+  background-color: govuk-colour("light-grey", $legacy: "grey-4");
   line-height: 0;
 }
 
@@ -99,18 +99,19 @@ $app-toolbar-button-size: 50px;
 }
 
 .app-c-markdown-editor__toolbar-button {
-  @include govuk-focusable-fill;
   display: inline-block;
   width: $app-toolbar-button-size;
   height: $app-toolbar-button-size;
   background: none;
 
   &:focus {
-    outline-offset: -$govuk-focus-width;
+    @include govuk-focused-text;
+    outline: none;
+    box-shadow: none;
   }
 
   &:hover {
-    background-color: govuk-colour("grey-3");
+    background-color: govuk-colour("light-grey", $legacy: "grey-3");
     cursor: pointer;
   }
 }
@@ -127,7 +128,7 @@ $app-toolbar-button-size: 50px;
   width: auto;
   padding: govuk-spacing(3);
   border: 0;
-  border-left: 4px solid govuk-colour("white");
+  border-left: 4px solid govuk-colour("white", $legacy: "white");
   background: transparent;
   vertical-align: top;
 }

--- a/app/assets/stylesheets/components/_panel.scss
+++ b/app/assets/stylesheets/components/_panel.scss
@@ -1,14 +1,14 @@
 .app-c-panel {
   &.govuk-panel--inverse {
-    color: govuk-colour('white');
-    background-color: govuk-colour('blue');
+    color: govuk-colour("white", $legacy: "white");
+    background-color: govuk-colour("blue", $legacy: "blue");
     text-align: left;
 
     .app-c-panel__title,
     .govuk-body,
     .govuk-body-s,
     .govuk-list {
-      color: govuk-colour('white');
+      color: govuk-colour("white", $legacy: "white");
     }
   }
 }

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -3,7 +3,7 @@
   @include govuk-clearfix;
 
   padding: govuk-spacing(3);
-  background: govuk-colour("grey-4");
+  background: govuk-colour("light-grey", $legacy: "grey-4");
 }
 
 .app-side__actions {

--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -1,7 +1,3 @@
-.gem-c-layout-for-admin {
-  @include _govuk-font-face-nta;
-}
-
 .gem-c-phase-banner {
   .gem-c-phase-banner__banner-item {
     display: none;
@@ -34,12 +30,12 @@
 
 .govuk-tag {
   &.govuk-tag--warning {
-    background-color: govuk-colour('yellow');
-    color: govuk-colour('black');
+    background-color: govuk-colour("yellow", $legacy: "yellow");
+    color: govuk-colour("black", $legacy: "black");
   }
 
   &.govuk-tag--success {
-    background-color: govuk-colour('green');
+    background-color: govuk-colour("green", $legacy: "green");
   }
 }
 

--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -1,4 +1,5 @@
 class StepByStepPagePresenter
+  include Rails.application.routes.url_helpers
   include TimeOptionsHelper
   attr_reader :step_by_step_page
 
@@ -19,6 +20,37 @@ class StepByStepPagePresenter
       )
     end
     items
+  end
+
+  def summary_list_params
+    {
+      borderless: true,
+      title: "Content",
+      edit: {
+        href: edit_step_by_step_page_path(step_by_step_page),
+        data_attributes: {
+          gtm: "edit-title-summary-body"
+        }
+      },
+      items: [
+        {
+          field: "Title",
+          value: step_by_step_page.title
+        },
+        {
+          field: "Slug",
+          value: step_by_step_page.slug
+        },
+        {
+          field: "Introduction",
+          value: step_by_step_page.introduction
+        },
+        {
+          field: "Description",
+          value: step_by_step_page.description
+        }
+      ]
+    }
   end
 
   def last_saved

--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -23,15 +23,9 @@ class StepByStepPagePresenter
   end
 
   def summary_list_params
-    {
+    params = {
       borderless: true,
       title: "Content",
-      edit: {
-        href: edit_step_by_step_page_path(step_by_step_page),
-        data_attributes: {
-          gtm: "edit-title-summary-body"
-        }
-      },
       items: [
         {
           field: "Title",
@@ -51,6 +45,15 @@ class StepByStepPagePresenter
         }
       ]
     }
+    if step_by_step_page.can_be_edited?
+      params.merge!(edit: {
+        href: edit_step_by_step_page_path(step_by_step_page),
+        data_attributes: {
+          gtm: "edit-title-summary-body"
+        }
+      })
+    end
+    params
   end
 
   def last_saved

--- a/app/views/components/_tabs.html.erb
+++ b/app/views/components/_tabs.html.erb
@@ -6,17 +6,17 @@
     <h2 class="govuk-tabs__title">
       Contents
     </h2>
-    <ul class="govuk-tabs__list">
+    <ul class="govuk-tabs__list" role="tablist">
       <% tabs.each do |tab| %>
-      <li class="govuk-tabs__list-item">
-        <%
-          tab[:class] = %w(govuk-tabs__tab)
-          tab[:class] << "govuk-tabs__tab--selected" if tab[:active]
-          tab[:class] = tab[:class].join(" ")
-        %>
+      <%
+        tab[:class] = %w(govuk-tabs__list-item)
+        tab[:class] << "govuk-tabs__list-item--selected" if tab[:active]
+        tab[:class] = tab[:class].join(" ")
+      %>
+      <li class="<%= tab[:class] %>" role="presentation">
         <%= link_to(tab[:label],
                     tab[:href],
-                    class: tab[:class]) %>
+                    class: "govuk-tabs__tab") %>
       </li>
       <% end %>
     </ul>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -18,6 +18,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.summary_list_params %>
+
     <table class="govuk-table step-list">
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "license": "MIT",
   "dependencies": {
     "@webcomponents/custom-elements": "^1.2.1",
-    "es5-polyfill": "^0.0.6",
+    "accessible-autocomplete": "^1.6.2",
     "core-js-bundle": "^3.0.0-alpha.1",
+    "es5-polyfill": "^0.0.6",
     "markdown-toolbar-element": "^0.2.0"
   }
 }

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -39,6 +39,14 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_the_new_step_by_step_page
   end
 
+  scenario "User visits an existing step by step page" do
+    given_there_is_a_step_by_step_page
+    when_I_view_the_step_by_step_page
+    then_I_can_see_a_summary_section
+    and_I_can_edit_the_summary_section
+    and_I_can_see_a_metadata_section
+  end
+
   scenario "Validation fails" do
     when_I_visit_the_new_step_by_step_form
     and_I_fill_in_the_form_with_invalid_data
@@ -299,6 +307,37 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_the_step_by_step_page
     expect(page).to have_content("How to be amazing")
+  end
+
+  def then_I_can_see_a_summary_section
+    within_summary_section do
+      expect(page).to have_content "Content"
+      expect(page).to have_content "Title #{@step_by_step_page.title}"
+      expect(page).to have_content "Slug #{@step_by_step_page.slug}"
+      expect(page).to have_content "Introduction #{@step_by_step_page.introduction}"
+      expect(page).to have_content "Description #{@step_by_step_page.description}"
+    end
+  end
+
+  def and_I_can_edit_the_summary_section
+    within_summary_section do
+      expect(page).to have_link("Edit", :href => edit_step_by_step_page_path(@step_by_step_page))
+    end
+  end
+
+  def within_summary_section
+    expect(page).to have_css(".gem-c-summary-list")
+    within(".gem-c-summary-list") do
+      yield
+    end
+  end
+
+  def and_I_can_see_a_metadata_section
+    within(".gem-c-metadata") do
+      expect(page).to have_content("Status: Draft")
+      expect(page).to have_content("Last saved")
+      expect(page).to have_content("Created")
+    end
   end
 
   def and_I_visit_the_publish_or_delete_page

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -171,6 +171,8 @@ RSpec.feature "Managing step by step pages" do
       and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at 10:26am on 20 April 2030"
       and_the_step_by_step_is_not_editable
       when_I_view_the_step_by_step_page
+      then_I_can_see_a_summary_section
+      but_I_cannot_edit_the_summary_section
       then_I_can_preview_the_step_by_step
       and_the_steps_can_be_checked_for_broken_links
     end
@@ -322,6 +324,12 @@ RSpec.feature "Managing step by step pages" do
   def and_I_can_edit_the_summary_section
     within_summary_section do
       expect(page).to have_link("Edit", :href => edit_step_by_step_page_path(@step_by_step_page))
+    end
+  end
+
+  def but_I_cannot_edit_the_summary_section
+    within_summary_section do
+      expect(page).not_to have_link("Edit")
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,13 @@
   resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.2.4.tgz#7074543155396114617722724d6f6cb7b3800a14"
   integrity sha512-WiTlgz6/kuwajYIcgyq64rSlCtb2AvbxwwrExP3wr6rKbJ72I3hi/sb4KdGUumfC+isDn2F0btZGk4MnWpyO1Q==
 
+accessible-autocomplete@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-1.6.2.tgz#cb69d37748ba5b0351c84422468538890e25759c"
+  integrity sha512-7S+6Vi82LQFSSd5feKedu46tiY2/DShpdXiRp0NY3cLwc+DKe1ayWd66mb3JVi8LTQubRM7jco+u92e6w0bbvg==
+  dependencies:
+    preact "^8.3.1"
+
 core-js-bundle@^3.0.0-alpha.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/core-js-bundle/-/core-js-bundle-3.2.1.tgz#264f563b51583179ebc8f180d7741c31b2e055e5"
@@ -20,3 +27,8 @@ es5-polyfill@^0.0.6:
 markdown-toolbar-element@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/markdown-toolbar-element/-/markdown-toolbar-element-0.2.0.tgz#df9f1bc347e1f3174ddc4d69e4e6f5fe2c32285a"
+
+preact@^8.3.1:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.2.tgz#2f532da485287c07369e08150cf4d23921a09789"
+  integrity sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg==


### PR DESCRIPTION
Trello card: https://trello.com/c/qXVCEouI/23-show-the-content-title-slug-introduction-description-using-the-summary-component

Depended on by https://github.com/alphagov/collections-publisher/pull/709.

## What

1. Upgrades govuk_publishing_components to 19.0.0, and
2. Uses summary_list component to render new sections on the 'step by step' admin page: 'Content', showing title/slug/intro/description (and an Edit link).
3. Adds tests so we can start having confidence that the right content is appearing on this page.

## Why upgrade govuk_publishing_components?

The summary list component was added to govuk_publishing_components
v18.2.0, hence the upgrade. As this is a major version change, there have
been some breaking changes (all detailed in the commit message).

A note from Alex:

> The legacy mode is not required in this app, but I'd keep it on for a while
> until we figure out how to use the new colours all over the app.

Since opening the PR, govuk_publishing_components v19 has been released,
and contains a number of changes we've made to components to feed into the
new step by step design, so rather than upgrade our dependency twice in 2 PRs,
I've just bumped straight to v19.
v19 is another breaking change but only affects apps that rely on mixins and variables
from govuk_frontend_toolkit (which is no longer included in v19 of govuk_publishing_components).
This doesn't appear to apply to collections-publisher, as evidenced in the screenshots below.

## Index before & after

There shouldn’t be any differences in the screenshots below. (NB there _were_ differences the first time I uploaded screenshots, but I’ve made some tweaks and now the output is about the same).

| Before | After |
|--------|------|
|<img width="807" alt="Screen Shot 2019-09-03 at 11 39 17" src="https://user-images.githubusercontent.com/5111927/64166760-a780ac00-ce3f-11e9-8e5b-ee75a1b4e7d3.png">|<img width="1004" alt="Screen Shot 2019-09-03 at 11 25 58" src="https://user-images.githubusercontent.com/5111927/64165881-d007a680-ce3d-11e9-9cce-20cf5a15a757.png">|

## Scheduling page before & after

(I've had to provide the now deprecated autocomplete module, so have taken screenshots of this page where it is used. Not quite sure why the 'Before' doesn't show an arrow next to the time, as I'm sure that used to be there... 🤔 )

| Before | After |
|--------|------|
|<img width="794" alt="Screen Shot 2019-09-03 at 11 39 08" src="https://user-images.githubusercontent.com/5111927/64166741-9fc10780-ce3f-11e9-9223-761a03cdd5f7.png">|<img width="892" alt="Screen Shot 2019-09-03 at 11 26 22" src="https://user-images.githubusercontent.com/5111927/64165858-c8e09880-ce3d-11e9-989a-61bdf6d36aec.png">|

## Steps page before & after

Now have a "Content" section with the title, slug, description & introduction and a link to edit them.

| Before | After |
|--------|------|
|<img width="803" alt="Screen Shot 2019-09-03 at 11 38 54" src="https://user-images.githubusercontent.com/5111927/64166720-96d03600-ce3f-11e9-9c5d-1ab385005f01.png">|<img width="794" alt="Screen Shot 2019-09-03 at 11 26 42" src="https://user-images.githubusercontent.com/5111927/64165845-c0885d80-ce3d-11e9-9d54-ce4ca5405a50.png">|

And here is the summary-list component with no 'Edit' link, which happens when the step by step is not editable (eg when scheduled):

<img width="996" alt="Screen Shot 2019-09-03 at 12 10 23" src="https://user-images.githubusercontent.com/5111927/64168631-dc8efd80-ce43-11e9-8a0d-da298d6a4128.png">

