### PR TITLE
Use a random UUID for the auth_bypass_id

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -25,10 +25,11 @@ class StepByStepPage < ApplicationRecord
   validate :reviewer_is_not_same_as_review_requester
 
   before_validation :strip_slug_spaces
-  before_validation :generate_content_id, on: :create
   before_destroy :discard_notes
 
   scope :by_title, -> { order(:title) }
+
+  attribute :content_id, :string, default: -> { SecureRandom.uuid }
 
   def has_been_published?
     published_at.present?
@@ -174,10 +175,6 @@ class StepByStepPage < ApplicationRecord
   end
 
 private
-
-  def generate_content_id
-    self.content_id ||= SecureRandom.uuid
-  end
 
   def strip_slug_spaces
     self.slug.gsub!(/^\s+|\s+$/, "")

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -88,6 +88,10 @@ class StepByStepPage < ApplicationRecord
     update_attribute(:status, "approved_2i")
   end
 
+  def refresh_auth_bypass_id
+    update_attribute(:auth_bypass_id, SecureRandom.uuid)
+  end
+
   def self.validate_redirect(redirect_url)
     regex = /\A\/([a-z0-9]+-)*[a-z0-9]+\z/
     redirect_url =~ regex

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -30,6 +30,7 @@ class StepByStepPage < ApplicationRecord
   scope :by_title, -> { order(:title) }
 
   attribute :content_id, :string, default: -> { SecureRandom.uuid }
+  attribute :auth_bypass_id, :string, default: -> { SecureRandom.uuid }
 
   def has_been_published?
     published_at.present?
@@ -127,21 +128,6 @@ class StepByStepPage < ApplicationRecord
 
   def steps_have_content?
     steps.any? && steps.map(&:contents).all?(&:present?)
-  end
-
-  # Create a deterministic, but unique token that will be used to give one-time
-  # access to a piece of draft content.
-  # This token is created by using an id that should be unique so that there is
-  # little chance of the same token being created to view another piece of content.
-  # The code to create the token has been "borrowed" from SecureRandom.uuid,
-  # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
-  def auth_bypass_id
-    @auth_bypass_id ||= begin
-      ary = Digest::SHA256.hexdigest(content_id.to_s).unpack("NnnnnN")
-      ary[2] = (ary[2] & 0x0fff) | 0x4000
-      ary[3] = (ary[3] & 0x3fff) | 0x8000
-      "%08x-%04x-%04x-%04x-%04x%08x" % ary
-    end
   end
 
   def links_last_checked_date

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,5 +1,6 @@
 class StepNavPublisher
   def self.update(step_by_step_page, publish_intent = PublishIntent.minor_update)
+    step_by_step_page.refresh_auth_bypass_id if step_by_step_page.status == "published"
     step_by_step_page.mark_draft_updated unless %w(submitted_for_2i in_review approved_2i).include?(step_by_step_page.status)
     presenter = StepNavPresenter.new(step_by_step_page)
     payload = presenter.render_for_publishing_api(publish_intent)

--- a/db/migrate/20191008111813_add_auth_bypass_id_column_to_step_by_step_pages.rb
+++ b/db/migrate/20191008111813_add_auth_bypass_id_column_to_step_by_step_pages.rb
@@ -1,0 +1,5 @@
+class AddAuthBypassIdColumnToStepByStepPages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :step_by_step_pages, :auth_bypass_id, :string
+  end
+end

--- a/db/migrate/20191008113036_populate_auth_bypass_id.rb
+++ b/db/migrate/20191008113036_populate_auth_bypass_id.rb
@@ -1,0 +1,17 @@
+class PopulateAuthBypassId < ActiveRecord::Migration[5.2]
+  class StepByStepPage < ActiveRecord::Base; end
+
+  def up
+    StepByStepPage.find_each do |step_by_step|
+      auth_bypass_id = generate_legacy_auth_bypass_id(step_by_step.content_id)
+      step_by_step.update(auth_bypass_id: auth_bypass_id)
+    end
+  end
+
+  def generate_legacy_auth_bypass_id(content_id)
+    ary = Digest::SHA256.hexdigest(content_id.to_s).unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+  end
+end

