### PR TITLE
2i reviewer can approve and request changes on step by steps

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -1,6 +1,7 @@
 class ReviewController < ApplicationController
   layout "admin_layout"
 
+  before_action :set_step_by_step_page
   before_action :require_gds_editor_permissions!
   before_action :require_unreleased_feature_permissions!
   before_action :require_2i_reviewer_permissions!, only: %i(
@@ -10,7 +11,12 @@ class ReviewController < ApplicationController
     show_approve_2i_review_form
     show_request_change_2i_review_form
   )
-  before_action :set_step_by_step_page
+  before_action :require_user_to_be_the_2i_reviewer!, only: %i(
+    approve_2i_review
+    request_change_2i_review
+    show_approve_2i_review_form
+    show_request_change_2i_review_form
+  )
 
   def show_approve_2i_review_form
     render :submit_2i_verdict, locals: { approved: true }
@@ -108,5 +114,9 @@ private
 
   def set_step_by_step_page
     @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
+  end
+
+  def require_user_to_be_the_2i_reviewer!
+    render "shared/forbidden", status: :forbidden unless current_user.uid == @step_by_step_page.reviewer_id
   end
 end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -16,7 +16,7 @@ class ReviewController < ApplicationController
     )
       generate_change_note("2i approved")
 
-      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully approved_2i."
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved."
     end
   end
 

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -14,7 +14,7 @@ class ReviewController < ApplicationController
       reviewer_id: nil,
       status: status,
     )
-      generate_change_note("2i approved")
+      generate_change_note("2i approved", params[:additional_comment])
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved."
     end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -3,8 +3,18 @@ class ReviewController < ApplicationController
 
   before_action :require_gds_editor_permissions!
   before_action :require_unreleased_feature_permissions!
-  before_action :require_2i_reviewer_permissions!, only: %i(approve_2i_review claim_2i_review request_change_2i_review)
+  before_action :require_2i_reviewer_permissions!, only: %i(
+    approve_2i_review
+    claim_2i_review
+    request_change_2i_review
+    show_approve_2i_review_form
+    show_request_change_2i_review_form
+  )
   before_action :set_step_by_step_page
+
+  def show_approve_2i_review_form
+    render :submit_2i_verdict, locals: { approved: true }
+  end
 
   def approve_2i_review
     status = "approved_2i"
@@ -17,6 +27,8 @@ class ReviewController < ApplicationController
       generate_change_note("2i approved", params[:additional_comment])
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved."
+    else
+      render :submit_2i_verdict, locals: { approved: true }, status: :unprocessable_entity
     end
   end
 
@@ -33,6 +45,10 @@ class ReviewController < ApplicationController
     end
   end
 
+  def show_request_change_2i_review_form
+    render :submit_2i_verdict, locals: { approved: false }
+  end
+
   def request_change_2i_review
     status = "draft"
 
@@ -44,6 +60,8 @@ class ReviewController < ApplicationController
       generate_change_note("2i changes requested", params[:requested_change])
 
       redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested."
+    else
+      render :submit_2i_verdict, locals: { approved: false }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -32,7 +32,7 @@ class ReviewController < ApplicationController
     )
       generate_change_note("2i approved", params[:additional_comment])
 
-      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved."
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved. Please let the author know."
     else
       render :submit_2i_verdict, locals: { approved: true }, status: :unprocessable_entity
     end
@@ -65,7 +65,7 @@ class ReviewController < ApplicationController
     )
       generate_change_note("2i changes requested", params[:requested_change])
 
-      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested."
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested. Please let the author know."
     else
       render :submit_2i_verdict, locals: { approved: false }, status: :unprocessable_entity
     end

--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -9,6 +9,12 @@ module StepNavActionsHelper
       can_take_over_review?(step_by_step_page, user)
   end
 
