### PR TITLE
Allow access to the reviewer and review requester details

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -13,6 +13,9 @@ class StepByStepPage < ApplicationRecord
   has_many :internal_change_notes, -> { order(created_at: :desc) }
   has_many :secondary_content_links, -> { order(title: :asc) }, dependent: :destroy
 
+  belongs_to :reviewer, primary_key: "uid", class_name: "User", optional: true
+  belongs_to :review_requester, primary_key: "uid", class_name: "User", optional: true
+
   validates :title, :slug, :introduction, :description, presence: true
   validates :scheduled_at, in_future: true
   validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -20,6 +20,29 @@ RSpec.describe StepByStepPage do
     end
   end
 
+  describe "associations" do
+    let(:stub_user) { create(:user, name: "Author Name") }
+
+    before do
+      step_by_step_page.review_requester_id = stub_user.uid
+    end
+
+    it "should allow return of review requester name" do
+      step_by_step_page.save
+
+      expect(step_by_step_page.review_requester.name).to eq stub_user.name
+    end
+
+    it "should allow return of reviewer name" do
+      reviewer_user = create(:user, name: "Reviewer Name")
+      step_by_step_page.reviewer_id = reviewer_user.uid
+
+      step_by_step_page.save
+
+      expect(step_by_step_page.reviewer.name).to eq reviewer_user.name
+    end
+  end
+
   describe "validations" do
     it "is created with valid attributes" do
       expect(step_by_step_page).to be_valid


### PR DESCRIPTION
This enables access to details about the reviewer and review requester, e.g. to get the reviewer name:

```
step_by_step_page.reviewer.name
```

Trello card: https://trello.com/c/Fwo562zl/72-2i-reviewer-can-claim-sbs-for-review