### PR TITLE
[DO NOT MERGE] Only 2i approved step by steps can be published or scheduled

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -5,6 +5,7 @@ class StepByStepPagesController < ApplicationController
 
   before_action :require_gds_editor_permissions!
   before_action :set_step_by_step_page, only: %i[show edit update destroy]
+  before_action :require_to_be_2i_approved, only: %i[publish schedule schedule_datetime]
 
   def index
     @step_by_step_pages = StepByStepFilter::Results.new(filter_params).call
@@ -245,5 +246,12 @@ private
 
   def set_current_page_as_step_by_step
     @step_by_step_page = StepByStepPage.find(params[:step_by_step_page_id])
+  end
+
+  def require_to_be_2i_approved
+    set_current_page_as_step_by_step
+    unless @step_by_step_page.status.approved_2i?
+      redirect_to @step_by_step_page, notice: "Step by step must be 2i approved before you can #{action_name} this step by step."
+    end
   end
 end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -104,7 +104,8 @@ class StepByStepPage < ApplicationRecord
       !scheduled_for_publishing? &&
       steps_have_content? &&
       links_checked_since_last_update? &&
-      !broken_links_found?
+      !broken_links_found? &&
+      status.approved_2i?
   end
 
   def can_be_unpublished?

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -173,7 +173,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User schedules publishing without a public change note" do
-      given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
+      given_there_is_a_2i_approved_step_by_step_page_with_secondary_content_and_navigation_rules
       and_I_visit_the_scheduling_page
       then_I_should_see_a_publish_form_with_changenotes
       and_when_I_click_button "Continue"
@@ -197,7 +197,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User schedules publishing with a public change note" do
-      given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
+      given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
       and_I_visit_the_scheduling_page
       then_I_should_see_a_publish_form_with_changenotes
       and_I_fill_in_the_changenote_form
@@ -212,7 +212,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User tries to schedule publishing for date in the past" do
-      given_there_is_a_draft_step_by_step_page
+      given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
       and_I_visit_the_scheduling_page
       then_I_should_see_a_publish_form_with_changenotes
       and_when_I_click_button "Continue"
@@ -243,7 +243,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User tries using invalid values for schedule date and time" do
-      given_there_is_a_draft_step_by_step_page
+      given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
       and_I_visit_the_scheduling_page
       then_I_should_see_a_publish_form_with_changenotes
       and_when_I_click_button "Continue"
@@ -366,7 +366,7 @@ RSpec.feature "Managing step by step pages" do
     end
 
     scenario "User publishes a page" do
-      given_there_is_a_step_by_step_page_with_a_link_report
+      given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
       when_I_view_the_step_by_step_page
       when_I_click_button "Publish"
       then_I_am_told_that_it_is_published

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -277,9 +277,17 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be false
     end
 
-    it "should return false if step by step is in draft but has no issues blocking its publication" do
+    it "should return true if step by step is in draft but has no issues blocking its publication" do
       step_by_step_with_step = create(:draft_step_by_step_page)
       stub_link_checker_report_success(step_by_step_with_step.steps.first)
+
+      expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be true
+    end
+
+    it "should return false if step by step is 2i approved and has no issues blocking its publication" do
+      step_by_step_with_step = create(:draft_step_by_step_page)
+      stub_link_checker_report_success(step_by_step_with_step.steps.first)
+      step_by_step_with_step.status = "approved_2i"
 
       expect(step_by_step_with_step.should_show_required_prepublish_actions?).to be false
     end
@@ -470,8 +478,9 @@ RSpec.describe StepByStepPage do
       allow(step_by_step_page).to receive(:links_checked_since_last_update?) { true }
     end
 
-    it "can be published if it has a draft, is not scheduled, all steps have content, links have been checked since last update and there are no broken links" do
+    it "can be published if it has a draft, is not scheduled, all steps have content, links have been checked since last update, there are no broken links and it is 2i approved" do
       step_by_step_page.mark_draft_updated
+      step_by_step_page.status = "approved_2i"
 
       expect(step_by_step_page.can_be_published?).to be true
     end
@@ -512,6 +521,13 @@ RSpec.describe StepByStepPage do
     it "cannot be published if broken links were found when links were checked" do
       step_by_step_page.mark_draft_updated
       stub_link_checker_report_broken_link(step_by_step_page.steps.first)
+
+      expect(step_by_step_page.can_be_published?).to be false
+    end
+
+    it "cannot be published if it is not 2i approved" do
+      step_by_step_page.mark_draft_updated
+      step_by_step_page.status = "in_review"
 
       expect(step_by_step_page.can_be_published?).to be false
     end

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -90,6 +90,7 @@ module StepNavSteps
 
   def given_I_am_assigned_to_a_published_step_by_step_page_with_unpublished_changes
     @step_by_step_page = create(:published_step_by_step_page, draft_updated_at: 1.day.ago, assigned_to: stub_user.name)
+    @step_by_step_page.mark_as_approved_2i
   end
 
   def given_there_is_a_scheduled_step_by_step_page
@@ -124,6 +125,7 @@ module StepNavSteps
     step = create(:step)
     stub_link_checker_report_success(step)
     @step_by_step_page = create(:step_by_step_with_unpublished_changes, steps: [step], slug: "step-by-step-with-unpublished-changes")
+    @step_by_step_page.mark_as_approved_2i
   end
 
   def given_there_is_an_approved_2i_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
@@ -156,9 +158,9 @@ module StepNavSteps
     create(:step, contents: "", step_by_step_page: @step_by_step_page)
   end
 
-  def given_there_is_a_draft_step_by_step_page_with_secondary_content_and_navigation_rules
+  def given_there_is_a_2i_approved_step_by_step_page_with_secondary_content_and_navigation_rules
     @step_by_step_page = create(:step_by_step_page_with_secondary_content_and_navigation_rules)
-    expect(@step_by_step_page.status).to be_draft
+    @step_by_step_page.mark_as_approved_2i
   end
 
   def given_there_is_a_step_by_step_page_with_steps_missing_content


### PR DESCRIPTION
Requires a step by step to have been 2i approved before it can be scheduled or published.

This protects the relevant routes to ensure the approved status is set, and updates the `can_be_published?` logic so the relevant actions are only shown after approval.

Tests have been updated to match this change.  Feature tests have been changed to assume the SBS have been 2i approved in all cases, except where the test is specifically testing the 2i workflow.

Not to be merged until the 2i workflow is to be released and "Unreleased feature" flag is removed.

Trello card: https://trello.com/c/8o8PMB6n/88-only-approved-step-by-steps-can-be-published-or-scheduled-after-2i-is-released