### PR TITLE
Fix ordering of steps

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -3,6 +3,7 @@ class Step < ApplicationRecord
   validates_presence_of :step_by_step_page
   validates :title, :logic, presence: true
   has_many :link_reports, :dependent => :destroy
+  after_create :set_step_position
 
   def broken_links?
     broken_links.present? && broken_links.any?
@@ -48,5 +49,9 @@ private
 
   def most_recent_batch
     LinkReport.where(step_id: self.id).last
+  end
+
+  def set_step_position
+    update!(position: step_by_step_page.steps.count)
   end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -4,6 +4,7 @@ class Step < ApplicationRecord
   validates :title, :logic, presence: true
   has_many :link_reports, :dependent => :destroy
   after_create :set_step_position
+  after_destroy :set_parent_step_positions
 
   def broken_links?
     broken_links.present? && broken_links.any?
@@ -53,5 +54,9 @@ private
 
   def set_step_position
     update!(position: step_by_step_page.steps.count)
+  end
+
+  def set_parent_step_positions
+    step_by_step_page.make_step_positions_sequential
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -158,6 +158,12 @@ class StepByStepPage < ApplicationRecord
     internal_change_notes.where(edition_number: nil).delete_all
   end
 
+  def make_step_positions_sequential
+    steps.sort_by(&:position).each.with_index(1) do |step, index|
+      step.update_attributes!(position: index)
+    end
+  end
+
 private
 
   def generate_content_id

--- a/db/migrate/20190927080905_set_step_positions.rb
+++ b/db/migrate/20190927080905_set_step_positions.rb
@@ -1,0 +1,11 @@
+class SetStepPositions < ActiveRecord::Migration[5.2]
+  def change
+    StepByStepPage.all.each do |step_by_step_page|
+      # Assumption: all step by steps `steps` array are in order, whether they have a `position` or not
+      # This is the same logic as relied upon in show.html
+      step_by_step_page.steps.each.with_index(1) do |step, index|
+        step.update_attributes!(position: index)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_25_124652) do
+ActiveRecord::Schema.define(version: 2019_09_27_080905) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe Step do
       step = create(:step, step_by_step_page: step_by_step_page)
       expect(step.position).to eq 3
     end
+
+    it "should update step positions when a step is deleted" do
+      step_by_step_page = create(:step_by_step_page_with_steps)
+      expect(step_by_step_page.steps.count).to eq 2
+      original_step_one = step_by_step_page.steps.first
+      original_step_two = step_by_step_page.steps.last
+      expect(original_step_one.position).to eq 1
+      expect(original_step_two.position).to eq 2
+
+      original_step_one.destroy
+      step_by_step_page.reload
+      original_step_two.reload
+
+      expect(original_step_two.position).to eq 1
+      expect(step_by_step_page.steps.first).to eq original_step_two
+      expect(step_by_step_page.steps.count).to eq 1
+    end
   end
 
   describe "broken_links" do

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -40,6 +40,25 @@ RSpec.describe Step do
       expect(step_item.errors).to have_key(:logic)
     end
   end
+
+  describe "position" do
+    it "should default to position 1 if it is the first step to have been added" do
+      step_by_step_page = create(:step_by_step_page)
+      expect(step_by_step_page.steps.count).to eq 0
+
+      step = create(:step, step_by_step_page: step_by_step_page)
+      expect(step.position).to eq 1
+    end
+
+    it "should increment if there are existing steps" do
+      step_by_step_page = create(:step_by_step_page_with_steps)
+      expect(step_by_step_page.steps.count).to eq 2
+
+      step = create(:step, step_by_step_page: step_by_step_page)
+      expect(step.position).to eq 3
+    end
+  end
+
   describe "broken_links" do
     it "should return nothing if there are no link reports yet" do
       expect(step_item.broken_links).to be_nil

--- a/spec/services/step_links_for_rules_spec.rb
+++ b/spec/services/step_links_for_rules_spec.rb
@@ -1,16 +1,11 @@
 require "rails_helper"
 
 RSpec.describe StepLinksForRules do
+  include StepLinkFixtures
+
   let(:step_page) { create(:step_by_step_page_with_steps) }
   let(:first_step) { step_page.steps.first }
