### PR TITLE
2i reviewers can claim step by step

### DIFF
--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -1,4 +1,9 @@
 module StepNavActionsHelper
+  def can_submit_for_2i?(step_by_step_page, user)
+    step_by_step_page.status.draft? &&
+      user.has_permission?("Unreleased feature")
+  end
+
   def can_review?(step_by_step_page, user)
     can_claim_first_review?(step_by_step_page, user) ||
       can_take_over_review?(step_by_step_page, user)
@@ -8,12 +13,14 @@ private
 
   def can_claim_first_review?(step_by_step_page, user)
     step_by_step_page.status.submitted_for_2i? &&
-      step_by_step_page.review_requester_id != user.uid
+      step_by_step_page.review_requester_id != user.uid &&
+      user.has_permission?("Unreleased feature")
   end
 
   def can_take_over_review?(step_by_step_page, user)
     step_by_step_page.status.in_review? &&
       step_by_step_page.review_requester_id != user.uid &&
-      step_by_step_page.reviewer_id != user.uid
+      step_by_step_page.reviewer_id != user.uid &&
+      user.has_permission?("Unreleased feature")
   end
 end

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -33,8 +33,13 @@
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
     <% elsif @step_by_step_page.has_draft? %>
-      <% if @step_by_step_page.status.draft? &&
-        (current_user.has_permission? "Unreleased feature") # remove this line when the feature flag is removed %>
+      <% if can_review?(@step_by_step_page, current_user) %>
+        <%= form_for(@step_by_step_page, url: step_by_step_page_claim_2i_review_path(@step_by_step_page), method: :post) do %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Claim for 2i review"
+          } %>
+        <% end %>
+      <% elsif can_submit_for_2i?(@step_by_step_page, current_user) %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit for 2i review",
           href: step_by_step_page_submit_for_2i_path(@step_by_step_page)

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -46,4 +46,8 @@
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <p class="govuk-body">Not yet claimed for 2i</p>
   <% end %>
+<% elsif @step_by_step_page.status.in_review? %>
+  <%= render "govuk_publishing_components/components/inset_text" do %>
+    <p class="govuk-body">The 2i reviewer is <%= @step_by_step_page.reviewer.name %></p>
+  <% end %>
 <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -70,6 +70,15 @@ FactoryBot.define do
     status { "submitted_for_2i" }
   end
 
+  factory :step_by_step_page_claimed_for_2i, parent: :step_by_step_page_submitted_for_2i do
+    status { "submitted_for_2i" }
+    review_requester_id { SecureRandom.uuid }
+
+    after(:create) do |step_by_step_page|
+      step_by_step_page.update_attributes!(status: "in_review")
+    end
+  end
+
   factory :step do
     title { "Check how awesome you are" }
     logic { "number" }

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Reviewing step by step pages" do
 
   before do
     given_I_am_a_GDS_editor
+    given_I_am_a_2i_reviewer
     given_I_can_access_unreleased_features
     setup_publishing_api
   end
@@ -34,6 +35,13 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_can_see_additional_comments_in_the_change_note
   end
 
+  scenario "User claims step by step for 2i review" do
+    given_there_is_a_step_by_step_that_has_been_submitted_for_2i
+    when_I_view_the_step_by_step_page
+    and_I_claim_the_step_by_step_for_2i
+    and_I_cannot_see_a_claim_for_2i_button
+  end
+
   def when_I_visit_the_submit_for_2i_page
     visit step_by_step_page_submit_for_2i_path(@step_by_step_page)
   end
@@ -42,12 +50,20 @@ RSpec.feature "Reviewing step by step pages" do
     visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
   end
 
+  def when_I_view_the_step_by_step_page
+    visit step_by_step_page_path(@step_by_step_page)
+  end
+
   def and_I_submit_the_form
     click_on "Submit for 2i"
   end
 
   def and_I_fill_in_additional_comments
     fill_in "Additional comments", with: additional_comments
+  end
+
+  def and_I_claim_the_step_by_step_for_2i
+    click_on "Claim for 2i review"
   end
 
   def then_I_see_a_submitted_for_2i_success_notice
@@ -61,6 +77,12 @@ RSpec.feature "Reviewing step by step pages" do
   def and_I_cannot_see_a_submit_for_2i_button
     within(".app-side__actions") do
       expect(page).to_not have_link("Submit for 2i review")
+    end
+  end
+
+  def and_I_cannot_see_a_claim_for_2i_button
+    within(".app-side__actions") do
+      expect(page).to_not have_link("Claim for 2i review")
     end
   end
 

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Reviewing step by step pages" do
     given_there_is_a_step_by_step_that_has_been_submitted_for_2i
     when_I_view_the_step_by_step_page
     and_I_claim_the_step_by_step_for_2i
+    then_I_see_a_claimed_for_2i_prompt
     and_I_cannot_see_a_claim_for_2i_button
   end
 
@@ -72,6 +73,10 @@ RSpec.feature "Reviewing step by step pages" do
 
   def and_I_see_a_not_yet_claimed_for_2i_prompt
     expect(page).to have_css(".govuk-inset-text", text: "Not yet claimed for 2i")
+  end
+
+  def then_I_see_a_claimed_for_2i_prompt
+    expect(page).to have_css(".govuk-inset-text", text: "The 2i reviewer is #{stub_user.name}")
   end
 
   def and_I_cannot_see_a_submit_for_2i_button

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Contextual action buttons for step by step pages" do
   before do
     given_I_am_a_GDS_editor
     given_I_can_access_unreleased_features
+    given_there_are_review_users
     setup_publishing_api
   end
 
