### PR TITLE
2i reviewer can claim step-by-step for review (backend)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,10 @@ private
     controller_name
   end
 
+  def require_2i_reviewer_permissions!
+    authorise_user!("2i reviewer")
+  end
+
   def require_gds_editor_permissions!
     authorise_user!("GDS Editor")
   end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -3,7 +3,10 @@ class ReviewController < ApplicationController
 
   before_action :require_gds_editor_permissions!
   before_action :require_unreleased_feature_permissions!
+  before_action :require_2i_reviewer_permissions!, only: %i(claim_2i_review)
   before_action :set_step_by_step_page
+
+  def claim_2i_review; end
 
   def submit_for_2i
     if request.post?

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -6,7 +6,14 @@ class ReviewController < ApplicationController
   before_action :require_2i_reviewer_permissions!, only: %i(claim_2i_review)
   before_action :set_step_by_step_page
 
-  def claim_2i_review; end
+  def claim_2i_review
+    if @step_by_step_page.update(
+      reviewer_id: current_user.uid,
+      status: "in_review"
+    )
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully claimed for review."
+    end
+  end
 
   def submit_for_2i
     if request.post?

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -7,10 +7,14 @@ class ReviewController < ApplicationController
   before_action :set_step_by_step_page
 
   def claim_2i_review
+    status = "in_review"
+
     if @step_by_step_page.update(
       reviewer_id: current_user.uid,
-      status: "in_review"
+      status: status
     )
+      generate_change_note(status)
+
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully claimed for review."
     end
   end
@@ -34,7 +38,7 @@ class ReviewController < ApplicationController
 
 private
 
-  def generate_change_note(status, change_note)
+  def generate_change_note(status, change_note = nil)
     description = "#{status.humanize} by #{current_user.name}"
     description << "\n\n#{change_note}" if change_note.present?
 

--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -1,0 +1,6 @@
+module StepNavActionsHelper
+  def can_review?(step_by_step_page, user)
+    step_by_step_page.status.submitted_for_2i? &&
+      step_by_step_page.review_requester_id != user.uid
+  end
+end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -55,6 +55,7 @@ class StepByStepPage < ApplicationRecord
       draft_updated_at: now,
       scheduled_at: nil,
       assigned_to: nil,
+      review_requester_id: nil,
       reviewer_id: nil,
       status: "published"
     )

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -55,6 +55,7 @@ class StepByStepPage < ApplicationRecord
       draft_updated_at: now,
       scheduled_at: nil,
       assigned_to: nil,
+      reviewer_id: nil,
       status: "published"
     )
   end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -17,6 +17,7 @@ class StepByStepPage < ApplicationRecord
   validates :slug, slug: true, on: :create
   validates :status, inclusion: { in: STATUSES }, presence: true
   validates :status, status_prerequisite: true
+  validate :reviewer_is_not_same_as_review_requester
 
   before_validation :generate_content_id, on: :create
   before_destroy :discard_notes
@@ -141,5 +142,11 @@ private
 
   def generate_content_id
     self.content_id ||= SecureRandom.uuid
+  end
+
+  def reviewer_is_not_same_as_review_requester
+    if review_requester_id.present? && review_requester_id == reviewer_id
+      errors.add(:reviewer_id, "can't be the same as review_requester_id")
+    end
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,6 +1,7 @@
 class StepByStepPage < ApplicationRecord
   STATUSES = %w(
     draft
+    in_review
     published
     scheduled
     submitted_for_2i

--- a/app/validators/status_prerequisite_validator.rb
+++ b/app/validators/status_prerequisite_validator.rb
@@ -1,5 +1,11 @@
 class StatusPrerequisiteValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    if value == "in_review"
+      return true if can_be_in_review?(record)
+
+      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be submitted_for_2i"
+    end
+
     if value == "scheduled"
       return true if can_be_scheduled?(record)
 
@@ -14,6 +20,12 @@ class StatusPrerequisiteValidator < ActiveModel::EachValidator
   end
 
 private
+
+  def can_be_in_review?(record)
+    record.has_draft? &&
+      record.reviewer_id.present? &&
+      record.status_was == "submitted_for_2i"
+  end
 
   def can_be_scheduled?(record)
     record.has_draft? && record.scheduled_at.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   resources :step_by_step_pages, path: 'step-by-step-pages' do
     post :check_links
+    post 'claim-2i-review', to: 'review#claim_2i_review'
     get 'internal-change-notes', to: 'interal_change_notes'
     post 'internal-change-notes', to: 'internal_change_notes#create'
     get 'navigation-rules', to: 'navigation_rules#edit'

--- a/db/migrate/20190913122638_add_reviewer_to_step_by_step_pages.rb
+++ b/db/migrate/20190913122638_add_reviewer_to_step_by_step_pages.rb
@@ -1,0 +1,6 @@
+class AddReviewerToStepByStepPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :step_by_step_pages, :reviewer_id, :string
+    add_foreign_key :step_by_step_pages, :users, column: :reviewer_id, primary_key: 'uid'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_11_125734) do
+ActiveRecord::Schema.define(version: 2019_09_13_122638) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -108,8 +108,10 @@ ActiveRecord::Schema.define(version: 2019_09_11_125734) do
     t.datetime "scheduled_at"
     t.string "status", null: false
     t.string "review_requester_id"
