### PR TITLE
Add submit for 2i review action

### DIFF
--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -15,8 +15,6 @@
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
     <% elsif @step_by_step_page.can_be_published? %>
-      <p class="govuk-body">Before publishing check for broken links.</p>
-      <p class="govuk-body">After publishing add this step by step to a mainstream browse category and a taxonomy topic.</p>
       <% if @step_by_step_page.has_been_published? %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Publish",
@@ -32,9 +30,6 @@
         step_by_step_page_schedule_path(@step_by_step_page),
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
-    <% elsif !@step_by_step_page.steps_have_content? %>
-      <p class="govuk-body">Step by steps cannot be published until all steps have content.</p>
-      <%= preview_link %>
     <% elsif @step_by_step_page.has_draft? %>
       <%= preview_link %>
     <% end %>

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -14,7 +14,9 @@
         method: :post,
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
-    <% elsif @step_by_step_page.can_be_published? %>
+    <% elsif
+      @step_by_step_page.can_be_published? && !(current_user.has_permission? "Unreleased feature") || # remove this line when the feature flag is removed
+      @step_by_step_page.status.approved_2i? && (current_user.has_permission? "Unreleased feature") %>
       <% if @step_by_step_page.has_been_published? %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Publish",
@@ -31,6 +33,13 @@
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
     <% elsif @step_by_step_page.has_draft? %>
+      <% if !@step_by_step_page.status.submitted_for_2i? &&
+        (current_user.has_permission? "Unreleased feature") # remove this line when the feature flag is removed %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Submit for 2i review",
+          href: step_by_step_page_submit_for_2i_path(@step_by_step_page)
+        } %>
+      <% end %>
       <%= preview_link %>
     <% end %>
 

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -29,3 +29,9 @@
     </ul>
   <% end %>
 <% end %>
+
+<% if @step_by_step_page.status.submitted_for_2i? %>
+  <%= render "govuk_publishing_components/components/inset_text" do %>
+    <p class="govuk-body">Not yet claimed for 2i</p>
+  <% end %>
+<% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -66,6 +66,10 @@ FactoryBot.define do
     end
   end
 
+  factory :step_by_step_page_submitted_for_2i, parent: :step_by_step_page_with_steps do
+    status { "submitted_for_2i" }
+  end
+
   factory :step do
     title { "Check how awesome you are" }
     logic { "number" }

--- a/spec/features/create_step_by_step_spec.rb
+++ b/spec/features/create_step_by_step_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Create new step by step page" do
 
   before do
     given_I_am_a_GDS_editor
+    given_I_can_access_unreleased_features
     setup_publishing_api
     stub_default_publishing_api_put_intent
   end
@@ -18,6 +19,7 @@ RSpec.feature "Create new step by step page" do
     and_I_fill_in_the_form
     and_I_see_a_page_created_success_notice
     and_I_see_I_saved_it_last
+    and_I_can_submit_the_step_by_step_for_2i_review
     and_I_can_preview_the_step_by_step
     when_I_visit_the_step_by_step_pages_index
     then_I_see_the_new_step_by_step_page

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -230,8 +230,7 @@ RSpec.feature "Managing step by step pages" do
   scenario "A step doesn't have any content" do
     given_there_is_a_step_by_step_page_with_steps_missing_content
     when_I_view_the_step_by_step_page
-    then_I_should_see "Step by steps cannot be published until all steps have content."
-    and_I_should_see_an_inset_prompt
+    then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_link_to_steps_section "Add content to all your steps"
     and_I_cannot_publish_or_schedule_the_step_by_step
   end

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -15,6 +15,8 @@ RSpec.feature "Reviewing step by step pages" do
     when_I_visit_the_submit_for_2i_page
     and_I_submit_the_form
     then_I_see_a_submitted_for_2i_success_notice
+    and_I_see_a_not_yet_claimed_for_2i_prompt
+    and_I_cannot_see_a_submit_for_2i_button
     when_I_view_internal_change_notes
     then_I_can_see_an_automated_change_note
   end
@@ -25,13 +27,11 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_fill_in_additional_comments
     and_I_submit_the_form
     then_I_see_a_submitted_for_2i_success_notice
+    and_I_see_a_not_yet_claimed_for_2i_prompt
+    and_I_cannot_see_a_submit_for_2i_button
     when_I_view_internal_change_notes
     then_I_can_see_an_automated_change_note
     and_I_can_see_additional_comments_in_the_change_note
-  end
-
-  def given_I_can_access_unreleased_features
-    stub_user.permissions << "Unreleased feature"
   end
 
   def when_I_visit_the_submit_for_2i_page
@@ -52,6 +52,16 @@ RSpec.feature "Reviewing step by step pages" do
 
   def then_I_see_a_submitted_for_2i_success_notice
     expect(page).to have_content("Step by step page was successfully submitted for 2i")
