### PR TITLE
Remove feature flag from 2i workflow

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -3,7 +3,6 @@ class ReviewController < ApplicationController
 
   before_action :set_step_by_step_page
   before_action :require_gds_editor_permissions!
-  before_action :require_unreleased_feature_permissions!
   before_action :require_2i_reviewer_permissions!, only: %i(
     approve_2i_review
     claim_2i_review

--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -1,9 +1,4 @@
 module StepNavActionsHelper
-  def can_submit_for_2i?(step_by_step_page, user)
-    step_by_step_page.status.draft? &&
-      user.has_permission?("Unreleased feature")
-  end
-
   def can_review?(step_by_step_page, user)
     can_claim_first_review?(step_by_step_page, user) ||
       can_take_over_review?(step_by_step_page, user)
@@ -11,8 +6,7 @@ module StepNavActionsHelper
 
   def can_submit_2i_review?(step_by_step_page, user)
     step_by_step_page.status.in_review? &&
-      step_by_step_page.reviewer_id == user.uid &&
-      user.has_permission?("Unreleased feature")
+      step_by_step_page.reviewer_id == user.uid
   end
 
 private
@@ -20,7 +14,6 @@ private
   def can_claim_first_review?(step_by_step_page, user)
     step_by_step_page.status.submitted_for_2i? &&
       step_by_step_page.review_requester_id != user.uid &&
-      user.has_permission?("Unreleased feature") &&
       user.has_permission?("2i reviewer")
   end
 
@@ -28,7 +21,6 @@ private
     step_by_step_page.status.in_review? &&
       step_by_step_page.review_requester_id != user.uid &&
       step_by_step_page.reviewer_id != user.uid &&
-      user.has_permission?("Unreleased feature") &&
       user.has_permission?("2i reviewer")
   end
 end

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -15,9 +15,7 @@
         method: :post,
         class: %w(govuk-link govuk-link--no-visited-state app-link--right)
       %>
-    <% elsif
-      @step_by_step_page.can_be_published? && !(current_user.has_permission? "Unreleased feature") || # remove this line when the feature flag is removed
-      @step_by_step_page.status.approved_2i? && (current_user.has_permission? "Unreleased feature") %>
+    <% elsif @step_by_step_page.can_be_published? %>
       <% if @step_by_step_page.has_been_published? %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Publish",
@@ -40,7 +38,7 @@
             text: "Claim for 2i review"
           } %>
         <% end %>
-      <% elsif can_submit_for_2i?(@step_by_step_page, current_user) %>
+      <% elsif @step_by_step_page.status.draft? %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Submit for 2i review",
           href: step_by_step_page_submit_for_2i_path(@step_by_step_page)

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe ReviewController do
 
     describe "submit for 2i" do
       describe "GET submit for 2i page" do
-        required_permissions = ["signin", "GDS Editor", "Unreleased feature"]
+        required_permissions = ["signin", "GDS Editor"]
 
-        it "can be accessed by users with GDS editor and Unreleased feature permissions" do
+        it "can be accessed by users with GDS editor permission" do
           stub_user.permissions = required_permissions
           get :submit_for_2i, params: { step_by_step_page_id: step_by_step_page.id }
 
@@ -32,7 +32,7 @@ RSpec.describe ReviewController do
 
       describe "POST submit for 2i" do
         before do
-          required_permissions = ["signin", "GDS Editor", "Unreleased feature"]
+          required_permissions = ["signin", "GDS Editor"]
           stub_user.permissions = required_permissions
           stub_user.name = "Firstname Lastname"
         end
@@ -87,10 +87,10 @@ RSpec.describe ReviewController do
         stub_user.uid = reviewer_user.uid
       end
 
-      required_permissions = ["signin", "GDS Editor", "Unreleased feature", "2i reviewer"]
+      required_permissions = ["signin", "GDS Editor", "2i reviewer"]
 
       describe "GET approve 2i review" do
