### PR TITLE
Update change note title and entry

### DIFF
--- a/app/controllers/internal_change_notes_controller.rb
+++ b/app/controllers/internal_change_notes_controller.rb
@@ -19,6 +19,7 @@ private
   def other_fields
     fields = {
       step_by_step_page_id: step_by_step_page.id,
+      headline: "Internal note",
       author: current_user.name,
     }
 

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -41,7 +41,7 @@ class ReviewController < ApplicationController
       review_requester_id: nil,
       status: status,
     )
-      generate_change_note("Changes requested", params[:requested_change])
+      generate_change_note("2i changes requested", params[:requested_change])
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested."
     end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -81,12 +81,10 @@ class ReviewController < ApplicationController
 private
 
   def generate_change_note(status, change_note = nil)
-    description = "#{status.humanize} by #{current_user.name}"
-    description << "\n\n#{change_note}" if change_note.present?
-
     @step_by_step_page.internal_change_notes.create(
       author: current_user.name,
-      description: description,
+      headline: status.humanize,
+      description: change_note,
     )
   end
 

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -14,7 +14,7 @@ class ReviewController < ApplicationController
       reviewer_id: nil,
       status: status,
     )
-      generate_change_note(status)
+      generate_change_note("2i approved")
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully approved_2i."
     end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -27,7 +27,7 @@ class ReviewController < ApplicationController
       reviewer_id: current_user.uid,
       status: status,
     )
-      generate_change_note(status)
+      generate_change_note("Claimed for review")
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully claimed for review."
     end

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -137,6 +137,7 @@ class StepByStepPagesController < ApplicationController
     if request.post?
       discard_draft
       revert_page
+      generate_internal_change_note("Draft discarded")
       redirect_to @step_by_step_page, notice: "Draft successfully discarded."
     else
       render :edit

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -126,7 +126,7 @@ class StepByStepPagesController < ApplicationController
     set_current_page_as_step_by_step
     @step_by_step_page.update(scheduled_at: nil)
     unschedule_publishing
-    note_headline = "Publishing was unscheduled"
+    note_headline = "Scheduled publishing stopped"
     generate_internal_change_note(note_headline)
     set_change_note_version
     redirect_to @step_by_step_page, notice: "Publishing of '#{@step_by_step_page.title}' has been unscheduled."

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -67,9 +67,8 @@ class StepByStepPagesController < ApplicationController
     if request.post?
       @publish_intent = PublishIntent.new(publish_intent_params)
       if @publish_intent.valid?
-        note_headline = publish_note_headline
         publish_page(@publish_intent)
-        generate_internal_change_note(note_headline, publish_note_description)
+        generate_internal_change_note("Published", publish_note_description)
         set_change_note_version
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been published."
       end
@@ -212,10 +211,6 @@ private
     payload = Services.publishing_api.get_content(@step_by_step_page.content_id, version: published_version).to_hash
 
     StepByStepPageReverter.new(@step_by_step_page, payload).repopulate_from_publishing_api
-  end
-
-  def publish_note_headline
-    @step_by_step_page.has_been_published? ? "Published" : "First published"
   end
 
   def publish_note_description

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -198,6 +198,7 @@ private
       Rails.logger.info "Unpublishing #{@step_by_step_page.content_id} failed"
     end
     @step_by_step_page.mark_as_unpublished
+    generate_internal_change_note("Unpublished")
   end
 
   def unschedule_publishing

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -95,7 +95,7 @@ class StepByStepPagesController < ApplicationController
         render :schedule_datetime
       elsif @step_by_step_page.update_attributes(scheduled_at: scheduled_at)
         schedule_to_publish(session[:update_type], session[:public_change_note])
-        note_headline = "Scheduled"
+        note_headline = "Scheduled to publish"
         note_description = "Scheduled at #{format_full_date_and_time(scheduled_at)}"
         note_description << " with change note: #{session[:public_change_note]}" if session[:public_change_note].present?
         generate_internal_change_note(note_headline, note_description)

--- a/app/models/internal_change_note.rb
+++ b/app/models/internal_change_note.rb
@@ -1,5 +1,5 @@
 class InternalChangeNote < ApplicationRecord
