### PR TITLE
Merge "Where to show" sections

### DIFF
--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -79,8 +79,7 @@ class StepByStepPagePresenter
 
   def sidebar_settings
     {
-      title: "Sidebar settings",
-      id: "sidebar-settings",
+      field: "Sidebar settings",
       edit: {
         link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
         href: step_by_step_page_navigation_rules_path(step_by_step_page),
@@ -93,8 +92,7 @@ class StepByStepPagePresenter
 
   def secondary_links_settings
     {
-      title: "Secondary links",
-      id: "secondary-links",
+      field: "Secondary links",
       edit: {
         link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
         href: step_by_step_page_secondary_content_links_path(step_by_step_page),

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -65,18 +65,15 @@
       </div>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.sidebar_settings %>
-
-    <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.secondary_links_settings do %>
-      <p class="govuk-body">Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.</p>
-
-      <p class="govuk-body">We use it for content which:</p>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task</li>
-        <li>is optional and not useful enough to be included in the step by step</li>
-      </ul>
-    <% end %>
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: "Where to show this step by step",
+      id: "where-to-show",
+      borderless: true,
+      items: [
+        @step_by_step_page_presenter.sidebar_settings,
+        @step_by_step_page_presenter.secondary_links_settings
+      ]
+    }  %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -47,8 +47,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_see_a_steps_overview_section_with_no_steps
     and_I_cannot_check_for_broken_links
     and_I_cannot_reorder_the_steps
-    and_I_can_see_a_sidebar_settings_section_with_link "Edit"
-    and_I_can_see_a_secondary_links_section_with_link "Edit"
+    and_I_can_see_a_where_to_show_section_with_links "Edit"
     and_I_can_see_a_metadata_section
   end
 
@@ -60,8 +59,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_see_a_steps_overview_section
     and_I_can_edit_and_delete_steps
     and_I_can_reorder_the_steps
-    and_I_can_see_a_sidebar_settings_section_with_link "Edit"
-    and_I_can_see_a_secondary_links_section_with_link "Edit"
+    and_I_can_see_a_where_to_show_section_with_links "Edit"
     and_I_can_see_a_metadata_section
   end
 
@@ -191,8 +189,7 @@ RSpec.feature "Managing step by step pages" do
       and_I_can_see_a_steps_overview_section
       but_I_cannot_edit_or_delete_steps
       and_I_cannot_reorder_the_steps
-      and_I_can_see_a_sidebar_settings_section_with_link "View"
-      and_I_can_see_a_secondary_links_section_with_link "View"
+      and_I_can_see_a_where_to_show_section_with_links "Edit"
       then_I_can_preview_the_step_by_step
       and_the_steps_can_be_checked_for_broken_links
     end
@@ -428,16 +425,10 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to_not have_link("Reorder", exact: true)
   end
 
-  def and_I_can_see_a_sidebar_settings_section_with_link(link_text)
-    within(".gem-c-summary-list#sidebar-settings") do
-      expect(page).to have_content "Sidebar settings"
+  def and_I_can_see_a_where_to_show_section_with_links(link_text)
+    within(".gem-c-summary-list#where-to-show") do
+      expect(page).to have_content "Where to show this step by step"
       expect(page).to have_link(link_text, :href => step_by_step_page_navigation_rules_path(@step_by_step_page))
-    end
-  end
-
-  def and_I_can_see_a_secondary_links_section_with_link(link_text)
-    within(".gem-c-summary-list#secondary-links") do
-      expect(page).to have_content "Secondary links"
       expect(page).to have_link(link_text, :href => step_by_step_page_secondary_content_links_path(@step_by_step_page))
     end
   end


### PR DESCRIPTION
Merged "Sidebar settings" and "Secondary links" into one summary list.

### Before
<img width="675" alt="Screen Shot 2019-09-16 at 13 12 30" src="https://user-images.githubusercontent.com/788096/64956887-8f6b4c80-d883-11e9-9f7c-955bb9413dfc.png">


### After
<img width="676" alt="Screen Shot 2019-09-16 at 13 12 13" src="https://user-images.githubusercontent.com/788096/64956891-91351000-d883-11e9-89b8-84d294825e88.png">

[Trello card](https://trello.com/c/ABI6zopj/27-merge-the-choose-navigation-and-secondary-links-under-new-title-where-it-appears)