### PR TITLE
Move existing step by step guidance to a YAML file

### DIFF
--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -50,13 +50,9 @@
 
             <%= render "govuk_publishing_components/components/input", {
               label: {
-                text: "Base Path"
+                text: t("secondary_content_links.index.base_path.label")
               },
-              hint: capture do %>
-                For example:
-                <a href="https://www.gov.uk/pay-vat" target="_blank" class="govuk-link">https://www.gov.uk/pay-vat</a>
-                or <a href="https://www.gov.uk/bank-holidays" class="govuk-link" target="_blank">/bank-holidays</a>
-              <% end,
+              hint: t("secondary_content_links.index.base_path.hint"),
               name: "base_path"
             } %>
           </div>

--- a/app/views/shared/steps/_markdown_help.html.erb
+++ b/app/views/shared/steps/_markdown_help.html.erb
@@ -6,15 +6,4 @@
 </p>
 
 <%# intentionally not indented properly because the PRE formats all whitespace %>
-<pre class="small markdown-example">Paragraphs are separated by empty lines.
-Use non-bulleted lists for tasks. Add any costs after the link:
-
-[task name](/link) £10 to £20
-[task name](/link)
-
-Only use bullets to show when a task has a number of options to choose from:
-
-- [download form option 1](/link)
-- [download form option 2](/link)
-- bullet with no link
-</pre>
+<pre class="small markdown-example"><%= t("steps.content_tasks_links.formatting_guidance") %></pre>

--- a/app/views/step_by_step_pages/_change_notes.html.erb
+++ b/app/views/step_by_step_pages/_change_notes.html.erb
@@ -1,18 +1,18 @@
 <% textarea = capture do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: "Public change note",
+        text: t("step_by_step_pages.change_notes.label"),
       },
       name: "change_note",
       rows: 4,
-      hint: "Describe the change for users. This change note will be emailed to subscribers."
+      hint: t("step_by_step_pages.change_notes.hint"),
     } %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="change-note">
     <%= render "govuk_publishing_components/components/radio", {
-      heading: "Notify users about this change?",
+      heading: t("step_by_step_pages.change_notes.title"),
       heading_size: "s",
       name: "update_type",
       id: "update-type",

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -27,9 +27,9 @@
       <% if @step_by_step_page.can_be_edited? %>
         <%= render "govuk_publishing_components/components/input", {
           label: {
-            text: "Slug"
+            text: t("step_by_step_pages.form.slug.label")
           },
-          hint: "No slashes",
+          hint: t("step_by_step_pages.form.slug.hint"),
           name: "step_by_step_page[slug]",
           value: step_by_step_page.slug
         } %>

--- a/app/views/step_by_step_pages/reorder.html.erb
+++ b/app/views/step_by_step_pages/reorder.html.erb
@@ -23,8 +23,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.</p>
-    <p class="govuk-body">Step numbers will be automatically updated on save.</p>
+    <p class="govuk-body"><%= t("step_by_step_pages.reorder.instructions") %></p>
+    <p class="govuk-body"><%= t("step_by_step_pages.reorder.automatically_updated") %></p>
 
     <%
       step_number = 1

--- a/app/views/step_by_step_pages/schedule_datetime.html.erb
+++ b/app/views/step_by_step_pages/schedule_datetime.html.erb
@@ -15,7 +15,7 @@
 %>
 
 <% legend = capture do %>
-  <span class="govuk-heading-s govuk-!-margin-bottom-0">Date</span>
+  <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("step_by_step_pages.schedule_datetime.date.label") %></span>
 <% end %>
 
 <%= render 'shared/steps/step_breadcrumb', links: links %>
@@ -37,7 +37,7 @@
       <%= render "govuk_publishing_components/components/date_input", {
         legend_text: legend,
         name: "schedule[date]",
-        hint: "For example, 01 08 2027",
+        hint: t("step_by_step_pages.schedule_datetime.date.hint"),
         id: "date",
         error_items: issues_for(:date),
         items: [
@@ -63,7 +63,7 @@
         id: "time",
         name: "schedule[time]",
         label: {
-          text: "Time",
+          text: t("step_by_step_pages.schedule_datetime.date.label"),
           bold: true,
         },
         input: {

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -36,9 +36,9 @@
 
     <%= render "govuk_publishing_components/components/radio", {
       name: "step[optional]",
-      heading: "Is this step optional?",
+      heading: t("steps.optional.heading"),
       heading_size: "s",
-      hint: "You must select one of these so that user activity is tracked correctly in Google Analytics.",
+      hint: t("steps.optional.hint"),
       items: [
         {
           value: "false",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,40 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  shared:
+    steps:
+      markdown_help:
+        formatting_guidance: |
+          Paragraphs are separated by empty lines.
+          Use non-bulleted lists for tasks. Add any costs after the link:
+           [task name](/link) £10 to £20
+           [task name](/link)
+          Only use bullets to show when a task has a number of options to choose from:
+          - [download form option 1](/link)
+          - [download form option 2](/link)
+          - bullet with no links
+  step_by_step_pages:
+    form:
+      slug:
+        label: Slug
+        hint: No slashes
+    reorder:
+      instructions: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
+      automatically_updated: Step numbers will be automatically updated on save.
+    change_notes:
+      title: Notify users about this change?
+      label: Public change note
+      hint: Describe the change for users. This change note will be emailed to subscribers.
+    schedule_datetime:
+      date:
+        label: Date
+        hint: For example, 01 08 2027
+      time:
+        label: Time
+  steps:
+    optional:
+      heading: Is this step optional?
+      hint: You must select one of these so that user activity is tracked correctly in Google Analytics.
+  secondary_content_links:
+    index:
+      base_path:
+        label: Base Path
+        hint: "For example: https://www.gov.uk/pay-vat or /bank-holidays"


### PR DESCRIPTION
### User story

**As a** content designer
**I want** to be able to update contextual guidance in human readable files
**So that** I can do this without knowing Ruby
 
---

-  Decided to store the guidance in a single file as it will be easier for content designers to find and amend without knowing the structure of the folders and files. _This can be revised when we add more text._
- YAML file structure follows the folder structure of the views so it can be easily followed and the text can be reused in the future. It's the preferred way and it also allows to use a 'lazy' lookup without providing full path to the key when referencing it in the `t` method eg. `t(".slug_guidance")`

_Note:_ Not moved as it contains Markdown:
- Guidance on markdown `shared/steps/markdown_help.html.erb` 
- Guidance on secondary links `secondary_content_links/index.html.erb`

[Trello card](https://trello.com/c/lBPFRJQY/100-create-yaml-file-to-store-the-guidance-and-add-current-guidance-to-that-yaml-file)