### PR TITLE
Only approved_2i step by steps can be published or scheduled

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -75,7 +75,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def mark_as_unscheduled
-    update_attribute(:status, "draft")
+    update_attribute(:status, "approved_2i")
   end
 
   def self.validate_redirect(redirect_url)

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -151,7 +151,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def links_checked_since_last_update?
-    links_checked? && links_last_checked_date > draft_updated_at
+    (links_checked? && links_last_checked_date > draft_updated_at) || status.approved_2i?
   end
 
   def links_checked?

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -65,8 +65,8 @@ class StepByStepPage < ApplicationRecord
   def mark_as_unpublished
     update(
       published_at: nil,
-      draft_updated_at: nil,
-      status: "draft",
+      draft_updated_at: Time.zone.now,
+      status: "approved_2i",
     )
   end
 

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -49,6 +49,10 @@ class StepByStepPage < ApplicationRecord
     update_attribute(:draft_updated_at, nil)
   end
 
+  def mark_as_approved_2i
+    update_attribute(:status, "approved_2i")
+  end
+
   def mark_as_published
     now = Time.zone.now
     update(

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -143,7 +143,7 @@ class StepByStepPage < ApplicationRecord
   end
 
   def should_show_required_prepublish_actions?
-    has_draft? && !scheduled_for_publishing? && !can_be_published?
+    (has_draft? && !scheduled_for_publishing? && !can_be_published?) || status.in_review?
   end
 
   def broken_links_found?

--- a/app/validators/status_prerequisite_validator.rb
+++ b/app/validators/status_prerequisite_validator.rb
@@ -3,7 +3,7 @@ class StatusPrerequisiteValidator < ActiveModel::EachValidator
     if value == "approved_2i"
       return true if can_be_2i_approved?(record)
 
-      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review"
+      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review or scheduled"
     end
 
     if value == "in_review"
@@ -43,6 +43,9 @@ private
 
   def can_be_2i_approved?(record)
     record.has_draft? &&
-      record.status_was == "in_review"
+      (
+        record.status_was == "in_review" ||
+        record.status_was == "scheduled"
+      )
   end
 end

--- a/app/validators/status_prerequisite_validator.rb
+++ b/app/validators/status_prerequisite_validator.rb
@@ -3,7 +3,7 @@ class StatusPrerequisiteValidator < ActiveModel::EachValidator
     if value == "approved_2i"
       return true if can_be_2i_approved?(record)
 
-      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review or scheduled"
+      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review, scheduled or published"
     end
 
     if value == "in_review"
@@ -42,10 +42,7 @@ private
   end
 
   def can_be_2i_approved?(record)
-    record.has_draft? &&
-      (
-        record.status_was == "in_review" ||
-        record.status_was == "scheduled"
-      )
+    allowed_previous_statuses = %w(in_review scheduled published)
+    record.has_draft? && allowed_previous_statuses.include?(record.status_was)
   end
 end

--- a/app/validators/status_prerequisite_validator.rb
+++ b/app/validators/status_prerequisite_validator.rb
@@ -3,13 +3,13 @@ class StatusPrerequisiteValidator < ActiveModel::EachValidator
     if value == "approved_2i"
       return true if can_be_2i_approved?(record)
 
-      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review, scheduled or published"
+      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be in_review, scheduled, published or approved_2i"
     end
 
     if value == "in_review"
       return true if can_be_in_review?(record)
 
-      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be submitted_for_2i"
+      record.errors[attribute] << "#{value}, requires a draft, a reviewer and for status to be submitted_for_2i or in_review"
     end
 
     if value == "scheduled"
@@ -30,7 +30,10 @@ private
   def can_be_in_review?(record)
     record.has_draft? &&
       record.reviewer_id.present? &&
-      record.status_was == "submitted_for_2i"
+      (
+        record.status_was == "submitted_for_2i" ||
+        record.status_was == "in_review"
+      )
   end
 
   def can_be_scheduled?(record)
@@ -42,7 +45,7 @@ private
   end
 
   def can_be_2i_approved?(record)
-    allowed_previous_statuses = %w(in_review scheduled published)
+    allowed_previous_statuses = %w(in_review scheduled published approved_2i)
     record.has_draft? && allowed_previous_statuses.include?(record.status_was)
   end
 end

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -33,7 +33,7 @@
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
     <% elsif @step_by_step_page.has_draft? %>
-      <% if !@step_by_step_page.status.submitted_for_2i? &&
+      <% if @step_by_step_page.status.draft? &&
         (current_user.has_permission? "Unreleased feature") # remove this line when the feature flag is removed %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit for 2i review",

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -26,6 +26,18 @@
           <%= link_to "Fix broken links", '#steps', class: 'govuk-link govuk-link--no-visited-state' %>
         </li>
       <% end %>
+
+      <% if @step_by_step_page.status.in_review? %>
+        <% if current_user.id == @step_by_step_page.reviewer_id %>
+          <li>
+            <p class="govuk-body">2i approve it</p>
+          </li>
+        <% else %>
+          <li>
+            <p class="govuk-body">get 2i approval</p>
+          </li>
+        <% end %>
+      <% end %>
     </ul>
   <% end %>
 <% end %>

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -211,14 +211,14 @@ RSpec.describe StepByStepPagesController do
       stub_publishing_api_for_scheduling
     end
 
-    it "clears Scheduled status and sets it back to Draft" do
+    it "clears scheduled status and sets it back to approved_2i" do
       step_by_step_page = create(:scheduled_step_by_step_page, slug: "how-to-be-fantastic")
 
       unschedule_publishing(step_by_step_page)
 
       expect(step_by_step_page.scheduled_at).to eq nil
       expect(step_by_step_page.scheduled_for_publishing?).to be false
-      expect(step_by_step_page.status).to be_draft
+      expect(step_by_step_page.status).to be_approved_2i
     end
 
     it "creates an internal change note" do

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe StepByStepPagesController do
       stub_publishing_api
     end
 
-    it "sets status to draft" do
+    it "sets status to approved_2i" do
       step_by_step_page = create(:published_step_by_step_page, slug: "a-step-by-step")
       post :unpublish, params: { step_by_step_page_id: step_by_step_page.id, redirect_url: "/somewhere" }
 
       step_by_step_page.reload
 
-      expect(step_by_step_page.status).to be_draft
+      expect(step_by_step_page.status).to be_approved_2i
       expect(step_by_step_page.review_requester_id).to be_nil
       expect(step_by_step_page.reviewer_id).to be_nil
     end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -359,12 +359,15 @@ RSpec.describe StepByStepPage do
     end
 
     it "should reset published date" do
-      step_by_step_page.mark_as_unpublished
+      nowish = Time.zone.now
+      Timecop.freeze do
+        step_by_step_page.mark_as_unpublished
 
-      expect(step_by_step_page.published_at).to be nil
-      expect(step_by_step_page.has_been_published?).to be false
-      expect(step_by_step_page.draft_updated_at).to be nil
-      expect(step_by_step_page.has_draft?).to be false
+        expect(step_by_step_page.published_at).to be nil
+        expect(step_by_step_page.has_been_published?).to be false
+        expect(step_by_step_page.draft_updated_at).to be_within(1.second).of nowish
+        expect(step_by_step_page.has_draft?).to be true
+      end
     end
 
     it "should have a deterministically generated hex string" do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -291,6 +291,16 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe "#mark_as_approved_2i" do
+    it "changes the status to approved_2i" do
+      step_by_step_with_step = create(:step_by_step_page_with_steps)
+      expect(step_by_step_with_step.status).to eq "draft"
+
+      step_by_step_with_step.mark_as_approved_2i
+      expect(step_by_step_with_step.status).to eq "approved_2i"
+    end
+  end
+
   describe "publishing" do
     let(:step_by_step_page) { create(:step_by_step_page) }
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -224,6 +224,12 @@ RSpec.describe StepByStepPage do
 
       expect(step_by_step_with_step.links_checked_since_last_update?).to be true
     end
+
+    it "returns true if the status is approved_2i" do
+      step_by_step_with_step.mark_as_approved_2i
+
+      expect(step_by_step_with_step.links_checked_since_last_update?).to be true
+    end
   end
 
   describe "should_show_required_prepublish_actions?" do

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -257,6 +257,13 @@ RSpec.describe StepByStepPage do
 
       expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be true
     end
+
+    it "should return true if step by step is in review" do
+      step_by_step_with_step = create(:step_by_step_page)
+      allow(step_by_step_page).to receive(:status).and_return("in_review")
+
+      expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be true
+    end
   end
 
   describe "broken_links_found?" do

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -103,6 +103,15 @@ module StepNavSteps
 
   alias_method :given_there_is_a_step_that_has_no_broken_links, :given_there_is_a_step_by_step_page_with_a_link_report
 
+  def given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
+    step = create(:step)
+    stub_link_checker_report_success(step)
+    @step_by_step_page = create(:draft_step_by_step_page, steps: [step], slug: "step-by-step-with-link-report")
+    @step_by_step_page.mark_as_approved_2i
+  end
+
+  alias_method :given_there_is_an_approved_2i_step_that_has_no_broken_links, :given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
+
   def given_there_is_a_step_by_step_page_with_broken_links_and_unpublished_changes
     step = create(:step)
     stub_link_checker_report_broken_link(step)
@@ -113,6 +122,13 @@ module StepNavSteps
     step = create(:step)
     stub_link_checker_report_success(step)
     @step_by_step_page = create(:step_by_step_with_unpublished_changes, steps: [step], slug: "step-by-step-with-unpublished-changes")
+  end
+
+  def given_there_is_an_approved_2i_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
+    step = create(:step)
+    stub_link_checker_report_success(step)
+    @step_by_step_page = create(:step_by_step_with_unpublished_changes, steps: [step], slug: "step-by-step-with-unpublished-changes")
+    @step_by_step_page.mark_as_approved_2i
   end
 
   def given_a_step_by_step_has_been_updated_after_links_last_checked

--- a/spec/validators/status_prerequisite_validator_spec.rb
+++ b/spec/validators/status_prerequisite_validator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe StatusPrerequisiteValidator do
   end
 
   context "#approved_2i" do
-    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review or scheduled" }
+    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review, scheduled or published" }
 
     it "does not allow status to be approved_2i if there is no draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(false)
@@ -67,6 +67,14 @@ RSpec.describe StatusPrerequisiteValidator do
     it "allows status to be approved_2i if the current status is scheduled and there is a draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
       allow(step_by_step_page).to receive(:status_was).and_return("scheduled")
+      step_by_step_page.status = "approved_2i"
+
+      expect(step_by_step_page).to be_valid
+    end
+
+    it "allows status to be approved_2i if the current status is published and there is a draft" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+      allow(step_by_step_page).to receive(:status_was).and_return("published")
       step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page).to be_valid

