### PR TITLE
Simplify tests and fix redirect inconsistency

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -25,9 +25,10 @@ class StepsController < ApplicationController
   def update
     if step.update(step_params)
       update_downstream
-      flash.now[:notice] = 'Step was successfully updated.'
+      redirect_to edit_step_by_step_page_step_path(:id => @step[:id]), notice: 'Step was successfully updated.'
+    else
+      render :edit
     end
-    render :edit
   end
 
   def destroy

--- a/spec/features/create_step_by_step_spec.rb
+++ b/spec/features/create_step_by_step_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+
+RSpec.feature "Create new step by step page" do
+  include CommonFeatureSteps
+  include NavigationSteps
+  include StepNavSteps
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    given_I_am_a_GDS_editor
+    setup_publishing_api
+    stub_default_publishing_api_put_intent
+  end
+
+  scenario "User creates a new step by step page" do
+    when_I_visit_the_new_step_by_step_form
+    and_I_fill_in_the_form
+    and_I_see_a_page_created_success_notice
+    and_I_see_I_saved_it_last
+    and_I_can_preview_the_step_by_step
+    when_I_visit_the_step_by_step_pages_index
+    then_I_see_the_new_step_by_step_page
+  end
+
+  scenario "Validation fails" do
+    when_I_visit_the_new_step_by_step_form
+    and_I_fill_in_the_form_with_invalid_data
+    then_I_see_a_validation_error
+  end
+
+  scenario "The slug has already been taken" do
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_visit_the_new_step_by_step_form
+    and_the_slug_has_been_taken
+    and_I_fill_in_the_form_with_a_taken_slug
+    then_I_see_a_slug_already_taken_error
+  end
+
+  def and_I_see_a_page_created_success_notice
+    expect(page).to have_content("Step by step page was successfully created.")
+  end
+
+  def and_I_fill_in_the_form
+    fill_in "Title", with: "How to bake a cake"
+    fill_in "Slug", with: "how-to-bake-a-cake"
+    fill_in "Introduction", with: "Learn how you can bake a cake"
+    fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
+
+    click_on "Save"
+  end
+
+  def and_I_fill_in_the_form_with_a_taken_slug
+    fill_in "Title", with: "How to bake a cake"
+    fill_in "Slug", with: @step_by_step_page.slug
+    fill_in "Introduction", with: "Learn how you can bake a cake"
+    fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
+
+    click_on "Save"
+  end
+
+  def and_I_fill_in_the_form_with_invalid_data
+    fill_in "Title", with: ""
+    fill_in "Slug", with: ""
+    fill_in "Introduction", with: ""
+    fill_in "Meta description", with: ""
+    click_on "Save"
+  end
+
+  def then_I_see_a_validation_error
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Slug can't be blank")
+    expect(page).to have_content("Introduction can't be blank")
+    expect(page).to have_content("Description can't be blank")
+  end
+
+  def and_the_slug_has_been_taken
+    expect(
+      Services.publishing_api
+    ).to(
+      receive(:lookup_content_id)
+      .with(base_path: "/#{@step_by_step_page.slug}", with_drafts: true)
+      .and_return("A-TAKEN-CONTENT-ID")
+    )
+  end
+
+  def then_I_see_a_slug_already_taken_error
+    expect(page).to have_content("Slug has already been taken")
+  end
+
+  def and_I_see_I_saved_it_last
+    within(".gem-c-metadata") do
+      expect(page).to have_content("Status: Draft")
+      expect(page).to have_content("by Test author")
+    end
+  end
+end