+  def can_submit_2i_review?(step_by_step_page, user)
+    step_by_step_page.status.in_review? &&
+      step_by_step_page.reviewer_id == user.uid &&
+      user.has_permission?("Unreleased feature")
+  end
+
 private
 
   def can_claim_first_review?(step_by_step_page, user)

--- a/app/views/review/submit_2i_verdict.erb
+++ b/app/views/review/submit_2i_verdict.erb
@@ -1,5 +1,5 @@
 <%
-  title = 'Approve step by step'
+  title = approved ? 'Approve step by step' : 'Request changes to step by step'
   links = [
     {
       text: 'Step by step publisher',
@@ -31,9 +31,9 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: "Add a note (optional)"
+          text: approved ? "Describe changes required" : "Add a note (optional)"
         },
-        name: "additional_comment",
+        name: approved ? "additional_comment" : "requested_change",
       } %>
     </div>
   </div>
@@ -41,7 +41,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/button", {
-        text: "Yes, approve 2i"
+        text: approved ? "Yes, approve 2i" : "Send change request"
       } %>
     </div>
     <div class="govuk-grid-column-full govuk-!-margin-top-3">

--- a/app/views/review/submit_2i_verdict.erb
+++ b/app/views/review/submit_2i_verdict.erb
@@ -1,0 +1,33 @@
+<%
+  title = 'TBC'
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: step_by_step_page_path(@step_by_step_page)
+    },
+    {
+      text: title
+    }
+  ]
+%>
+
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<%= render 'shared/steps/heading',
+  step_nav: @step_by_step_page.title,
+  action: title
+%>
+
+<% if @step_by_step_page.errors.any? %>
+  <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+<% end %>
+
+<div class="row">
+  <div class="col-md-7">
+    TBC
+  </div>
+</div>

--- a/app/views/review/submit_2i_verdict.erb
+++ b/app/views/review/submit_2i_verdict.erb
@@ -1,5 +1,5 @@
 <%
-  title = 'TBC'
+  title = 'Approve step by step'
   links = [
     {
       text: 'Step by step publisher',
@@ -26,8 +26,26 @@
   <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 <% end %>
 
-<div class="row">
-  <div class="col-md-7">
-    TBC
+<%= form_tag do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Add a note (optional)"
+        },
+        name: "additional_comment",
+      } %>
+    </div>
   </div>
-</div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Yes, approve 2i"
+      } %>
+    </div>
+    <div class="govuk-grid-column-full govuk-!-margin-top-3">
+      <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/forbidden.html.erb
+++ b/app/views/shared/forbidden.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "Forbidden" %>
+
+<div class="govuk-body">
+  You do not have permission to access this page.
+</div>

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -44,6 +44,16 @@
           text: "Submit for 2i review",
           href: step_by_step_page_submit_for_2i_path(@step_by_step_page)
         } %>
+      <% elsif can_submit_2i_review?(@step_by_step_page, current_user) %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Approve",
+          href: step_by_step_page_approve_2i_review_path(@step_by_step_page)
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Request changes",
+          href: step_by_step_page_request_change_2i_review_path(@step_by_step_page),
+          secondary: true
+        } %>
       <% end %>
       <%= preview_link %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root to: redirect("/step-by-step-pages", status: 302)
 
   resources :step_by_step_pages, path: "step-by-step-pages" do
+    get "approve-2i-review", to: "review#show_approve_2i_review_form"
     post "approve-2i-review", to: "review#approve_2i_review"
     post :check_links
     post "claim-2i-review", to: "review#claim_2i_review"
@@ -15,6 +16,7 @@ Rails.application.routes.draw do
     post :publish
     get :reorder
     post :reorder
+    get "request-change-2i-review", to: "review#show_request_change_2i_review_form"
     post "request-change-2i-review", to: "review#request_change_2i_review"
     post :revert
     post "revert-to-draft", to: "review#revert_to_draft"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     post "approve-2i-review", to: "review#approve_2i_review"
     post :check_links
     post "claim-2i-review", to: "review#claim_2i_review"
