### PR TITLE
Update index page

### DIFF
--- a/app/assets/stylesheets/admin_layout.scss
+++ b/app/assets/stylesheets/admin_layout.scss
@@ -2,6 +2,7 @@ $govuk-use-legacy-palette: true;
 
 @import "govuk_publishing_components/all_components";
 @import "./components/all";
+@import "./objects/grid";
 @import "./objects/side";
 @import "./utilities/overrides";
 @import "./steps";

--- a/app/assets/stylesheets/objects/_grid.scss
+++ b/app/assets/stylesheets/objects/_grid.scss
@@ -1,0 +1,3 @@
+.app-grid-column--align-right {
+  text-align: right;
+}

--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -74,3 +74,25 @@
     @include govuk-clearfix;
   }
 }
+
+.govuk-table {
+  .gem-c-document-list__item {
+    margin: 0;
+    padding: 0;
+  }
+
+  .gem-c-document-list__item-title {
+    @extend %govuk-link;
+    font-weight: normal;
+  }
+
+  .gem-c-document-list__attribute {
+    @include govuk-font(16);
+  }
+
+  .govuk-table__body {
+    .govuk-table__cell {
+      @include govuk-font(16);
+    }
+  }
+}

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -20,6 +20,10 @@ module TimeOptionsHelper
     datetime.strftime('%-l:%M%P on %-d %B %Y')
   end
 
+  def format_full_date(datetime)
+    datetime.strftime('%-d %B %Y')
+  end
+
   def default_datetime_placeholder(
     year: 1.day.from_now.year,
     month: 1.day.from_now.month,

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -55,13 +55,17 @@
         } %>
       <% end %>
 
-
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <span class="govuk-caption-l"><%= yield(:context) %></span>
-          <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+      <% if yield(:title).present? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <span class="govuk-caption-l"><%= yield(:context) %></span>
+            <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+          </div>
+          <div class="govuk-grid-column-one-third app-grid-column--align-right">
+            <%= yield(:title_side) %>
+          </div>
         </div>
-      </div>
+      <% end %>
       <%= yield %>
     </main>
   </div>

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -6,24 +6,18 @@
   ]
 %>
 
-<%= render 'shared/steps/page_title', links: links %>
+<% content_for :title, render("govuk_publishing_components/components/heading", {
+  text: "Step by step navigation publisher",
+  margin_bottom: 6
+}) %>
 
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Step by step navigation publisher",
-  margin_bottom: 6
-} %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Create new",
-      href: new_step_by_step_page_path
-    } %>
-  </div>
-</div>
+<% content_for :title_side, render("govuk_publishing_components/components/button", {
+  text: "Create new step by step",
+  href: new_step_by_step_page_path,
+  margin_bottom: true
+}) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-5">
   <div class="govuk-grid-column-one-quarter">

--- a/app/views/step_by_step_pages/index.html.erb
+++ b/app/views/step_by_step_pages/index.html.erb
@@ -6,12 +6,9 @@
   ]
 %>
 
-<% content_for :title, render("govuk_publishing_components/components/heading", {
-  text: "Step by step navigation publisher",
-  margin_bottom: 6
-}) %>
-
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
+
+<% content_for :title, "Step by steps" %>
 
 <% content_for :title_side, render("govuk_publishing_components/components/button", {
   text: "Create new step by step",
@@ -19,94 +16,25 @@
   margin_bottom: true
 }) %>
 
-<div class="govuk-grid-row govuk-!-margin-top-5">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
-    <div class="govuk-grid-row">
-      <%= form_tag({}, enforce_utf8: false, method: :get) do %>
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: "Title or URL",
-              bold: true
-            },
-            name: "title_or_url",
-            value: params[:title_or_url],
-            id: "title_or_url"
-          } %>
-        </div>
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/label", {
-            text: "Status",
-            html_for: "status",
-            bold: true
-          } %>
-          <%= render "govuk_publishing_components/components/select", {
-            id: "status",
-            name: "status",
-            label: "",
-            full_width: true,
-            options: StepByStepFilter::Options.statuses(params[:status])
-          } %>
-        </div>
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Filter",
-            margin_bottom: true
-          } %>
-        </div>
-      <% end %>
-    </div>
-
-    <p class="govuk-body">
-      <%= link_to "Clear all filters",
-        step_by_step_pages_path,
-        class: "govuk-link govuk-link--no-visited-state"
-      %>
-    </p>
+    <%= render "step_by_step_pages/index/filters" %>
   </div>
 
   <div class="govuk-grid-column-three-quarters">
     <p class="govuk-body govuk-!-margin-bottom-1"><%= pluralize(@step_by_step_pages.count, "step by step") %></p>
-    <table class="gem-c-table govuk-table govuk-table--sortable step-by-step-list__table">
-      <thead class="govuk-table__head">
-        <tr>
-          <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Title</th>
-          <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Status</th>
-          <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Base path / preview</th>
-        </tr>
-      </thead>
 