+    t.string "reviewer_id"
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["review_requester_id"], name: "fk_rails_d4fb625ca0"
+    t.index ["reviewer_id"], name: "fk_rails_7247412df6"
     t.index ["slug"], name: "index_step_by_step_pages_on_slug", unique: true
   end
 
@@ -173,6 +175,7 @@ ActiveRecord::Schema.define(version: 2019_09_11_125734) do
   add_foreign_key "redirect_routes", "tags"
   add_foreign_key "secondary_content_links", "step_by_step_pages"
   add_foreign_key "step_by_step_pages", "users", column: "review_requester_id", primary_key: "uid"
+  add_foreign_key "step_by_step_pages", "users", column: "reviewer_id", primary_key: "uid"
   add_foreign_key "steps", "step_by_step_pages"
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -119,6 +119,18 @@ RSpec.describe ReviewController do
         expect(step_by_step_page.status).to eq("in_review")
         expect(step_by_step_page.reviewer_id).to eq(stub_user.uid)
       end
+
+      it "creates an internal change note" do
+        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.name = "Firstname Lastname"
+
+        expected_change_note = "In review by Firstname Lastname"
+
+        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+        step_by_step_page.reload
+
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+      end
     end
   end
 end

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -8,66 +8,96 @@ RSpec.describe ReviewController do
       allow(Services.publishing_api).to receive(:lookup_content_id)
     end
 
-    describe "GET submit for 2i page" do
-      it "can only be accessed by users with GDS editor and Unreleased feature permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
-        get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+    describe "submit for 2i" do
+      describe "GET submit for 2i page" do
+        it "can be accessed by users with GDS editor and Unreleased feature permissions" do
+          stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
+          get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
 
-        expect(response.status).to eq(200)
+          expect(response.status).to eq(200)
+        end
+
+        it "cannot be accessed by users with only GDS editor permissions" do
+          stub_user.permissions << "GDS Editor"
+          get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+
+          expect(response.status).to eq(403)
+        end
+
+        it "cannot be accessed by users with neither GDS editor and Unreleased feature permissions" do
+          stub_user.permissions = %w(signin)
+          get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+
+          expect(response.status).to eq(403)
+        end
+      end
+
+      describe "POST submit for 2i" do
+        before do
+          stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
+          stub_user.name = "Firstname Lastname"
+        end
+
+        it "sets status to submit_for_2i" do
+          post :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+
+          step_by_step_page.reload
+
+          expect(step_by_step_page.status).to eq("submitted_for_2i")
+          expect(step_by_step_page.review_requester_id).to eq(stub_user.uid)
+        end
+
+        describe "internal change notes" do
+          it "creates an internal change note" do
+            expected_change_note = "Submitted for 2i by Firstname Lastname"
+
+            post :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+            step_by_step_page.reload
+
+            expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+          end
+
+          it "records the additional comments in the internal change note" do
+            additional_comments = "additional comments for reviewer"
+
+            post :submit_for_2i, params: {
+              step_by_step_page_id: step_by_step_page.id,
+              additional_comments: additional_comments
+            }
+
+            expect(step_by_step_page.internal_change_notes.first.description).to include(additional_comments)
+          end
+        end
+      end
+    end
+
+    describe "POST claim 2i review" do
+      it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
+        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response.status).to eq(204)
       end
 
       it "cannot be accessed by users with only GDS editor permissions" do
         stub_user.permissions << "GDS Editor"
-        get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         expect(response.status).to eq(403)
       end
 
-      it "cannot be accessed by users with
-
-       neither GDS editor and Unreleased feature permissions" do
-        stub_user.permissions = %w(signin)
-        get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
-      end
-    end
-
-    describe "POST submit for 2i" do
-      before do
+      it "cannot be accessed by users with only GDS editor and Unreleased feature permissions" do
         stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
-        stub_user.name = "Firstname Lastname"
+        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response.status).to eq(403)
       end
 
