### PR TITLE
Move metadata summary content into new StepByStepPresenter

### DIFF
--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -77,5 +77,4 @@
 
     @include govuk-clearfix;
   }
-
 }

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -14,7 +14,9 @@ class StepByStepPagesController < ApplicationController
     @step_by_step_page = StepByStepPage.new
   end
 
-  def show; end
+  def show
+    @step_by_step_page_presenter = StepByStepPagePresenter.new(@step_by_step_page)
+  end
 
   def reorder
     set_current_page_as_step_by_step

--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -1,0 +1,34 @@
+class StepByStepPagePresenter
+  include TimeOptionsHelper
+  attr_reader :step_by_step_page
+
+  def initialize(step_by_step_page)
+    @step_by_step_page = step_by_step_page
+  end
+
+  def summary_metadata
+    items = {
+      "Status" => step_by_step_page.status[:text],
+      "Last saved" => last_saved,
+      "Created" => format_full_date_and_time(step_by_step_page.created_at),
+    }
+
+    if step_by_step_page.links_checked?
+      items.merge!(
+        "Links checked" => format_full_date_and_time(step_by_step_page.links_last_checked_date)
+      )
+    end
+    items
+  end
+
+  def last_saved
+    last_saved_time = format_full_date_and_time(step_by_step_page.updated_at)
+    return "#{last_saved_time} by #{step_by_step_page.assigned_to}" if assigned?
+
+    last_saved_time
+  end
+
+  def assigned?
+    step_by_step_page.assigned_to.present?
+  end
+end

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -90,15 +90,9 @@
     </div>
 
     <div class="app-side">
-      <%
-        metadata = {}
-        metadata.store("Status", @step_by_step_page.status[:text])
-        metadata.store("Last updated", format_full_date_and_time(@step_by_step_page.updated_at))
-        metadata["Last updated"] = "#{metadata["Last updated"]} by #{@step_by_step_page.assigned_to}" if @step_by_step_page.assigned_to.present?
-        metadata.store("Created", format_full_date_and_time(@step_by_step_page.created_at))
-        metadata.store("Links checked", format_full_date_and_time(@step_by_step_page.links_last_checked_date)) if @step_by_step_page.links_checked?
-      %>
-      <%= render "govuk_publishing_components/components/metadata", { other: metadata } %>
+      <%= render "govuk_publishing_components/components/metadata", {
+        other: @step_by_step_page_presenter.summary_metadata
+      } %>
     </div>
   </div>
 </div>

--- a/spec/presenters/step_by_step_page_presenter_spec.rb
+++ b/spec/presenters/step_by_step_page_presenter_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+RSpec.describe StepByStepPagePresenter do
+  include TimeOptionsHelper
+
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
+  describe "#summary_list" do
+    let(:step_nav) { create(:step_by_step_page_with_steps) }
+    let(:default_summary) {
+      {
+        "Status" => "Draft",
+        "Last saved" => format_full_date_and_time(Time.zone.now),
+        "Created" => format_full_date_and_time(Time.zone.now)
+      }
+    }
+
+    subject { described_class.new(step_nav).summary_metadata }
+
+    it "presents a list of key/value metadata" do
+      expect(subject).to eq(default_summary)
+    end
+
+    it "shows who made the most recent change" do
+      step_nav.assigned_to = "Firstname Lastname"
+
+      expect(subject["Last saved"]).to eq("#{format_full_date_and_time(Time.zone.now)} by #{step_nav.assigned_to}")
+    end
+
+    it "has additional metadata showing when links were checked" do
+      create(:link_report, step: step_nav.steps.first)
+      summary_with_links_checked = default_summary.merge(
+        "Links checked" => format_full_date_and_time(Time.zone.now)
+      )
+
+      expect(subject).to eq(summary_with_links_checked)
+    end
+  end
+end


### PR DESCRIPTION
Moved the business logic into a presenter rather than muddying the
view.

Did this as part of #703 then realised it was out of scope, so moving into its own PR.
There's no Trello card dependent on this, but it's probably a good idea to clean up
our view for maintainability.