### PR TITLE
Remove optional / essential radio buttons

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -56,6 +56,6 @@ private
   end
 
   def step_params
-    params.require(:step).permit(:title, :logic, :optional, :contents)
+    params.require(:step).permit(:title, :logic, :contents)
   end
 end

--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -79,7 +79,6 @@ private
         title: step.title,
         contents: step_content_parser.parse(step.contents),
       }.tap do |optional_content|
-        optional_content[:optional] = !! step.optional # if it's nil return false.
         optional_content[:logic] = step.logic if %w(and or).include?(step.logic)
       end
     end

--- a/app/services/step_by_step_page_reverter.rb
+++ b/app/services/step_by_step_page_reverter.rb
@@ -51,7 +51,7 @@ private
       Step.new(
         title: step[:title],
         logic: logic(step),
-        optional: step[:optional],
+        optional: nil,
         position: index + 1,
         contents: contents(step[:contents]),
       )

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -33,25 +33,6 @@
         }
       ]
     } %>
-
-    <%= render "govuk_publishing_components/components/radio", {
-      name: "step[optional]",
-      heading: t("steps.optional.heading"),
-      heading_size: "s",
-      hint: t("steps.optional.hint"),
-      items: [
-        {
-          value: "false",
-          text: "essential",
-          checked: !step.optional.present? || !step.optional
-        },
-        {
-          value: "true",
-          text: "optional",
-          checked: step.optional
-        }
-      ]
-    } %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,10 +29,6 @@ en:
         hint: For example, 01 08 2027
       time:
         label: Time
-  steps:
-    optional:
-      heading: Is this step optional?
-      hint: You must select one of these so that user activity is tracked correctly in Google Analytics.
   secondary_content_links:
     index:
       base_path:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -98,7 +98,6 @@ FactoryBot.define do
 
     factory :or_step do
       title { "Dress like the Fonz" }
-      optional { "true" }
       logic { "or" }
       position { 2 }
       contents {

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -136,7 +136,6 @@ RSpec.feature "Managing step by step pages" do
   def and_I_fill_in_the_form_with_content
     fill_in "Step title", with: "Buy Mary Berry's 'Simple Cakes' book"
     choose "number"
-    choose "essential"
     fill_in "Content, tasks and links in this step", with: "* [Booky booky book book.com](http://bbbb.com)\n* [Words inside cardboard.com](http://wic.com)"
   end
 

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -25,17 +25,6 @@ RSpec.describe StepNavPresenter do
       expect(presented[:routes]).to eq([{ path: "/how-to-be-the-amazing-1", type: "exact" }])
     end
 
-    it "copes with optional properties" do
-      presented = subject.render_for_publishing_api
-      steps = presented[:details][:step_by_step_nav][:steps]
-
-      expect(steps[0][:optional]).to be false
-      expect(steps[1][:optional]).to be true
-
-      expect(steps[0][:logic]).to be nil
-      expect(steps[1][:logic]).to eq "or"
-    end
-
     it "presents edition links correctly" do
       presented = subject.render_for_publishing_api
       expect(presented[:links][:pages_part_of_step_nav].count).to eq(2)

--- a/spec/services/step_by_step_page_reverter_spec.rb
+++ b/spec/services/step_by_step_page_reverter_spec.rb
@@ -89,12 +89,6 @@ RSpec.describe StepByStepPageReverter do
         expect(step_by_step_page.steps[3].logic).to eq("and")
       end
 
-      it "saves whether the step is optional" do
-        expect(step_by_step_page.steps[1].optional).to be false
-        expect(step_by_step_page.steps[2].optional).to be true
-        expect(step_by_step_page.steps[3].optional).to be false
-      end
-
       it "saves the position of the step" do
         expect(step_by_step_page.steps[0].position).to eq(1)
         expect(step_by_step_page.steps[1].position).to eq(2)
@@ -297,7 +291,6 @@ RSpec.describe StepByStepPageReverter do
                   "text": "A second paragraph of text in the first step.",
                 },
               ],
-              "optional": false,
             },
             {
               "title": "Step two of the step by step",
@@ -312,7 +305,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": false,
             },
             {
               "title": "Step three of the step by step",
@@ -328,7 +320,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": true,
               "logic": "or",
             },
             {
@@ -352,7 +343,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": false,
               "logic": "and",
             },
             {
@@ -368,7 +358,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": false,
             },
             {
               "title": "Step six of the step by step",
@@ -384,7 +373,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": false,
             },
             {
               "title": "Step seven of the step by step",
@@ -401,7 +389,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": false,
             },
             {
               "title": "Step eight of the step by step",
@@ -448,7 +435,6 @@ RSpec.describe StepByStepPageReverter do
                   ],
                 },
               ],
-              "optional": false,
             },
           ],
         },


### PR DESCRIPTION
Trello - https://trello.com/c/P1mSis5e/97-hide-optional-vs-essential-question-when-editing-step

Content designers say it wasn't being used consistently and it was confusing users

Pr to remove from Content Schemas
https://github.com/alphagov/govuk-content-schemas/pull/927