--- a/spec/features/filter_step_by_steps_spec.rb
+++ b/spec/features/filter_step_by_steps_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+
+RSpec.feature "View step by step pages index and filter results" do
+  include CommonFeatureSteps
+  include NavigationSteps
+  include StepNavSteps
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    given_I_am_a_GDS_editor
+    setup_publishing_api
+    stub_default_publishing_api_put_intent
+  end
+
+  scenario "User visits the index page" do
+    given_there_is_a_step_by_step_page
+    when_I_visit_the_step_by_step_pages_index
+    then_I_see_the_step_by_step_page
+  end
+
+  scenario "User filters results on index page" do
+    given_there_are_step_by_step_pages
+    when_I_visit_the_step_by_step_pages_index
+    and_I_filter_by_title_and_status
+    then_I_should_see_a_filtered_list_of_step_by_steps
+  end
+
+  def then_I_see_the_step_by_step_page
+    expect(page).to have_content("How to be amazing")
+  end
+
+  def and_I_filter_by_title_and_status
+    fill_in "title_or_url", with: "step nav"
+    select "Draft", from: "status"
+    click_on "Filter"
+  end
+
+  def then_I_should_see_a_filtered_list_of_step_by_steps
+    within(".govuk-table__body") do
+      expect(page).to have_xpath(".//tr", :count => 1)
+      expect(page).to have_content("A draft step nav")
+      expect(page).to_not have_content("A published step nav")
+    end
+  end
+end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -17,29 +17,6 @@ RSpec.feature "Managing step by step pages" do
     stub_default_publishing_api_put_intent
   end
 
-  scenario "User visits the index page" do
-    given_there_is_a_step_by_step_page
-    when_I_visit_the_step_by_step_pages_index
-    then_I_see_the_step_by_step_page
-  end
-
-  scenario "User filters results on index page" do
-    given_there_are_step_by_step_pages
-    when_I_visit_the_step_by_step_pages_index
-    and_I_filter_by_title_and_status
-    then_I_should_see_a_filtered_list_of_step_by_steps
-  end
-
-  scenario "User creates a new step by step page" do
-    when_I_visit_the_new_step_by_step_form
-    and_I_fill_in_the_form
-    and_I_see_a_page_created_success_notice
-    and_I_see_I_saved_it_last
-    and_I_can_preview_the_step_by_step
-    when_I_visit_the_step_by_step_pages_index
-    then_I_see_the_new_step_by_step_page
-  end
-
   scenario "User visits a step by step page with no steps" do
     given_there_is_a_draft_step_by_step_page_with_no_steps
     when_I_view_the_step_by_step_page
@@ -62,20 +39,6 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_reorder_the_steps
     and_I_can_see_a_where_to_show_section_with_links "Edit"
     and_I_can_see_a_metadata_section
-  end
-
-  scenario "Validation fails" do
-    when_I_visit_the_new_step_by_step_form
-    and_I_fill_in_the_form_with_invalid_data
-    then_I_see_a_validation_error
-  end
-
-  scenario "The slug has already been taken" do
-    given_there_is_a_step_by_step_page_with_steps
-    when_I_visit_the_new_step_by_step_form
-    and_the_slug_has_been_taken
-    and_I_fill_in_the_form_with_a_taken_slug
-    then_I_see_a_slug_already_taken_error
   end
 
   scenario "User edits step by step information when there is a step" do
@@ -426,10 +389,6 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Step by step page was successfully unpublished.")
   end
 
-  def and_I_see_a_page_created_success_notice
-    expect(page).to have_content("Step by step page was successfully created.")
-  end
-
   def when_I_view_the_step_by_step_page
     visit step_by_step_page_path(@step_by_step_page)
   end
@@ -531,15 +490,6 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  def and_I_fill_in_the_form
-    fill_in "Title", with: "How to bake a cake"
-    fill_in "Slug", with: "how-to-bake-a-cake"
-    fill_in "Introduction", with: "Learn how you can bake a cake"
-    fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
-
-    click_on "Save"
-  end
-
   def and_I_fill_in_the_edit_form
     fill_in "Title", with: "How to bake a cake"
     fill_in "Introduction", with: "Learn how you can bake a cake"
@@ -547,19 +497,6 @@ RSpec.feature "Managing step by step pages" do
 
     expect_update_worker
     click_on "Save"
