### PR TITLE
Add "revert to draft" button for approved step by steps

### DIFF
--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,6 +1,6 @@
 class StepNavPublisher
   def self.update(step_by_step_page, publish_intent = PublishIntent.minor_update)
-    step_by_step_page.mark_draft_updated unless %w(submitted_for_2i in_review).include?(step_by_step_page.status)
+    step_by_step_page.mark_draft_updated unless %w(submitted_for_2i in_review approved_2i).include?(step_by_step_page.status)
     presenter = StepNavPresenter.new(step_by_step_page)
     payload = presenter.render_for_publishing_api(publish_intent)
     Services.publishing_api.put_content(step_by_step_page.content_id, payload)

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -59,6 +59,10 @@
       <%= preview_link %>
     <% end %>
 
+    <% if @step_by_step_page.status.approved_2i? %>
+      <%= link_to 'Revert to draft', { controller: "review", action: "revert_to_draft", step_by_step_page_id: @step_by_step_page.id }, method: :post, data: { confirm: 'This will remove existing 2i approval. Do you want to revert to draft?' }, class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
+    <% end %>
+
     <% if @step_by_step_page.can_discard_changes? %>
       <%= link_to 'Discard changes', { action: "revert", step_by_step_page_id: @step_by_step_page.id }, method: :post, data: { confirm: 'This will delete your draft. Do you want to discard your changes?' }, class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
     <% end %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -60,6 +60,16 @@ RSpec.feature "Managing step by step pages" do
     then_there_should_be_a_change_note "Published"
   end
 
+  scenario "User reverts an approved page to draft" do
+    given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
+    when_I_view_the_step_by_step_page
+    when_I_click_button "Revert to draft"
+    then_I_see_the_step_by_step_page
+    then_I_see_a_reverted_success_notice
+    when_I_visit_the_history_page
+    then_there_should_be_a_change_note "Reverted to draft"
+  end
+
   scenario "User cannot publish or schedule a page if it's not 2i approved" do
     given_there_is_a_step_by_step_that_has_been_claimed_for_2i
     when_I_view_the_step_by_step_page
@@ -640,6 +650,10 @@ RSpec.feature "Managing step by step pages" do
 
   def then_I_see_a_page_reverted_success_notice
     expect(page).to have_content("Draft successfully discarded.")
+  end
+
+  def then_I_see_a_reverted_success_notice
+    expect(page).to have_content("Step by step page was successfully reverted to draft.")
   end
 
   def and_I_visit_the_scheduling_page

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Contextual action buttons for step by step pages" do
       when_I_visit_the_step_by_step_page
       then_the_primary_action_should_be "Publish"
       and_there_should_be_secondary_actions_to %w(Preview)
-      and_there_should_be_tertiary_actions_to %w(Schedule Delete)
+      and_there_should_be_tertiary_actions_to ["Revert to draft", "Schedule", "Delete"]
     end
   end
 

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe StepNavPublisher do
         expect(step_nav.status).to eq "in_review"
       end
 
-      it "reverts to draft if a step by step in approved_2i state is edited" do
+      it "does not revert to draft if a step by step in approved_2i state is edited" do
         step_nav.update_attributes(status: "approved_2i", review_requester_id: review_requester_user.uid, reviewer_id: reviewer_user.uid)
         StepNavPublisher.update(step_nav)
-        expect(step_nav.status).to eq "draft"
+        expect(step_nav.status).to eq "approved_2i"
       end
 
       it "reverts to draft if a step by step in published state is edited" do


### PR DESCRIPTION
Once a step by step has been approved, content designers may wish to make minor edits without having to get 2i approval again.

This PR therefore makes two changes:

- Editing an approved step by step will not change the status to draft
- Adds a "revert to draft" action for approved step by steps (with warning prompt)

Example action:
![Screen Shot 2019-10-09 at 11 12 31](https://user-images.githubusercontent.com/6329861/66476661-162fd580-ea8e-11e9-9b18-0ec5c7872be3.png)

Example warning:
![Screen Shot 2019-10-09 at 11 12 41](https://user-images.githubusercontent.com/6329861/66476671-1b8d2000-ea8e-11e9-8e0f-1b2672349f83.png)

Trello card: https://trello.com/c/eS79gejo