-  validates :author, :description, presence: true
+  validates :author, :headline, presence: true
   belongs_to :step_by_step_page
 
   def readable_created_date

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -50,7 +50,7 @@
             content: {
               html: sanitize(records.map { |note|
                   "<div class='app-c-timeline-entry'>
-                    <h4 class='app-c-timeline-entry__type'>Internal note</h4>
+                    <h4 class='app-c-timeline-entry__type'>#{note.headline}</h4>
                     <p class='app-c-timeline-entry__dateline'>#{note.readable_created_date} by #{note.author}</p>
                     <pre class='app-c-timeline-entry__description'>#{note.description}</pre>
                   </div>"

--- a/app/workers/step_by_step_draft_update_worker.rb
+++ b/app/workers/step_by_step_draft_update_worker.rb
@@ -34,7 +34,7 @@ class StepByStepDraftUpdateWorker
   def generate_internal_change_note
     change_note = step_by_step_page.internal_change_notes.new(
       author: @current_user,
-      description: "Draft saved by #{@current_user}",
+      headline: "Draft saved",
     )
     change_note.save
   end

--- a/app/workers/step_by_step_scheduled_publish_worker.rb
+++ b/app/workers/step_by_step_scheduled_publish_worker.rb
@@ -21,7 +21,7 @@ class StepByStepScheduledPublishWorker
   def generate_internal_change_note(step_nav)
     change_note = step_nav.internal_change_notes.new(
       author: "Scheduled publishing",
-      description: "Published on schedule",
+      headline: "Published on schedule",
     )
     change_note.save!
   end

--- a/db/migrate/20190925124652_add_internal_change_note_headline.rb
+++ b/db/migrate/20190925124652_add_internal_change_note_headline.rb
@@ -1,0 +1,6 @@
+class AddInternalChangeNoteHeadline < ActiveRecord::Migration[5.2]
+  def change
+    add_column :internal_change_notes, :headline, :string
+    InternalChangeNote.update_all(headline: 'Internal note')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_122638) do
+ActiveRecord::Schema.define(version: 2019_09_25_124652) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_09_13_122638) do
     t.bigint "step_by_step_page_id"
     t.datetime "created_at"
     t.integer "edition_number"
+    t.string "headline"
     t.index ["step_by_step_page_id"], name: "index_internal_change_notes_on_step_by_step_page_id"
   end
 

--- a/spec/controllers/internal_change_notes_controller_spec.rb
+++ b/spec/controllers/internal_change_notes_controller_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe InternalChangeNotesController, type: :controller do
       post :create, params: { step_by_step_page_id: 0, internal_change_note: { description: "Test description" } }
       expect(InternalChangeNote.first.author).to eql "Test author"
       expect(InternalChangeNote.first.edition_number).to be nil
+      expect(InternalChangeNote.first.headline).to eql "Internal note"
+      expect(InternalChangeNote.first.description).to eql "Test description"
     end
 
     it "saves a change note with an edition_number for a published version" do

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe ReviewController do
 
         describe "internal change notes" do
           it "creates an internal change note" do
-            expected_change_note = "Submitted for 2i by Firstname Lastname"
+            expected_change_note = "Submitted for 2i"
 
             post :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
             step_by_step_page.reload
 
-            expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+            expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_change_note
           end
 
           it "records the additional comments in the internal change note" do
@@ -120,12 +120,12 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "Approved 2i by Firstname Lastname"
+        expected_change_note = "Approved 2i"
 
         post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
         step_by_step_page.reload
 
-        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_change_note
       end
     end
 
@@ -179,11 +179,13 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "Changes requested by Firstname Lastname\n\nSome change request"
+        expected_headline = "Changes requested"
+        expected_change_note = "Some change request"
 
         post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id, requested_change: "Some change request" }
         step_by_step_page.reload
 
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
         expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
       end
     end
@@ -232,12 +234,12 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "In review by Firstname Lastname"
+        expected_change_note = "In review"
 
         post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
         step_by_step_page.reload
 
-        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_change_note
       end
     end
 
@@ -291,12 +293,12 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "Reverted to draft by Firstname Lastname"
+        expected_change_note = "Reverted to draft"
 
         post :revert_to_draft, params: { step_by_step_page_id: step_by_step_page.id }
         step_by_step_page.reload
 
-        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_change_note
       end
     end
   end

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "Approved 2i"
+        expected_change_note = "2i approved"
 
         post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
         step_by_step_page.reload

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_headline = "Changes requested"
+        expected_headline = "2i changes requested"
         expected_change_note = "Some change request"
 
         post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id, requested_change: "Some change request" }

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe ReviewController do
         stub_user.permissions = required_permissions
         stub_user.name = "Firstname Lastname"
 
-        expected_change_note = "In review"
+        expected_change_note = "Claimed for review"
 
         post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
         step_by_step_page.reload

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe StepByStepPagesController do
     it "creates an internal change note for minor change" do
       schedule_for_future
 