-      <tbody class="govuk-table__body">
-        <% if @step_by_step_pages.present? %>
-          <% @step_by_step_pages.each do |step_by_step_page| %>
-            <tr class="govuk-table__row" data-status="<%= step_by_step_page.status %>">
-              <td class="govuk-table__cell">
-                <strong><%= link_to step_by_step_page.title, step_by_step_page %></strong>
-              </td>
-              <td class="govuk-table__cell">
-                <span class="h4">
-                  <span class="label" title="<%= step_by_step_page.status.humanize %>"><%= step_by_step_page.status.humanize %></span>
-                </span>
-              </td>
-              <td class="govuk-table__cell">
-                <% if step_by_step_page.has_draft? %>
-                  <%= link_to "/#{step_by_step_page.slug}", preview_url(step_by_step_page.slug, auth_bypass_id: step_by_step_page.auth_bypass_id), target: "_blank" %>
-                <% elsif step_by_step_page.status.published? %>
-                  <%= link_to "/#{step_by_step_page.slug}", published_url(step_by_step_page.slug), target: "_blank" %>
-                <% else %>
-                  /<%= step_by_step_page.slug %>
-                <% end %>
-              </td>
-            </tr>
-          <% end %>
-        <% else %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell" colspan="3">
-              <p class="govuk-hint">No step by steps have been created yet.</p>
-            </tr>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% if @step_by_step_pages.none? %>
+      <div class="govuk-body">
+        <p>Improve your search results by:</p>
+        <ul>
+          <li>removing filters</li>
+          <li>searching for something less specific</li>
+          <li>double-checking your spelling</li>
+        </ul>
+      </div>
+    <% else %>
+      <%= render "step_by_step_pages/index/results" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/step_by_step_pages/index/_filters.erb
+++ b/app/views/step_by_step_pages/index/_filters.erb
@@ -1,0 +1,38 @@
+<%= form_tag({}, enforce_utf8: false, method: :get) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Title or URL",
+      bold: true
+    },
+    name: "title_or_url",
+    value: params[:title_or_url],
+    id: "title_or_url"
+  } %>
+
+  <div class="govuk-form-group">
+    <%= render "govuk_publishing_components/components/label", {
+      text: "Status",
+      html_for: "status",
+      bold: true
+    } %>
+    <%= render "govuk_publishing_components/components/select", {
+      id: "status",
+      name: "status",
+      label: "",
+      full_width: true,
+      options: StepByStepFilter::Options.statuses(params[:status])
+    } %>
+  </div>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Filter",
+    margin_bottom: true
+  } %>
+
+  <p class="govuk-body">
+    <%= link_to "Clear all filters",
+      step_by_step_pages_path,
+      class: "govuk-link govuk-link--no-visited-state"
+    %>
+  </p>
+<% end %>

--- a/app/views/step_by_step_pages/index/_results.erb
+++ b/app/views/step_by_step_pages/index/_results.erb
@@ -1,0 +1,41 @@
+<table class="gem-c-table govuk-table govuk-table--sortable step-by-step-list__table">
+  <thead class="govuk-table__head">
+    <tr>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Title</th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Status</th>
+      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Base path / preview</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% if @step_by_step_pages.present? %>
+      <% @step_by_step_pages.each do |step_by_step_page| %>
+        <tr class="govuk-table__row" data-status="<%= step_by_step_page.status[:name] %>">
+          <td class="govuk-table__cell">
+            <strong><%= link_to step_by_step_page.title, step_by_step_page %></strong>
+          </td>
+          <td class="govuk-table__cell">
+            <span class="h4">
+              <span class="label <%= step_by_step_page.status[:label_class] %>" title="<%= step_by_step_page.status[:text] %>"><%= step_by_step_page.status[:text] %></span>
+            </span>
+          </td>
+          <td class="govuk-table__cell">
+            <% if step_by_step_page.has_draft? %>
+              <%= link_to "/#{step_by_step_page.slug}", preview_url(step_by_step_page.slug, auth_bypass_id: step_by_step_page.auth_bypass_id), target: "_blank" %>
+            <% elsif step_by_step_page.status[:name] == "live" %>
+              <%= link_to "/#{step_by_step_page.slug}", live_url(step_by_step_page.slug), target: "_blank" %>
+            <% else %>
+              /<%= step_by_step_page.slug %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell" colspan="3">
+          <p class="govuk-hint">No step by steps have been created yet.</p>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/step_by_step_pages/index/_results.erb
+++ b/app/views/step_by_step_pages/index/_results.erb
@@ -1,41 +1,42 @@
-<table class="gem-c-table govuk-table govuk-table--sortable step-by-step-list__table">
-  <thead class="govuk-table__head">
-    <tr>
-      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Title</th>
-      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Status</th>
-      <th class="govuk-table__header govuk-!-font-weight-bold" scope="col">Base path / preview</th>
-    </tr>
-  </thead>
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Documents list", { sortable: true, caption_classes: "govuk-visually-hidden" }) do |t| %>
 
