### PR TITLE
Couple of small fixes

### DIFF
--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -5,7 +5,7 @@
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Collections Publisher",
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-  browser_title: yield(:page_title) do %>
+  browser_title: yield(:page_title).presence || yield(:title) do %>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -93,7 +93,7 @@
           text: "Save"
         } %>
       </div>
-      <div class="govuk-grid-column-full govuk-!-margin-top-3">
+      <div class="govuk-grid-column-full govuk-!-margin-top-3 govuk-body">
         <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -94,7 +94,7 @@
         } %>
       </div>
       <div class="govuk-grid-column-full govuk-!-margin-top-3">
-        <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link" %>
+        <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state" %>
       </div>
     <% end %>
   </div>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -136,6 +136,6 @@
       text: "Save step",
       margin_bottom: true
     } %>
-    <%= tag.p (link_to 'Return to overview', @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
+    <%= tag.p (link_to 'Return to overview', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>
   </div>
 </div>


### PR DESCRIPTION
This resolves an issue where the title of pages in the step-by-step section are quite frequently missing. For example https://collections-publisher.integration.publishing.service.gov.uk/step-by-step-pages currently has `<title> - GOV.UK Collections Publisher</title>` whereas with this change it has: `<title>Step by steps - GOV.UK Collections Publisher</title>`

This also resolves a couple of contextual links that act as controls which show a visited state - which adds some confusion.

Before:
![Screen Shot 2019-09-30 at 11 42 55](https://user-images.githubusercontent.com/282717/65871983-7b414800-e377-11e9-9c5e-51aa24289623.png)

After:
![Screen Shot 2019-09-30 at 11 45 32](https://user-images.githubusercontent.com/282717/65872133-d410e080-e377-11e9-8f49-476fac4cfee6.png)


Before:
![Screen Shot 2019-09-30 at 11 43 54](https://user-images.githubusercontent.com/282717/65872040-99a74380-e377-11e9-990a-9e6142ec415c.png)

After:
![Screen Shot 2019-09-30 at 11 45 55](https://user-images.githubusercontent.com/282717/65872160-e25efc80-e377-11e9-9a88-17007a5de570.png)

