### PR TITLE
Flag actions to do before publishing step by step

### DIFF
--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -102,3 +102,7 @@
   }
 }
 // scss-lint:enable IdSelector
+
+.gem-c-inset-text {
+  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+}

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -86,7 +86,10 @@ class StepByStepPage < ApplicationRecord
   end
 
   def can_be_published?
-    has_draft? && !scheduled_for_publishing? && steps_have_content? && links_checked?
+    has_draft? &&
+      !scheduled_for_publishing? &&
+      steps_have_content? &&
+      links_checked_since_last_update?
   end
 
   def can_be_unpublished?
@@ -126,6 +129,10 @@ class StepByStepPage < ApplicationRecord
 
   def links_last_checked_date
     steps.map(&:links_last_checked_date).reject(&:blank?).max
+  end
+
+  def links_checked_since_last_update?
+    links_checked? && links_last_checked_date > draft_updated_at
   end
 
   def links_checked?

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -86,7 +86,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def can_be_published?
-    has_draft? && !scheduled_for_publishing? && steps_have_content?
+    has_draft? && !scheduled_for_publishing? && steps_have_content? && links_checked?
   end
 
   def can_be_unpublished?

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -131,6 +131,10 @@ class StepByStepPage < ApplicationRecord
     steps.map(&:links_last_checked_date).reject(&:blank?).max
   end
 
+  def should_show_required_prepublish_actions?
+    has_draft? && !scheduled_for_publishing? && !can_be_published?
+  end
+
   def links_checked_since_last_update?
     links_checked? && links_last_checked_date > draft_updated_at
   end

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -18,6 +18,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "step_by_step_pages/show/required_actions" %>
+
     <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.summary_list_params %>
 
     <%

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,6 +1,6 @@
 <% unless @step_by_step_page.steps_have_content? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
-    <p class="govuk-body">Add content to all your steps</p>
+    <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
   <% end %>
 <% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,12 +1,25 @@
 <% unless @step_by_step_page.can_be_published? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
