### PR TITLE
Add "notify users about change" to step-by-step scheduling workflow

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -96,6 +96,7 @@ class StepByStepPagesController < ApplicationController
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish(session[:update_type], session[:public_change_note])
         note_description = "Scheduled by #{current_user.name} for publishing at #{format_full_date_and_time(scheduled_at)}"
+        note_description << " with change note: #{session[:public_change_note]}" if session[:public_change_note].present?
         generate_internal_change_note(note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been scheduled to publish."

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -78,7 +78,11 @@ class StepByStepPagesController < ApplicationController
 
   def schedule
     set_current_page_as_step_by_step
-    if request.post?
+  end
+
+  def schedule_datetime
+    set_current_page_as_step_by_step
+    if params[:schedule]
       date_params = params[:schedule][:date].permit(:year, :month, :day).to_h.symbolize_keys
       time_param = params[:schedule][:time]
       @schedule_placeholder = default_datetime_placeholder(date_params.merge(time: time_param))
@@ -88,18 +92,18 @@ class StepByStepPagesController < ApplicationController
         @parser.issues.each do |issue|
           @step_by_step_page.errors.add :base, issue.values.first
         end
-        render :schedule
+        render :schedule_datetime
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish
         note_description = "Scheduled by #{current_user.name} for publishing at #{format_full_date_and_time(scheduled_at)}"
         generate_internal_change_note(note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been scheduled to publish."
-      else
-        render :schedule
       end
     else
       @schedule_placeholder = default_datetime_placeholder
+      session[:update_type] = params[:update_type]
+      session[:public_change_note] = params[:change_note]
     end
   end
 

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -94,7 +94,7 @@ class StepByStepPagesController < ApplicationController
         end
         render :schedule_datetime
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
-        schedule_to_publish
+        schedule_to_publish(session[:update_type], session[:public_change_note])
         note_description = "Scheduled by #{current_user.name} for publishing at #{format_full_date_and_time(scheduled_at)}"
         generate_internal_change_note(note_description)
         set_change_note_version
@@ -185,8 +185,10 @@ private
     @step_by_step_page.mark_as_published
   end
 
-  def schedule_to_publish
+  def schedule_to_publish(update_type, change_note)
+    publish_intent = PublishIntent.new(update_type: update_type, change_note: change_note)
     StepNavPublisher.schedule_for_publishing(@step_by_step_page)
+    StepNavPublisher.update(@step_by_step_page, publish_intent)
     @step_by_step_page.mark_as_scheduled
   end
 

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -22,7 +22,7 @@
 
 <%= render 'shared/steps/heading',
   step_nav: @step_by_step_page.title,
-  action: 'Set a date and time to publish'
+  action: 'Schedule publish'
 %>
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active: "schedule" %>
@@ -33,58 +33,17 @@
 
 <div class="row">
   <div class="col-md-7">
-    <%= form_tag do %>
-      <%= render "govuk_publishing_components/components/date_input", {
-        legend_text: legend,
-        name: "schedule[date]",
-        hint: "For example, 01 08 2027",
-        id: "date",
-        error_items: issues_for(:date),
-        items: [
-          {
-            name: "day",
-            width: 2,
-            value: @schedule_placeholder[:day]
-          },
-          {
-            name: "month",
-            width: 2,
-            value: @schedule_placeholder[:month]
-          },
-          {
-            name: "year",
-            width: 4,
-            value: @schedule_placeholder[:year]
-          }
-        ]
-      } %>
-
-      <%= render "components/autocomplete", {
-        id: "time",
-        name: "schedule[time]",
-        label: {
-          text: "Time",
-          bold: true,
-        },
-        input: {
-          options: time_options,
-          value: @schedule_placeholder[:time],
-        },
-        error_items: issues_for(:time),
-        data_attributes: {
-          "autocomplete-without-narrowing-results": true,
-        },
-        width: "narrow",
-      } %>
+    <%= form_tag(step_by_step_page_schedule_datetime_path(@step_by_step_page)) do %>
+      <%= render "step_by_step_pages/change_notes" %>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= render "govuk_publishing_components/components/button", {
-            text: "Schedule to publish",
+            text: "Continue"
           } %>
         </div>
         <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to "Cancel", step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "govuk-link" %>
+          <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
         </div>
       </div>
     <% end %>

--- a/app/views/step_by_step_pages/schedule_datetime.html.erb
+++ b/app/views/step_by_step_pages/schedule_datetime.html.erb
@@ -1,0 +1,92 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: 'Schedule'
+    }
+  ]
+%>
+
+<% legend = capture do %>
+  <span class="govuk-heading-s govuk-!-margin-bottom-0">Date</span>
+<% end %>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: 'Set a date and time to publish'
+%>
+
+<%= render 'nav', step_by_step_page: @step_by_step_page, active: "schedule" %>
+
+<% if @step_by_step_page.errors.any? %>
+  <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-7">
+    <%= form_tag do %>
+      <%= render "govuk_publishing_components/components/date_input", {
+        legend_text: legend,
+        name: "schedule[date]",
+        hint: "For example, 01 08 2027",
+        id: "date",
+        error_items: issues_for(:date),
+        items: [
+          {
+            name: "day",
+            width: 2,
+            value: @schedule_placeholder[:day]
+          },
+          {
+            name: "month",
+            width: 2,
+            value: @schedule_placeholder[:month]
+          },
+          {
+            name: "year",
+            width: 4,
+            value: @schedule_placeholder[:year]
+          }
+        ]
+      } %>
+
+      <%= render "components/autocomplete", {
+        id: "time",
+        name: "schedule[time]",
+        label: {
+          text: "Time",
+          bold: true,
+        },
+        input: {
+          options: time_options,
+          value: @schedule_placeholder[:time],
+        },
+        error_items: issues_for(:time),
+        data_attributes: {
+          "autocomplete-without-narrowing-results": true,
+        },
+        width: "narrow",
+      } %>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Schedule to publish",
+          } %>
+        </div>
+        <div class="govuk-grid-column-full govuk-!-margin-top-3">
+          <%= link_to "Cancel", step_by_step_page_publish_or_delete_path(@step_by_step_page), class: "govuk-link" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     post :revert
     get :schedule
     post :schedule
