### PR TITLE
Fix scheduling validation check

### DIFF
--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe StepByStepPage do
         nil,
         'foo', # automatically converted to nil
         1.day.from_now,
-        Time.zone.now + 1.second,
+        Time.zone.now + 1.minute,
       ]
       invalid_values = [
         Time.zone.now,


### PR DESCRIPTION
Fixes error:

```
  1) StepByStepPage validations must have a scheduled_at value that is nil or in the future
     Failure/Error: expect(step_by_step_page).to be_valid
       expected #<StepByStepPage id: nil, title: "Construct a giant castle made of armadillos", slug: "how-to-be-the-amazing-1", introduction: "Find out the steps to become amazing", description: "How to be amazing - find out the steps to become a...", created_at: nil, updated_at: nil, content_id: "826a0245-74b9-4d67-9a54-441acd06cd20", published_at: nil, draft_updated_at: nil, assigned_to: nil, scheduled_at: "2019-09-04 09:37:11", status: "draft"> to be valid, but got errors: Scheduled at can't be in the past
     # ./spec/models/step_by_step_page_spec.rb:70:in `block (4 levels) in <top (required)>'
     # ./spec/models/step_by_step_page_spec.rb:68:in `each'
     # ./spec/models/step_by_step_page_spec.rb:68:in `block (3 levels) in <top (required)>'
```

We only allow users to schedule publishing down to the minute, so it's ok to limit our tests to the same.