-    <% if @step_by_step_page.steps.empty? %>
-      <%= link_to('Add at least one step', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
-    <% elsif !@step_by_step_page.steps_have_content? %>
-      <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
-    <% elsif !@step_by_step_page.links_checked_since_last_update? %>
-      <%= link_to "Check for broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
-    <% end %>
+
+    <ul class="govuk-list">
+      <% if @step_by_step_page.steps.empty? %>
+        <li>
+          <%= link_to('Add at least one step', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
+        </li>
+      <% end %>
+
+      <% if @step_by_step_page.steps.any? && !@step_by_step_page.steps_have_content? %>
+        <li>
+          <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
+        </li>
+      <% end %>
+
+      <% if @step_by_step_page.steps.any? && !@step_by_step_page.links_checked_since_last_update? %>
+        <li>
+          <%= link_to "Check for broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
 <% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,10 +1,12 @@
-<% unless @step_by_step_page.steps_have_content? %>
+<% unless @step_by_step_page.steps_have_content? && @step_by_step_page.links_checked? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
     <% if @step_by_step_page.steps.empty? %>
       <%= link_to('Add at least one step', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
-    <% else %>
+    <% elsif !@step_by_step_page.steps_have_content? %>
       <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
+    <% elsif !@step_by_step_page.links_checked? %>
+      <%= link_to "Check for broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,4 +1,4 @@
-<% unless @step_by_step_page.steps_have_content? && @step_by_step_page.links_checked? %>
+<% unless @step_by_step_page.can_be_published? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
     <% if @step_by_step_page.steps.empty? %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,4 +1,4 @@
-<% unless @step_by_step_page.can_be_published? %>
+<% if @step_by_step_page.should_show_required_prepublish_actions? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
 

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,0 +1,6 @@
+<% unless @step_by_step_page.steps_have_content? %>
+  <%= render "govuk_publishing_components/components/inset_text" do %>
+    <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
+    <p class="govuk-body">Add content to all your steps</p>
+  <% end %>
+<% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -1,6 +1,10 @@
 <% unless @step_by_step_page.steps_have_content? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <h2 class="govuk-heading-m">To publish this step by step you need to</h2>
-    <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
+    <% if @step_by_step_page.steps.empty? %>
+      <%= link_to('Add at least one step', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
+    <% else %>
+      <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -5,7 +5,7 @@
       <%= link_to('Add at least one step', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
     <% elsif !@step_by_step_page.steps_have_content? %>
       <%= link_to('Add content to all your steps', '#steps', class: 'govuk-link govuk-link--no-visited-state') %>
-    <% elsif !@step_by_step_page.links_checked? %>
+    <% elsif !@step_by_step_page.links_checked_since_last_update? %>
       <%= link_to "Check for broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
     <% end %>
   <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,6 +26,12 @@ FactoryBot.define do
     status { "published" }
   end
 
+  factory :step_by_step_with_unpublished_changes, parent: :step_by_step_page_with_steps do
+    published_at { 3.hours.ago }
+    draft_updated_at { 2.hours.ago }
+    status { "draft" }
+  end
+
   factory :scheduled_step_by_step_page, parent: :step_by_step_page_with_steps do
     scheduled_at { 3.hours.from_now }
     status { "scheduled" }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     status { "draft" }
     draft_updated_at { 3.hours.ago }
 
-    factory :step_by_step_page_with_steps do
+    factory :step_by_step_page_with_steps, aliases: [:draft_step_by_step_page] do
       after(:create) do |step_by_step_page|
         create(:step, step_by_step_page: step_by_step_page)
         create(:or_step, step_by_step_page: step_by_step_page)
@@ -26,13 +26,7 @@ FactoryBot.define do
     status { "published" }
   end
 
-  factory :draft_step_by_step_page, parent: :step_by_step_page_with_steps do
-    draft_updated_at { 1.day.ago }
-    status { "draft" }
-  end
-
   factory :scheduled_step_by_step_page, parent: :step_by_step_page_with_steps do
-    draft_updated_at { 3.hours.ago }
     scheduled_at { 3.hours.from_now }
     status { "scheduled" }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     introduction { "Find out the steps to become amazing" }
     description { "How to be amazing - find out the steps to become amazing" }
     status { "draft" }
+    draft_updated_at { 3.hours.ago }
 
     factory :step_by_step_page_with_steps do
       after(:create) do |step_by_step_page|
@@ -21,7 +22,6 @@ FactoryBot.define do
   end
 
   factory :published_step_by_step_page, parent: :step_by_step_page_with_steps do
-    draft_updated_at { 3.hours.ago }
     published_at { 3.hours.ago }
     status { "published" }
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -291,6 +291,15 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
+  scenario "Multiple required actions are listed in the inset prompt" do
+    given_a_step_by_step_has_an_empty_step_added_after_links_last_checked
+    when_I_view_the_step_by_step_page
+    then_I_should_see_an_inset_prompt
+    and_the_prompt_should_contain_link_to_steps_section "Add content to all your steps"
+    and_the_prompt_should_contain_link_to_steps_section "Check for broken links"
+    and_I_cannot_publish_or_schedule_the_step_by_step
+  end
+
   def and_it_has_change_notes
     create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -286,6 +286,15 @@ RSpec.feature "Managing step by step pages" do
     and_there_should_be_no_schedule_button
   end
 
+  scenario "Step by step has been updated since it was last checked for broken links" do
+    given_a_step_by_step_has_been_updated_after_links_last_checked
+    when_I_view_the_step_by_step_page
+    then_I_should_see_an_inset_prompt
+    and_the_prompt_should_contain_link_to_steps_section "Check for broken links"
+    and_there_should_be_no_publish_button
+    and_there_should_be_no_schedule_button
+  end
+
   def and_it_has_change_notes
     create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -238,6 +238,8 @@ RSpec.feature "Managing step by step pages" do
     given_there_is_a_step_by_step_page_with_steps_missing_content
     when_I_view_the_step_by_step_page
     then_I_should_see "Step by steps cannot be published until all steps have content."
+    and_I_should_see_an_inset_prompt
+    and_the_prompt_should_contain "Add content to all your steps"
     and_there_should_be_no_publish_button
     and_there_should_be_no_schedule_button
   end
@@ -622,6 +624,16 @@ RSpec.feature "Managing step by step pages" do
   end
 
   alias_method :then_there_should_be_no_schedule_button, :and_there_should_be_no_schedule_button
+
+  def and_I_should_see_an_inset_prompt
+    expect(page).to have_css('.govuk-inset-text', text: "To publish this step by step you need to")
+  end
+
+  def and_the_prompt_should_contain(prompt)
+    within('.govuk-inset-text') do
+      expect(page).to have_content prompt
+    end
+  end
 
   def then_I_should_see(content, scope = nil)
     scope_selector = case scope

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -300,6 +300,15 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
+  scenario "Publishing/scheduling a step by step does not prompt to check for broken links" do
+    given_there_is_a_step_that_has_no_broken_links
+    when_I_view_the_step_by_step_page
+    then_there_should_be_no_inset_prompt
+    and_when_I_click_button "Publish"
+    then_I_am_told_that_it_is_published
+    and_there_should_continue_to_be_no_inset_prompt
+  end
+
   def and_it_has_change_notes
     create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end
@@ -660,6 +669,12 @@ RSpec.feature "Managing step by step pages" do
   end
 
   alias_method :then_I_should_see_an_inset_prompt, :and_I_should_see_an_inset_prompt
+
+  def then_there_should_be_no_inset_prompt
+    expect(page).not_to have_css('.govuk-inset-text', text: "To publish this step by step you need to")
+  end
+
+  alias_method :and_there_should_continue_to_be_no_inset_prompt, :then_there_should_be_no_inset_prompt
 
   def and_the_prompt_should_contain_link_to_steps_section(prompt)
     within('.govuk-inset-text') do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -85,9 +85,9 @@ RSpec.feature "Managing step by step pages" do
   end
 
   scenario "User publishes a page" do
-    given_there_is_a_draft_step_by_step_page
+    given_there_is_a_step_by_step_page_with_a_link_report
     when_I_view_the_step_by_step_page
-    and_when_I_click_button "Publish"
+    when_I_click_button "Publish"
     then_I_am_told_that_it_is_published
     then_I_see_the_step_by_step_page
     and_I_see_an_unpublish_button
@@ -151,7 +151,7 @@ RSpec.feature "Managing step by step pages" do
   end
 
   scenario "User publishes changes to a published step by step page" do
-    given_there_is_a_published_step_by_step_page_with_unpublished_changes
+    given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
     when_I_view_the_step_by_step_page
     and_when_I_click_button "Publish"
     then_I_should_see_a_publish_form_with_changenotes
@@ -646,6 +646,8 @@ RSpec.feature "Managing step by step pages" do
   def and_I_should_see_an_inset_prompt
     expect(page).to have_css('.govuk-inset-text', text: "To publish this step by step you need to")
   end
+
+  alias_method :then_I_should_see_an_inset_prompt, :and_I_should_see_an_inset_prompt
 
   def and_the_prompt_should_contain_link_to_steps_section(prompt)
     within('.govuk-inset-text') do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -240,8 +240,7 @@ RSpec.feature "Managing step by step pages" do
     then_I_should_see "Step by steps cannot be published until all steps have content."
     and_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_link_to_steps_section "Add content to all your steps"
-    and_there_should_be_no_publish_button
-    and_there_should_be_no_schedule_button
+    and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
   scenario "A step has not been tested for broken links" do
@@ -273,8 +272,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_view_the_step_by_step_page
     then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_link_to_steps_section "Add at least one step"
-    and_there_should_be_no_publish_button
-    and_there_should_be_no_schedule_button
+    and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
   scenario "Step by step has not been checked for broken links" do
@@ -282,8 +280,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_view_the_step_by_step_page
     then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_link_to_steps_section "Check for broken links"
-    and_there_should_be_no_publish_button
-    and_there_should_be_no_schedule_button
+    and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
   scenario "Step by step has been updated since it was last checked for broken links" do
@@ -291,8 +288,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_view_the_step_by_step_page
     then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_link_to_steps_section "Check for broken links"
-    and_there_should_be_no_publish_button
-    and_there_should_be_no_schedule_button
+    and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
   def and_it_has_change_notes
@@ -650,8 +646,6 @@ RSpec.feature "Managing step by step pages" do
     expect(page).not_to have_link("Schedule")
   end
 
-  alias_method :then_there_should_be_no_schedule_button, :and_there_should_be_no_schedule_button
-
   def and_I_should_see_an_inset_prompt
     expect(page).to have_css('.govuk-inset-text', text: "To publish this step by step you need to")
   end
@@ -806,7 +800,10 @@ RSpec.feature "Managing step by step pages" do
     end
   end
 
-  alias_method :and_there_should_be_no_publish_button, :then_there_should_be_no_publish_button
+  def and_I_cannot_publish_or_schedule_the_step_by_step
+    then_there_should_be_no_publish_button
+    and_there_should_be_no_schedule_button
+  end
 
   def then_there_should_be_no_discard_changes_button
     within(".app-side__actions") do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -239,7 +239,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_view_the_step_by_step_page
     then_I_should_see "Step by steps cannot be published until all steps have content."
     and_I_should_see_an_inset_prompt
-    and_the_prompt_should_contain "Add content to all your steps"
+    and_the_prompt_should_contain_link_to_steps_section "Add content to all your steps"
     and_there_should_be_no_publish_button
     and_there_should_be_no_schedule_button
   end
@@ -629,9 +629,9 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_css('.govuk-inset-text', text: "To publish this step by step you need to")
   end
 
-  def and_the_prompt_should_contain(prompt)
+  def and_the_prompt_should_contain_link_to_steps_section(prompt)
     within('.govuk-inset-text') do
-      expect(page).to have_content prompt
+      expect(page).to have_link(prompt, href: '#steps')
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -39,8 +39,8 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_the_new_step_by_step_page
   end
 
-  scenario "User visits an existing step by step page" do
-    given_there_is_a_step_by_step_page
+  scenario "User visits a step by step page with no steps" do
+    given_there_is_a_draft_step_by_step_page_with_no_steps
     when_I_view_the_step_by_step_page
     then_I_can_see_a_summary_section
     and_I_can_edit_the_summary_section
@@ -51,7 +51,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_see_a_metadata_section
   end
 
-  scenario "User visits an existing step by step page with steps" do
+  scenario "User visits a step by step page with steps" do
     given_there_is_a_step_by_step_page_with_steps
     when_I_view_the_step_by_step_page
     then_I_can_see_a_summary_section

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -277,6 +277,15 @@ RSpec.feature "Managing step by step pages" do
     and_there_should_be_no_schedule_button
   end
 
+  scenario "Step by step has not been checked for broken links" do
+    given_there_is_a_draft_step_by_step_page
+    when_I_view_the_step_by_step_page
+    then_I_should_see_an_inset_prompt
+    and_the_prompt_should_contain_link_to_steps_section "Check for broken links"
+    and_there_should_be_no_publish_button
+    and_there_should_be_no_schedule_button
+  end
+
   def and_it_has_change_notes
     create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -620,7 +620,7 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_there_should_be_no_schedule_button
-    expect(page).not_to have_css("a", text: "Schedule")
+    expect(page).not_to have_link("Schedule")
   end
 
   alias_method :then_there_should_be_no_schedule_button, :and_there_should_be_no_schedule_button
@@ -773,7 +773,7 @@ RSpec.feature "Managing step by step pages" do
 
   def then_there_should_be_no_publish_button
     within(".app-side__actions") do
-      expect(page).to_not have_css("button", text: "Publish")
+      expect(page).to_not have_link("Publish")
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -268,6 +268,15 @@ RSpec.feature "Managing step by step pages" do
     then_the_step_should_confirm_it_has_multiple_broken_links
   end
 
+  scenario "Step by step doesn't have any steps" do
+    given_there_is_a_draft_step_by_step_page_with_no_steps
+    when_I_view_the_step_by_step_page
+    then_I_should_see_an_inset_prompt
+    and_the_prompt_should_contain_link_to_steps_section "Add at least one step"
+    and_there_should_be_no_publish_button
+    and_there_should_be_no_schedule_button
+  end
+
   def and_it_has_change_notes
     create(:internal_change_note, step_by_step_page_id: @step_by_step_page.id)
   end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -308,7 +308,11 @@ RSpec.describe StepByStepPage do
   describe '#can_be_published?' do
     let(:step_by_step_page) { create(:published_step_by_step_page) }
 
-    it 'can be published if it has a draft, is not scheduled for publishing and all steps have content' do
+    before do
+      allow(step_by_step_page).to receive(:links_checked?) { true }
+    end
+
+    it 'can be published if it has a draft, is not scheduled, all steps have content and links have been checked' do
       step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be true
@@ -336,6 +340,13 @@ RSpec.describe StepByStepPage do
     it 'cannot be published if all steps do not have content' do
       create(:step, step_by_step_page: step_by_step_page, contents: "")
       step_by_step_page.mark_draft_updated
+
+      expect(step_by_step_page.can_be_published?).to be false
+    end
+
+    it 'cannot be published if links have not been checked' do
+      step_by_step_page.mark_draft_updated
+      allow(step_by_step_page).to receive(:links_checked?) { false }
 
       expect(step_by_step_page.can_be_published?).to be false
     end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -213,6 +213,33 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe 'should_show_required_prepublish_actions?' do
+    it 'should return false if step by step is scheduled' do
+      step_by_step_with_step = create(:step_by_step_page, status: 'scheduled', scheduled_at: 1.day.from_now)
+
+      expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be false
+    end
+
+    it 'should return false if the status of the step by step is published' do
+      step_by_step_with_step = create(:published_step_by_step_page)
+
+      expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be false
+    end
+
+    it 'should return false if step by step is in draft but has no issues blocking its publication' do
+      step_by_step_with_step = create(:draft_step_by_step_page)
+      create(:link_report, batch_id: 1, step_id: step_by_step_with_step.steps.first.id)
+
+      expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be false
+    end
+
+    it 'should return true if step by step is in draft and cannot be published' do
+      step_by_step_with_step = create(:draft_step_by_step_page)
+
+      expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be true
+    end
+  end
+
   describe 'links_checked?' do
     it 'returns true if links have been checked' do
       step_by_step_with_step = create(:step_by_step_page)

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe StepByStepPage do
   end
 
   describe '#can_be_published?' do
-    let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
+    let(:step_by_step_page) { create(:published_step_by_step_page) }
 
     it 'can be published if it has a draft, is not scheduled for publishing and all steps have content' do
       step_by_step_page.mark_draft_updated

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -192,6 +192,27 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe 'links_checked_since_last_update?' do
+    let(:step_by_step_with_step) { create(:step_by_step_page_with_steps) }
+
+    it 'returns false if links have never been checked' do
+      expect(step_by_step_with_step.links_checked_since_last_update?).to be false
+    end
+
+    it 'returns false if content changed since links were last checked' do
+      create(:link_report, batch_id: 1, step_id: step_by_step_with_step.steps.last.id, created_at: 1.day.ago)
+      step_by_step_with_step.mark_draft_updated
+
+      expect(step_by_step_with_step.links_checked_since_last_update?).to be false
+    end
+
+    it 'returns true if links were checked more recently than content changed' do
+      create(:link_report, batch_id: 1, step_id: step_by_step_with_step.steps.last.id, created_at: 1.minute.ago)
+
+      expect(step_by_step_with_step.links_checked_since_last_update?).to be true
+    end
+  end
+
   describe 'links_checked?' do
     it 'returns true if links have been checked' do
       step_by_step_with_step = create(:step_by_step_page)
@@ -309,10 +330,10 @@ RSpec.describe StepByStepPage do
     let(:step_by_step_page) { create(:published_step_by_step_page) }
 
     before do
-      allow(step_by_step_page).to receive(:links_checked?) { true }
+      allow(step_by_step_page).to receive(:links_checked_since_last_update?) { true }
     end
 
-    it 'can be published if it has a draft, is not scheduled, all steps have content and links have been checked' do
+    it 'can be published if it has a draft, is not scheduled, all steps have content and links have been checked since last update' do
       step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be true
@@ -344,9 +365,9 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.can_be_published?).to be false
     end
 
-    it 'cannot be published if links have not been checked' do
+    it 'cannot be published if step by step updated since links were last checked' do
       step_by_step_page.mark_draft_updated
-      allow(step_by_step_page).to receive(:links_checked?) { false }
+      allow(step_by_step_page).to receive(:links_checked_since_last_update?) { false }
 
       expect(step_by_step_page.can_be_published?).to be false
     end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -77,12 +77,12 @@ module StepNavSteps
   end
 
   def given_there_is_a_published_step_by_step_page_with_unpublished_changes
-    @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: Time.zone.now, status: "draft")
+    @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: 1.day.ago, status: "draft")
     expect(@step_by_step_page.status).to be_draft
   end
 
   def given_I_am_assigned_to_a_published_step_by_step_page_with_unpublished_changes
-    @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: Time.zone.now, assigned_to: stub_user.name)
+    @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: 1.day.ago, assigned_to: stub_user.name)
   end
 
   def given_there_is_a_scheduled_step_by_step_page