-  let(:base_paths) { ["/good/stuff", "/also/good/stuff", "/not/as/great"] }
-  let(:base_paths_return_data) do
-    {
-      "/good/stuff" => "fd6b1901d-b925-47c5-b1ca-1e52197097e1",
-      "/also/good/stuff" => "fd6b1901d-b925-47c5-b1ca-1e52197097e2",
-      "/not/as/great" => "fd6b1901d-b925-47c5-b1ca-1e52197097e3",
-    }
-  end
+  let(:base_paths) { step_link_fixtures_return_data.keys }
 
   before do
     publishing_api_receives_request_to_lookup_content_id(
@@ -69,11 +64,11 @@ RSpec.describe StepLinksForRules do
 
         publishing_api_receives_request_to_lookup_content_ids(
           base_paths: base_paths << base_path_data.keys.first,
-          return_data: base_paths_return_data.merge(base_path_data),
+          return_data: step_link_fixtures_return_data.merge(base_path_data),
         )
 
         publishing_api_receives_get_content_id_request(
-          content_items: initial_content_items << amazing_content_item,
+          content_items: step_link_fixtures_content_items << amazing_content_item,
         )
 
         described_class.new(step_by_step_page: step_page).call
@@ -92,11 +87,11 @@ RSpec.describe StepLinksForRules do
 
         publishing_api_receives_request_to_lookup_content_ids(
           base_paths: base_paths,
-          return_data: base_paths_return_data,
+          return_data: step_link_fixtures_return_data,
         )
 
         publishing_api_receives_get_content_id_request(
-          content_items: initial_content_items,
+          content_items: step_link_fixtures_content_items,
         )
 
         described_class.new(step_by_step_page: step_page).call
@@ -123,7 +118,7 @@ RSpec.describe StepLinksForRules do
         )
 
         publishing_api_receives_get_content_id_request(
-          content_items: [initial_content_items.first],
+          content_items: [step_link_fixtures_content_items.first],
         )
 
         expect(
@@ -141,78 +136,12 @@ RSpec.describe StepLinksForRules do
 
   def setup_test_with_publishing_api_requests
     publishing_api_receives_request_to_lookup_content_ids(
-      base_paths: base_paths,
-      return_data: base_paths_return_data,
+      base_paths: step_link_fixtures_return_data.keys,
+      return_data: step_link_fixtures_return_data,
     )
 
     publishing_api_receives_get_content_id_request(
-      content_items: initial_content_items,
+      content_items: step_link_fixtures_content_items,
     )
-  end
-
-  def publishing_api_receives_request_to_lookup_content_id(base_path:)
-    allow(Services.publishing_api).to(
-      receive(:lookup_content_id).with(
-        base_path: base_path,
-        with_drafts: true,
-      ),
-    )
-  end
-
-  def publishing_api_receives_request_to_lookup_content_ids(base_paths:, return_data: nil)
-    expectation = expect(Services.publishing_api).to receive(:lookup_content_ids).with(
-      base_paths: base_paths,
-      with_drafts: true,
-    )
-
-    if return_data
-      expectation.and_return(
-        return_data,
-      )
-    end
-  end
-
-  def publishing_api_receives_get_content_id_request(content_items:)
-    content_items.each do |content_item|
-      expect(Services.publishing_api).to(
-        receive(:get_content).with(content_item[:content_id]),
-      ).and_return(content_item)
-    end
-  end
-
-  def initial_content_items
-    [
-      basic_content_item(
-        title: "Good Stuff",
-        base_path: "/good/stuff",
-        content_id: "fd6b1901d-b925-47c5-b1ca-1e52197097e1",
-        publishing_app: "publisher",
-        schema_name: "guide",
-      ),
-      basic_content_item(
-        title: "Also Good Stuff",
-        base_path: "/also/good/stuff",
-        content_id: "fd6b1901d-b925-47c5-b1ca-1e52197097e2",
-        publishing_app: "publisher",
-        schema_name: "guide",
-      ),
-      basic_content_item(
-        title: "Not as Great",
-        base_path: "/not/as/great",
-        content_id: "fd6b1901d-b925-47c5-b1ca-1e52197097e3",
-        publishing_app: "publisher",
-        schema_name: "guide",
-      ),
-    ]
-  end
-
-  def basic_content_item(title:, base_path:, content_id:, publishing_app:, schema_name:)
-    {
-      "title": title,
-      "base_path": base_path,
-      "content_id": content_id,
-      "publishing_app": publishing_app,
-      "schema_name": schema_name,
-    }.with_indifferent_access
   end
 end

--- a/spec/support/publishing_api_helpers.rb
+++ b/spec/support/publishing_api_helpers.rb
@@ -25,6 +25,36 @@ module PublishingApiHelpers
     url = PUBLISHING_API_V2_ENDPOINT + "/linked/"
     stub_request(:get, %r[#{url}]).to_return(status: 200, body: [].to_json)
   end
+
+  def publishing_api_receives_request_to_lookup_content_id(base_path:)
+    allow(Services.publishing_api).to(
+      receive(:lookup_content_id).with(
+        base_path: base_path,
+        with_drafts: true,
+      ),
+    )
+  end
+
+  def publishing_api_receives_request_to_lookup_content_ids(base_paths:, return_data: nil)
+    expectation = expect(Services.publishing_api).to receive(:lookup_content_ids).with(
+      base_paths: base_paths,
+      with_drafts: true,
+    )
+
+    if return_data
+      expectation.and_return(
+        return_data,
+      )
+    end
+  end
+
+  def publishing_api_receives_get_content_id_request(content_items:)
+    content_items.each do |content_item|
+      expect(Services.publishing_api).to(
+        receive(:get_content).with(content_item[:content_id]),
+      ).and_return(content_item)
+    end
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/step_link_fixtures.rb
+++ b/spec/support/step_link_fixtures.rb
@@ -1,0 +1,45 @@
+module StepLinkFixtures
+  def step_link_fixtures_return_data
+    {
+      "/good/stuff" => "fd6b1901d-b925-47c5-b1ca-1e52197097e1",
+      "/also/good/stuff" => "fd6b1901d-b925-47c5-b1ca-1e52197097e2",
+      "/not/as/great" => "fd6b1901d-b925-47c5-b1ca-1e52197097e3",
+    }
+  end
+
+  def step_link_fixtures_content_items
+    [
+      basic_content_item(
+        title: "Good Stuff",
+        base_path: "/good/stuff",
+        content_id: "fd6b1901d-b925-47c5-b1ca-1e52197097e1",
+        publishing_app: "publisher",
+        schema_name: "guide",
+      ),
+      basic_content_item(
+        title: "Also Good Stuff",
+        base_path: "/also/good/stuff",
+        content_id: "fd6b1901d-b925-47c5-b1ca-1e52197097e2",
+        publishing_app: "publisher",
+        schema_name: "guide",
+      ),
+      basic_content_item(
+        title: "Not as Great",
+        base_path: "/not/as/great",
+        content_id: "fd6b1901d-b925-47c5-b1ca-1e52197097e3",
+        publishing_app: "publisher",
+        schema_name: "guide",
+      ),
+    ]
+  end
+
+  def basic_content_item(title:, base_path:, content_id:, publishing_app:, schema_name:)
+    {
+      "title": title,
+      "base_path": base_path,
+      "content_id": content_id,
+      "publishing_app": publishing_app,
+      "schema_name": schema_name,
+    }.with_indifferent_access
+  end
+end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "support/link_checker"
 
 module StepNavSteps
   include LinkChecker


### PR DESCRIPTION
Adding new steps would not set the `position` property - this was only being set when explicitly reordering steps from the reorder screen - which led to strange bugs such as new steps being added to the top of the step by step.

We now set `position` to the "number of steps in the step by step + 1" so that it is added to the end. We also reset the positions if a step is deleted, to prevent step numbers becoming out of sync with how many steps there are.

I had hoped to implement this at the schema level with an `auto_increment` on the `positions` field, however this is not allowed on non-primary key fields, and in any case would not work properly as there are multiple step by steps (so incrementing would apply based on the number of steps in the database, irrespective of which step by step the steps are a part of).

Trello: https://trello.com/c/GkAjQcLt/26-ordering-of-new-steps-is-inconsistent-after-x-amount-of-steps