-  end
-
-  def and_I_fill_in_the_form_with_a_taken_slug
-    fill_in "Title", with: "How to bake a cake"
-    fill_in "Slug", with: @step_by_step_page.slug
-    fill_in "Introduction", with: "Learn how you can bake a cake"
-    fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
-
-    click_on "Save"
-  end
-
-  def then_I_see_the_new_step_by_step_page
-    expect(page).to have_content("How to bake a cake")
   end
 
   def then_I_see_delete_and_publish_buttons
@@ -584,35 +521,6 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  def and_I_fill_in_the_form_with_invalid_data
-    fill_in "Title", with: ""
-    fill_in "Slug", with: ""
-    fill_in "Introduction", with: ""
-    fill_in "Meta description", with: ""
-    click_on "Save"
-  end
-
-  def then_I_see_a_validation_error
-    expect(page).to have_content("Title can't be blank")
-    expect(page).to have_content("Slug can't be blank")
-    expect(page).to have_content("Introduction can't be blank")
-    expect(page).to have_content("Description can't be blank")
-  end
-
-  def and_the_slug_has_been_taken
-    expect(
-      Services.publishing_api
-    ).to(
-      receive(:lookup_content_id)
-      .with(base_path: "/#{@step_by_step_page.slug}", with_drafts: true)
-      .and_return("A-TAKEN-CONTENT-ID")
-    )
-  end
-
-  def then_I_see_a_slug_already_taken_error
-    expect(page).to have_content("Slug has already been taken")
-  end
-
   def and_I_publish_the_page
     click_on "Publish"
   end
@@ -633,13 +541,6 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_a_page_reverted_success_notice
     expect(page).to have_content("Draft successfully discarded.")
-  end
-
-  def and_I_see_I_saved_it_last
-    within(".gem-c-metadata") do
-      expect(page).to have_content("Status: Draft")
-      expect(page).to have_content("by Test author")
-    end
   end
 
   def and_I_visit_the_scheduling_page
@@ -894,14 +795,6 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  def then_I_can_preview_the_step_by_step
-    within(".app-side__actions") do
-      expect(page).to have_link("Preview")
-    end
-  end
-
-  alias_method :and_I_can_preview_the_step_by_step, :then_I_can_preview_the_step_by_step
-
   def and_the_steps_can_be_checked_for_broken_links
     expect(page).to have_button("Check for broken links")
   end
@@ -924,19 +817,5 @@ RSpec.feature "Managing step by step pages" do
 
   def first_step_summary
     find(".gem-c-summary-list#steps .govuk-summary-list__row:first-child .govuk-summary-list__value")
-  end
-
-  def and_I_filter_by_title_and_status
-    fill_in "title_or_url", with: "step nav"
-    select "Draft", from: "status"
-    click_on "Filter"
-  end
-
-  def then_I_should_see_a_filtered_list_of_step_by_steps
-    within(".govuk-table__body") do
-      expect(page).to have_xpath(".//tr", :count => 1)
-      expect(page).to have_content("A draft step nav")
-      expect(page).to_not have_content("A published step nav")
-    end
   end
 end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -41,11 +41,11 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_see_a_metadata_section
   end
 
-  scenario "User edits step by step information when there is a step" do
-    given_there_is_a_step_by_step_page_with_steps
+  scenario "User edits step by step information" do
+    given_there_is_a_step_by_step_page
     when_I_edit_the_step_by_step_page
     and_I_fill_in_the_edit_form
-    then_I_see_the_new_step_by_step_page
+    then_the_step_by_step_information_should_have_updated
   end
 
   scenario "User publishes a page" do
@@ -492,11 +492,21 @@ RSpec.feature "Managing step by step pages" do
 
   def and_I_fill_in_the_edit_form
     fill_in "Title", with: "How to bake a cake"
+    fill_in "Slug", with: "how-to-bake-a-cake"
     fill_in "Introduction", with: "Learn how you can bake a cake"
     fill_in "Meta description", with: "How to bake a cake - learn how you can bake a cake"
 
     expect_update_worker
     click_on "Save"
