### PR TITLE
Fix broken links before publish

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -141,6 +141,10 @@ class StepByStepPage < ApplicationRecord
     has_draft? && !scheduled_for_publishing? && !can_be_published?
   end
 
+  def broken_links_found?
+    steps.any?(&:broken_links?)
+  end
+
   def links_checked_since_last_update?
     links_checked? && links_last_checked_date > draft_updated_at
   end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -95,7 +95,8 @@ class StepByStepPage < ApplicationRecord
     has_draft? &&
       !scheduled_for_publishing? &&
       steps_have_content? &&
-      links_checked_since_last_update?
+      links_checked_since_last_update? &&
+      !broken_links_found?
   end
 
   def can_be_unpublished?

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -20,6 +20,12 @@
           <%= link_to "Check for broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
         </li>
       <% end %>
+
+      <% if @step_by_step_page.broken_links_found? %>
+        <li>
+          <%= link_to "Fix broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
+        </li>
+      <% end %>
     </ul>
   <% end %>
 <% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -15,7 +15,7 @@
         </li>
       <% end %>
 
-      <% if @step_by_step_page.steps.any? && !@step_by_step_page.links_checked_since_last_update? %>
+      <% if @step_by_step_page.steps.any? && !@step_by_step_page.links_checked_since_last_update? && !@step_by_step_page.broken_links_found? %>
         <li>
           <%= link_to "Check for broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
         </li>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -293,6 +293,14 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
+  scenario "Step by step contains broken links" do
+    given_there_is_a_step_by_step_page_with_broken_links
+    when_I_view_the_step_by_step_page
+    then_I_should_see_an_inset_prompt
+    and_the_prompt_should_contain_link_to_steps_section "Fix broken links"
+    and_I_cannot_publish_or_schedule_the_step_by_step
+  end
+
   scenario "Step by step has been updated since it was last checked for broken links" do
     given_a_step_by_step_has_been_updated_after_links_last_checked
     when_I_view_the_step_by_step_page

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -294,10 +294,11 @@ RSpec.feature "Managing step by step pages" do
   end
 
   scenario "Step by step contains broken links" do
-    given_there_is_a_step_by_step_page_with_broken_links
+    given_there_is_a_step_by_step_page_with_broken_links_and_unpublished_changes
     when_I_view_the_step_by_step_page
     then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_link_to_steps_section "Fix broken links"
+    and_the_prompt_should_not_contain "Check for broken links"
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
@@ -650,6 +651,12 @@ RSpec.feature "Managing step by step pages" do
   def and_the_prompt_should_contain_link_to_steps_section(prompt)
     within('.govuk-inset-text') do
       expect(page).to have_link(prompt, href: '#steps')
+    end
+  end
+
+  def and_the_prompt_should_not_contain(prompt)
+    within('.govuk-inset-text') do
+      expect(page).not_to have_content prompt
     end
   end
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe StepByStepPage do
+  include LinkChecker
+
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
   end
@@ -248,6 +250,28 @@ RSpec.describe StepByStepPage do
       step_by_step_with_step = create(:draft_step_by_step_page)
 
       expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be true
+    end
+  end
+
+  describe 'broken_links_found?' do
+    let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
+
+    it 'returns false if links have not been checked' do
+      allow(step_by_step_page).to receive(:links_checked?).and_return(false)
+
+      expect(step_by_step_page.broken_links_found?).to be false
+    end
+
+    it 'returns false if links have been checked and there were no broken links' do
+      stub_link_checker_report_success(step_by_step_page.steps.first)
+
+      expect(step_by_step_page.broken_links_found?).to be false
+    end
+
+    it 'returns true if broken links were found' do
+      stub_link_checker_report_multiple_broken_links(step_by_step_page.steps.first)
+
+      expect(step_by_step_page.broken_links_found?).to be true
     end
   end
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe StepByStepPage do
 
     it 'should return false if step by step is in draft but has no issues blocking its publication' do
       step_by_step_with_step = create(:draft_step_by_step_page)
-      create(:link_report, batch_id: 1, step_id: step_by_step_with_step.steps.first.id)
+      stub_link_checker_report_success(step_by_step_with_step.steps.first)
 
       expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be false
     end