--- a/spec/validators/status_prerequisite_validator_spec.rb
+++ b/spec/validators/status_prerequisite_validator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe StatusPrerequisiteValidator do
   end
 
   context "#in_review" do
-    let(:error_message) { "in_review, requires a draft, a reviewer and for status to be submitted_for_2i" }
+    let(:error_message) { "in_review, requires a draft, a reviewer and for status to be submitted_for_2i or in_review" }
 
     it "does not allow status to be in_review if reviewer_id is missing" do
       step_by_step_page.reviewer_id = nil
@@ -27,7 +27,21 @@ RSpec.describe StatusPrerequisiteValidator do
       expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
     end
 
-    it "does not allow status to be in_review if the current status is not submitted_for_2i" do
+    not_allowed_statuses = %w(draft approved_2i scheduled published)
+
+    not_allowed_statuses.each do |not_allowed_status|
+      it "does not allow status to be in_review if the current is #{not_allowed_status}" do
+        allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+        step_by_step_page.reviewer_id = SecureRandom.uuid
+        allow(step_by_step_page).to receive(:status_was).and_return(not_allowed_status)
+        step_by_step_page.status = "in_review"
+
+        expect(step_by_step_page).not_to be_valid
+        expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
+      end
+    end
+
+    it "allows status to be in_review if the current status is submitted_for_2i" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
       step_by_step_page.reviewer_id = SecureRandom.uuid
       step_by_step_page.status = "in_review"