-      it "sets status to submit_for_2i" do
-        post :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+      it "cannot be accessed by users with only signin permissions" do
+        stub_user.permissions = %w(signin)
+        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
-        step_by_step_page.reload
-
-        expect(step_by_step_page.status).to eq("submitted_for_2i")
-        expect(step_by_step_page.review_requester_id).to eq(stub_user.uid)
-      end
-
-      describe "internal change notes" do
-        it "creates an internal change note" do
-          expected_change_note = "Submitted for 2i by Firstname Lastname"
-
-          post :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
-          step_by_step_page.reload
-
-          expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
-        end
-
-        it "records the additional comments in the internal change note" do
-          additional_comments = "additional comments for reviewer"
-
-          post :submit_for_2i, params: {
-            step_by_step_page_id: step_by_step_page.id,
-            additional_comments: additional_comments
-          }
-
-          expect(step_by_step_page.internal_change_notes.first.description).to include(additional_comments)
-        end
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe StepNavActionsHelper do
+  let(:step_by_step_page) { create(:draft_step_by_step_page) }
+  let(:user) { create(:user) }
+
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
+  describe "#can_review?" do
+    it "returns false if the step-by-step has not been submitted for 2i" do
+      expect(helper.can_review?(step_by_step_page, user)).to be false
+    end
+
+    it "returns false if the user who requested a review trys to claim the review" do
+      step_by_step_page.status = "submitted_for_2i"
+      step_by_step_page.review_requester_id = user.uid
+      expect(helper.can_review?(step_by_step_page, user)).to be false
+    end
+  end
+end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -269,6 +269,14 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.assigned_to).to be nil
     end
 
+    it 'should unassign the review requester' do
+      stub_user = create(:user)
+      step_by_step_page.review_requester_id = stub_user.uid
+      step_by_step_page.mark_as_published
+
+      expect(step_by_step_page.review_requester_id).to be nil
+    end
+
     it 'should unassign the reviewer' do
       stub_user = create(:user)
       step_by_step_page.review_requester_id = stub_user.uid

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -269,6 +269,15 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.assigned_to).to be nil
     end
 
+    it 'should unassign the reviewer' do
+      stub_user = create(:user)
+      step_by_step_page.review_requester_id = stub_user.uid
+      step_by_step_page.reviewer_id = stub_user.uid
+      step_by_step_page.mark_as_published
+
+      expect(step_by_step_page.reviewer_id).to be nil
+    end
+
     it 'should reset published date' do
       step_by_step_page.mark_as_unpublished
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -119,6 +119,17 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.errors.full_messages).to eq(["Slug has already been taken."])
     end
 
+    it 'does not allow the reviewer to be the same as the review requester' do
+      user_uid = SecureRandom.uuid
+      step_by_step_page.review_requester_id = user_uid
+      step_by_step_page.reviewer_id = user_uid
+
+      step_by_step_page.save
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors).to have_key(:reviewer_id)
+    end
+
     describe '#status' do
       it 'requires a status' do
         step_by_step_page.status = ''

--- a/spec/validators/status_prerequisite_validator_spec.rb
+++ b/spec/validators/status_prerequisite_validator_spec.rb
@@ -7,6 +7,36 @@ RSpec.describe StatusPrerequisiteValidator do
     allow(Services.publishing_api).to receive(:lookup_content_id)
   end
 
+  context "#in_review" do
+    let(:error_message) { "in_review, requires a draft, a reviewer and for status to be submitted_for_2i" }
+
+    it "does not allow status to be in_review if reviewer_id is missing" do
+      step_by_step_page.reviewer_id = nil
+      step_by_step_page.status = "in_review"
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
+    end
+
+    it "does not allow status to be in_review if there is no draft" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(false)
+      step_by_step_page.reviewer_id = SecureRandom.uuid
+      step_by_step_page.status = "in_review"
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
+    end
+
+    it "does not allow status to be in_review if the current status is not submitted_for_2i" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+      step_by_step_page.reviewer_id = SecureRandom.uuid
+      step_by_step_page.status = "in_review"
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
+    end
+  end
+
   context "#scheduled" do
     let(:error_message) { "scheduled, requires a draft and scheduled_at date to be present" }
 


### PR DESCRIPTION
Trello: https://trello.com/c/axseYRGB

This is a WIP. Things left to do:

1. Add "Claim 2i Review" action on overview page
2. Show who has claimed the review

Tested locally by:

1. Adding a temporary button to the overview page:
`<%= button_to "Claim 2i review", {controller: "review", action: "claim_2i_review", step_by_step_page_id: @step_by_step_page.id}, method: :post, class: "govuk-button gem-c-button gem-c-button--secondary-quiet" %>`

2. Creating a new user, and setting the `review_requester_id` to the uid of the new user

The status changes to "In review" as expected.

![Screen Shot 2019-09-16 at 16 08 31](https://user-images.githubusercontent.com/5793815/64969663-407de100-d89c-11e9-8d1f-ffb71ff3ec13.png)

### Status changes

![Screen Shot 2019-09-16 at 16 11 08](https://user-images.githubusercontent.com/5793815/64969961-cd289f00-d89c-11e9-9b7c-35036e432f7f.png)
![Screen Shot 2019-09-16 at 16 11 21](https://user-images.githubusercontent.com/5793815/64969982-d285e980-d89c-11e9-9003-ec9897988beb.png)
