### PR TITLE
Clarify major and minor updates

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -90,7 +90,7 @@ class StepByStepPagesController < ApplicationController
         render :schedule
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish
-        note_description = "Minor update scheduled by #{current_user.name} for publishing at #{format_full_date_and_time(scheduled_at)}"
+        note_description = "Scheduled by #{current_user.name} for publishing at #{format_full_date_and_time(scheduled_at)}"
         generate_internal_change_note(note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been scheduled to publish."
@@ -207,8 +207,8 @@ private
   def publish_note_description
     return "First published by #{current_user.name}" unless @step_by_step_page.has_been_published?
 
-    custom_note = " with note: #{@publish_intent.change_note}" unless @publish_intent.change_note.empty?
-    "#{@publish_intent.update_type.capitalize} update published by #{current_user.name}#{custom_note}"
+    custom_note = " with change note: #{@publish_intent.change_note}" unless @publish_intent.change_note.empty?
+    "Published by #{current_user.name}#{custom_note}"
   end
 
   def generate_internal_change_note(note_description)

--- a/app/views/step_by_step_pages/_change_notes.html.erb
+++ b/app/views/step_by_step_pages/_change_notes.html.erb
@@ -1,0 +1,32 @@
+<% textarea = capture do %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Public change note",
+      },
+      name: "change_note",
+      rows: 4,
+      hint: "Describe the change for users. This change note will be emailed to subscribers."
+    } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds" id="change-note">
+    <%= render "govuk_publishing_components/components/radio", {
+      heading: "Notify users about this change?",
+      name: "update_type",
+      id: "update-type",
+      items: [
+        {
+          value: "major",
+          text: "Yes",
+          conditional: textarea,
+        },
+        {
+          value: "minor",
+          text: "No",
+          checked: true,
+        }
+      ]
+    } %>
+  </div>
+</div>

--- a/app/views/step_by_step_pages/publish.html.erb
+++ b/app/views/step_by_step_pages/publish.html.erb
@@ -25,38 +25,8 @@
   <%= render "shared/steps/form_errors", resource: @publish_intent %>
 <% end %>
 
-
 <%= form_tag do %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/radio", {
-        heading: "Update type",
-        name: "update_type",
-        items: [
-          {
-            value: "minor",
-            text: "Minor",
-            checked: true
-          },
-          {
-            value: "major",
-            text: "Major"
-          }
-        ]
-      } %>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Change note"
-        },
-        name: "change_note"
-      } %>
-    </div>
-  </div>
+  <%= render "step_by_step_pages/change_notes" %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe StepByStepPagesController do
         change_note_text = "Testing major change note"
         post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "major", change_note: change_note_text }
 
-        expected_description = "Major update published by Name Surname with note: #{change_note_text}"
+        expected_description = "Published by Name Surname with change note: #{change_note_text}"
         expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
       end
     end
@@ -77,21 +77,11 @@ RSpec.describe StepByStepPagesController do
     context 'minor updates' do
       let(:step_by_step_page) { create(:published_step_by_step_page) }
 
-      it "generates an internal change note with change note text" do
-        stub_publishing_api
-
-        change_note_text = "Corrected a typo"
-        post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: change_note_text }
-
-        expected_description = "Minor update published by Name Surname with note: #{change_note_text}"
-        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
-      end
-
       it "generates an internal change note without change note text" do
         stub_publishing_api
         post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: "" }
 
-        expected_description = "Minor update published by Name Surname"
+        expected_description = "Published by Name Surname"
         expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
       end
     end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature "Managing step by step pages" do
     given_I_am_assigned_to_a_live_step_by_step_page_with_unpublished_changes
     and_I_visit_the_publish_page
     and_I_publish_the_page
-    then_there_should_be_a_change_note "Minor update published by #{stub_user.name}"
+    then_there_should_be_a_change_note "Published by #{stub_user.name}"
     when_I_view_the_step_by_step_page
     and_I_delete_the_first_step
     then_there_should_be_a_change_note "Draft saved by #{stub_user.name}"
@@ -168,7 +168,7 @@ RSpec.feature "Managing step by step pages" do
       when_I_submit_the_form
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
-      and_there_should_be_a_change_note "Minor update scheduled by Test author for publishing at 10:26am on 20 April 2030"
+      and_there_should_be_a_change_note "Scheduled by Test author for publishing at 10:26am on 20 April 2030"
       and_the_step_by_step_is_not_editable
       when_I_view_the_step_by_step_page
       then_I_can_see_a_summary_section

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -477,7 +477,7 @@ RSpec.feature "Managing step by step pages" do
   alias_method :and_when_I_click_button, :and_I_click_button
 
   def then_I_should_see_a_publish_form_with_changenotes
-    expect(page).to have_content("Update type")
+    expect(page).to have_content("Notify users about this change?")
     expect(page).to have_css('input[type="radio"][name="update_type"]', count: 2)
     expect(page).to have_css('textarea[name="change_note"]')
   end


### PR DESCRIPTION
**What**
- View is updated in line with the [card](https://trello.com/c/ZB4lH4G8/28-publish-delete-tab-clarify-what-major-and-minor-updates-mean) description
- References to minor/major are removed from UI

**Why**
Content designers were not sure what does the minor and major update mean.

**Example**
<img width="522" alt="change_note" src="https://user-images.githubusercontent.com/38078064/64445506-8da8c880-d0ce-11e9-9786-b9fbed8da737.png">