-  <tbody class="govuk-table__body">
-    <% if @step_by_step_pages.present? %>
-      <% @step_by_step_pages.each do |step_by_step_page| %>
-        <tr class="govuk-table__row" data-status="<%= step_by_step_page.status[:name] %>">
-          <td class="govuk-table__cell">
-            <strong><%= link_to step_by_step_page.title, step_by_step_page %></strong>
-          </td>
-          <td class="govuk-table__cell">
-            <span class="h4">
-              <span class="label <%= step_by_step_page.status[:label_class] %>" title="<%= step_by_step_page.status[:text] %>"><%= step_by_step_page.status[:text] %></span>
-            </span>
-          </td>
-          <td class="govuk-table__cell">
-            <% if step_by_step_page.has_draft? %>
-              <%= link_to "/#{step_by_step_page.slug}", preview_url(step_by_step_page.slug, auth_bypass_id: step_by_step_page.auth_bypass_id), target: "_blank" %>
-            <% elsif step_by_step_page.status[:name] == "live" %>
-              <%= link_to "/#{step_by_step_page.slug}", live_url(step_by_step_page.slug), target: "_blank" %>
-            <% else %>
-              /<%= step_by_step_page.slug %>
-            <% end %>
-          </td>
-        </tr>
+  <%= t.head do %>
+    <%= t.header "Title" %>
+    <%= t.header "Status" %>
+    <%= t.header "Last updated" %>
+  <% end %>
+
+  <%= t.body do %>
+    <% @step_by_step_pages.each do |step_by_step_page| %>
+
+      <% preview_link = capture do %>
+        <% if step_by_step_page.has_draft? %>
+          <%= link_to "/#{step_by_step_page.slug}", preview_url(step_by_step_page.slug, auth_bypass_id: step_by_step_page.auth_bypass_id), target: "_blank", class: "govuk-link" %>
+        <% elsif step_by_step_page.status.published? %>
+          <%= link_to "/#{step_by_step_page.slug}", published_url(step_by_step_page.slug), target: "_blank", class: "govuk-link" %>
+        <% else %>
+          /<%= step_by_step_page.slug %>
+        <% end %>
       <% end %>
-    <% else %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell" colspan="3">
-          <p class="govuk-hint">No step by steps have been created yet.</p>
-        </td>
-      </tr>
+
+      <%= t.row do %>
+        <%= t.cell render "govuk_publishing_components/components/document_list", {
+          items: [
+            {
+              link: {
+                text: step_by_step_page.title,
+                path: step_by_step_page
+              },
+              metadata: {
+                preview_link: preview_link
+              }
+            }
+          ]
+        } %>
+
+        <%= t.cell step_by_step_page.status.humanize %>
+        <%= t.cell step_by_step_page.created_at.strftime('%-d %B %Y') %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
+  <% end %>
+<% end %>

--- a/app/views/step_by_step_pages/index/_results.erb
+++ b/app/views/step_by_step_pages/index/_results.erb
@@ -35,7 +35,7 @@
         } %>
 
         <%= t.cell step_by_step_page.status.humanize %>
-        <%= t.cell step_by_step_page.created_at.strftime('%-d %B %Y') %>
+        <%= t.cell format_full_date(step_by_step_page.updated_at) %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -564,7 +564,7 @@ RSpec.feature "Managing step by step pages" do
 
   def and_the_step_by_step_should_have_the_status(status)
     visit step_by_step_pages_url
-    expect(page).to have_css("tr[data-status=#{status.downcase}]")
+    expect(page).to have_content(status)
   end
 
   def and_there_should_be_a_change_note(change_note)

--- a/spec/helpers/time_options_helper_spec.rb
+++ b/spec/helpers/time_options_helper_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe TimeOptionsHelper do
     end
   end
 
+  describe "#format_full_date" do
+    it "formats the date correctly" do
+      date = Time.new(2030, 4, 20)
+      expect(helper.format_full_date(date)).to eq("20 April 2030")
+    end
+  end
+
   describe "#default_datetime_placeholder" do
     let(:default_day) { Time.current.tomorrow.day }
     let(:default_month) { Time.current.tomorrow.month }


### PR DESCRIPTION
This PR updates the summary page as follows:
- Update the heading and the "Create new" button
- Splits the index page into `_filters` and `_results` for maintainability and consistency with other publishing apps
- Updates the header of the page to use the admin_layout yield blocks and show the add button next to the title
- Updates the results table to use the table helper and document list component to generate the results consistently across publishing apps.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![index-before](https://user-images.githubusercontent.com/788096/64351339-07b74f80-cff2-11e9-98cf-6b315e619289.png)

</td><td valign="top">

![index-after](https://user-images.githubusercontent.com/788096/64351351-0d149a00-cff2-11e9-9895-067de487cfc5.png)

</td></tr>
</table>

co-author: @AgaDufrat

[Trello card](https://trello.com/c/C4HHCrAX)