-    get "internal-change-notes", to: "interal_change_notes"
+    get "internal-change-notes"
     post "internal-change-notes", to: "internal_change_notes#create"
     get "navigation-rules", to: "navigation_rules#edit"
     put "navigation-rules", to: "navigation_rules#update"
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
     post "revert-to-draft", to: "review#revert_to_draft"
     get :schedule
     post :schedule
-    post "schedule-datetime", to: "schedule_datetime"
+    post "schedule-datetime"
     get "submit-for-2i", to: "review#submit_for_2i"
     post "submit-for-2i", to: "review#submit_for_2i"
     get :unpublish

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe ReviewController do
 
       before do
         step_by_step_page.update_attributes(:status => "in_review", :reviewer_id => reviewer_user.uid)
+        stub_user.uid = reviewer_user.uid
       end
 
       required_permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
@@ -104,6 +105,14 @@ RSpec.describe ReviewController do
 
             expect(response.status).to eq(403)
           end
+        end
+
+        it "cannot be accessed by users other than the reviewer, even with the necessary permissions" do
+          stub_user.permissions = required_permissions
+          stub_user.uid = SecureRandom.uuid
+          get :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
+
+          expect(response.status).to eq(403)
         end
       end
 

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -88,6 +88,44 @@ RSpec.describe ReviewController do
 
       required_permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
 
+      describe "GET approve 2i review" do
+        it "can be accessed by the reviewer, if they have GDS editor, Unreleased feature and 2i reviewer permissions" do
+          stub_user.permissions = required_permissions
+          get :show_request_change_2i_review_form, params: { step_by_step_page_id: step_by_step_page.id }
+
+          expect(response.status).to eq(200)
+        end
+
+        (required_permissions - %w(signin)).each do |required_permission|
+          it "cannot be accessed by users without the #{required_permission} permission" do
+            stub_user.permissions = required_permissions
+            stub_user.permissions.delete(required_permission)
+            get :show_request_change_2i_review_form, params: { step_by_step_page_id: step_by_step_page.id }
+
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+
+      describe "GET request change after 2i review" do
+        it "can be accessed by the reviewer, if they have GDS editor, Unreleased feature and 2i reviewer permissions" do
+          stub_user.permissions = required_permissions
+          get :show_approve_2i_review_form, params: { step_by_step_page_id: step_by_step_page.id }
+
+          expect(response.status).to eq(200)
+        end
+
+        (required_permissions - %w(signin)).each do |required_permission|
+          it "cannot be accessed by users without the #{required_permission} permission" do
+            stub_user.permissions = required_permissions
+            stub_user.permissions.delete(required_permission)
+            get :show_approve_2i_review_form, params: { step_by_step_page_id: step_by_step_page.id }
+
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+
       describe "POST approve 2i review" do
         it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
           stub_user.permissions = required_permissions

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -127,6 +127,20 @@ RSpec.describe ReviewController do
 
         expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_change_note
       end
+
+      it "creates an internal change note with additional comments" do
+        stub_user.permissions = required_permissions
+        stub_user.name = "Firstname Lastname"
+
+        expected_headline = "2i approved"
+        expected_change_note = "Approved provided you fix the typo in the first step"
+
+        post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id, additional_comment: "Approved provided you fix the typo in the first step" }
+        step_by_step_page.reload
+
+        expect(step_by_step_page.internal_change_notes.first.headline).to eq expected_headline
+        expect(step_by_step_page.internal_change_notes.first.description).to eq expected_change_note
+      end
     end
 
     describe "POST request change after 2i review" do

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Managing step by step pages" do
 
   before do
     given_I_am_a_GDS_editor
-    given_there_are_review_users
     given_I_can_access_unreleased_features
     setup_publishing_api
     stub_default_publishing_api_put_intent

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -86,10 +86,6 @@ RSpec.feature "Managing step by step pages" do
     visit step_by_step_page_reorder_path(@step_by_step_page)
   end
 