--- a/db/migrate/20191009091313_disallow_null_auth_bypass_id.rb
+++ b/db/migrate/20191009091313_disallow_null_auth_bypass_id.rb
@@ -1,0 +1,5 @@
+class DisallowNullAuthBypassId < ActiveRecord::Migration[5.2]
+  def change
+    change_column :step_by_step_pages, :auth_bypass_id, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_111813) do
+ActiveRecord::Schema.define(version: 2019_10_08_113036) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_27_080905) do
+ActiveRecord::Schema.define(version: 2019_10_08_111813) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2019_09_27_080905) do
     t.string "status", null: false
     t.string "review_requester_id"
     t.string "reviewer_id"
+    t.string "auth_bypass_id"
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["review_requester_id"], name: "fk_rails_d4fb625ca0"
     t.index ["reviewer_id"], name: "fk_rails_7247412df6"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_113036) do
+ActiveRecord::Schema.define(version: 2019_10_09_091313) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 2019_10_08_113036) do
     t.string "status", null: false
     t.string "review_requester_id"
     t.string "reviewer_id"
-    t.string "auth_bypass_id"
+    t.string "auth_bypass_id", null: false
     t.index ["content_id"], name: "index_step_by_step_pages_on_content_id", unique: true
     t.index ["review_requester_id"], name: "fk_rails_d4fb625ca0"
     t.index ["reviewer_id"], name: "fk_rails_7247412df6"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     description { "How to be amazing - find out the steps to become amazing" }
     status { "draft" }
     draft_updated_at { 3.hours.ago }
+    auth_bypass_id { "33ac75d8-4adf-48a7-acb2-bbf4e7f644a3" }
 
     factory :step_by_step_page_with_steps, aliases: [:draft_step_by_step_page] do
       after(:create) do |step_by_step_page|

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -433,11 +433,6 @@ RSpec.describe StepByStepPage do
       end
     end
 
-    it "should have a deterministically generated hex string" do
-      step_by_step_with_custom_id = create(:step_by_step_page, content_id: 123, slug: "slug")
-      expect(step_by_step_with_custom_id.auth_bypass_id).to eq("61363635-6134-4539-b230-343232663964")
-    end
-
     it "should have a status of draft if published and then changes are made" do
       step_by_step_page.mark_as_published
 

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe StepNavPublisher do
     context "step by step being edited" do
       let(:step_nav) { create(:step_by_step_page_with_steps) }
 
+      before do
+        allow(SecureRandom).to receive(:uuid).and_return("bd814775-304c-46d0-919f-f9e0f6cba4e9")
+      end
+
       it "does not revert to draft if a step by step in submitted_for_2i state is edited" do
         step_nav.update_attributes(status: "submitted_for_2i", review_requester_id: review_requester_user.uid, reviewer_id: reviewer_user.uid)
         StepNavPublisher.update(step_nav)
@@ -63,6 +67,17 @@ RSpec.describe StepNavPublisher do
         step_nav.update_attributes(status: "scheduled")
         StepNavPublisher.update(step_nav)
         expect(step_nav.status).to eq "draft"
+      end
+
+      it "does not change the auth_bypass_id when step by step in draft state is edited" do
+        StepNavPublisher.update(step_nav)
+        expect(step_nav.auth_bypass_id).to eq "33ac75d8-4adf-48a7-acb2-bbf4e7f644a3"
+      end
+
+      it "changes the auth_bypass_id when step by step in published state is edited" do
+        step_nav.update_attributes(status: "published")
+        StepNavPublisher.update(step_nav)
+        expect(step_nav.auth_bypass_id).to eq "bd814775-304c-46d0-919f-f9e0f6cba4e9"
       end
     end
   end


### PR DESCRIPTION
Rather than [mutate a content_id](https://github.com/alphagov/collections-publisher/blob/master/app/models/step_by_step_page.rb#L130-L143) to calculate the `auth_bypass_id`, this instead uses a random UUID which changes for each edition. This makes it so that the same token cannot be used to preview later versions of the content and stops the ID being a predictable value.

Due to the random nature, we now store the `auth_bypass_id` in the database, rather than calculate it each time it is required.

This will require a two-step deployment.  Firstly, the release should be deployed using the `app:migrate` deploy task to add the `auth_bypass_id` database column and backfill this with existing IDs.  Secondly, the application can be deployed normally to actually switch to using the randomised IDs.  This will prevent the possibility of deploying the code whilst the `auth_bypass_id` column contains `nil` values, which could prevent access to the previews, or errors sending drafts to the Publishing API.

Trello card: https://trello.com/c/jKRvjyAe