### PR TITLE
Step edit page uses breadcrumbs

### DIFF
--- a/app/views/steps/edit.html.erb
+++ b/app/views/steps/edit.html.erb
@@ -14,11 +14,7 @@
   ]
 %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: @step_by_step_page
-  } %>
-<% end %>
+<%= render 'shared/steps/step_breadcrumb', links: links %>
 
 <%= render 'shared/steps/page_title', links: links %>
 


### PR DESCRIPTION
This removes the last instance of a page using the back link rather than breadcrumbs. This means that the whole process is consistent. 

Trello - https://trello.com/c/6Sv1xIAx/98-make-navigation-consistent-use-breadcrumbs

### Visual Changes

#### Before
<img width="1072" alt="Screen Shot 2019-10-01 at 16 55 43" src="https://user-images.githubusercontent.com/24547207/65978913-65fa1580-e46c-11e9-8b3e-13f4ed967fbc.png">

#### After
<img width="1017" alt="Screen Shot 2019-10-01 at 16 55 23" src="https://user-images.githubusercontent.com/24547207/65978904-6397bb80-e46c-11e9-9a32-c7f23f9ae666.png">

