### PR TITLE
Add message to warn user that notifications aren't sent

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -32,7 +32,7 @@ class ReviewController < ApplicationController
     )
       generate_change_note("2i approved", params[:additional_comment])
 
-      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved. Please let the author know."
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Step by step page was successfully 2i approved. Please let the author know. This app has not sent any notifications."
     else
       render :submit_2i_verdict, locals: { approved: true }, status: :unprocessable_entity
     end
@@ -65,7 +65,7 @@ class ReviewController < ApplicationController
     )
       generate_change_note("2i changes requested", params[:requested_change])
 
-      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested. Please let the author know."
+      redirect_to step_by_step_page_path(@step_by_step_page.id), notice: "Changes to the step by step page were requested. Please let the author know. This app has not sent any notifications."
     else
       render :submit_2i_verdict, locals: { approved: false }, status: :unprocessable_entity
     end

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_am_the_reviewer
     when_I_visit_the_step_by_step_page
     and_I_approve_the_step_by_step_with_an_optional_note
-    then_I_can_see_a_success_message "Step by step page was successfully 2i approved. Please let the author know."
+    then_I_can_see_a_success_message "Step by step page was successfully 2i approved. Please let the author know. This app has not sent any notifications."
     and_the_step_by_step_status_should_be "Approved 2i"
     and_I_should_see_my_optional_note_in_the_change_notes
   end
@@ -66,7 +66,7 @@ RSpec.feature "Reviewing step by step pages" do
     and_I_am_the_reviewer
     when_I_visit_the_step_by_step_page
     and_I_request_changes_to_the_step_by_step
-    then_I_can_see_a_success_message "Changes to the step by step page were requested. Please let the author know."
+    then_I_can_see_a_success_message "Changes to the step by step page were requested. Please let the author know. This app has not sent any notifications."
     and_the_step_by_step_status_should_be "Draft"
     and_I_should_see_my_requested_changes_in_the_change_notes
   end


### PR DESCRIPTION
Just being asked to tell an author that a 2i had been approved or that a SbS needed changes was slightly confusing. This adds a line that makes it clear that no messages are automatically sent in these situations.

Trello - https://trello.com/c/Itc6JTZO/120-add-text-to-make-it-clear-that-the-app-has-not-sent-any-notifications-when-the-2ier-approves-or-requests-changes