-      expected_headline = "Scheduled"
+      expected_headline = "Scheduled to publish"
       expected_description = "Scheduled at 10:26am on 20 April 2030"
       expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
       expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
@@ -171,7 +171,7 @@ RSpec.describe StepByStepPagesController do
       schedule_with_public_change_note
       schedule_for_future
 
-      expected_headline = "Scheduled"
+      expected_headline = "Scheduled to publish"
       expected_description = "Scheduled at 10:26am on 20 April 2030 with change note: This is a public change note."
       expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
       expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -115,6 +115,17 @@ RSpec.describe StepByStepPagesController do
       expect(step_by_step_page.review_requester_id).to be_nil
       expect(step_by_step_page.reviewer_id).to be_nil
     end
+
+    it "generates an internal change note stating Unpublished" do
+      step_by_step_page = create(:published_step_by_step_page, slug: "a-step-by-step")
+      post :unpublish, params: { step_by_step_page_id: step_by_step_page.id, redirect_url: "/somewhere" }
+
+      step_by_step_page.reload
+
+      expected_headline = "Unpublished"
+      expect(step_by_step_page.internal_change_notes.last.headline).to eq expected_headline
+      expect(step_by_step_page.internal_change_notes.last.description).to be_nil
+    end
   end
 
   describe "#schedule" do

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe StepByStepPagesController do
   end
 
   describe "#revert" do
-    it "reverts the step by step page to the published version" do
+    before do
       allow(Services.publishing_api).to receive(:discard_draft)
 
       allow(Services.publishing_api).to receive(:get_content)
@@ -240,10 +240,20 @@ RSpec.describe StepByStepPagesController do
         .and_return(content_item(step_by_step_page))
 
       allow_any_instance_of(StepByStepPageReverter).to receive(:repopulate_from_publishing_api)
+    end
 
+    it "reverts the step by step page to the published version" do
       expect(Services.publishing_api).to receive(:get_content).with(step_by_step_page.content_id, version: 2)
 
       post :revert, params: { step_by_step_page_id: step_by_step_page.id }
+    end
+
+    it "generates an internal change note stating Draft discarded" do
+      post :revert, params: { step_by_step_page_id: step_by_step_page.id, redirect_url: "/somewhere" }
+
+      expected_headline = "Draft discarded"
+      expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
+      expect(step_by_step_page.internal_change_notes.first.description).to be_nil
     end
   end
 

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe StepByStepPagesController do
 
         post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor" }
 
-        expected_description = "First published by Name Surname"
-        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+        expected_headline = "First published"
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
+        expect(step_by_step_page.internal_change_notes.first.description).to be_nil
       end
     end
 
@@ -69,7 +70,9 @@ RSpec.describe StepByStepPagesController do
         change_note_text = "Testing major change note"
         post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "major", change_note: change_note_text }
 
-        expected_description = "Published by Name Surname with change note: #{change_note_text}"
+        expected_headline = "Published"
+        expected_description = "With change note: #{change_note_text}"
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
         expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
       end
     end
@@ -81,8 +84,9 @@ RSpec.describe StepByStepPagesController do
         stub_publishing_api
         post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: "" }
 
-        expected_description = "Published by Name Surname"
-        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+        expected_description = "Published"
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_description
+        expect(step_by_step_page.internal_change_notes.first.description).to be_nil
       end
     end
 
@@ -90,7 +94,7 @@ RSpec.describe StepByStepPagesController do
       create(:internal_change_note, step_by_step_page_id: step_by_step_page.id)
 
       stub_publishing_api
-      post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", change_note: "" }
+      post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", headline: "" }
 
       expect(step_by_step_page.internal_change_notes.first.edition_number).to eq(3)
     end
@@ -157,7 +161,9 @@ RSpec.describe StepByStepPagesController do
     it "creates an internal change note for minor change" do
       schedule_for_future
 
-      expected_description = "Scheduled by Name Surname for publishing at 10:26am on 20 April 2030"
+      expected_headline = "Scheduled"
+      expected_description = "Scheduled at 10:26am on 20 April 2030"
+      expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
       expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
     end
 
@@ -165,7 +171,9 @@ RSpec.describe StepByStepPagesController do
       schedule_with_public_change_note
       schedule_for_future
 