@@ -108,6 +108,18 @@ module StepNavSteps
     step = create(:step)
     create(:link_report, step_id: step.id)
     @step_by_step_page = create(:step_by_step_with_unpublished_changes, steps: [step], slug: 'step-by-step-with-unpublished-changes')
+  end
+
+  def given_a_step_by_step_has_been_updated_after_links_last_checked
+    link_checker_api_get_batch(id: 1, links: [link_checker_api_link_report_success])
+    step = create(:step)
+    create(:link_report, step_id: step.id)
+    @step_by_step_page = create(
+      :step_by_step_with_unpublished_changes,
+      steps: [step],
+      slug: 'step-by-step-with-recent-unpublished-changes',
+      draft_updated_at: Time.zone.now
+    )
   end
 
   def given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -56,6 +56,8 @@ module StepNavSteps
     @step_by_step_page = create(:step_by_step_page)
   end
 
+  alias_method :given_there_is_a_draft_step_by_step_page_with_no_steps, :given_there_is_a_step_by_step_page
+
   def given_there_is_a_step_by_step_page_with_steps
     @step_by_step_page = create(:step_by_step_page_with_steps)
   end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -122,6 +122,19 @@ module StepNavSteps
     )
   end
 
+  def given_a_step_by_step_has_an_empty_step_added_after_links_last_checked
+    link_checker_api_get_batch(id: 1, links: [link_checker_api_link_report_success])
+    @step_by_step_page = create(
+      :step_by_step_with_unpublished_changes,
+      slug: 'step-by-step-with-link-report-and-empty-step-added-since-links-checked',
+      draft_updated_at: Time.zone.now
+    )
+
+    step_with_link_report = create(:step, step_by_step_page: @step_by_step_page)
+    create(:link_report, step_id: step_with_link_report.id)
+    create(:step, contents: "", step_by_step_page: @step_by_step_page)
+  end
+
   def given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
     @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules)
     expect(@step_by_step_page.status).to be_draft

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -103,6 +103,13 @@ module StepNavSteps
 
   alias_method :given_there_is_a_step_that_has_no_broken_links, :given_there_is_a_step_by_step_page_with_a_link_report
 
