### PR TITLE
Allow 2i reviews to be approved, or changes requested

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -3,8 +3,22 @@ class ReviewController < ApplicationController
 
   before_action :require_gds_editor_permissions!
   before_action :require_unreleased_feature_permissions!
-  before_action :require_2i_reviewer_permissions!, only: %i(claim_2i_review)
+  before_action :require_2i_reviewer_permissions!, only: %i(approve_2i_review claim_2i_review)
   before_action :set_step_by_step_page
+
+  def approve_2i_review
+    status = "2i_approved"
+
+    if @step_by_step_page.update(
+      review_requester_id: nil,
+      reviewer_id: nil,
+      status: status
+    )
+      generate_change_note(status)
+
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i_approved."
+    end
+  end
 
   def claim_2i_review
     status = "in_review"

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -3,7 +3,7 @@ class ReviewController < ApplicationController
 
   before_action :require_gds_editor_permissions!
   before_action :require_unreleased_feature_permissions!
-  before_action :require_2i_reviewer_permissions!, only: %i(approve_2i_review claim_2i_review)
+  before_action :require_2i_reviewer_permissions!, only: %i(approve_2i_review claim_2i_review request_change_2i_review)
   before_action :set_step_by_step_page
 
   def approve_2i_review
@@ -30,6 +30,20 @@ class ReviewController < ApplicationController
       generate_change_note(status)
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully claimed for review."
+    end
+  end
+
+  def request_change_2i_review
+    status = "draft"
+
+    if @step_by_step_page.update(
+      reviewer_id: nil,
+      review_requester_id: nil,
+      status: status
+    )
+      generate_change_note("Changes requested", params[:requested_change])
+
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested."
     end
   end
 

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,5 +1,6 @@
 class StepByStepPage < ApplicationRecord
   STATUSES = %w(
+    2i_approved
     draft
     in_review
     published

--- a/app/validators/status_prerequisite_validator.rb
+++ b/app/validators/status_prerequisite_validator.rb
@@ -1,5 +1,11 @@
 class StatusPrerequisiteValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    if value == "2i_approved"
+      return true if can_be_2i_approved?(record)
+
+      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review"
+    end
+
     if value == "in_review"
       return true if can_be_in_review?(record)
 
@@ -33,5 +39,10 @@ private
 
   def can_be_submitted_for_2i?(record)
     record.has_draft? && record.review_requester_id.present?
+  end
+
+  def can_be_2i_approved?(record)
+    record.has_draft? &&
+      record.status_was == "in_review"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     post :check_links
     post 'approve-2i-review', to: 'review#approve_2i_review'
     post 'claim-2i-review', to: 'review#claim_2i_review'
+    post 'request-change-2i-review', to: 'review#request_change_2i_review'
     get 'internal-change-notes', to: 'interal_change_notes'
     post 'internal-change-notes', to: 'internal_change_notes#create'
     get 'navigation-rules', to: 'navigation_rules#edit'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   resources :step_by_step_pages, path: 'step-by-step-pages' do
     post :check_links
+    post 'approve-2i-review', to: 'review#approve_2i_review'
     post 'claim-2i-review', to: 'review#claim_2i_review'
     get 'internal-change-notes', to: 'interal_change_notes'
     post 'internal-change-notes', to: 'internal_change_notes#create'

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -71,6 +71,74 @@ RSpec.describe ReviewController do
       end
     end
 
+    describe "POST approve 2i review" do
+      let(:user) { create(:user) }
+      let(:reviewer_user) { create(:user) }
+
+      let(:step_by_step_page) do
+        create(
+          :draft_step_by_step_page,
+          review_requester_id: user.uid,
+          status: "submitted_for_2i"
+        )
+      end
+
+      before do
+        step_by_step_page.update_attributes(:status => 'in_review', :reviewer_id => reviewer_user.uid)
+      end
+
+      it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
+        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response).to redirect_to step_by_step_page_path(step_by_step_page)
+      end
+
+      it "cannot be accessed by users with only GDS editor permissions" do
+        stub_user.permissions << "GDS Editor"
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response.status).to eq(403)
+      end
+
+      it "cannot be accessed by users with only GDS editor and Unreleased feature permissions" do
+        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response.status).to eq(403)
+      end
+
+      it "cannot be accessed by users with only signin permissions" do
+        stub_user.permissions = %w(signin)
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response.status).to eq(403)
+      end
+
+      it "sets status to 2i_approved removes reviewer_id and review_requester_id" do
+        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+        step_by_step_page.reload
+
+        expect(step_by_step_page.status).to eq("2i_approved")
+        expect(step_by_step_page.reviewer_id).to be_nil
+        expect(step_by_step_page.review_requester_id).to be_nil
+      end
+
+      it "creates an internal change note" do
+        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.name = "Firstname Lastname"
+
+        expected_change_note = "2i approved by Firstname Lastname"
+
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+        step_by_step_page.reload
+
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+      end
+    end
+
     describe "POST claim 2i review" do
       let(:user) { create(:user) }
 

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -10,31 +10,30 @@ RSpec.describe ReviewController do
 
     describe "submit for 2i" do
       describe "GET submit for 2i page" do
