### PR TITLE
Add route and logic to revert something back to draft

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -64,6 +64,20 @@ class ReviewController < ApplicationController
     end
   end
 
+  def revert_to_draft
+    status = "draft"
+
+    if @step_by_step_page.update(
+      reviewer_id: nil,
+      review_requester_id: nil,
+      status: status,
+    )
+      generate_change_note("Reverted to draft")
+
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully reverted to draft."
+    end
+  end
+
 private
 
   def generate_change_note(status, change_note = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     get :reorder
     post :reorder
     post :revert
+    post "revert-to-draft", to: "review#revert_to_draft"
     get :schedule
     post :schedule
     post "schedule-datetime", to: "schedule_datetime"

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -240,5 +240,64 @@ RSpec.describe ReviewController do
         expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
       end
     end
+
+    describe "POST revert to draft" do
+      let(:user) { create(:user) }
+      let(:reviewer_user) { create(:user) }
+
+      let(:step_by_step_page) do
+        create(
+          :draft_step_by_step_page,
+          review_requester_id: user.uid,
+          status: "submitted_for_2i",
+        )
+      end
+
+      before do
+        step_by_step_page.update_attributes(:status => "in_review", :reviewer_id => reviewer_user.uid)
+      end
+
+      required_permissions = ["signin", "GDS Editor", "Unreleased feature"]
+
+      it "can be accessed by users with GDS Editor and Unreleased feature permissions" do
+        stub_user.permissions = required_permissions
+        post :revert_to_draft, params: { step_by_step_page_id: step_by_step_page.id }
+
+        expect(response).to redirect_to step_by_step_page_path(step_by_step_page)
+      end
+
+      (required_permissions - %w(signin)).each do |required_permission|
+        it "cannot be accessed by users without the #{required_permission} permission" do
+          stub_user.permissions = required_permissions
+          stub_user.permissions.delete(required_permission)
+          post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+          expect(response.status).to eq(403)
+        end
+      end
+
+      it "sets status to draft and removes the reviewer id and review requester id" do
+        stub_user.permissions = required_permissions
+        post :revert_to_draft, params: { step_by_step_page_id: step_by_step_page.id }
+
+        step_by_step_page.reload
+
+        expect(step_by_step_page.status).to eq("draft")
+        expect(step_by_step_page.reviewer_id).to be_nil
+        expect(step_by_step_page.review_requester_id).to be_nil
+      end
+
+      it "creates an internal change note" do
+        stub_user.permissions = required_permissions
+        stub_user.name = "Firstname Lastname"
+
+        expected_change_note = "Reverted to draft by Firstname Lastname"
+
+        post :revert_to_draft, params: { step_by_step_page_id: step_by_step_page.id }
+        step_by_step_page.reload
+
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/eS79gejo/39-content-designer-can-revert-to-draft-if-changes-are-needed-after-2i

This adds logic to revert a step by step page back to draft. This will be needed in the event that a reviewer requests major changes that cannot be implemented without a 2nd approval.