-      expected_description = "Scheduled by Name Surname for publishing at 10:26am on 20 April 2030 with change note: This is a public change note."
+      expected_headline = "Scheduled"
+      expected_description = "Scheduled at 10:26am on 20 April 2030 with change note: This is a public change note."
+      expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
       expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
     end
   end
@@ -190,8 +198,8 @@ RSpec.describe StepByStepPagesController do
 
       unschedule_publishing(step_by_step_page)
 
-      expected_description = "Publishing was unscheduled by Name Surname."
-      expect(step_by_step_page.internal_change_notes.first.description).to eq expected_description
+      expected_headline = "Publishing was unscheduled"
+      expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
     end
   end
 

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -50,12 +50,12 @@ RSpec.describe StepByStepPagesController do
 
   describe "#publish" do
     context "first publish" do
-      it "generates an internal change note stating that this is the first publication" do
+      it "generates an internal change note stating that this is published" do
         stub_publishing_api
 
         post :publish, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor" }
 
-        expected_headline = "First published"
+        expected_headline = "Published"
         expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
         expect(step_by_step_page.internal_change_notes.first.description).to be_nil
       end

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe StepByStepPagesController do
 
       unschedule_publishing(step_by_step_page)
 
-      expected_headline = "Publishing was unscheduled"
+      expected_headline = "Scheduled publishing stopped"
       expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
     end
   end

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -100,6 +100,23 @@ RSpec.describe StepByStepPagesController do
     end
   end
 
+  describe "#unpublish" do
+    before :each do
+      stub_publishing_api
+    end
+
+    it "sets status to draft" do
+      step_by_step_page = create(:published_step_by_step_page, slug: "a-step-by-step")
+      post :unpublish, params: { step_by_step_page_id: step_by_step_page.id, redirect_url: "/somewhere" }
+
+      step_by_step_page.reload
+
+      expect(step_by_step_page.status).to be_draft
+      expect(step_by_step_page.review_requester_id).to be_nil
+      expect(step_by_step_page.reviewer_id).to be_nil
+    end
+  end
+
   describe "#schedule" do
     let(:step_by_step_page) { create(:draft_step_by_step_page) }
 
@@ -248,6 +265,7 @@ RSpec.describe StepByStepPagesController do
 
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
+    stub_any_publishing_api_unpublish
   end
 
   def stub_publishing_api_for_scheduling

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -195,6 +195,7 @@ FactoryBot.define do
   factory :internal_change_note do
     step_by_step_page_id { 0 }
     author { "Test Author" }
+    headline { "Some change" }
     description { "Description of the changes I made" }
     created_at { "2018-08-07 10:35:38" }
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -209,7 +209,7 @@ RSpec.feature "Managing step by step pages" do
       then_I_should_see "has been unscheduled"
       and_the_step_by_step_should_have_the_status "Draft"
       when_I_visit_the_history_page
-      then_there_should_be_a_change_note "Publishing was unscheduled"
+      then_there_should_be_a_change_note "Scheduled publishing stopped"
     end
 
     scenario "User tries using invalid values for schedule date and time" do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_see_an_unpublish_button
     and_I_see_a_view_on_govuk_link
     when_I_visit_the_history_page
-    then_there_should_be_a_change_note "First published by #{stub_user.name}"
+    then_there_should_be_a_change_note "First published"
   end
 
   scenario "User unpublishes a step by step page with a valid redirect url" do
@@ -130,11 +130,11 @@ RSpec.feature "Managing step by step pages" do
     and_I_visit_the_publish_page
     and_I_publish_the_page
     when_I_visit_the_history_page
-    then_there_should_be_a_change_note "Published by #{stub_user.name}"
+    then_there_should_be_a_change_note "Published"
     when_I_view_the_step_by_step_page
     and_I_delete_the_first_step
     when_I_visit_the_history_page
-    then_there_should_be_a_change_note "Draft saved by #{stub_user.name}"
+    then_there_should_be_a_change_note "Draft saved"
   end
 
   context "Scheduling" do
@@ -153,7 +153,7 @@ RSpec.feature "Managing step by step pages" do
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
       when_I_visit_the_history_page
-      then_there_should_be_a_change_note "Scheduled by Test author for publishing at 10:26am on 20 April 2030"
+      then_there_should_be_a_change_note "Scheduled at 10:26am on 20 April 2030"
       and_the_step_by_step_is_not_editable
       when_I_view_the_step_by_step_page
       then_I_can_see_a_summary_section
@@ -178,7 +178,7 @@ RSpec.feature "Managing step by step pages" do
       then_I_should_see "has been scheduled to publish"
       and_the_step_by_step_should_have_the_status "Scheduled"
       when_I_visit_the_history_page