@@ -412,7 +412,7 @@ RSpec.describe StepByStepPage do
       allow(step_by_step_page).to receive(:links_checked_since_last_update?) { true }
     end
 
-    it 'can be published if it has a draft, is not scheduled, all steps have content and links have been checked since last update' do
+    it 'can be published if it has a draft, is not scheduled, all steps have content, links have been checked since last update and there are no broken links' do
       step_by_step_page.mark_draft_updated
 
       expect(step_by_step_page.can_be_published?).to be true
@@ -447,6 +447,13 @@ RSpec.describe StepByStepPage do
     it 'cannot be published if step by step updated since links were last checked' do
       step_by_step_page.mark_draft_updated
       allow(step_by_step_page).to receive(:links_checked_since_last_update?) { false }
+
+      expect(step_by_step_page.can_be_published?).to be false
+    end
+
+    it 'cannot be published if broken links were found when links were checked' do
+      step_by_step_page.mark_draft_updated
+      stub_link_checker_report_broken_link(step_by_step_page.steps.first)
 
       expect(step_by_step_page.can_be_published?).to be false
     end

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -1,0 +1,44 @@
+module LinkChecker
+  def stub_link_checker_report_success(step)
+    link_checker_api_get_batch(
+      id: 1,
+      links: [link_checker_api_link_report_success]
+    )
+    create(:link_report, step_id: step.id)
+  end
+
+  def stub_link_checker_report_broken_link(step)
+    link_checker_api_get_batch(
+      id: 1,
+      links: [link_checker_api_link_report_fail]
+    )
+    create(:link_report, step_id: step.id)
+  end
+
+  def stub_link_checker_report_multiple_broken_links(step)
+    link_checker_api_get_batch(
+      id: 1,
+      links: [link_checker_api_link_report_fail, link_checker_api_link_report_fail]
+    )
+    create(:link_report, step_id: step.id)
+  end
+
+  def link_checker_api_link_report_success
+    {
+      "uri": "https://www.gov.uk/",
+      "status": "ok",
+      "checked": "2017-04-12T18:47:16Z",
+      "errors": [],
+      "warnings": [],
+      "problem_summary": "null",
+      "suggested_fix": "null"
+    }
+  end
+
+  def link_checker_api_link_report_fail
+    {
+      "uri": "https://www.gov.uk/foo",
+      "status": "broken"
+    }
+  end
+end

--- a/spec/support/link_checker.rb
+++ b/spec/support/link_checker.rb
@@ -1,4 +1,8 @@
+require 'gds_api/test_helpers/link_checker_api'
+
 module LinkChecker