@@ -38,7 +52,7 @@ RSpec.describe StatusPrerequisiteValidator do
   end
 
   context "#approved_2i" do
-    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review, scheduled or published" }
+    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review, scheduled, published or approved_2i" }
 
     it "does not allow status to be approved_2i if there is no draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(false)
@@ -48,7 +62,7 @@ RSpec.describe StatusPrerequisiteValidator do
       expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
     end
 
-    it "does not allow status to be approved_2i if the current status is not in_review or scheduled" do
+    it "does not allow status to be approved_2i if the current status is not in_review, scheduled or approved_2i" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
       step_by_step_page.status = "approved_2i"
 
@@ -75,6 +89,14 @@ RSpec.describe StatusPrerequisiteValidator do
     it "allows status to be approved_2i if the current status is published and there is a draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
       allow(step_by_step_page).to receive(:status_was).and_return("published")
+      step_by_step_page.status = "approved_2i"
+
+      expect(step_by_step_page).to be_valid
+    end
+
+    it "allows status to be approved_2i if the current status is approved_2i and there is a draft" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+      allow(step_by_step_page).to receive(:status_was).and_return("approved_2i")
       step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page).to be_valid

--- a/spec/validators/status_prerequisite_validator_spec.rb
+++ b/spec/validators/status_prerequisite_validator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe StatusPrerequisiteValidator do
   end
 
   context "#approved_2i" do
