### PR TITLE
Keep content designers on same page when editing a step

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -25,7 +25,7 @@ class StepsController < ApplicationController
   def update
     if step.update(step_params)
       update_downstream
-      redirect_to step_by_step_page_path(step_by_step_page.id), notice: "Step was successfully updated."
+      redirect_to edit_step_by_step_page_step_path(step_by_step_page.id), notice: "Step was successfully updated."
     else
       render :edit
     end

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Managing step by step pages" do
         when_I_visit_the_step_by_step_page
         and_I_edit_the_first_step
         and_I_fill_the_edit_form_and_submit
-        then_I_should_be_on_the_step_by_step_page
+        then_I_should_still_be_on_the_edit_step_page
         and_I_can_see_a_success_message "Step was successfully updated."
       end
 
@@ -206,5 +206,10 @@ RSpec.feature "Managing step by step pages" do
       expect(page).to have_css(".govuk-accordion__section-heading", text: "Current version", count: 1)
       expect(page).to have_css(".govuk-accordion__section-content", text: "I've changed this step by step!", count: 1)
     end
+  end
+
+  def then_I_should_still_be_on_the_edit_step_page
+    edit_step_path = edit_step_by_step_page_step_path(@step_by_step_page.id, @step_by_step_page.steps.first.id)
+    expect(current_url).to end_with edit_step_path
   end
 end


### PR DESCRIPTION
Content designers like to make small changes, save steps, refresh their preview
and repeat. Therefore there was an additional overhead involved in navigating
back to the step that is being edited, when making multiple small changes to it.

A product decision has been made to keep content designers on the 'Edit Step' page
when updating a step, to enable them to make multiple changes more easily. This
reverses logic added in https://github.com/alphagov/collections-publisher/pull/759

NB, we DO want to redirect to the overview page when CREATING steps, but we want
to stay on the edit page when updating existing steps.

Trello card: https://trello.com/c/qqOsgr1W/117-change-app-behaviour-to-not-redirect-user-to-summary-page-after-saving-a-step