### PR TITLE
Require rails_helper in StepNavSteps

### DIFF
--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 module StepNavSteps
   include LinkChecker
 


### PR DESCRIPTION
Tests were failing intermittently due to:

```
NameError: uninitialized constant StepNavSteps::LinkChecker
```

When running StepNavSteps in isolation, this error was reported on every run.

The rails_helper loads all support files for the tests.

Rspec runs the tests in a random order, so it appears 'rails_helper' had already been loaded from a previous spec on times when it passed.