+  end
+
+  def and_I_see_a_not_yet_claimed_for_2i_prompt
+    expect(page).to have_css(".govuk-inset-text", text: "Not yet claimed for 2i")
+  end
+
+  def and_I_cannot_see_a_submit_for_2i_button
+    within(".app-side__actions") do
+      expect(page).to_not have_link("Submit for 2i review")
+    end
   end
 
   def then_I_can_see_an_automated_change_note

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.feature "Contextual action buttons for step by step pages" do
+  include CommonFeatureSteps
+  include NavigationSteps
+  include StepNavSteps
+
+  before do
+    given_I_am_a_GDS_editor
+    given_I_can_access_unreleased_features
+    setup_publishing_api
+  end
+
+  context "Step by step is in draft" do
+    scenario "show the relevant actions to the step by step author" do
+      given_there_is_a_step_by_step_page_with_a_link_report
+      when_I_visit_the_step_by_step_page
+      then_the_primary_action_should_be "Submit for 2i review"
+      and_the_secondary_action_should_be "Preview"
+      and_there_should_be_tertiary_actions_to %w(Delete)
+    end
+  end
+
+  context "Step by step has been submitted for 2i" do
+    scenario "show the relevant actions to the step by step author" do
+      given_there_is_a_step_by_step_that_has_been_submitted_for_2i
+      and_I_am_the_step_by_step_author
+      when_I_visit_the_step_by_step_page
+      then_there_should_be_no_primary_action
+      and_the_secondary_action_should_be "Preview"
+      and_there_should_be_tertiary_actions_to %w(Delete)
+    end
+  end
+
+  def then_the_primary_action_should_be(action_text)
+    custom_error = "Couldn't find '#{action_text}' as a primary action in: \n #{action_html}"
+    expect(page).to have_css(".app-side__actions .gem-c-button:not(.gem-c-button--secondary)", text: action_text), custom_error
+  end
+
+  def then_there_should_be_no_primary_action
+    expect(page).not_to have_css(".app-side__actions .gem-c-button:not(.gem-c-button--secondary)")
+  end
+
+  def and_the_secondary_action_should_be(action_text)
+    custom_error = "Couldn't find '#{action_text}' as a secondary action in: \n #{action_html}"
+    expect(page).to have_css(".app-side__actions .gem-c-button--secondary", text: action_text), custom_error
+  end
+
+  def and_there_should_be_tertiary_actions_to(actions_text)
+    actions_text.each do |action_text|
+      custom_error = "Couldn't find '#{action_text}' as a tertiary action in: \n #{action_html}"
+      expect(page).to have_css(".app-side__actions .govuk-link", text: action_text), custom_error
+    end
+  end
+
+  def action_html
+    find(".app-side__actions").native.inner_html.strip
+  end
+
+  def and_I_am_the_step_by_step_author
+    @current_user = @review_requester
+  end
+end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -16,4 +16,8 @@ module CommonFeatureSteps
   def and_I_submit_the_form
     find("input[type=submit]").click
   end
+
+  def given_I_can_access_unreleased_features
+    stub_user.permissions << "Unreleased feature"
+  end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -171,6 +171,11 @@ module StepNavSteps
     stub_link_checker_report_multiple_broken_links(step)
   end
 
+  def given_there_is_a_step_by_step_that_has_been_submitted_for_2i
+    @review_requester = create(:user, name: "Original Author")
+    @step_by_step_page = create(:step_by_step_page_submitted_for_2i, review_requester_id: @review_requester.uid)
+  end
+
   def then_I_can_see_a_success_message(message)
     within(".gem-c-success-alert") do
       expect(page).to have_content message
@@ -187,6 +192,12 @@ module StepNavSteps
 
   def then_I_see_the_new_step_by_step_page
     expect(page).to have_content("How to bake a cake")
+  end
+
+  def and_I_can_submit_the_step_by_step_for_2i_review
+    within(".app-side__actions") do
+      expect(page).to have_link("Submit for 2i review")
+    end
   end
 
   def then_I_can_preview_the_step_by_step


### PR DESCRIPTION
This work introduces the "Submit for 2i review" and the results or that action. I'm trying to avoid a massive PR, so since we're behind a feature flag I'm raising early to check the direction of this work with the rest of the team. Planning to raise a follow up PR that enables "claiming" after this gets merged.

### Preview
In draft state or with changes after being published
<img width="1000" alt="2i-draft" src="https://user-images.githubusercontent.com/788096/65442762-b518c880-de24-11e9-874d-a784c75c1d3e.png">

After submitted for 2i
<img width="1001" alt="2i-submitted-for-2i" src="https://user-images.githubusercontent.com/788096/65442782-c1048a80-de24-11e9-8cf1-b29d80b4b212.png">


[Trello card](https://trello.com/c/Fwo562zl)