### PR TITLE
Allow an in_review step by step to be taken over by another reviewer

### DIFF
--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -1,6 +1,19 @@
 module StepNavActionsHelper
   def can_review?(step_by_step_page, user)
+    can_claim_first_review?(step_by_step_page, user) ||
+      can_take_over_review?(step_by_step_page, user)
+  end
+
+private
+
+  def can_claim_first_review?(step_by_step_page, user)
     step_by_step_page.status.submitted_for_2i? &&
       step_by_step_page.review_requester_id != user.uid
+  end
+
+  def can_take_over_review?(step_by_step_page, user)
+    step_by_step_page.status.in_review? &&
+      step_by_step_page.review_requester_id != user.uid &&
+      step_by_step_page.reviewer_id != user.uid
   end
 end

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe StepNavActionsHelper do
   let(:step_by_step_page) { create(:draft_step_by_step_page) }
   let(:user) { create(:user) }
+  let(:reviewer_user) { create(:user) }
+  let(:second_reviewer_user) { create(:user) }
 
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
@@ -17,6 +19,26 @@ RSpec.describe StepNavActionsHelper do
       step_by_step_page.status = "submitted_for_2i"
       step_by_step_page.review_requester_id = user.uid
       expect(helper.can_review?(step_by_step_page, user)).to be false
+    end
+
+    it "returns true if another user tries to claim the review" do
+      step_by_step_page.status = "submitted_for_2i"
+      step_by_step_page.review_requester_id = user.uid
+      expect(helper.can_review?(step_by_step_page, reviewer_user)).to be true
+    end
+
+    it "returns true if another reviewer tries to take over the review" do
+      step_by_step_page.status = "in_review"
+      step_by_step_page.review_requester_id = user.uid
+      step_by_step_page.reviewer_id = reviewer_user.uid
+      expect(helper.can_review?(step_by_step_page, second_reviewer_user)).to be true
+    end
+
+    it "returns false if the reviewer tries to claim review again" do
+      step_by_step_page.status = "in_review"
+      step_by_step_page.review_requester_id = user.uid
+      step_by_step_page.reviewer_id = reviewer_user.uid
+      expect(helper.can_review?(step_by_step_page, reviewer_user)).to be false
     end
   end
 end


### PR DESCRIPTION
The current logic only permits a step by step to be claimed for review once.  There could be cases where another reviewer needs to take over the review.

This changes the logic so `can_review?` returns true if a user who is neither the current reviewer nor the review requester wishes to review the step by step.

Trello card: https://trello.com/c/Fwo562zl/72-2i-reviewer-can-claim-sbs-for-review