### PR TITLE
Show submission confirmation to user when they check for broken links

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -145,6 +145,7 @@ class StepByStepPagesController < ApplicationController
   def check_links
     set_current_page_as_step_by_step
     @step_by_step_page.steps.each(&:request_broken_links)
+    redirect_to @step_by_step_page, notice: "Links are currently being checked. Please refresh the page to check progress. When all links have been checked, you'll see a message below each step."
   end
 
   def internal_change_notes

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -271,6 +271,24 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
+  scenario "Checking for broken links" do
+    stub_link_checker_api_create_batch(
+      uris: [
+        "http://example.com/good",
+        "https://www.gov.uk/good/stuff",
+        "https://www.gov.uk/also/good/stuff",
+        "https://www.gov.uk/not/as/great"
+      ],
+      webhook_uri: Plek.new.external_url_for("collections-publisher") + "/link_report"
+    )
+    stub_link_checker_api_get_batch(id: 0)
+
+    given_there_is_a_step_by_step_page_with_steps
+    when_I_view_the_step_by_step_page
+    when_I_click_button "Check for broken links"
+    then_I_should_see "Links are currently being checked."
+  end
+
   scenario "A step has not been tested for broken links" do
     given_there_is_a_step_that_has_not_been_tested_for_broken_links
     when_I_view_the_step_by_step_page


### PR DESCRIPTION
When a user checks for broken links, they should see a message telling
them that their check is in progress. Previously we provided no feedback.
If the user refreshes the page, the message goes away.

Trello: https://trello.com/c/qensq3Jw/57-provide-feedback-when-clicking-check-for-broken-links

![Screen Shot 2019-09-13 at 09 44 53](https://user-images.githubusercontent.com/5111927/64850323-19f64680-d60d-11e9-9e48-798e81855805.png)