+  end
+
+  def then_the_step_by_step_information_should_have_updated
+    within ".gem-c-summary-list#content" do
+      expect(page).to have_content("Title How to bake a cake")
+      expect(page).to have_content("Slug how-to-bake-a-cake")
+      expect(page).to have_content("Introduction Learn how you can bake a cake")
+      expect(page).to have_content("Description How to bake a cake - learn how you can bake a cake")
+    end
   end
 
   def then_I_see_delete_and_publish_buttons

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -17,16 +17,17 @@ RSpec.feature "Managing step by step pages" do
         when_I_visit_the_step_by_step_page
         and_I_create_a_new_step
         and_I_fill_in_the_form
-        then_I_can_see_the_edit_page
+        then_I_can_see_a_success_message "Step was successfully created."
+        and_I_should_still_be_on_the_edit_step_page
       end
 
       scenario "User edits step" do
         given_there_is_a_step_by_step_page_with_steps
         when_I_visit_the_step_by_step_page
         and_I_edit_the_first_step
-        then_I_can_see_the_edit_page
         and_I_fill_the_edit_form_and_submit
-        then_I_can_see_the_edit_page
+        then_I_can_see_a_success_message "Step was successfully updated."
+        and_I_should_still_be_on_the_edit_step_page
       end
 
       scenario "User deletes step", js: true do
@@ -34,7 +35,7 @@ RSpec.feature "Managing step by step pages" do
         when_I_visit_the_step_by_step_page
         and_I_can_see_the_first_step
         and_I_delete_the_first_step
-        and_the_step_is_deleted
+        then_the_step_is_deleted
       end
     end
 
@@ -132,12 +133,19 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  def and_the_step_is_deleted
-    expect(page).not_to have_css(".govuk-summary-list__value", text: "Check how awesome you are")
+  def then_the_step_is_deleted
+    expect(page).not_to have_content("Check how awesome you are")
   end
 
-  def then_I_can_see_the_edit_page
-    expect(page).to have_css("label", text: "Step title")
+  def then_I_can_see_a_success_message(message)
+    within('.gem-c-success-alert') do
+      expect(page).to have_content message
+    end
+  end
+
+  def and_I_should_still_be_on_the_edit_step_page
+    edit_step_path = edit_step_by_step_page_step_path(@step_by_step_page.id, @step_by_step_page.steps.first.id)
+    expect(current_url).to end_with edit_step_path
   end
 
   def and_I_fill_in_the_form_with_content

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -82,10 +82,6 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  def when_I_visit_the_step_by_step_page
-    visit step_by_step_page_path(@step_by_step_page)
-  end
-
   def and_I_visit_the_reorder_steps_page
     visit step_by_step_page_reorder_path(@step_by_step_page)
   end
@@ -135,12 +131,6 @@ RSpec.feature "Managing step by step pages" do
 
   def then_the_step_is_deleted
     expect(page).not_to have_content("Check how awesome you are")
-  end
-
-  def then_I_can_see_a_success_message(message)
-    within('.gem-c-success-alert') do
-      expect(page).to have_content message
-    end
   end
 
   def and_I_should_still_be_on_the_edit_step_page

--- a/spec/features/secondary_content_for_step_by_steps_spec.rb
+++ b/spec/features/secondary_content_for_step_by_steps_spec.rb
@@ -12,33 +12,33 @@ RSpec.feature "Managing secondary content for step by step pages" do
   scenario "User views secondary content links" do
     given_there_is_a_step_by_step_page_with_secondary_content
     when_I_visit_the_step_by_step_page
-    when_I_visit_the_secondary_content_page
-    then_can_I_see_the_existing_secondary_content_listed
+    and_I_click_the_secondary_links_edit_link
+    then_I_can_see_the_existing_secondary_content_listed
   end
 
   scenario "User adds new secondary content link" do
     given_there_is_a_step_by_step_page_with_secondary_content
-    when_I_visit_the_step_by_step_page
     when_I_visit_the_secondary_content_page
-    when_I_add_secondary_content
-    then_I_see_a_successfully_linked_notice
-    and_can_I_see_the_new_secondary_content_listed
+    and_I_add_secondary_content
+    then_I_can_see_a_success_message "Secondary content was successfully linked."
+    and_I_can_see_the_new_secondary_content_listed
+    and_I_should_still_be_on_the_secondary_links_page
   end
 