+  include GdsApi::TestHelpers::LinkCheckerApi
+
   def stub_link_checker_report_success(step)
     link_checker_api_get_batch(
       id: 1,

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -100,6 +100,12 @@ module StepNavSteps
 
   alias_method :given_there_is_a_step_that_has_no_broken_links, :given_there_is_a_step_by_step_page_with_a_link_report
 
+  def given_there_is_a_step_by_step_page_with_broken_links
+    step = create(:step)
+    stub_link_checker_report_broken_link(step)
+    @step_by_step_page = create(:step_by_step_page, steps: [step], slug: "step-by-step-with-broken-links")
+  end
+
   def given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
     step = create(:step)
     stub_link_checker_report_success(step)

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -1,4 +1,6 @@
 module StepNavSteps
+  include LinkChecker
+
   def setup_publishing_api
     stub_any_publishing_api_put_content
     stub_any_publishing_api_discard_draft
@@ -91,29 +93,22 @@ module StepNavSteps
   end
 
   def given_there_is_a_step_by_step_page_with_a_link_report
-    link_checker_api_get_batch(
-      id: 1,
-      links: [link_checker_api_link_report_success]
-    )
-
     step = create(:step)
-    create(:link_report, step_id: step.id)
+    stub_link_checker_report_success(step)
     @step_by_step_page = create(:step_by_step_page, steps: [step], slug: "step-by-step-with-link-report")
   end
 
   alias_method :given_there_is_a_step_that_has_no_broken_links, :given_there_is_a_step_by_step_page_with_a_link_report
 
   def given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
-    link_checker_api_get_batch(id: 1, links: [link_checker_api_link_report_success])
     step = create(:step)
-    create(:link_report, step_id: step.id)
+    stub_link_checker_report_success(step)
     @step_by_step_page = create(:step_by_step_with_unpublished_changes, steps: [step], slug: 'step-by-step-with-unpublished-changes')
   end
 
   def given_a_step_by_step_has_been_updated_after_links_last_checked
-    link_checker_api_get_batch(id: 1, links: [link_checker_api_link_report_success])
     step = create(:step)
-    create(:link_report, step_id: step.id)
+    stub_link_checker_report_success(step)
     @step_by_step_page = create(
       :step_by_step_with_unpublished_changes,
       steps: [step],
@@ -123,7 +118,6 @@ module StepNavSteps
   end
 
   def given_a_step_by_step_has_an_empty_step_added_after_links_last_checked
-    link_checker_api_get_batch(id: 1, links: [link_checker_api_link_report_success])
     @step_by_step_page = create(
       :step_by_step_with_unpublished_changes,
       slug: 'step-by-step-with-link-report-and-empty-step-added-since-links-checked',
@@ -131,7 +125,7 @@ module StepNavSteps
     )
 
     step_with_link_report = create(:step, step_by_step_page: @step_by_step_page)
-    create(:link_report, step_id: step_with_link_report.id)
+    stub_link_checker_report_success(step_with_link_report)
     create(:step, contents: "", step_by_step_page: @step_by_step_page)
   end
 
@@ -160,40 +154,13 @@ module StepNavSteps
   def given_there_is_a_step_with_a_broken_link
     @step_by_step_page = create(:step_by_step_page)
     step = create(:step, step_by_step_page: @step_by_step_page)
-    link_checker_api_get_batch(
-      id: 1,
-      links: [link_checker_api_link_report_fail]
-    )
-    create(:link_report, step_id: step.id)
+    stub_link_checker_report_broken_link(step)
   end
 
   def given_there_is_a_step_with_multiple_broken_links
     @step_by_step_page = create(:step_by_step_page)
     step = create(:step, step_by_step_page: @step_by_step_page)
-    link_checker_api_get_batch(
-      id: 1,
-      links: [link_checker_api_link_report_fail, link_checker_api_link_report_fail]
-    )
-    create(:link_report, step_id: step.id)
-  end
-
-  def link_checker_api_link_report_success
-    {
-      "uri": "https://www.gov.uk/",
-      "status": "ok",
-      "checked": "2017-04-12T18:47:16Z",
-      "errors": [],
-      "warnings": [],
-      "problem_summary": "null",
-      "suggested_fix": "null"
-    }
-  end
-
-  def link_checker_api_link_report_fail
-    {
-      "uri": "https://www.gov.uk/foo",
-      "status": "broken"
-    }
+    stub_link_checker_report_multiple_broken_links(step)
   end
 
   def then_I_can_see_a_success_message(message)

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -100,10 +100,10 @@ module StepNavSteps
 
   alias_method :given_there_is_a_step_that_has_no_broken_links, :given_there_is_a_step_by_step_page_with_a_link_report
 
-  def given_there_is_a_step_by_step_page_with_broken_links
+  def given_there_is_a_step_by_step_page_with_broken_links_and_unpublished_changes
     step = create(:step)
     stub_link_checker_report_broken_link(step)
-    @step_by_step_page = create(:step_by_step_page, steps: [step], slug: "step-by-step-with-broken-links")
+    @step_by_step_page = create(:step_by_step_page, steps: [step], draft_updated_at: Time.zone.now, slug: "step-by-step-with-broken-links-and-unpublished-changes")
   end
 
   def given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked


### PR DESCRIPTION
Prevents publishing/scheduling of step by steps if they contain broken links.

Trello: https://trello.com/c/9hBzk8lJ/69-change-inset-text-to-tell-user-to-fix-broken-links

Screenshot:

![Screen Shot 2019-09-20 at 13 46 05](https://user-images.githubusercontent.com/5111927/65327925-0cacff00-dbad-11e9-9ca5-3a9411a06b39.png)
