### PR TITLE
Remove spaces from start and end of step paths

### DIFF
--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -45,7 +45,8 @@ private
   end
 
   def content_item
-    base_path = URI.parse(params[:base_path]).path
+    base_path = params[:base_path].gsub(/^\s+|\s+$/, "")
+    base_path = URI.parse(base_path).path
     content_id = Services.publishing_api.lookup_content_id(base_path: base_path, with_drafts: true)
 
     if content_id.nil?

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -24,6 +24,7 @@ class StepByStepPage < ApplicationRecord
   validates :status, status_prerequisite: true
   validate :reviewer_is_not_same_as_review_requester
 
+  before_validation :strip_slug_spaces
   before_validation :generate_content_id, on: :create
   before_destroy :discard_notes
 
@@ -175,6 +176,10 @@ private
 
   def generate_content_id
     self.content_id ||= SecureRandom.uuid
+  end
+
+  def strip_slug_spaces
+    self.slug.gsub!(/^\s+|\s+$/, "")
   end
 
   def reviewer_is_not_same_as_review_requester

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -22,37 +22,38 @@ RSpec.describe SecondaryContentLinksController do
   end
 
   describe "#create" do
-    it "adds a new secondary content link" do
-      stub_user.permissions << "GDS Editor"
+    context "The content item exists" do
+      before do
+        stub_user.permissions << "GDS Editor"
+        allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
+        allow(Services.publishing_api).to receive(:get_content)
+          .with("a-content-id")
+          .and_return(content_item)
+        allow(Services.publishing_api).to receive(:put_content)
+        allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
+      end
 
-      allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
-      allow(Services.publishing_api).to receive(:get_content)
-        .with("a-content-id")
-        .and_return(content_item)
-      allow(Services.publishing_api).to receive(:put_content)
-      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
+      it "adds a new secondary content link" do
+        post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
 
-      post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
+        expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
+        expect(step_by_step_page.secondary_content_links.first.content_id).to eq("a-content-id")
+        expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
+      end
 
-      expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
-      expect(step_by_step_page.secondary_content_links.first.content_id).to eq("a-content-id")
-      expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
-    end
+      it "accepts a full url as the base_path" do
+        post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "http:/foo.com/base_path" }
 
-    it "adds a new secondary content link if the base_path has a leading or trailing space" do
-      stub_user.permissions << "GDS Editor"
+        expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
+      end
 
-      allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
-      allow(Services.publishing_api).to receive(:get_content)
-        .with("a-content-id")
-        .and_return(content_item)
-      allow(Services.publishing_api).to receive(:put_content)
-      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
+      it "adds a new secondary content link if the base_path has a leading or trailing space" do
+        post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: " /base_path " }
 
-      post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: " /base_path " }
-      expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
-      expect(step_by_step_page.secondary_content_links.first.content_id).to eq("a-content-id")
-      expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
+        expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
+        expect(step_by_step_page.secondary_content_links.first.content_id).to eq("a-content-id")
+        expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
+      end
     end
 
     it "returns an error if the base_path does not exist" do
@@ -62,19 +63,6 @@ RSpec.describe SecondaryContentLinksController do
 
       post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "/base_path" }
       expect(flash[:alert]).to be_present
-    end
-
-    it "accepts a full url as the base_path" do
-      stub_user.permissions << "GDS Editor"
-
-      allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
-      allow(Services.publishing_api).to receive(:get_content).and_return(content_item)
-      allow(Services.publishing_api).to receive(:put_content)
-      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
-
-      post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: "http:/foo.com/base_path" }
-
-      expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
     end
   end
 

--- a/spec/controllers/secondary_content_links_controller_spec.rb
+++ b/spec/controllers/secondary_content_links_controller_spec.rb
@@ -39,6 +39,22 @@ RSpec.describe SecondaryContentLinksController do
       expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
     end
 
+    it "adds a new secondary content link if the base_path has a leading or trailing space" do
+      stub_user.permissions << "GDS Editor"
+
+      allow(Services.publishing_api).to receive(:lookup_content_id).and_return("a-content-id")
+      allow(Services.publishing_api).to receive(:get_content)
+        .with("a-content-id")
+        .and_return(content_item)
+      allow(Services.publishing_api).to receive(:put_content)
+      allow(Services.publishing_api).to receive(:lookup_content_ids).and_return([])
+
+      post :create, params: { step_by_step_page_id: step_by_step_page.id, base_path: " /base_path " }
+      expect(step_by_step_page.secondary_content_links.first.base_path).to eq("/base_path")
+      expect(step_by_step_page.secondary_content_links.first.content_id).to eq("a-content-id")
+      expect(step_by_step_page.secondary_content_links.first.title).to eq("A Title")
+    end
+
     it "returns an error if the base_path does not exist" do
       stub_user.permissions << "GDS Editor"
 

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.errors).to have_key(:description)
     end
 
+    it "removes spaces from start and end of slug" do
+      step_by_step_page.slug = " a-slug "
+
+      step_by_step_page.save
+
+      expect(step_by_step_page).to be_valid
+      expect(step_by_step_page.slug).to eq "a-slug"
+    end
+
     it "must have a scheduled_at value that is nil or in the future" do
       valid_values = [
         nil,


### PR DESCRIPTION
Sometimes content designers will copy paths that have a space at the start or the end.

This PR makes two changes:
- Strips spaces from the beginning and end of secondary link paths.  These previously returned a 500 error.
- Strips spaces from the beginning and end of the step by step slug.  This would have given a `Slug is invalid` error.

Trello card: https://trello.com/c/kVsnP1b7