+    post 'schedule-datetime', to: 'schedule_datetime'
     get 'submit-for-2i', to: 'review#submit_for_2i'
     post 'submit-for-2i', to: 'review#submit_for_2i'
     get :unpublish

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -153,6 +153,21 @@ RSpec.describe StepByStepPagesController do
       payload = hash_including(update_type: 'major', change_note: 'This is a public change note.')
       expect(Services.publishing_api).to have_received(:put_content).with(step_by_step_page.content_id, payload)
     end
+
+    it "creates an internal change note for minor change" do
+      schedule_for_future
+
+      expected_description = "Scheduled by Name Surname for publishing at 10:26am on 20 April 2030"
+      expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+    end
+
+    it "creates an internal change note with public change note text for major change" do
+      schedule_with_public_change_note
+      schedule_for_future
+
+      expected_description = "Scheduled by Name Surname for publishing at 10:26am on 20 April 2030 with change note: This is a public change note."
+      expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+    end
   end
 
   describe "#unschedule" do

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -104,8 +104,16 @@ RSpec.describe StepByStepPagesController do
       stub_default_publishing_api_put_intent
     end
 
+    def schedule_with_public_change_note
+      post :schedule_datetime, params: {
+        step_by_step_page_id: step_by_step_page.id,
+        update_type: 'major',
+        change_note: 'This is a public change note.',
+      }
+    end
+
     def schedule_for_future
