### PR TITLE
Parse markdown in in-app guidance

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,4 +20,14 @@ module ApplicationHelper
   def published_url(slug)
     "#{Plek.new.website_root}/#{slug}"
   end
+
+  def markdown_to_html(markdown)
+    raw(Kramdown::Document.new(markdown).to_html)
+  end
+
+  def render_markdown(content)
+    render "govuk_publishing_components/components/govspeak" do
+      markdown_to_html(content)
+    end
+  end
 end

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -23,15 +23,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-  <h2 class="govuk-heading-m">What is secondary content?</h2>
-    <div class="govuk-body">
-      <p class="govuk-body-s">Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.</p>
-      <p class="govuk-body-s">We use it for content which:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li class="govuk-body-s">helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task</li>
-        <li class="govuk-body-s">is optional and not useful enough to be included in the step by step</li>
-      </ul>
-    </div>
+    <%= render_markdown t("secondary_content_links.guidance_markdown") %>
   </div>
 </div>
 

--- a/app/views/step_by_step_pages/reorder.html.erb
+++ b/app/views/step_by_step_pages/reorder.html.erb
@@ -23,8 +23,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body"><%= t("step_by_step_pages.reorder.instructions") %></p>
-    <p class="govuk-body"><%= t("step_by_step_pages.reorder.automatically_updated") %></p>
+    <%= render_markdown t("step_by_step_pages.reorder.instructions_markdown") %>
+    <%= render_markdown t("step_by_step_pages.reorder.automatically_updated_markdown") %>
 
     <%
       step_number = 1

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,8 +20,8 @@ en:
         label: Slug
         hint: No slashes
     reorder:
-      instructions: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
-      automatically_updated: Step numbers will be automatically updated on save.
+      instructions_markdown: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
+      automatically_updated_markdown: Step numbers will be automatically updated on save.
     change_notes:
       title: Notify users about this change?
       label: Public change note

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,15 @@ en:
       heading: Is this step optional?
       hint: You must select one of these so that user activity is tracked correctly in Google Analytics.
   secondary_content_links:
+    guidance_markdown: |
+      ##What is secondary content?
+
+      Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
+
+      We use it for content which:
+
+      - helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task
+      - is optional and not useful enough to be included in the step by step
     index:
       base_path:
         label: Base Path

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#markdown_to_html" do
+    it "converts markdown to html" do
+      text = "This is some **bold** text with a [link](/a-page)"
+      expected_html = "<p>This is some <strong>bold</strong> text with a <a href=\"/a-page\">link</a></p>\n"
+
+      expect(markdown_to_html(text)).to eq(expected_html)
+    end
+  end
+
+  describe "#render_markdown" do
+    it "converts markdown to html" do
+      text = "This is some **bold** text with a [link](/a-page)"
+      expected_html = "\n<div class=\"gem-c-govspeak govuk-govspeak \" data-module=\"govspeak\">\n    <p>This is some <strong>bold</strong> text with a <a href=\"/a-page\">link</a></p>\n\n</div>\n"
+
+      expect(render_markdown(text)).to eq(expected_html)
+    end
+  end
+
   def expected_step_nav_preview_url
     "#{draft_origin_url}/#{step_nav.slug}"
   end


### PR DESCRIPTION
Content designers may wish to update in-app guidance by raising PRs on YAML files.  At the moment they would have to include HTML for any formatting.  The changes in this PR allow markdown to be used in guidance, and updates the existing guidance to use valid markdown.

Trello card: https://trello.com/c/zNqQjbMo