-  def when_I_visit_the_change_notes_tab
-    visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
-  end
-
   def and_I_create_a_new_step
     click_on "Add step"
   end

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -54,6 +54,16 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_should_see_my_optional_note_in_the_change_notes
   end
 
+  scenario "2i reviewer requests changes to a step by step" do
+    given_there_is_a_step_by_step_that_has_been_claimed_for_2i
+    and_I_am_the_reviewer
+    when_I_visit_the_step_by_step_page
+    and_I_request_changes_to_the_step_by_step
+    then_I_can_see_a_success_message "Changes to the step by step page were requested. Please let the author know."
+    and_the_step_by_step_status_should_be "Draft"
+    and_I_should_see_my_requested_changes_in_the_change_notes
+  end
+
   def when_I_visit_the_submit_for_2i_page
     visit step_by_step_page_submit_for_2i_path(@step_by_step_page)
   end
@@ -73,10 +83,23 @@ RSpec.feature "Reviewing step by step pages" do
     click_button "Yes, approve 2i"
   end
 
+  def and_I_request_changes_to_the_step_by_step
+    click_link "Request changes"
+    expect(page).to have_css(".govuk-caption-l", text: "Request changes to step by step")
+    fill_in "requested_change", with: "Too many typos to publish"
+    click_button "Send change request"
+  end
+
   def and_I_should_see_my_optional_note_in_the_change_notes
     when_I_visit_the_change_notes_tab
     expect(page).to have_content "2i approved"
     expect(page).to have_content "Please fix typo before publishing"
+  end
+
+  def and_I_should_see_my_requested_changes_in_the_change_notes
+    when_I_visit_the_change_notes_tab
+    expect(page).to have_content "2i changes requested"
+    expect(page).to have_content "Too many typos to publish"
   end
 
   def and_the_step_by_step_status_should_be(status)

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Reviewing step by step pages" do
   include CommonFeatureSteps
+  include NavigationSteps
   include StepNavSteps
 
   before do
@@ -43,6 +44,16 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_cannot_see_a_claim_for_2i_button
   end
 
+  scenario "2i reviewer approves step by step" do
+    given_there_is_a_step_by_step_that_has_been_claimed_for_2i
+    and_I_am_the_reviewer
+    when_I_visit_the_step_by_step_page
+    and_I_approve_the_step_by_step_with_an_optional_note
+    then_I_can_see_a_success_message "Step by step page was successfully 2i approved. Please let the author know."
+    and_the_step_by_step_status_should_be "Approved 2i"
+    and_I_should_see_my_optional_note_in_the_change_notes
+  end
+
   def when_I_visit_the_submit_for_2i_page
     visit step_by_step_page_submit_for_2i_path(@step_by_step_page)
   end
@@ -53,6 +64,23 @@ RSpec.feature "Reviewing step by step pages" do
 
   def when_I_view_the_step_by_step_page
     visit step_by_step_page_path(@step_by_step_page)
+  end
+
+  def and_I_approve_the_step_by_step_with_an_optional_note
+    click_link "Approve"
+    expect(page).to have_css(".govuk-caption-l", text: "Approve step by step")
+    fill_in "additional_comment", with: "Please fix typo before publishing"
+    click_button "Yes, approve 2i"
+  end
+
+  def and_I_should_see_my_optional_note_in_the_change_notes
+    when_I_visit_the_change_notes_tab
+    expect(page).to have_content "2i approved"
+    expect(page).to have_content "Please fix typo before publishing"
+  end
+
+  def and_the_step_by_step_status_should_be(status)
+    expect(page).to have_css(".gem-c-metadata", text: "Status: #{status}")
   end
 
   def and_I_submit_the_form

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -44,22 +44,23 @@ RSpec.feature "Contextual action buttons for step by step pages" do
   end
 
   context "Step by step has been claimed for 2i" do
-    scenario "show the relevant actions to the step by step 2i reviewer" do
+    background do
       given_there_is_a_step_by_step_that_has_been_claimed_for_2i