-      post :schedule, params: {
+      post :schedule_datetime, params: {
         step_by_step_page_id: step_by_step_page.id,
         schedule: {
           date: { year: "2030", month: "04", day: "20" },
@@ -113,6 +121,13 @@ RSpec.describe StepByStepPagesController do
         },
       }
       step_by_step_page.reload
+    end
+
+    it "sets session variables for update type and public change note" do
+      schedule_with_public_change_note
+
+      expect(session[:update_type]).to eq 'major'
+      expect(session[:public_change_note]).to eq 'This is a public change note.'
     end
 
     it "sets `scheduled_at` to a datetime" do

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe StepByStepPagesController do
       expect(step_by_step_page.status).to be_draft
     end
 
-    it "creates and internal change note" do
+    it "creates an internal change note" do
       step_by_step_page = create(:scheduled_step_by_step_page, slug: 'how-to-be-fantastic')
 
       unschedule_publishing(step_by_step_page)

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe StepByStepPagesController do
     before :each do
       stub_publishing_api_for_scheduling
       stub_default_publishing_api_put_intent
+      stub_publishing_api
     end
 
     def schedule_with_public_change_note
@@ -141,6 +142,16 @@ RSpec.describe StepByStepPagesController do
       schedule_for_future
 
       expect(step_by_step_page.status).to be_scheduled
+    end
+
+    it "sends update_type and change note to Publishing API" do
+      allow(Services.publishing_api).to receive(:put_content)
+
+      schedule_with_public_change_note
+      schedule_for_future
+
+      payload = hash_including(update_type: 'major', change_note: 'This is a public change note.')
+      expect(Services.publishing_api).to have_received(:put_content).with(step_by_step_page.content_id, payload)
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature "Managing step by step pages" do
       stub_publishing_api_destroy_intent('/how-to-be-the-amazing-1')
     end
 
-    scenario "User schedules publishing" do
+    scenario "User schedules publishing without a public change note" do
       given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
       and_I_visit_the_scheduling_page
       then_I_should_see_a_publish_form_with_changenotes
@@ -182,6 +182,20 @@ RSpec.feature "Managing step by step pages" do
       and_I_can_see_a_secondary_links_section_with_link "View"
       then_I_can_preview_the_step_by_step
       and_the_steps_can_be_checked_for_broken_links
+    end
+
+    scenario "User schedules publishing with a public change note" do
+      given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
+      and_I_visit_the_scheduling_page
+      then_I_should_see_a_publish_form_with_changenotes
+      and_I_fill_in_the_changenote_form
+      and_when_I_click_button "Continue"
+      then_inputs_should_have_tomorrows_date
+      and_I_fill_in_the_scheduling_form
+      when_I_submit_the_form
+      then_I_should_see "has been scheduled to publish"
+      and_the_step_by_step_should_have_the_status "Scheduled"
+      and_there_should_be_a_change_note "Scheduled by Test author for publishing at 10:26am on 20 April 2030 with change note: We made some changes"
     end
 
     scenario "User tries to schedule publishing for date in the past" do
@@ -506,6 +520,11 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("Notify users about this change?")
     expect(page).to have_css('input[type="radio"][name="update_type"]', count: 2)
     expect(page).to have_css('textarea[name="change_note"]')
+  end
+
+  def and_I_fill_in_the_changenote_form
+    choose 'Yes'
+    fill_in 'change_note', with: 'We made some changes'
   end
 
   def and_I_fill_in_the_scheduling_form

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -166,6 +166,9 @@ RSpec.feature "Managing step by step pages" do
     scenario "User schedules publishing" do
       given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
       and_I_visit_the_scheduling_page
+      then_I_should_see_a_publish_form_with_changenotes
+      and_when_I_click_button "Continue"
+      then_inputs_should_have_tomorrows_date
       and_I_fill_in_the_scheduling_form
       when_I_submit_the_form
       then_I_should_see "has been scheduled to publish"
@@ -184,6 +187,8 @@ RSpec.feature "Managing step by step pages" do
     scenario "User tries to schedule publishing for date in the past" do
       given_there_is_a_draft_step_by_step_page
       and_I_visit_the_scheduling_page
+      then_I_should_see_a_publish_form_with_changenotes
+      and_when_I_click_button "Continue"
       then_inputs_should_have_tomorrows_date
       and_I_fill_in_the_scheduling_form_with_a_date_in_the_past
       when_I_submit_the_form
@@ -212,6 +217,9 @@ RSpec.feature "Managing step by step pages" do
     scenario "User tries using invalid values for schedule date and time" do
       given_there_is_a_draft_step_by_step_page
       and_I_visit_the_scheduling_page
+      then_I_should_see_a_publish_form_with_changenotes
+      and_when_I_click_button "Continue"
+      then_inputs_should_have_tomorrows_date
       and_I_fill_in_the_scheduling_form_with_nonsense_data
       when_I_submit_the_form
       then_I_should_see "Enter a valid date", :at_the_top_of_the_page


### PR DESCRIPTION
Updates scheduling workflow to let content designers choose if they want to tell users about the change to a step-by-step.

This is an option when publishing a step-by-step immediately, but was not available when scheduling.

First view in the workflow:
<img width="733" alt="Screen Shot 2019-09-12 at 15 08 54" src="https://user-images.githubusercontent.com/6329861/64791429-a05c4b00-d56f-11e9-8449-35b9a405b39a.png">

Second view in the workflow:
<img width="733" alt="Screen Shot 2019-09-12 at 15 09 01" src="https://user-images.githubusercontent.com/6329861/64791439-a3573b80-d56f-11e9-9a48-e396f3e37153.png">

Trello card: https://trello.com/c/XM1zjRfM/62-add-notify-users-about-change-to-scheduling-workflow

This is a much simplified version of https://github.com/alphagov/collections-publisher/pull/735.