### PR TITLE
Update tabs

### DIFF
--- a/app/assets/stylesheets/_steps.scss
+++ b/app/assets/stylesheets/_steps.scss
@@ -122,11 +122,6 @@ $dark-grey-2: #6f777b;
   margin: 20px 0 20px;
 }
 
-.last-saved-by--text {
-  margin: 20px 0 20px;
-  color: $dark-grey;
-}
-
 .add-secondary-link--details {
   margin-bottom: 20px;
 

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,4 +1,3 @@
-@import "./tabs";
 @import "./panel";
 @import "./markdown-editor";
 @import "./timeline-entry";

--- a/app/assets/stylesheets/components/_tabs.scss
+++ b/app/assets/stylesheets/components/_tabs.scss
@@ -1,5 +1,0 @@
-.app-c-tabs {
-  .govuk-tabs__tab {
-    font-size: 14px;
-  }
-}

--- a/app/views/components/_tabs.html.erb
+++ b/app/views/components/_tabs.html.erb
@@ -2,7 +2,7 @@
   tabs ||= []
 %>
 <% if tabs.present? %>
-  <div class="govuk-tabs app-c-tabs">
+  <div class="govuk-tabs">
     <h2 class="govuk-tabs__title">
       Contents
     </h2>

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -25,7 +25,6 @@
   action: 'Choose on-page side navigation'
 %>
 
-<%= render 'step_by_step_pages/nav', step_by_step_page: @step_by_step_page, active: "choose-navigation" %>
 <div class="govuk-grid-row">
     <%= form_for(step_by_step_page_navigation_rules_path(@step_by_step_page), method: :put) do |form| %>
       <div class="govuk-grid-column-full">

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -21,8 +21,6 @@
   action: 'Secondary links'
 %>
 
-<%= render '/step_by_step_pages/nav', step_by_step_page: @step_by_step_page, active:"secondary-links" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "components/panel", {

--- a/app/views/shared/steps/_heading.html.erb
+++ b/app/views/shared/steps/_heading.html.erb
@@ -1,6 +1,2 @@
 <% content_for :title, step_nav %>
 <% content_for :context, action %>
-
-<% if @step_by_step_page.assigned_to.present? %>
-  <%= render 'shared/steps/last-saved-by', assigned_to: @step_by_step_page.assigned_to %>
-<% end %>

--- a/app/views/shared/steps/_last-saved-by.html.erb
+++ b/app/views/shared/steps/_last-saved-by.html.erb
@@ -1,3 +1,0 @@
-<%= render "govuk_publishing_components/components/hint", {
-  text: "Last saved by " + assigned_to
-} %>

--- a/app/views/step_by_step_pages/_nav.html.erb
+++ b/app/views/step_by_step_pages/_nav.html.erb
@@ -1,45 +1,18 @@
 <%
-  unless defined? active
-    active = ''
-  end
-%>
-
-<%
-  tabs = [
-    {
-      href: @step_by_step_page,
-      label: @step_by_step_page.can_be_edited? ? "Edit steps" : "View steps",
-      active: active == 'edit-steps'
-    },
-    {
-      href: step_by_step_page_reorder_path(@step_by_step_page),
-      label: "Reorder steps",
-      active: active == 'reorder-steps'
-    },
-    {
-      href: edit_step_by_step_page_path(@step_by_step_page),
-      label: "Title and intro",
-      active: active == 'title-and-intro'
-    },
-    {
-      href: step_by_step_page_navigation_rules_path(@step_by_step_page),
-      label: "Choose navigation",
-      active: active == 'choose-navigation'
-    },
-    {
-      href: step_by_step_page_secondary_content_links_path(@step_by_step_page),
-      label: "Secondary links",
-      active: active == 'secondary-links'
-    },
-    {
-      href: step_by_step_page_internal_change_notes_path(@step_by_step_page),
-      label: "Change notes",
-      active: active == 'internal-change-notes'
-    }
-  ]
-  tabs.delete_at(1) unless @step_by_step_page.can_be_edited?
+  active ||= ''
 %>
 
 <%= render "components/tabs", {
-  tabs: tabs
+  tabs: [
+    {
+      href: @step_by_step_page,
+      label: "Summary",
+      active: active == 'edit-steps'
+    },
+    {
+      href: step_by_step_page_internal_change_notes_path(@step_by_step_page),
+      label: "History",
+      active: active == 'internal-change-notes'
+    }
+  ]
 } %>

--- a/app/views/step_by_step_pages/edit.html.erb
+++ b/app/views/step_by_step_pages/edit.html.erb
@@ -23,6 +23,4 @@
   action: 'Title and intro'
 %>
 
-<%= render 'nav', step_by_step_page: @step_by_step_page, active: "title-and-intro" %>
-
 <%= render 'form', step_by_step_page: @step_by_step_page %>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -1,7 +1,7 @@
 <%
   links = [
     {
-      text: 'Step by step publisher',
+      text: 'Step by steps',
       href: step_by_step_pages_path
     },
     {
@@ -9,19 +9,14 @@
       href: @step_by_step_page
     },
     {
-      text: 'Change notes'
+      text: 'History'
     }
   ]
 %>
 
-<%= render 'shared/steps/step_breadcrumb', links: links %>
-
-<%= render 'shared/steps/page_title', links: links %>
-
-<%= render 'shared/steps/heading',
-  step_nav: @step_by_step_page.title,
-  action: 'Change notes'
-%>
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, @step_by_step_page.title %>
+<% content_for :context, 'Step by step' %>
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active: "internal-change-notes" %>
 

--- a/app/views/step_by_step_pages/reorder.html.erb
+++ b/app/views/step_by_step_pages/reorder.html.erb
@@ -21,8 +21,6 @@
   action: 'Reorder steps'
 %>
 
-<%= render 'nav', step_by_step_page: @step_by_step_page, active: "reorder-steps" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.</p>

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -25,8 +25,6 @@
   action: 'Set a date and time to publish'
 %>
 
-<%= render 'nav', step_by_step_page: @step_by_step_page, active: "schedule" %>
-
 <% if @step_by_step_page.errors.any? %>
   <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 <% end %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -92,7 +92,8 @@ RSpec.feature "Managing step by step pages" do
     then_I_see_the_step_by_step_page
     and_I_see_an_unpublish_button
     and_I_see_a_view_on_govuk_link
-    and_there_should_be_a_change_note "First published by Test author"
+    when_I_visit_the_history_page
+    then_there_should_be_a_change_note "First published by #{stub_user.name}"
   end
 
   scenario "User unpublishes a step by step page with a valid redirect url" do
@@ -163,9 +164,11 @@ RSpec.feature "Managing step by step pages" do
     given_I_am_assigned_to_a_published_step_by_step_page_with_unpublished_changes
     and_I_visit_the_publish_page
     and_I_publish_the_page
+    when_I_visit_the_history_page
     then_there_should_be_a_change_note "Published by #{stub_user.name}"
     when_I_view_the_step_by_step_page
     and_I_delete_the_first_step
+    when_I_visit_the_history_page
     then_there_should_be_a_change_note "Draft saved by #{stub_user.name}"
   end
 
@@ -181,7 +184,8 @@ RSpec.feature "Managing step by step pages" do
       when_I_submit_the_form
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
-      and_there_should_be_a_change_note "Scheduled by Test author for publishing at 10:26am on 20 April 2030"
+      when_I_visit_the_history_page
+      then_there_should_be_a_change_note "Scheduled by Test author for publishing at 10:26am on 20 April 2030"
       and_the_step_by_step_is_not_editable
       when_I_view_the_step_by_step_page
       then_I_can_see_a_summary_section
@@ -219,7 +223,8 @@ RSpec.feature "Managing step by step pages" do
       when_I_unschedule_publishing
       then_I_should_see "has been unscheduled"
       and_the_step_by_step_should_have_the_status "Draft"
-      and_there_should_be_a_change_note "Publishing was unscheduled by Test author."
+      when_I_visit_the_history_page
+      then_there_should_be_a_change_note "Publishing was unscheduled by #{stub_user.name}."
     end
 
     scenario "User tries using invalid values for schedule date and time" do
@@ -646,12 +651,13 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content(status)
   end
 
-  def and_there_should_be_a_change_note(change_note)
+  def when_I_visit_the_history_page
     visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
-    expect(page).to have_content(change_note)
   end
 
-  alias_method :then_there_should_be_a_change_note, :and_there_should_be_a_change_note
+  def then_there_should_be_a_change_note(change_note)
+    expect(page).to have_content(change_note)
+  end
 
   def then_I_see_an_unschedule_button
     within(".app-side__actions") do

--- a/spec/features/step_by_step_navigation_spec.rb
+++ b/spec/features/step_by_step_navigation_spec.rb
@@ -44,11 +44,11 @@ RSpec.feature "Managing step by step navigation" do
 
   def then_I_see_the_step_by_step_page
     expect(page).to have_content("Your navigation choices have been saved")
-    expect(page).to have_link("Choose navigation")
+    expect(page).to have_link("Edit Sidebar settings")
   end
 
   def then_I_visit_the_navigation_steps_page_again
-    click_on("Choose navigation")
+    click_on("Edit Sidebar settings")
   end
 
   def and_I_see_my_selected_preferences


### PR DESCRIPTION
This updates the tabs section to only show the Summary and History (as all the rest of them became now redundant, being accessed using the links in the summary-list component or the actions block on the right-hand side).

Based on #711, but a lot less ambitious.

### Before
<img width="1424" alt="Screen Shot 2019-09-16 at 14 28 34" src="https://user-images.githubusercontent.com/788096/64961724-073e7480-d88e-11e9-9ef4-ff6bc9df66f4.png">

### After
<img width="1440" alt="Screen Shot 2019-09-16 at 14 27 49" src="https://user-images.githubusercontent.com/788096/64961684-f7269500-d88d-11e9-9fc9-b5287b5722da.png">

[Trello card](https://trello.com/c/ss4RmXoT)