### PR TITLE
Show preview link when the step-by-step has a draft

### DIFF
--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -35,7 +35,7 @@
     <% elsif !@step_by_step_page.steps_have_content? %>
       <p class="govuk-body">Step by steps cannot be published until all steps have content.</p>
       <%= preview_link %>
-    <% else %>
+    <% elsif @step_by_step_page.has_draft? %>
       <%= preview_link %>
     <% end %>
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -122,6 +122,7 @@ RSpec.feature "Managing step by step pages" do
     then_I_should_see_a_publish_form_with_changenotes
     and_when_I_click_the_publish_button_in_the_publish_form
     then_I_am_told_that_it_is_published
+    and_I_cannot_preview_the_step_by_step
   end
 
   scenario "User publishes and then makes more changes to a step by step page" do

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -186,4 +186,12 @@ module StepNavSteps
   end
 
   alias_method :and_I_can_preview_the_step_by_step, :then_I_can_preview_the_step_by_step
+
+  def then_I_cannot_preview_the_step_by_step
+    within(".app-side__actions") do
+      expect(page).not_to have_link("Preview")
+    end
+  end
+
+  alias_method :and_I_cannot_preview_the_step_by_step, :then_I_cannot_preview_the_step_by_step
 end


### PR DESCRIPTION
This fix prevents the preview link from being shown when a step by step has been published and doesn't have changes since then.