-  scenario "User trys to add broken secondary link" do
+  scenario "User tries to add broken secondary link" do
     given_there_is_a_step_by_step_page_with_secondary_content
-    when_I_visit_the_step_by_step_page
     when_I_visit_the_secondary_content_page
-    when_I_try_to_add_secondary_content_with_a_broken_link
-    then_I_see_a_failure_notice
+    and_I_try_to_add_secondary_content_with_a_broken_link
+    then_I_should_see_a_failure_notice
+    and_I_should_still_be_on_the_secondary_links_page
   end
 
   scenario "User removes a secondary content link" do
     given_there_is_a_step_by_step_page_with_secondary_content
-    when_I_visit_the_step_by_step_page
     when_I_visit_the_secondary_content_page
-    when_I_delete_secondary_content
-    then_I_see_a_successfully_deleted_notice
+    and_I_delete_secondary_content
+    then_I_should_see_a_successfully_deleted_notice
+    and_I_should_still_be_on_the_secondary_links_page
     and_I_cannot_see_any_secondary_content_listed
   end
 
@@ -50,7 +50,7 @@ RSpec.feature "Managing secondary content for step by step pages" do
     visit step_by_step_page_path(@step_by_step_page)
   end
 
-  def when_I_add_secondary_content
+  def and_I_add_secondary_content
     setup_publishing_api_request_expectations
     expect_update_worker
 
@@ -58,38 +58,43 @@ RSpec.feature "Managing secondary content for step by step pages" do
     find('button[type=submit]').click
   end
 
-  def when_I_try_to_add_secondary_content_with_a_broken_link
+  def and_I_try_to_add_secondary_content_with_a_broken_link
     fill_in "base_path", with: broken_base_path
     find('button[type=submit]').click
   end
 
-  def when_I_delete_secondary_content
+  def and_I_delete_secondary_content
     expect_update_worker
 
     find('.govuk-button--warning').click
   end
 
+  def and_I_click_the_secondary_links_edit_link
+    click_on 'Edit Secondary links'
+  end
+
   def when_I_visit_the_secondary_content_page
-    visit step_by_step_page_secondary_content_links_path(@step_by_step_page)
+    when_I_visit_the_step_by_step_page
+    and_I_click_the_secondary_links_edit_link
   end
 
-  def then_I_see_a_successfully_linked_notice
-    expect(page).to have_content("Secondary content was successfully linked.")
+  def and_I_should_still_be_on_the_secondary_links_page
+    expect(current_url).to end_with step_by_step_page_secondary_content_links_path(@step_by_step_page)
   end
 
-  def then_I_see_a_successfully_deleted_notice
+  def then_I_should_see_a_successfully_deleted_notice
     expect(page).to have_content("Secondary content link was successfully deleted.")
   end
 
-  def then_I_see_a_failure_notice
+  def then_I_should_see_a_failure_notice
     expect(page).to have_content("#{broken_base_path} doesn't exist on GOV.UK.")
   end
 
-  def then_can_I_see_the_existing_secondary_content_listed
+  def then_I_can_see_the_existing_secondary_content_listed
     expect(find('tbody')).to have_content(@step_by_step_page.secondary_content_links.first.title)
   end
 
-  def and_can_I_see_the_new_secondary_content_listed
+  def and_I_can_see_the_new_secondary_content_listed
     expect(find('tbody')).to have_content(base_path)
   end
 

--- a/spec/features/step_by_step_navigation_spec.rb
+++ b/spec/features/step_by_step_navigation_spec.rb
@@ -13,20 +13,23 @@ RSpec.feature "Managing step by step navigation" do
 
     scenario "User configures navigation" do
       given_there_is_a_step_by_step_page_with_navigation_rules