-        it "can be accessed by the reviewer, if they have GDS editor, Unreleased feature and 2i reviewer permissions" do
+        it "can be accessed by the reviewer, if they have GDS editor and 2i reviewer permissions" do
           stub_user.permissions = required_permissions
           get :show_request_change_2i_review_form, params: { step_by_step_page_id: step_by_step_page.id }
 
@@ -117,7 +117,7 @@ RSpec.describe ReviewController do
       end
 
       describe "GET request change after 2i review" do
-        it "can be accessed by the reviewer, if they have GDS editor, Unreleased feature and 2i reviewer permissions" do
+        it "can be accessed by the reviewer, if they have GDS editor and 2i reviewer permissions" do
           stub_user.permissions = required_permissions
           get :show_approve_2i_review_form, params: { step_by_step_page_id: step_by_step_page.id }
 
@@ -136,7 +136,7 @@ RSpec.describe ReviewController do
       end
 
       describe "POST approve 2i review" do
-        it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
+        it "can be accessed by users with GDS editor and 2i reviewer permissions" do
           stub_user.permissions = required_permissions
           post :approve_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
@@ -192,7 +192,7 @@ RSpec.describe ReviewController do
       end
 
       describe "POST request change after 2i review" do
-        it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
+        it "can be accessed by users with GDS editor and 2i reviewer permissions" do
           stub_user.permissions = required_permissions
           post :request_change_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
@@ -236,7 +236,7 @@ RSpec.describe ReviewController do
       end
 
       describe "POST claim 2i review" do
-        it "can be accessed by users with GDS editor, Unreleased feature and 2i reviewer permissions" do
+        it "can be accessed by users with GDS editor and 2i reviewer permissions" do
           stub_user.permissions = required_permissions
           post :claim_2i_review, params: { step_by_step_page_id: step_by_step_page.id }
 
@@ -277,7 +277,7 @@ RSpec.describe ReviewController do
       end
 
       describe "POST revert to draft" do
-        it "can be accessed by users with GDS Editor and Unreleased feature permissions" do
+        it "can be accessed by users with GDS Editor permissions" do
           stub_user.permissions = required_permissions
           post :revert_to_draft, params: { step_by_step_page_id: step_by_step_page.id }
 

--- a/spec/features/create_step_by_step_spec.rb
+++ b/spec/features/create_step_by_step_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature "Create new step by step page" do
 
   before do
     given_I_am_a_GDS_editor
-    given_I_can_access_unreleased_features
     setup_publishing_api
     stub_default_publishing_api_put_intent
   end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Managing step by step pages" do
 
   before do
     given_I_am_a_GDS_editor
-    given_I_can_access_unreleased_features
     setup_publishing_api
     stub_default_publishing_api_put_intent
   end
@@ -365,43 +364,6 @@ RSpec.feature "Managing step by step pages" do
     and_when_I_click_button "Publish"
     then_I_am_told_that_it_is_published
     and_there_should_continue_to_be_no_inset_prompt
-  end
-
-  context "No Unreleased feature permissions" do
-    before do
-      stub_user.permissions = ["signin", "GDS Editor"]
-      setup_publishing_api
-      stub_default_publishing_api_put_intent
-    end
-
-    scenario "User publishes a page" do
-      given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
-      when_I_view_the_step_by_step_page
-      when_I_click_button "Publish"
-      then_I_am_told_that_it_is_published
-      then_I_see_the_step_by_step_page
-      when_I_visit_the_history_page
-      then_there_should_be_a_change_note "Published"
-    end
-
-    scenario "Publishing/scheduling a step by step does not prompt to check for broken links" do
-      given_there_is_an_approved_2i_step_that_has_no_broken_links
-      when_I_view_the_step_by_step_page
-      then_there_should_be_no_inset_prompt
-      and_when_I_click_button "Publish"
-      then_I_am_told_that_it_is_published
-      and_there_should_continue_to_be_no_inset_prompt
-    end
-
-    scenario "User publishes changes to a published step by step page" do
-      given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
-      when_I_view_the_step_by_step_page
-      and_when_I_click_button "Publish"
-      then_I_should_see_a_publish_form_with_changenotes
-      and_when_I_click_the_publish_button_in_the_publish_form
-      then_I_am_told_that_it_is_published
-      and_I_cannot_preview_the_step_by_step
-    end
   end
 
   def and_it_has_change_notes

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "Reviewing step by step pages" do
   before do
     given_I_am_a_GDS_editor
     given_I_am_a_2i_reviewer