@@ -22,9 +23,31 @@ RSpec.feature "Contextual action buttons for step by step pages" do
   end
 
   context "Step by step has been submitted for 2i" do
-    scenario "show the relevant actions to the step by step author" do
+    background do
       given_there_is_a_step_by_step_that_has_been_submitted_for_2i
+    end
+
+    scenario "show the relevant actions to the step by step author" do
       and_I_am_the_step_by_step_author
+      when_I_visit_the_step_by_step_page
+      then_there_should_be_no_primary_action
+      and_the_secondary_action_should_be "Preview"
+      and_there_should_be_tertiary_actions_to %w(Delete)
+    end
+
+    scenario "show the relevant actions to the step by step 2i reviewer" do
+      and_I_am_the_reviewer
+      when_I_visit_the_step_by_step_page
+      then_the_primary_action_should_be "Claim for 2i review"
+      and_the_secondary_action_should_be "Preview"
+      and_there_should_be_tertiary_actions_to %w(Delete)
+    end
+  end
+
+  context "Step by step has been claimed for 2i" do
+    scenario "show the relevant actions to the step by step 2i reviewer" do
+      given_there_is_a_step_by_step_that_has_been_claimed_for_2i
+      and_I_am_the_reviewer
       when_I_visit_the_step_by_step_page
       then_there_should_be_no_primary_action
       and_the_secondary_action_should_be "Preview"
@@ -58,6 +81,10 @@ RSpec.feature "Contextual action buttons for step by step pages" do
   end
 
   def and_I_am_the_step_by_step_author
-    @current_user = @review_requester
+    login_as_user @review_requester
+  end
+
+  def and_I_am_the_reviewer
+    login_as_user @reviewer
   end
 end

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 RSpec.describe StepNavActionsHelper do
+  include CommonFeatureSteps
+
   let(:step_by_step_page) { create(:draft_step_by_step_page) }
   let(:user) { create(:user) }
-  let(:reviewer_user) { create(:user) }
-  let(:second_reviewer_user) { create(:user) }
+  let(:reviewer_user) { create(:user, permissions: required_permissions_for_2i) }
+  let(:second_reviewer_user) { create(:user, permissions: required_permissions_for_2i) }
 
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
@@ -39,6 +41,22 @@ RSpec.describe StepNavActionsHelper do
       step_by_step_page.review_requester_id = user.uid
       step_by_step_page.reviewer_id = reviewer_user.uid
       expect(helper.can_review?(step_by_step_page, reviewer_user)).to be false
+    end
+  end
+
+  describe "#can_submit_for_2i?" do
+    it "returns false if not in draft status" do
+      step_by_step_page.status = "published"
+      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
+    end
+
+    it "returns false if author doesn't have permissions" do
+      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
+    end
+
+    it "returns true if in draft and if author has permissions" do
+      user.permissions << "Unreleased feature"
+      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be true
     end
   end
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -21,6 +21,10 @@ module AuthenticationFeatureHelpers
     @stub_user ||= FactoryBot.create(:user)
   end
 
+  def login_as_user(user)
+    GDS::SSO.test_user = user
+  end
+
   def login_as_stub_user
     GDS::SSO.test_user = stub_user
   end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -21,12 +21,8 @@ module AuthenticationFeatureHelpers
     @stub_user ||= FactoryBot.create(:user)
   end
 
-  def login_as_user(user)
+  def login_as_user(user = stub_user)
     GDS::SSO.test_user = user
-  end
-
-  def login_as_stub_user
-    GDS::SSO.test_user = stub_user
   end
 end
 
@@ -38,6 +34,6 @@ RSpec.configure do |config|
 
   config.include AuthenticationFeatureHelpers, :type => :feature
   config.before(:each, type: :feature) do
-    login_as_stub_user
+    login_as_user
   end
 end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -20,4 +20,12 @@ module CommonFeatureSteps
   def given_I_can_access_unreleased_features
     stub_user.permissions << "Unreleased feature"
   end
+
+  def given_I_am_a_2i_reviewer
+    stub_user.permissions << "2i reviewer"
+  end
+
+  def required_permissions_for_2i
+    ["signin", "GDS Editor", "2i reviewer", "Unreleased feature"]
+  end
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -3,6 +3,7 @@ require "support/link_checker"
 
 module StepNavSteps
   include LinkChecker
+  include CommonFeatureSteps
 
   def setup_publishing_api
     stub_any_publishing_api_put_content
@@ -189,8 +190,17 @@ module StepNavSteps
   end
 
   def given_there_is_a_step_by_step_that_has_been_submitted_for_2i
-    @review_requester = create(:user, name: "Original Author")
+    @review_requester = create(:user, name: "Original Author", permissions: required_permissions_for_2i)
     @step_by_step_page = create(:step_by_step_page_submitted_for_2i, review_requester_id: @review_requester.uid)
+  end
+
+  def given_there_is_a_step_by_step_that_has_been_claimed_for_2i
+    @step_by_step_page = create(:step_by_step_page_claimed_for_2i, review_requester_id: @review_requester.uid, reviewer_id: @reviewer.uid)
+  end
+
+  def given_there_are_review_users
+    @review_requester = create(:user, name: "Original Author", permissions: required_permissions_for_2i)
+    @reviewer = create(:user, name: "Reviewer", permissions: required_permissions_for_2i)
   end
 
   def then_I_can_see_a_success_message(message)


### PR DESCRIPTION
- [x] step-by-step must be "submitted_for_2i" status before it can be claimed by any user except for the one who requests the review
- [x] an inset prompt on the summary page shows who claimed the step by step for review

[Trello card](https://trello.com/c/Fwo562zl)