### PR TITLE
Require 2i reviewer permission to see claim button

### DIFF
--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -20,13 +20,15 @@ private
   def can_claim_first_review?(step_by_step_page, user)
     step_by_step_page.status.submitted_for_2i? &&
       step_by_step_page.review_requester_id != user.uid &&
-      user.has_permission?("Unreleased feature")
+      user.has_permission?("Unreleased feature") &&
+      user.has_permission?("2i reviewer")
   end
 
   def can_take_over_review?(step_by_step_page, user)
     step_by_step_page.status.in_review? &&
       step_by_step_page.review_requester_id != user.uid &&
       step_by_step_page.reviewer_id != user.uid &&
-      user.has_permission?("Unreleased feature")
+      user.has_permission?("Unreleased feature") &&
+      user.has_permission?("2i reviewer")
   end
 end

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -44,6 +44,13 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_cannot_see_a_claim_for_2i_button
   end
 
+  scenario "User without 2i reviewer permission cannot claim step by step for 2i review" do
+    given_there_is_a_step_by_step_that_has_been_submitted_for_2i
+    and_I_am_a_non_2i_user
+    when_I_view_the_step_by_step_page
+    and_I_cannot_see_a_claim_for_2i_button
+  end
+
   scenario "2i reviewer approves step by step" do
     given_there_is_a_step_by_step_that_has_been_claimed_for_2i
     and_I_am_the_reviewer

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe StepNavActionsHelper do
   let(:user) { create(:user) }
   let(:reviewer_user) { create(:user, permissions: required_permissions_for_2i) }
   let(:second_reviewer_user) { create(:user, permissions: required_permissions_for_2i) }
+  let(:non_2i_user) { create(:user, permissions: required_permissions_for_2i - ["2i reviewer"]) }
 
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
@@ -57,6 +58,12 @@ RSpec.describe StepNavActionsHelper do
       step_by_step_page.review_requester_id = user.uid
       step_by_step_page.reviewer_id = reviewer_user.uid
       expect(helper.can_review?(step_by_step_page, reviewer_user)).to be false
+    end
+
+    it "returns false if the reviewer is not a 2i reviewer" do
+      step_by_step_page.status = "submitted_for_2i"
+      step_by_step_page.review_requester_id = user.uid
+      expect(helper.can_review?(step_by_step_page, non_2i_user)).to be false
     end
   end
 

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -193,6 +193,7 @@ module StepNavSteps
   def given_there_is_a_step_by_step_that_has_been_submitted_for_2i
     @review_requester = create(:user, name: "Original Author", permissions: required_permissions_for_2i)
     @reviewer = create(:user, name: "Reviewer", permissions: required_permissions_for_2i)
+    @non_2i_user = create(:user, name: "Reviewer", permissions: required_permissions_for_2i - ["2i reviewer"])
     @step_by_step_page = create(:step_by_step_page_submitted_for_2i, review_requester_id: @review_requester.uid)
   end
 
@@ -208,6 +209,10 @@ module StepNavSteps
 
   def and_I_am_the_reviewer
     login_as_user @reviewer
+  end
+
+  def and_I_am_a_non_2i_user
+    login_as_user @non_2i_user
   end
 
   def then_I_should_be_on_the_step_by_step_page


### PR DESCRIPTION
Users without the `2i reviewer` permission could see the `Claim for 2i` button.  This would have resulted in a 403 error when clicked, since the permission was checked on this action.

This updates the conditions for showing the `Claim for 2i` button so only eligible users can see it.

Trello card: https://trello.com/c/mK2oXYID