### PR TITLE
Resolve CI build release tagging error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,11 @@ node {
   govuk.buildProject(
     beforeTest: {
       sh("yarn install")
-    }
+    },
+    sassLint: false,
+    rubyLintDiff: false,
+    publishingE2ETests: true,
+    brakeman: true
   )
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
-  govuk.buildProject(sassLint: false, rubyLintDiff: false, publishingE2ETests: true, brakeman: true)
 }


### PR DESCRIPTION
Every CI build since a2114054c05be6eac7e79f8f09c41e9596a1cc8c (inclusive) has failed with an error:

```
+ git tag -a release_n -m Jenkinsfile tagging with release_n
fatal: tag 'release_n' already exists
```

Whilst the release was being tagged, the CI build was marked as failing, therefore making it difficult to differentiate between passed and failed builds in the Jenkins interface.

The cause was due to govuk.buildProject being executed twice.  This has now been reduced down to a single request.