-      and_I_am_the_reviewer
+    end
+
+    scenario "show the relevant actions to the step by step author" do
+      and_I_am_the_step_by_step_author
       when_I_visit_the_step_by_step_page
       then_there_should_be_no_primary_action
       and_the_secondary_action_should_be "Preview"
       and_there_should_be_tertiary_actions_to %w(Delete)
     end
-  end
 
-  context "Step by step has been claimed for 2i" do
-    scenario "show the relevant actions to the step by step author" do
-      given_there_is_a_step_by_step_that_has_been_claimed_for_2i
-      and_I_am_the_step_by_step_author
+    scenario "show the relevant actions to the step by step 2i reviewer" do
+      and_I_am_the_reviewer
       when_I_visit_the_step_by_step_page
-      then_there_should_be_no_primary_action
+      then_the_primary_action_should_be "Approve"
+      and_the_secondary_action_should_be "Request changes"
       and_the_secondary_action_should_be "Preview"
       and_there_should_be_tertiary_actions_to %w(Delete)
     end

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "Contextual action buttons for step by step pages" do
   before do
     given_I_am_a_GDS_editor
     given_I_can_access_unreleased_features
-    given_there_are_review_users
     setup_publishing_api
   end
 
@@ -48,6 +47,17 @@ RSpec.feature "Contextual action buttons for step by step pages" do
     scenario "show the relevant actions to the step by step 2i reviewer" do
       given_there_is_a_step_by_step_that_has_been_claimed_for_2i
       and_I_am_the_reviewer
+      when_I_visit_the_step_by_step_page
+      then_there_should_be_no_primary_action
+      and_the_secondary_action_should_be "Preview"
+      and_there_should_be_tertiary_actions_to %w(Delete)
+    end
+  end
+
+  context "Step by step has been claimed for 2i" do
+    scenario "show the relevant actions to the step by step author" do
+      given_there_is_a_step_by_step_that_has_been_claimed_for_2i
+      and_I_am_the_step_by_step_author
       when_I_visit_the_step_by_step_page
       then_there_should_be_no_primary_action
       and_the_secondary_action_should_be "Preview"

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -75,4 +75,34 @@ RSpec.describe StepNavActionsHelper do
       expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be true
     end
   end
+
+  describe "#can_submit_2i_review?" do
+    it "returns false if the step by step is not in review" do
+      step_by_step_page.status = "submitted_for_2i"
+      step_by_step_page.review_requester_id = user.uid
+      expect(helper.can_submit_2i_review?(step_by_step_page, user)).to be false
+    end
+
+    it "returns false if the current user is not the reviewer" do
+      step_by_step_page.status = "in_review"
+      step_by_step_page.review_requester_id = user.uid
+      step_by_step_page.reviewer_id = reviewer_user.uid
+      expect(helper.can_submit_2i_review?(step_by_step_page, second_reviewer_user)).to be false
+    end
+
+    it "returns false if the step by step is in review and the current user is the reviewer but they don't have permissions" do
+      step_by_step_page.status = "in_review"
+      step_by_step_page.review_requester_id = user.uid
+      step_by_step_page.reviewer_id = reviewer_user.uid
+      reviewer_user.permissions = reviewer_user.permissions - ["Unreleased feature"]
+      expect(helper.can_submit_2i_review?(step_by_step_page, reviewer_user)).to be false
+    end
+
+    it "returns true if the step by step is in review and the current user is the reviewer and they have permissions" do
+      step_by_step_page.status = "in_review"
+      step_by_step_page.review_requester_id = user.uid
+      step_by_step_page.reviewer_id = reviewer_user.uid
+      expect(helper.can_submit_2i_review?(step_by_step_page, reviewer_user)).to be true
+    end
+  end
 end

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -12,6 +12,22 @@ RSpec.describe StepNavActionsHelper do
     allow(Services.publishing_api).to receive(:lookup_content_id)
   end
 