-    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review" }
+    let(:error_message) { "approved_2i, requires a draft, a reviewer and for status to be in_review or scheduled" }
 
     it "does not allow status to be approved_2i if there is no draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(false)
@@ -48,7 +48,7 @@ RSpec.describe StatusPrerequisiteValidator do
       expect(step_by_step_page.errors.messages[:status]).to eq([error_message])
     end
 
-    it "does not allow status to be approved_2i if the current status is not in_review" do
+    it "does not allow status to be approved_2i if the current status is not in_review or scheduled" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
       step_by_step_page.status = "approved_2i"
 
@@ -58,7 +58,15 @@ RSpec.describe StatusPrerequisiteValidator do
 
     it "allows status to be approved_2i if the current status is in_review and there is a draft" do
       allow(step_by_step_page).to receive(:has_draft?).and_return(true)
-      allow(step_by_step_page).to receive(:status_was). and_return("in_review")
+      allow(step_by_step_page).to receive(:status_was).and_return("in_review")
+      step_by_step_page.status = "approved_2i"
+
+      expect(step_by_step_page).to be_valid
+    end
+
+    it "allows status to be approved_2i if the current status is scheduled and there is a draft" do
+      allow(step_by_step_page).to receive(:has_draft?).and_return(true)
+      allow(step_by_step_page).to receive(:status_was).and_return("scheduled")
       step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page).to be_valid


### PR DESCRIPTION
**Step by step in review, not approved (reviewer): **
<kbd>
<img width="780" alt="reviewer" src="https://user-images.githubusercontent.com/38078064/65754731-93ac2b00-e109-11e9-944c-48045f66fa00.png">
</kbd>

**Step by step in review, not approved (review requestor): **
<kbd>
<img width="791" alt="requestor" src="https://user-images.githubusercontent.com/38078064/65754253-8b9fbb80-e108-11e9-832a-872b250e9554.png">
</kbd>

**Step by step approved:**
<kbd><img width="783" alt="approved_2i" src="https://user-images.githubusercontent.com/38078064/65701825-e2aa7f80-e079-11e9-8f75-87362e589edd.png"></kbd>

**TO DO** in a separate PR after feature flag is removed: 
*(WIP in improve-2i-publish-schedule branch)*
- Add `approved_2i?` condition to `can_be_published` method in the model and add unit tests
- Publish and schedule routes should not be usable unless SBS is in an approved_2i state

[Trello card](https://trello.com/c/yvGd29qp/74-only-approved-step-by-steps-can-be-published-or-scheduled)