-    given_I_can_access_unreleased_features
     setup_publishing_api
   end
 

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature "Contextual action buttons for step by step pages" do
 
   before do
     given_I_am_a_GDS_editor
-    given_I_can_access_unreleased_features
     setup_publishing_api
   end
 

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -13,22 +13,6 @@ RSpec.describe StepNavActionsHelper do
     allow(Services.publishing_api).to receive(:lookup_content_id)
   end
 
-  describe "#can_submit_for_2i?" do
-    it "returns false if not in draft status" do
-      step_by_step_page.status = "published"
-      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
-    end
-
-    it "returns false if author doesn't have permissions" do
-      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
-    end
-
-    it "returns true if in draft and if author has permissions" do
-      user.permissions << "Unreleased feature"
-      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be true
-    end
-  end
-
   describe "#can_review?" do
     it "returns false if the step-by-step has not been submitted for 2i" do
       expect(helper.can_review?(step_by_step_page, user)).to be false
@@ -67,22 +51,6 @@ RSpec.describe StepNavActionsHelper do
     end
   end
 
-  describe "#can_submit_for_2i?" do
-    it "returns false if not in draft status" do
-      step_by_step_page.status = "published"
-      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
-    end
-
-    it "returns false if author doesn't have permissions" do
-      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be false
-    end
-
-    it "returns true if in draft and if author has permissions" do
-      user.permissions << "Unreleased feature"
-      expect(helper.can_submit_for_2i?(step_by_step_page, user)).to be true
-    end
-  end
-
   describe "#can_submit_2i_review?" do
     it "returns false if the step by step is not in review" do
       step_by_step_page.status = "submitted_for_2i"
@@ -95,14 +63,6 @@ RSpec.describe StepNavActionsHelper do
       step_by_step_page.review_requester_id = user.uid
       step_by_step_page.reviewer_id = reviewer_user.uid
       expect(helper.can_submit_2i_review?(step_by_step_page, second_reviewer_user)).to be false
-    end
-
-    it "returns false if the step by step is in review and the current user is the reviewer but they don't have permissions" do
-      step_by_step_page.status = "in_review"
-      step_by_step_page.review_requester_id = user.uid
-      step_by_step_page.reviewer_id = reviewer_user.uid
-      reviewer_user.permissions = reviewer_user.permissions - ["Unreleased feature"]
-      expect(helper.can_submit_2i_review?(step_by_step_page, reviewer_user)).to be false
     end
 
     it "returns true if the step by step is in review and the current user is the reviewer and they have permissions" do

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -17,16 +17,12 @@ module CommonFeatureSteps
     find("input[type=submit]").click
   end
 
-  def given_I_can_access_unreleased_features
-    stub_user.permissions << "Unreleased feature"
-  end
-
   def given_I_am_a_2i_reviewer
     stub_user.permissions << "2i reviewer"
   end
 
   def required_permissions_for_2i
-    ["signin", "GDS Editor", "2i reviewer", "Unreleased feature"]
+    ["signin", "GDS Editor", "2i reviewer"]
   end
 
   def then_I_can_see_a_success_message(message)


### PR DESCRIPTION
To be merged with #797 

I kept the `require_unreleased_feature_permissions!` method

[Trello card](https://trello.com/c/g1qXMozp/139-remove-all-references-of-the-feature-flag-in-the-code-and-any-tests)