+  def given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
+    link_checker_api_get_batch(id: 1, links: [link_checker_api_link_report_success])
+    step = create(:step)
+    create(:link_report, step_id: step.id)
+    @step_by_step_page = create(:step_by_step_with_unpublished_changes, steps: [step], slug: 'step-by-step-with-unpublished-changes')
+  end
+
   def given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
     @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules)
     expect(@step_by_step_page.status).to be_draft

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -104,7 +104,7 @@ module StepNavSteps
   alias_method :given_there_is_a_step_that_has_no_broken_links, :given_there_is_a_step_by_step_page_with_a_link_report
 
   def given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
-    @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules, draft_updated_at: 1.day.ago)
+    @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules)
     expect(@step_by_step_page.status).to be_draft
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/IEGDwZch/49-use-inset-text-component-to-flag-actions-that-need-to-be-done-before-publishing

This PR:

- Uses `inset-text` component to show the important actions a user must take before they can
  publish their step by step.
- Adds new pre-requisite: "Add at least one step"
  Whilst it was never possible to publish an empty step by step (would fail the `has_content?`
  check), it used to only have the generic error message "Every step must have content", which
  doesn't make much sense if you haven't even added a step.
- Adds new pre-requisite: "Check for broken links"
  Cannot publish a step by step without checking for broken links since your last update.
- Displays multiple links if step by step is affected by multiple things. Example:
  One step may have no content (fail # 1) and also the draft may have been updated since you last checked for broken links (fail # 2).

Note that if any links are broken, we should ideally prevent publishing and we should have another inset-text prompt that says links need fixing, but this needs fleshing out (e.g. should there be a prompt for every step where there is a broken link, linking out to that step, or should there be one prompt to cover them all, linking out just to the `#steps` section?). This is out of scope for this PR and will be done in https://trello.com/c/9hBzk8lJ.

![Screen Shot 2019-09-13 at 13 29 03](https://user-images.githubusercontent.com/5111927/64863458-c5fb5a00-d62c-11e9-88a9-3e19fdfa7836.png)
