### PR TITLE
Keep the case consistent in inset prompts

### DIFF
--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -34,7 +34,7 @@
           </li>
         <% else %>
           <li>
-            <p class="govuk-body">get 2i approval</p>
+            <p class="govuk-body">Get 2i approval</p>
           </li>
         <% end %>
       <% end %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Managing step by step pages" do
     then_there_should_be_no_publish_button
     and_there_should_be_no_schedule_button
     and_I_should_see_an_inset_prompt
-    and_inset_prompt_should_say "get 2i approval"
+    and_inset_prompt_should_say "Get 2i approval"
   end
 
   scenario "User unpublishes a step by step page with a valid redirect url" do


### PR DESCRIPTION
All the other inset prompts start with an uppercase letter, this changes "get 2i approval" to "Get 2i approval" to keep this consistent.