### PR TITLE
Make step markdown link-checking more robust (fix sidebar settings & preview)

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -39,10 +39,15 @@ class StepContentParser
   end
 
   def base_paths(step_text)
-    relative_paths(step_text).map do |path|
-      uri = URI.parse(path)
-      uri.path
+    paths = relative_paths(step_text).map do |path|
+      begin
+        uri = URI.parse(path)
+        uri.path
+      rescue URI::InvalidURIError
+        nil
+      end
     end
+    paths.compact
   end
 
   def all_paths(step_text)

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -39,15 +39,7 @@ class StepContentParser
   end
 
   def base_paths(step_text)
-    paths = relative_paths(step_text).map do |path|
-      begin
-        uri = URI.parse(path)
-        uri.path
-      rescue URI::InvalidURIError
-        nil
-      end
-    end
-    paths.compact
+    relative_paths(step_text).map { |path| safely_parse_path(path) }.compact
   end
 
   def all_paths(step_text)
@@ -55,6 +47,15 @@ class StepContentParser
   end
 
 private
+
+  def safely_parse_path(path)
+    begin
+      uri = URI.parse(path)
+      uri.path
+    rescue URI::InvalidURIError
+      nil
+    end
+  end
 
   def relative_paths(content)
     all_links_in_content(content).select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -87,16 +87,17 @@ private
 
   def link_content(section)
     section.map do |line|
-      if line.scan(/\[/).empty?
-        { "text": line[2..-1] }
-      elsif /\[(?<text>(.+))\]\((?<href>(.+))\)((?<context>.*))$/ =~ line
+      payload = {}
+      if /\[(?<text>(.+))\]\((?<href>(.+))\)((?<context>.*))$/ =~ line && safely_parse_path(href)
         payload = {
           "text": text,
           "href": href,
         }
         payload[:context] = context.strip unless context.blank?
-        payload
+      else
+        payload[:text] = line[2..-1]
       end
+      payload
     end
   end
 end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -343,6 +343,23 @@ RSpec.describe StepContentParser do
       )
     end
 
+    it "rejects invalid URLs" do
+      step_text = <<~HEREDOC
+        [All the prizes](/all-the-prizes)
+        - [A link with a space prefix]( /foo)
+        - [A link with a space suffix](/i-love-speed-boats )
+        - [An invalid link](ftp:/ gov . uk)
+        - [A dishwasher](/bargain-basement)
+      HEREDOC
+
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /all-the-prizes
+          /bargain-basement
+        )
+      )
+    end
+
     it "can cope with multiple links per line" do
       step_text = "[Find driving instructor training courses](/find-driving-instructor-training)[Revise and practise for your test](/adi-part-1-test/revision-practice)"
 

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -256,7 +256,10 @@ RSpec.describe StepContentParser do
           - [A very expensive speed boat](/i-love-speed-boats)
           * [Spending money](/spending-money)£5000 or so
           - [A dishwasher](http://dishwashers.org/bargain-basement)
+          - [I am a broken link]( ftp: / gov .uk)
           - And I'm a healthy bullet (although I eat ice cream everyday)
+
+          [And I am also broken]()
 
           You have to remember them all!
         HEREDOC
@@ -305,9 +308,16 @@ RSpec.describe StepContentParser do
                 "href": "http://dishwashers.org/bargain-basement",
               },
               {
+                "text": "[I am a broken link]( ftp: / gov .uk)",
+              },
+              {
                 "text": "And I'm a healthy bullet (although I eat ice cream everyday)",
               },
             ],
+          },
+          {
+            "type": "paragraph",
+            "text": "[And I am also broken]()",
           },
           {
             "type": "paragraph",
@@ -356,7 +366,7 @@ RSpec.describe StepContentParser do
         %w(
           /all-the-prizes
           /bargain-basement
-        )
+        ),
       )
     end
 


### PR DESCRIPTION
Fixes two bugs:

1) "Sidebar settings" page on step by step pages would break if there was a broken markdown URL in any step. They are now safely ignored (first commit).
2) Broken markdown links would also prevent the preview draft from updating. They are now safely ignored (and are simply rendered as broken markdown in the preview, making it obvious to content designers that there is a problem).

Trello card: https://trello.com/c/2hNZqWUY/67-preview-does-not-update-if-there-is-invalid-markdown-in-a-step