+        required_permissions = ["signin", "GDS Editor", "Unreleased feature"]
+
         it "can be accessed by users with GDS editor and Unreleased feature permissions" do
-          stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
+          stub_user.permissions = required_permissions
           get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
 
           expect(response.status).to eq(200)
         end
 
-        it "cannot be accessed by users with only GDS editor permissions" do
-          stub_user.permissions << "GDS Editor"
-          get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
+        (required_permissions - %w(signin)).each do |required_permission|
+          it "cannot be accessed by users without the #{required_permission} permission" do
+            stub_user.permissions = required_permissions
+            stub_user.permissions.delete(required_permission)
+            get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
 
-          expect(response.status).to eq(403)
-        end
-
-        it "cannot be accessed by users with neither GDS editor and Unreleased feature permissions" do
-          stub_user.permissions = %w(signin)
-          get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
-
-          expect(response.status).to eq(403)
+            expect(response.status).to eq(403)
+          end
         end
       end
 
       describe "POST submit for 2i" do
         before do
-          stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
+          required_permissions = ["signin", "GDS Editor", "Unreleased feature"]
+          stub_user.permissions = required_permissions
           stub_user.name = "Firstname Lastname"
         end
 
@@ -87,36 +86,27 @@ RSpec.describe ReviewController do
         step_by_step_page.update_attributes(:status => 'in_review', :reviewer_id => reviewer_user.uid)
       end
 
+      required_permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+
       it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         expect(response).to redirect_to step_by_step_page_path(step_by_step_page)
       end
 
-      it "cannot be accessed by users with only GDS editor permissions" do
-        stub_user.permissions << "GDS Editor"
-        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+      (required_permissions - %w(signin)).each do |required_permission|
+        it "cannot be accessed by users without the #{required_permission} permission" do
+          stub_user.permissions = required_permissions
+          stub_user.permissions.delete(required_permission)
+          post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
-        expect(response.status).to eq(403)
-      end
-
-      it "cannot be accessed by users with only GDS editor and Unreleased feature permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
-        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
-      end
-
-      it "cannot be accessed by users with only signin permissions" do
-        stub_user.permissions = %w(signin)
-        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
+          expect(response.status).to eq(403)
+        end
       end
 
       it "sets status to 2i_approved removes reviewer_id and review_requester_id" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         step_by_step_page.reload
@@ -127,7 +117,7 @@ RSpec.describe ReviewController do
       end
 
       it "creates an internal change note" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
         expected_change_note = "2i approved by Firstname Lastname"
@@ -155,36 +145,27 @@ RSpec.describe ReviewController do
         step_by_step_page.update_attributes(:status => 'in_review', :reviewer_id => reviewer_user.uid)
       end
 
