### PR TITLE
Set link checker 'checked_within' threshold to zero

### DIFF
--- a/app/models/link_report.rb
+++ b/app/models/link_report.rb
@@ -20,6 +20,7 @@ private
       Services.link_checker_api.create_batch(
         batch_of_links,
         webhook_uri: Plek.new.external_url_for("collections-publisher") + "/link_report",
+        checked_within: 0,
       )
     end
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -274,6 +274,7 @@ RSpec.feature "Managing step by step pages" do
         "https://www.gov.uk/not/as/great",
       ],
       webhook_uri: Plek.new.external_url_for("collections-publisher") + "/link_report",
+      checked_within: 0,
     )
     stub_link_checker_api_get_batch(id: 0)
 

--- a/spec/models/link_report_spec.rb
+++ b/spec/models/link_report_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe LinkReport, type: :model do
             "https://www.gov.uk/not/as/great",
           ],
           webhook_uri: "https://collections-publisher.test.gov.uk/link_report",
+          checked_within: 0,
         )
         link_report.create_record
         expect(LinkReport.find_by(batch_id: 0)).to be


### PR DESCRIPTION
Link Checker API uses cached check results if a URL has been checked at any point in the last 4 hours.  Some users may wish to add newly published pages to a step by step.  Therefore the 'checkec_within' threshold needs to be set to something lower than the default value.

Not to be merged until https://github.com/alphagov/link-checker-api/pull/306 is merged and deployed.

Trello card: https://trello.com/c/9mLVRWFC