+  describe "#can_submit_for_2i?" do
+    it "returns false if not in draft status" do
+      step_by_step_page.status = "published"
+      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
+    end
+
+    it "returns false if author doesn't have permissions" do
+      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
+    end
+
+    it "returns true if in draft and if author has permissions" do
+      user.permissions << "Unreleased feature"
+      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be true
+    end
+  end
+
   describe "#can_review?" do
     it "returns false if the step-by-step has not been submitted for 2i" do
       expect(helper.can_review?(step_by_step_page, user)).to be false

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -28,4 +28,12 @@ module CommonFeatureSteps
   def required_permissions_for_2i
     ["signin", "GDS Editor", "2i reviewer", "Unreleased feature"]
   end
+
+  def then_I_can_see_a_success_message(message)
+    within(".gem-c-success-alert") do
+      expect(page).to have_content message
+    end
+  end
+
+  alias_method :and_I_can_see_a_success_message, :then_I_can_see_a_success_message
 end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -192,16 +192,14 @@ module StepNavSteps
 
   def given_there_is_a_step_by_step_that_has_been_submitted_for_2i
     @review_requester = create(:user, name: "Original Author", permissions: required_permissions_for_2i)
+    @reviewer = create(:user, name: "Reviewer", permissions: required_permissions_for_2i)
     @step_by_step_page = create(:step_by_step_page_submitted_for_2i, review_requester_id: @review_requester.uid)
   end
 
   def given_there_is_a_step_by_step_that_has_been_claimed_for_2i
-    @step_by_step_page = create(:step_by_step_page_claimed_for_2i, review_requester_id: @review_requester.uid, reviewer_id: @reviewer.uid)
-  end
-
-  def given_there_are_review_users
     @review_requester = create(:user, name: "Original Author", permissions: required_permissions_for_2i)
     @reviewer = create(:user, name: "Reviewer", permissions: required_permissions_for_2i)
+    @step_by_step_page = create(:step_by_step_page_claimed_for_2i, review_requester_id: @review_requester.uid, reviewer_id: @reviewer.uid)
   end
 
   def then_I_can_see_a_success_message(message)

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -202,14 +202,6 @@ module StepNavSteps
     @step_by_step_page = create(:step_by_step_page_claimed_for_2i, review_requester_id: @review_requester.uid, reviewer_id: @reviewer.uid)
   end
 
-  def then_I_can_see_a_success_message(message)
-    within(".gem-c-success-alert") do
-      expect(page).to have_content message
-    end
-  end
-
-  alias_method :and_I_can_see_a_success_message, :then_I_can_see_a_success_message
-
   def and_I_am_the_step_by_step_author
     login_as_user @review_requester
   end
@@ -223,6 +215,10 @@ module StepNavSteps
   end
 
   alias_method :and_I_should_be_on_the_step_by_step_page, :then_I_should_be_on_the_step_by_step_page
+
+  def when_I_visit_the_change_notes_tab
+    visit step_by_step_page_internal_change_notes_path(@step_by_step_page)
+  end
 
   def then_I_see_the_new_step_by_step_page
     expect(page).to have_content("How to bake a cake")


### PR DESCRIPTION
Trello: https://trello.com/c/2hmErFyt/75-2i-reviewer-can-approve-and-request-changes-on-step-by-steps

- [x] Allow "Approve" action to take changenotes
- [x] 2i reviewers can see the Approve/Request Changes buttons
- [x] 2i reviewers can approve
- [x] 2i reviewers can request changes
~Write `step_by_step_actions_spec.rb` tests for `2i_approved` state.~ Will do this [later](https://trello.com/c/Qle5c1QQ/43-write-tests-display-the-appropriate-buttons-depending-on-the-state-of-the-sbs-and-who-is-logged-in).

NB, uses copy found in the sketch attached to the ["2i reviewer can claim SBS for review" card](https://trello.com/c/Fwo562zl/72-2i-reviewer-can-claim-sbs-for-review).
