### PR TITLE
Update secondary links contextual guidance

### DIFF
--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -35,17 +35,13 @@
           <div class="govuk-grid-column-full">
             <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 
-            <%= render "govuk_publishing_components/components/heading", {
-              text: "Add new secondary link",
-              margin_bottom: 5
-            } %>
-
             <%= render "govuk_publishing_components/components/input", {
               label: {
                 text: t("secondary_content_links.index.base_path.label")
               },
               hint: t("secondary_content_links.index.base_path.hint"),
-              name: "base_path"
+              name: "base_path",
+              heading_size: "m"
             } %>
           </div>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,5 +48,5 @@ en:
       - is optional and not useful enough to be included in the step by step
     index:
       base_path:
-        label: Base Path
+        label: Add new secondary link
         hint: "For example: https://www.gov.uk/pay-vat or /bank-holidays"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
 
       We use it for content which:
 
-      - helps you to complete a task in the journey, but is not the primary piece of content you need to visit to complete that task
+      - could help you complete a task but is not the main piece of content included in the step by step
       - is optional and not useful enough to be included in the step by step
     index:
       base_path:


### PR DESCRIPTION
- Updates a sentence in the guidance
- Removes `Base Path` label from input field

Documented in: https://docs.google.com/document/d/1YVTT-gJFGQPO5OKtP3BjWxI4IuJkijBRvEwU2EhQogE/edit#heading=h.837gql2zzefn

Trello card: https://trello.com/c/RKFEN2jg