### PR TITLE
New test suite: contextual action button tests for step by steps

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -66,6 +66,11 @@ FactoryBot.define do
     end
   end
 
+  factory :step_by_step_page_submitted_for_2i, parent: :step_by_step_page_with_steps do
+    status { "submitted_for_2i" }
+    # must pass `review_requester_id` when invoking
+  end
+
   factory :step do
     title { "Check how awesome you are" }
     logic { "number" }

--- a/spec/features/step_by_step_actions.rb
+++ b/spec/features/step_by_step_actions.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.feature "Contextual action buttons for step by step pages" do
+  include CommonFeatureSteps
+  include NavigationSteps
+  include StepNavSteps
+
+  before do
+    given_I_am_a_GDS_editor
+    setup_publishing_api
+  end
+
+  context "Step by step is in draft" do
+    scenario "show the relevant actions to the step by step author" do
+      given_there_is_a_step_by_step_page_with_a_link_report
+      when_I_visit_the_step_by_step_page
+      then_the_primary_action_should_be "Submit for 2i review"
+      and_the_secondary_action_should_be "Preview"
+      and_there_should_be_tertiary_actions_to %w(Delete)
+    end
+  end
+
+  def then_the_primary_action_should_be(action_text)
+    custom_error = "Couldn't find '#{action_text}' as a primary action in: \n #{action_html}"
+    expect(page).to have_link(".app-side__actions .gem-c-button:not(.gem-c-button--secondary)", text: action_text), custom_error
+  end
+
+  def action_html
+    find(".app-side__actions").native.inner_html.strip
+  end
+end


### PR DESCRIPTION
As we're implementing 2i workflow into step by step publication, and
there is the possibility of 'fact check' workflow thereafter, our test
suites are becoming more difficult to maintain and less all-encompassing
of all possible states and use cases.

This new test suite has a simple aim: to denote exactly which actions
are available (and whether they are Primary, Secondary or Tertiary),
given a step by step is in a particular state and being viewed by a
particular author.

To be merged into #761. NB, I expect the tests to fail because currently we're showing "Publish" instead of "Submit for 2i" if a step by step has passed all its pre-requisite checks (e.g. link checking). This will be fixed in #761. In other words, this entire PR is the 'Red' in the 'Red Green Refactor' TDD approach.

Whilst this PR specifically targets https://trello.com/c/Fwo562zl/72-2i-reviewer-can-claim-sbs-for-review, it is mostly intended to be part of https://trello.com/c/Qle5c1QQ/43-display-the-appropriate-buttons-depending-on-the-state-of-the-sbs-and-who-is-logged-in.