-      and_I_visit_the_navigation_rules_page
-      and_I_see_all_pages_included_in_navigation
-      and_I_set_some_navigation_preferences
-      then_I_see_the_step_by_step_page
-      then_I_visit_the_navigation_steps_page_again
-      and_I_see_my_selected_preferences
+      when_I_visit_the_step_by_step_page
+      and_I_click_the_sidebar_settings_link
+      then_I_should_be_on_the_navigation_rules_page
+      and_I_should_see_all_pages_included_in_navigation
+      and_when_I_set_some_navigation_preferences
+      then_I_can_see_a_success_message "Your navigation choices have been saved."
+      and_I_should_be_on_the_step_by_step_page
+      and_when_I_visit_the_navigation_steps_page_again
+      then_I_should_see_my_selected_preferences
     end
   end
 
-  def and_I_visit_the_navigation_rules_page
-    visit step_by_step_page_navigation_rules_path(@step_by_step_page)
+  def then_I_should_be_on_the_navigation_rules_page
+    expect(current_url).to end_with step_by_step_page_navigation_rules_path(@step_by_step_page)
   end
 
-  def and_I_see_all_pages_included_in_navigation
+  def and_I_should_see_all_pages_included_in_navigation
     expect(page).to have_css(".govuk-caption-l", text: "Choose on-page side navigation")
     expect(page).to have_css("h1", text: @step_by_step_page.title)
 
@@ -35,23 +38,24 @@ RSpec.feature "Managing step by step navigation" do
     expect(checked.count).to eq @step_by_step_page.navigation_rules.count
   end
 
-  def and_I_set_some_navigation_preferences
+  def and_when_I_set_some_navigation_preferences
     select("Never show navigation", match: :first)
 
     allow(StepByStepDraftUpdateWorker).to receive(:perform_async)
     click_on "Save"
   end
 
-  def then_I_see_the_step_by_step_page
-    expect(page).to have_content("Your navigation choices have been saved")
-    expect(page).to have_link("Edit Sidebar settings")
+  def and_I_should_be_on_the_step_by_step_page
+    expect(current_url).to end_with step_by_step_page_path(@step_by_step_page)
   end
 
-  def then_I_visit_the_navigation_steps_page_again
+  def and_I_click_the_sidebar_settings_link
     click_on("Edit Sidebar settings")
   end
 
-  def and_I_see_my_selected_preferences
+  alias_method :and_when_I_visit_the_navigation_steps_page_again, :and_I_click_the_sidebar_settings_link
+
+  def then_I_should_see_my_selected_preferences
     expect(page.all(:select)[0].value).to eq("never")
     expect(page.all(:select)[1].value).to eq("always")
   end

--- a/spec/support/navigation_steps.rb
+++ b/spec/support/navigation_steps.rb
@@ -30,4 +30,8 @@ module NavigationSteps
   def when_I_visit_the_new_step_by_step_form
     visit new_step_by_step_page_path
   end
+
+  def when_I_visit_the_step_by_step_page
+    visit step_by_step_page_path(@step_by_step_page)
+  end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -195,4 +195,10 @@ module StepNavSteps
       "status": "broken"
     }
   end
+
+  def then_I_can_see_a_success_message(message)
+    within('.gem-c-success-alert') do
+      expect(page).to have_content message
+    end
+  end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -201,4 +201,16 @@ module StepNavSteps
       expect(page).to have_content message
     end
   end
+
+  def then_I_see_the_new_step_by_step_page
+    expect(page).to have_content("How to bake a cake")
+  end
+
+  def then_I_can_preview_the_step_by_step
+    within(".app-side__actions") do
+      expect(page).to have_link("Preview")
+    end
+  end
+
+  alias_method :and_I_can_preview_the_step_by_step, :then_I_can_preview_the_step_by_step
 end


### PR DESCRIPTION
After the completion of the [UI revamp epic](https://trello.com/c/arYq0tST/22-epic-update-summary-page-layout-and-content) and half-complete addition of 2i workflow, our tests have become a little verbose and tricky to maintain. This is an attempt to split it into logical files, make each scenario more readable, and remove any redundant tests.

In writing these tests I also noted a redirect URL inconsistency, which I've fixed in my first commit.

Trello: https://trello.com/c/CXwhB5tD/76-simplify-tests-after-ui-changes