### PR TITLE
Do not revert step by step to draft under certain circumstances

### DIFF
--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,6 +1,6 @@
 class StepNavPublisher
   def self.update(step_by_step_page, publish_intent = PublishIntent.minor_update)
-    step_by_step_page.mark_draft_updated
+    step_by_step_page.mark_draft_updated unless %w(submitted_for_2i in_review).include?(step_by_step_page.status)
     presenter = StepNavPresenter.new(step_by_step_page)
     payload = presenter.render_for_publishing_api(publish_intent)
     Services.publishing_api.put_content(step_by_step_page.content_id, payload)


### PR DESCRIPTION
Sometimes a reviewer or review requester will want to make minor changes without getting stuck in a 2i review loop.  This change prevents the status from changing to 'draft' when a step by step that is currently submitted for 2i or in 2i review is edited.  If a step by step has been approved, published or scheduled, then the status is returned to 'draft' and another 2i review is required.

Trello card: https://trello.com/c/4FN9RaqT