### PR TITLE
Fix last updated date wrapping

### DIFF
--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -94,5 +94,9 @@
     .govuk-table__cell {
       @include govuk-font(16);
     }
+
+    .govuk-table__cell:last-child {
+      white-space: nowrap;
+    }
   }
 }


### PR DESCRIPTION
Last updated date is composed of 3 white-space-separated elements that wrap on new lines in default table conditions. Given we know this column will always be the last one in the results table we add an app-level overwrite to not wrap the cell content for this column.

### Before
<img width="714" alt="Screen Shot 2019-09-09 at 17 36 07" src="https://user-images.githubusercontent.com/788096/64549194-21290600-d328-11e9-92c4-f31d2e2d9957.png">

### After
<img width="714" alt="Screen Shot 2019-09-09 at 17 35 57" src="https://user-images.githubusercontent.com/788096/64549203-25552380-d328-11e9-84ee-579a7e859ec8.png">

[Trello card](https://trello.com/c/C4HHCrAX)