### PR TITLE
Ignore GOV.UK prefix to show absolute links on Sidebar Settings

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -12,6 +12,8 @@ class StepContentParser
   # matches [Link text](url)
   LINK_REGEX = /\[[^\[\]]+\]\(([^)]+)/.freeze
 
+  GOVUK_DOMAIN_REGEX = /^(https?:\/\/)?(www\.)?gov\.uk\//.freeze
+
   def parse(step_text)
     sections = step_text.rstrip.delete("\r").split("\n\n").map do |section|
       section.lines.map(&:chomp)
@@ -58,7 +60,9 @@ private
   end
 
   def relative_paths(content)
-    all_links_in_content(content).select { |href| href.match(/^\/[a-z0-9]+.*/i) }
+    all_links_in_content(content)
+      .map { |url| strip_govuk_prefix(url) }
+      .select { |href| href.match(/^\/[a-z0-9]+.*/i) }
   end
 
   def external_links(content)
@@ -75,6 +79,10 @@ private
 
   def prefix_govuk(path_to_prefix)
     "https://www.gov.uk" + path_to_prefix
+  end
+
+  def strip_govuk_prefix(url)
+    url.sub(GOVUK_DOMAIN_REGEX, "/")
   end
 
   def standard_list?(section)

--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -58,11 +58,11 @@ private
   end
 
   def relative_paths(content)
-    all_links_in_content(content).select { |href| href[0] =~ /^\/[a-z0-9]+.*/i if href.any? }.flatten
+    all_links_in_content(content).select { |href| href.match(/^\/[a-z0-9]+.*/i) }
   end
 
   def external_links(content)
-    all_links_in_content(content).flatten - relative_paths(content)
+    all_links_in_content(content) - relative_paths(content)
   end
 
   def internal_links(content)
@@ -70,7 +70,7 @@ private
   end
 
   def all_links_in_content(content)
-    content.scan(LINK_REGEX)
+    content.scan(LINK_REGEX).flatten
   end
 
   def prefix_govuk(path_to_prefix)

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe StepContentParser do
       expect(subject.base_paths(step_text)).to eq([])
     end
 
-    it "rejects fully qualified urls" do
+    it "rejects fully qualified urls that are not GOV.UK" do
       step_text = <<~HEREDOC
         [All the prizes](/all-the-prizes)
         - [A gondola trip for two](https://gondolier-r-us.com/default.asp)
@@ -349,6 +349,24 @@ RSpec.describe StepContentParser do
           /all-the-prizes
           /i-love-speed-boats
           /spending-money
+        ),
+      )
+    end
+
+    it "allows fully qualified GOV.UK urls" do
+      step_text = <<~HEREDOC
+        - [Insecure link         ](http://gov.uk/insecure-link)
+        - [Secure link           ](https://gov.uk/secure-link)
+        - [Insecure link with www](http://www.gov.uk/insecure-link-with-www)
+        - [Secure link with www  ](https://www.gov.uk/secure-link-with-www)
+      HEREDOC
+
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /insecure-link
+          /secure-link
+          /insecure-link-with-www
+          /secure-link-with-www
         ),
       )
     end


### PR DESCRIPTION
This will allow absolute URL links to be picked up by StepLinksForRules
for inclusion in the Sidebar Settings page.

This PR also refactors `StepContentParser` a little (see first commit).

Trello: https://trello.com/c/4JeWifGe/86-strip-govuk-from-link-markdown-and-show-them-on-sidebar-settings