### PR TITLE
Rename 2i approved status

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -7,7 +7,7 @@ class ReviewController < ApplicationController
   before_action :set_step_by_step_page
 
   def approve_2i_review
-    status = "2i_approved"
+    status = "approved_2i"
 
     if @step_by_step_page.update(
       review_requester_id: nil,
@@ -16,7 +16,7 @@ class ReviewController < ApplicationController
     )
       generate_change_note(status)
 
-      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i_approved."
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully approved_2i."
     end
   end
 

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -1,6 +1,6 @@
 class StepByStepPage < ApplicationRecord
   STATUSES = %w(
-    2i_approved
+    approved_2i
     draft
     in_review
     published

--- a/app/validators/status_prerequisite_validator.rb
+++ b/app/validators/status_prerequisite_validator.rb
@@ -1,6 +1,6 @@
 class StatusPrerequisiteValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if value == "2i_approved"
+    if value == "approved_2i"
       return true if can_be_2i_approved?(record)
 
       record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review"

--- a/docs/arch/adr-3-store-status.md
+++ b/docs/arch/adr-3-store-status.md
@@ -82,7 +82,7 @@ Create a new field in the database to store a value of `status` that allows valu
 - scheduled
 - submitted_for_2i
 - in_review
-- 2i_approved
+- approved_2i
 
 
 "draft" and "unpublished changes" mean the same thing in regards to their position in the publishing workflow, so if they are consolidated it won't be necessary to keep track of separate publication and workflow states. The presence of a `published_at` date can be used to determine if something has been previously published, as it is now.
@@ -97,11 +97,11 @@ That means the 2i workflow can be simplified.
 |Makes changes to step-by-step           |draft           |draft               |
 |Submit for 2i                           |draft           |submitted_for_2i    |
 |Claim Review                            |submitted_for_2i|in_review           |
-|2i Approved                             |in_review       |2i_approved         |
+|2i Approved                             |in_review       |approved_2i         |
 |2i Requests changes                     |in_review       |draft               |
-|Publish                                 |2i_approved     |published           |
-|Schedule                                |2i_approved     |scheduled           |
-|Unschedule                              |scheduled       |2i_approved         |
+|Publish                                 |approved_2i     |published           |
+|Schedule                                |approved_2i     |scheduled           |
+|Unschedule                              |scheduled       |approved_2i         |
 
 
 ### Other actions

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe ReviewController do
         end
       end
 
-      it "sets status to 2i_approved removes reviewer_id and review_requester_id" do
+      it "sets status to approved_2i removes reviewer_id and review_requester_id" do
         stub_user.permissions = required_permissions
         post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
         step_by_step_page.reload
 
-        expect(step_by_step_page.status).to eq("2i_approved")
+        expect(step_by_step_page.status).to eq("approved_2i")
         expect(step_by_step_page.reviewer_id).to be_nil
         expect(step_by_step_page.review_requester_id).to be_nil
       end
@@ -120,7 +120,7 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "2i approved by Firstname Lastname"
+        expected_change_note = "Approved 2i by Firstname Lastname"
 
         post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
         step_by_step_page.reload

--- a/spec/validators/status_prerequisite_validator_spec.rb
+++ b/spec/validators/status_prerequisite_validator_spec.rb
@@ -37,29 +37,29 @@ RSpec.describe StatusPrerequisiteValidator do
     end
   end
 
-  context "#2i_approved" do
-    let(:error_message) { "2i_approved, requires a draft, a reviewer and for status to be in_review" }
+  context "#approved_2i" do
+    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review" }
 
-    it "does not allow status to be 2i_approved if there is no draft" do
+    it "does not allow status to be approved_2i if there is no draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(false)
-      step_by_step_page.status = "2i_approved"
+      step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page).not_to be_valid
       expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
     end
 
-    it "does not allow status to be 2i_approved if the current status is not in_review" do
+    it "does not allow status to be approved_2i if the current status is not in_review" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
-      step_by_step_page.status = "2i_approved"
+      step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page).not_to be_valid
       expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
     end
 
-    it "allows status to be 2i_approved if the current status is in_review and there is a draft" do
+    it "allows status to be approved_2i if the current status is in_review and there is a draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
       allow(step_by_step_page).to receive(:status_was). and_return("in_review")
-      step_by_step_page.status = "2i_approved"
+      step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page).to be_valid
     end


### PR DESCRIPTION
Rename `2i_approved` status with `approved_2i` to enable references to it.