### PR TITLE
Add 'Sidebar settings' and 'Secondary links' sections

### DIFF
--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -71,6 +71,20 @@ class StepByStepPagePresenter
     }
   end
 
+  def secondary_links_settings
+    {
+      title: "Secondary links",
+      id: "secondary-links",
+      edit: {
+        link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
+        href: step_by_step_page_secondary_content_links_path(step_by_step_page),
+        data_attributes: {
+          gtm: "edit-secondary-links"
+        }
+      }
+    }
+  end
+
   def last_saved
     last_saved_time = format_full_date_and_time(step_by_step_page.updated_at)
     return "#{last_saved_time} by #{step_by_step_page.assigned_to}" if assigned?

--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -25,6 +25,7 @@ class StepByStepPagePresenter
   def summary_list_params
     params = {
       borderless: true,
+      id: "content",
       title: "Content",
       items: [
         {

--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -57,6 +57,20 @@ class StepByStepPagePresenter
     params
   end
 
+  def sidebar_settings
+    {
+      title: "Sidebar settings",
+      id: "sidebar-settings",
+      edit: {
+        link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
+        href: step_by_step_page_navigation_rules_path(step_by_step_page),
+        data_attributes: {
+          gtm: "edit-sidebar-settings"
+        }
+      }
+    }
+  end
+
   def last_saved
     last_saved_time = format_full_date_and_time(step_by_step_page.updated_at)
     return "#{last_saved_time} by #{step_by_step_page.assigned_to}" if assigned?

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -71,6 +71,8 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.sidebar_settings %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -73,6 +73,17 @@
     </table>
 
     <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.sidebar_settings %>
+
+    <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.secondary_links_settings do %>
+      <p class="govuk-body">Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.</p>
+
+      <p class="govuk-body">We use it for content which:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task</li>
+        <li>is optional and not useful enough to be included in the step by step</li>
+      </ul>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_view_the_step_by_step_page
     then_I_can_see_a_summary_section
     and_I_can_edit_the_summary_section
+    and_I_can_see_a_sidebar_settings_section_with_link "Edit"
     and_I_can_see_a_metadata_section
   end
 
@@ -173,6 +174,7 @@ RSpec.feature "Managing step by step pages" do
       when_I_view_the_step_by_step_page
       then_I_can_see_a_summary_section
       but_I_cannot_edit_the_summary_section
+      and_I_can_see_a_sidebar_settings_section_with_link "View"
       then_I_can_preview_the_step_by_step
       and_the_steps_can_be_checked_for_broken_links
     end
@@ -337,6 +339,13 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_css(".gem-c-summary-list#content")
     within(".gem-c-summary-list#content") do
       yield
+    end
+  end
+
+  def and_I_can_see_a_sidebar_settings_section_with_link(link_text)
+    within(".gem-c-summary-list#sidebar-settings") do
+      expect(page).to have_content "Sidebar settings"
+      expect(page).to have_link(link_text, :href => step_by_step_page_navigation_rules_path(@step_by_step_page))
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Managing step by step pages" do
     then_I_can_see_a_summary_section
     and_I_can_edit_the_summary_section
     and_I_can_see_a_sidebar_settings_section_with_link "Edit"
+    and_I_can_see_a_secondary_links_section_with_link "Edit"
     and_I_can_see_a_metadata_section
   end
 
@@ -175,6 +176,7 @@ RSpec.feature "Managing step by step pages" do
       then_I_can_see_a_summary_section
       but_I_cannot_edit_the_summary_section
       and_I_can_see_a_sidebar_settings_section_with_link "View"
+      and_I_can_see_a_secondary_links_section_with_link "View"
       then_I_can_preview_the_step_by_step
       and_the_steps_can_be_checked_for_broken_links
     end
@@ -346,6 +348,13 @@ RSpec.feature "Managing step by step pages" do
     within(".gem-c-summary-list#sidebar-settings") do
       expect(page).to have_content "Sidebar settings"
       expect(page).to have_link(link_text, :href => step_by_step_page_navigation_rules_path(@step_by_step_page))
+    end
+  end
+
+  def and_I_can_see_a_secondary_links_section_with_link(link_text)
+    within(".gem-c-summary-list#secondary-links") do
+      expect(page).to have_content "Secondary links"
+      expect(page).to have_link(link_text, :href => step_by_step_page_secondary_content_links_path(@step_by_step_page))
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -334,8 +334,8 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def within_summary_section
-    expect(page).to have_css(".gem-c-summary-list")
-    within(".gem-c-summary-list") do
+    expect(page).to have_css(".gem-c-summary-list#content")
+    within(".gem-c-summary-list#content") do
       yield
     end
   end


### PR DESCRIPTION
Trello cards: https://trello.com/c/h6Oj4hno/46-move-sidebar-settings-and-secondary-links-inside-the-summary-component

Dependent on https://github.com/alphagov/collections-publisher/pull/703

## What

1. Uses summary_list component to render new sections on the 'step by step' admin page:
   - 'Sidebar settings' (and Edit/View link)
   - 'Secondary links' (and Edit/View link), with guidance content taken from the secondary links page
2. Adds tests to verify that the correct content is appearing on this page.

Here are the additional sections added to the bottom of the page:

------

![Screen Shot 2019-08-29 at 17 00 14](https://user-images.githubusercontent.com/5111927/63956749-f369d480-ca7e-11e9-955d-190ff7f7f72f.png)
