### PR TITLE
Remove compatiblity with govuk-template

### DIFF
--- a/app/assets/stylesheets/_steps.scss
+++ b/app/assets/stylesheets/_steps.scss
@@ -28,7 +28,7 @@ $dark-grey-2: #6f777b;
   margin: 0 0 govuk-spacing(2);
   color: $black;
   word-wrap: break-word;
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
 }
 
 // hide up button in first row and down button in last row
@@ -164,7 +164,7 @@ $dark-grey-2: #6f777b;
   .js-reorder {
     padding: 20px;
     border: 1px solid $dark-grey-2;
-    background-color: govuk-colour("white", $legacy: "white");
+    background-color: govuk-colour("white");
   }
 
   .step-by-step-reorder__step-title {

--- a/app/assets/stylesheets/admin_layout.scss
+++ b/app/assets/stylesheets/admin_layout.scss
@@ -1,5 +1,3 @@
-$govuk-use-legacy-palette: true;
-
 @import "govuk_publishing_components/all_components";
 @import "./components/all";
 @import "./objects/broken-link-status";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,2 @@
-$govuk-compatibility-govuktemplate: true;
-
 @import "govuk_publishing_components/all_components";
 @import "./components/autocomplete";

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -4,7 +4,7 @@
 $app-focus-colour: #ffdd00;
 
 .autocomplete__wrapper {
-  background: govuk-colour("white", $legacy: "white");
+  background: govuk-colour("white");
 }
 
 .autocomplete__input {
@@ -30,10 +30,10 @@ $app-focus-colour: #ffdd00;
 
 .autocomplete__option--focused,
 .autocomplete__option:hover {
-  color: govuk-colour("white", $legacy: "white");
+  color: govuk-colour("white");
 
   .autocomplete__option-hint {
-    color: govuk-colour("white", $legacy: "white");
+    color: govuk-colour("white");
   }
 }
 

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -21,13 +21,13 @@ $app-toolbar-button-size: 50px;
   display: block;
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   border-bottom: 0;
-  background-color: govuk-colour("white", $legacy: "white");
+  background-color: govuk-colour("white");
 }
 
 .app-c-markdown-editor__preview-toggle {
   width: 100%;
   border-bottom: $govuk-border-width-form-element solid $govuk-border-colour;
-  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+  background-color: govuk-colour("light-grey");
 }
 
 .app-c-markdown-editor__button {
@@ -54,11 +54,11 @@ $app-toolbar-button-size: 50px;
   border-right: $govuk-border-width-form-element solid $govuk-border-colour;
   border-left: $govuk-border-width-form-element solid $govuk-border-colour;
   color: $govuk-text-colour;
-  background: govuk-colour("light-grey", $legacy: "grey-4");
+  background: govuk-colour("light-grey");
   text-decoration: none;
 
   &:focus {
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
   }
 
   &:first-child {
@@ -78,7 +78,7 @@ $app-toolbar-button-size: 50px;
   .govuk-textarea {
     padding: govuk-spacing(6);
     overflow: scroll;
-    background-color: govuk-colour("light-grey", $legacy: "grey-4");
+    background-color: govuk-colour("light-grey");
   }
 
   .govuk-govspeak {
@@ -89,7 +89,7 @@ $app-toolbar-button-size: 50px;
 }
 
 .app-c-markdown-editor__toolbar {
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
   line-height: 0;
 }
 
@@ -111,7 +111,7 @@ $app-toolbar-button-size: 50px;
   }
 
   &:hover {
-    background-color: govuk-colour("light-grey", $legacy: "grey-3");
+    background-color: govuk-colour("light-grey");
     cursor: pointer;
   }
 }
@@ -128,7 +128,7 @@ $app-toolbar-button-size: 50px;
   width: auto;
   padding: govuk-spacing(3);
   border: 0;
-  border-left: 4px solid govuk-colour("white", $legacy: "white");
+  border-left: 4px solid govuk-colour("white");
   background: transparent;
   vertical-align: top;
 }

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -3,7 +3,7 @@
   @include govuk-clearfix;
 
   padding: govuk-spacing(3);
-  background: govuk-colour("light-grey", $legacy: "grey-4");
+  background: govuk-colour("light-grey");
 }
 
 .app-side__actions {
@@ -41,7 +41,7 @@
 
     &:hover,
     &:active {
-      color: govuk-colour("bright-red");
+      color: govuk-colour("red");
     }
 
     &:focus {

--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -105,5 +105,5 @@
 
 .gem-c-inset-text {
   margin-top: 0;
-  background-color: govuk-colour("light-grey", $legacy: "grey-4");
+  background-color: govuk-colour("light-grey");
 }


### PR DESCRIPTION
This application doesn't rely on `govuk-template` so we're removing this flags to use the new colour scheme. This aligns the styles for Collections Publisher with Content Publisher and Signon.