+      required_permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+
       it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         expect(response).to redirect_to step_by_step_page_path(step_by_step_page)
       end
 
-      it "cannot be accessed by users with only GDS editor permissions" do
-        stub_user.permissions << "GDS Editor"
-        post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+      (required_permissions - %w(signin)).each do |required_permission|
+        it "cannot be accessed by users without the #{required_permission} permission" do
+          stub_user.permissions = required_permissions
+          stub_user.permissions.delete(required_permission)
+          post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
-        expect(response.status).to eq(403)
-      end
-
-      it "cannot be accessed by users with only GDS editor and Unreleased feature permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
-        post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
-      end
-
-      it "cannot be accessed by users with only signin permissions" do
-        stub_user.permissions = %w(signin)
-        post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
+          expect(response.status).to eq(403)
+        end
       end
 
       it "sets status to draft, removes reviewer_id and review_requester_id" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         step_by_step_page.reload
@@ -195,7 +176,7 @@ RSpec.describe ReviewController do
       end
 
       it "creates an internal change note" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
         expected_change_note = "Changes requested by Firstname Lastname\n\nSome change request"
@@ -218,36 +199,27 @@ RSpec.describe ReviewController do
         )
       end
 
+      required_permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+
       it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         expect(response).to redirect_to step_by_step_page_path(step_by_step_page)
       end
 
-      it "cannot be accessed by users with only GDS editor permissions" do
-        stub_user.permissions << "GDS Editor"
-        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+      (required_permissions - %w(signin)).each do |required_permission|
+        it "cannot be accessed by users without the #{required_permission} permission" do
+          stub_user.permissions = required_permissions
+          stub_user.permissions.delete(required_permission)
+          post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
-        expect(response.status).to eq(403)
-      end
-
-      it "cannot be accessed by users with only GDS editor and Unreleased feature permissions" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature"]
-        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
-      end
-
-      it "cannot be accessed by users with only signin permissions" do
-        stub_user.permissions = %w(signin)
-        post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
-
-        expect(response.status).to eq(403)
+          expect(response.status).to eq(403)
+        end
       end
 
       it "sets status to in_review" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         step_by_step_page.reload
@@ -257,7 +229,7 @@ RSpec.describe ReviewController do
       end
 
       it "creates an internal change note" do
-        stub_user.permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+        stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
         expected_change_note = "In review by Firstname Lastname"

--- a/spec/validators/status_prerequisite_validator_spec.rb
+++ b/spec/validators/status_prerequisite_validator_spec.rb
@@ -37,6 +37,34 @@ RSpec.describe StatusPrerequisiteValidator do
     end
   end
 
+  context "#2i_approved" do
+    let(:error_message) { "2i_approved, requires a draft, a reviewer and for status to be in_review" }
+
+    it "does not allow status to be 2i_approved if there is no draft" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(false)
+      step_by_step_page.status = "2i_approved"
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
+    end
+
+    it "does not allow status to be 2i_approved if the current status is not in_review" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+      step_by_step_page.status = "2i_approved"
+
+      expect(step_by_step_page).not_to be_valid
+      expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
+    end
+
+    it "allows status to be 2i_approved if the current status is in_review and there is a draft" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+      allow(step_by_step_page).to receive(:status_was). and_return("in_review")
+      step_by_step_page.status = "2i_approved"
+
+      expect(step_by_step_page).to be_valid
+    end
+  end
+
   context "#scheduled" do
     let(:error_message) { "scheduled, requires a draft and scheduled_at date to be present" }
 


### PR DESCRIPTION
Once a 2i review has been requested, the reviewer needs to be able to either approve the review or request changes.

This PR carries the backend work.  Frontend work will be done separately.

Trello cards: https://trello.com/c/R85nupi5/38-2i-reviewer-can-approve-step-by-steps-backend and https://trello.com/c/rlPS1Kyo/36-2i-reviewer-can-request-change-to-step-by-step-backend