-      then_there_should_be_a_change_note "Scheduled by Test author for publishing at 10:26am on 20 April 2030 with change note: We made some changes"
+      then_there_should_be_a_change_note "Scheduled at 10:26am on 20 April 2030 with change note: We made some changes"
     end
 
     scenario "User tries to schedule publishing for date in the past" do
@@ -209,7 +209,7 @@ RSpec.feature "Managing step by step pages" do
       then_I_should_see "has been unscheduled"
       and_the_step_by_step_should_have_the_status "Draft"
       when_I_visit_the_history_page
-      then_there_should_be_a_change_note "Publishing was unscheduled by #{stub_user.name}."
+      then_there_should_be_a_change_note "Publishing was unscheduled"
     end
 
     scenario "User tries using invalid values for schedule date and time" do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_see_an_unpublish_button
     and_I_see_a_view_on_govuk_link
     when_I_visit_the_history_page
-    then_there_should_be_a_change_note "First published"
+    then_there_should_be_a_change_note "Published"
   end
 
   scenario "User unpublishes a step by step page with a valid redirect url" do

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Reviewing step by step pages" do
   end
 
   def then_I_can_see_an_automated_change_note
-    expect(page).to have_content("Submitted for 2i by #{stub_user.name}")
+    expect(page).to have_content("Submitted for 2i")
   end
 
   def and_I_can_see_additional_comments_in_the_change_note

--- a/spec/models/internal_change_note.rb
+++ b/spec/models/internal_change_note.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe InternalChangeNote do
+  let!(:internal_change_note) { build(:internal_change_note) }
+
+  it "requires a headline" do
+    internal_change_note.headline = nil
+
+    expect(internal_change_note).not_to be_valid
+    expect(internal_change_note.errors).to have_key(:headline)
+  end
+end

--- a/spec/workers/step_by_step_draft_update_worker_spec.rb
+++ b/spec/workers/step_by_step_draft_update_worker_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe StepByStepDraftUpdateWorker do
   describe "#generate_internal_change_note" do
     let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
     context "when the guide is a new draft" do
-      it 'generates a note that says "Draft saved by New author"' do
+      it 'generates a note that says "Draft saved"' do
         described_class.new.perform(step_by_step_page.id, @current_user.name)
-        expect(step_by_step_page.internal_change_notes.first.description).to eql "Draft saved by New author"
+        expect(step_by_step_page.internal_change_notes.first.headline).to eql "Draft saved"
       end
     end
     context "when the guide is a draft that has already been updated" do

--- a/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
+++ b/spec/workers/step_by_step_scheduled_publish_worker_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe StepByStepScheduledPublishWorker do
     step_by_step_page = create(:scheduled_step_by_step_page, scheduled_at: future_datetime)
     Timecop.travel future_datetime do
       described_class.new.perform(step_by_step_page.id)
-      expect(step_by_step_page.internal_change_notes.first.description).to eq("Published on schedule")
+      expect(step_by_step_page.internal_change_notes.first.headline).to eq("Published on schedule")
     end
   end
 


### PR DESCRIPTION
Currently, we are displaying `Internal note` as the headline for all history entries.  A smaller description text explains the actual change (e.g. `Published`).

There are a number of issues with this:
- It is more difficult to users to scan through for specific status changes
- The author is duplicated (their name is appended to the description field, in addition to appearing after the timestamp)

This update adds a headline field to the internal change note table.  This is populated for each history entry with either a status change or where in the workflow it is.  All existing/historic history entries will retain their current style (i.e. labelled as `Internal note`).

Additionally, there are a number of copy changes detailed in a [Google document](https://docs.google.com/document/d/1pvx2HGX2y71voArlqvRt8lPc6hIRkFxcPlRIYnHfFlg/edit) that have been implemented as part of this change.

Finally, a number of missing change note entries have been added, as detailed in the document showing copy changes: when a draft is discarded, and when a step by step is unpublished.

Status entries before making these changes:
![Screen Shot 2019-09-26 at 10 03 53](https://user-images.githubusercontent.com/6329861/65674760-056e7100-e045-11e9-81a3-0bb27fa2274b.png)

Status changes having performed the same actions after this change:
![Screen Shot 2019-09-26 at 09 54 55](https://user-images.githubusercontent.com/6329861/65673993-c25fce00-e043-11e9-85b5-c4503451d374.png)

Trello card: https://trello.com/c/xdIoXx8s/81-update-change-note-titles-and-entry-stretch