### PR TITLE
Explicitly require CommonFeatureSteps

### DIFF
--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "support/common_feature_steps"
 require "support/link_checker"
 
 module StepNavSteps


### PR DESCRIPTION
Depending on the order in which the support files are required, `common_feature_steps` may not have been loaded by the time we include it.  Therefore this adds an explicit require.