### PR TITLE
Correct label when submitting 2i verdict

### DIFF
--- a/app/views/review/submit_2i_verdict.erb
+++ b/app/views/review/submit_2i_verdict.erb
@@ -31,7 +31,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: approved ? "Describe changes required" : "Add a note (optional)"
+          text: approved ? "Add a note (optional)" : "Describe changes required"
         },
         name: approved ? "additional_comment" : "requested_change",
       } %>

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -79,6 +79,7 @@ RSpec.feature "Reviewing step by step pages" do
   def and_I_approve_the_step_by_step_with_an_optional_note
     click_link "Approve"
     expect(page).to have_css(".govuk-caption-l", text: "Approve step by step")
+    expect(page).to have_css(".govuk-label", text: "Add a note (optional)")
     fill_in "additional_comment", with: "Please fix typo before publishing"
     click_button "Yes, approve 2i"
   end
@@ -86,6 +87,7 @@ RSpec.feature "Reviewing step by step pages" do
   def and_I_request_changes_to_the_step_by_step
     click_link "Request changes"
     expect(page).to have_css(".govuk-caption-l", text: "Request changes to step by step")
+    expect(page).to have_css(".govuk-label", text: "Describe changes required")
     fill_in "requested_change", with: "Too many typos to publish"
     click_button "Send change request"
   end


### PR DESCRIPTION
The labels were the wrong way round for the two 2i verdict actions (approve and request changes).

Also added a test to make sure the correct label is present in each scenario.

Trello card: https://trello.com/c/kx0JkDEb