### PR TITLE
Redirect users to summary page after step is saved

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -12,7 +12,7 @@ class StepsController < ApplicationController
     if @step.save
       update_downstream
 
-      redirect_to edit_step_by_step_page_step_path(:id => @step[:id]), notice: 'Step was successfully created.'
+      redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully created.'
     else
       render :new
     end
@@ -25,7 +25,7 @@ class StepsController < ApplicationController
   def update
     if step.update(step_params)
       update_downstream
-      redirect_to edit_step_by_step_page_step_path(:id => @step[:id]), notice: 'Step was successfully updated.'
+      redirect_to step_by_step_page_path(step_by_step_page.id), notice: 'Step was successfully updated.'
     else
       render :edit
     end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -17,8 +17,8 @@ RSpec.feature "Managing step by step pages" do
         when_I_visit_the_step_by_step_page
         and_I_create_a_new_step
         and_I_fill_in_the_form
-        then_I_can_see_a_success_message "Step was successfully created."
-        and_I_should_still_be_on_the_edit_step_page
+        then_I_should_be_on_the_step_by_step_page
+        and_I_can_see_a_success_message "Step was successfully created."
       end
 
       scenario "User edits step" do
@@ -26,8 +26,8 @@ RSpec.feature "Managing step by step pages" do
         when_I_visit_the_step_by_step_page
         and_I_edit_the_first_step
         and_I_fill_the_edit_form_and_submit
-        then_I_can_see_a_success_message "Step was successfully updated."
-        and_I_should_still_be_on_the_edit_step_page
+        then_I_should_be_on_the_step_by_step_page
+        and_I_can_see_a_success_message "Step was successfully updated."
       end
 
       scenario "User deletes step", js: true do
@@ -131,11 +131,6 @@ RSpec.feature "Managing step by step pages" do
 
   def then_the_step_is_deleted
     expect(page).not_to have_content("Check how awesome you are")
-  end
-
-  def and_I_should_still_be_on_the_edit_step_page
-    edit_step_path = edit_step_by_step_page_step_path(@step_by_step_page.id, @step_by_step_page.steps.first.id)
-    expect(current_url).to end_with edit_step_path
   end
 
   def and_I_fill_in_the_form_with_content

--- a/spec/features/step_by_step_navigation_spec.rb
+++ b/spec/features/step_by_step_navigation_spec.rb
@@ -45,10 +45,6 @@ RSpec.feature "Managing step by step navigation" do
     click_on "Save"
   end
 
-  def and_I_should_be_on_the_step_by_step_page
-    expect(current_url).to end_with step_by_step_page_path(@step_by_step_page)
-  end
-
   def and_I_click_the_sidebar_settings_link
     click_on("Edit Sidebar settings")
   end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -175,6 +175,14 @@ module StepNavSteps
     end
   end
 
+  alias_method :and_I_can_see_a_success_message, :then_I_can_see_a_success_message
+
+  def then_I_should_be_on_the_step_by_step_page
+    expect(current_url).to end_with step_by_step_page_path(@step_by_step_page)
+  end
+
+  alias_method :and_I_should_be_on_the_step_by_step_page, :then_I_should_be_on_the_step_by_step_page
+
   def then_I_see_the_new_step_by_step_page
     expect(page).to have_content("How to bake a cake")
   end


### PR DESCRIPTION
Users were being kept on the steps page after they added or updated a step.  This caused confusion during user research.

This returns them to the step by step overview page (with confirmation banner) once they have created/updated a step.

Trello card: https://trello.com/c/ZhgPvuXD/79-redirect-users-to-summary-page-after-step-is-saved