### PR TITLE
Add contextual guidance to edit pages

### DIFF
--- a/app/views/shared/steps/_markdown_help.html.erb
+++ b/app/views/shared/steps/_markdown_help.html.erb
@@ -1,9 +1,0 @@
-<p class="govuk-body">
-  <%= link_to "Content design guide",
-    "https://gov-uk.atlassian.net/wiki/spaces/MS/pages/268140618/Content+design+principles+for+step+by+step+navigation+Q4",
-    class: "govuk-link",
-    target: "_blank" %> for step by step navigation.
-</p>
-
-<%# intentionally not indented properly because the PRE formats all whitespace %>
-<pre class="small markdown-example"><%= t("shared.steps.markdown_help.formatting_guidance") %></pre>

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -1,101 +1,74 @@
 <%= form_for(@step_by_step_page) do |form| %>
   <%= render "shared/steps/form_errors", resource: step_by_step_page %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @step_by_step_page.can_be_edited? %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: "Title"
-          },
-          name: "step_by_step_page[title]",
-          value: step_by_step_page.title
-        } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/label", {
-          text: "Title",
-          bold: true,
-          html_for: 'step_by_step_page_title'
-        } %>
-        <%= tag.p step_by_step_page.title, id: "step_by_step_page_title", class: "govuk-body" %>
-      <% end %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "step_by_step_page_title",
+    title: t("step_by_step_pages.form.title.label"),
+    content: t("step_by_step_pages.form.title.guidance")
+  } do %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: t("step_by_step_pages.form.title.label"),
+        bold: true
+      },
+      id: "step_by_step_page_title",
+      name: "step_by_step_page[title]",
+      value: step_by_step_page.title
+    } %>
+  <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @step_by_step_page.can_be_edited? %>
-        <%= render "govuk_publishing_components/components/input", {
-          label: {
-            text: t("step_by_step_pages.form.slug.label")
-          },
-          hint: t("step_by_step_pages.form.slug.hint"),
-          name: "step_by_step_page[slug]",
-          value: step_by_step_page.slug
-        } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/label", {
-          text: "Slug",
-          bold: true,
-          html_for: 'step_by_step_page_slug'
-        } %>
-        <%= tag.p step_by_step_page.slug, id: "step_by_step_page_slug", class: "govuk-body" %>
-      <% end %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "step_by_step_page_slug",
+    title: t("step_by_step_pages.form.slug.label"),
+    content: t("step_by_step_pages.form.slug.guidance")
+  } do %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: t("step_by_step_pages.form.slug.label"),
+        bold: true
+      },
+      id: "step_by_step_page_slug",
+      name: "step_by_step_page[slug]",
+      value: step_by_step_page.slug
+    } %>
+  <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @step_by_step_page.can_be_edited? %>
-        <%= render "govuk_publishing_components/components/textarea", {
-          label: {
-            text: "Introduction"
-          },
-          name: "step_by_step_page[introduction]",
-          value: step_by_step_page.introduction
-        } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/label", {
-          text: "Introduction",
-          bold: true,
-          html_for: 'step_by_step_page_introduction'
-        } %>
-        <%= tag.p step_by_step_page.introduction, id: "step_by_step_page_introduction", class: "govuk-body" %>
-      <% end %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "step_by_step_page_introduction",
+    title: t("step_by_step_pages.form.introduction.label"),
+    content: t("step_by_step_pages.form.introduction.guidance")
+  } do %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: t("step_by_step_pages.form.introduction.label"),
+        bold: true
+      },
+      id: "step_by_step_page_introduction",
+      name: "step_by_step_page[introduction]",
+      value: step_by_step_page.introduction
+    } %>
+  <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @step_by_step_page.can_be_edited? %>
-        <%= render "govuk_publishing_components/components/textarea", {
-          label: {
-            text: "Meta description"
-          },
-          name: "step_by_step_page[description]",
-          value: step_by_step_page.description
-        } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/label", {
-          text: "Meta description",
-          bold: true,
-          html_for: 'step_by_step_page_description'
-        } %>
-        <%= tag.p step_by_step_page.description, id: "step_by_step_page_description", class: "govuk-body" %>
-      <% end %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "step_by_step_page_meta_description",
+    title: t("step_by_step_pages.form.meta_description.label"),
+    content: t("step_by_step_pages.form.meta_description.guidance")
+  } do %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: t("step_by_step_pages.form.meta_description.label"),
+        bold: true
+      },
+      id: "step_by_step_page_meta_description",
+      name: "step_by_step_page[description]",
+      value: step_by_step_page.description
+    } %>
+  <% end %>
 
-  <div class="govuk-grid-row">
-    <% if @step_by_step_page.can_be_edited? %>
-      <div class="govuk-grid-column-full">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Save"
-        } %>
-      </div>
-      <div class="govuk-grid-column-full govuk-!-margin-top-3 govuk-body">
-        <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state" %>
-      </div>
-    <% end %>
-  </div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save",
+    margin_bottom: true
+  } %>
+
+  <%= tag.p link_to('Cancel', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>
 <% end %>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -1,34 +1,47 @@
+<%= render "shared/steps/form_errors", resource: step %>
+
+<%= render "govuk_publishing_components/components/contextual_guidance", {
+  html_for: "step-title",
+  title: t("step_by_step_pages.step.title.label"),
+  content: t("step_by_step_pages.step.title.guidance")
+} do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("step_by_step_pages.step.title.label"),
+      bold: true
+    },
+    id: "step-title",
+    name: "step[title]",
+    value: step.title
+  } %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "shared/steps/form_errors", resource: step %>
-
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: "Step title",
-        bold: true
-      },
-      name: "step[title]",
-      value: step.title
-    } %>
-
     <%= render "govuk_publishing_components/components/radio", {
       name: "step[logic]",
-      heading: "Step label",
+      heading: t("step_by_step_pages.step.step_label.label"),
       heading_size: "s",
       items: [
         {
           value: "number",
-          text: "number",
+          text: t("step_by_step_pages.step.step_label.number.label"),
+          hint_text: t("step_by_step_pages.step.step_label.number.hint"),
+          bold: true,
           checked: !step.logic.present? || step.logic == "number"
         },
         {
           value: "and",
-          text: "and",
+          text: t("step_by_step_pages.step.step_label.and.label"),
+          hint_text: t("step_by_step_pages.step.step_label.and.hint"),
+          bold: true,
           checked: step.logic == "and"
         },
         {
           value: "or",
-          text: "or",
+          text: t("step_by_step_pages.step.step_label.or.label"),
+          hint_text: t("step_by_step_pages.step.step_label.or.hint"),
+          bold: true,
           checked: step.logic == "or"
         }
       ]
@@ -40,7 +53,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/details", {
-        title: "View broken links"
+        title: t("step_by_step_pages.step.view_broken_links")
       } do %>
           <% step.broken_links.each.with_index do |link, index| %>
             <dl class="govuk-summary-list">
@@ -91,32 +104,28 @@
   </div>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "components/markdown_editor", {
-      label: {
-        text: "Content, tasks and links in this step",
-        bold: true
-      },
-      textarea: {
-        name: "step[contents]",
-        id: "step-content",
-        rows: 20,
-        value: step.contents
-      }
-    } %>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <%= render 'shared/steps/markdown_help' %>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/contextual_guidance", {
+  html_for: "step-content",
+  title: t("step_by_step_pages.step.content.guidance_title"),
+  content: render_markdown(t("step_by_step_pages.step.content.guidance"))
+} do %>
+  <%= render "components/markdown_editor", {
+    label: {
+      text: t("step_by_step_pages.step.content.label"),
+      bold: true
+    },
+    textarea: {
+      name: "step[contents]",
+      id: "step-content",
+      rows: 20,
+      value: step.contents
+    }
+  } %>
+<% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Save step",
-      margin_bottom: true
-    } %>
-    <%= tag.p (link_to 'Return to overview', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Save step",
+  margin_bottom: true
+} %>
+
+<%= tag.p (link_to 'Return to overview', @step_by_step_page, class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,44 @@ en:
       meta_description:
         label: Meta description
         guidance: "Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters."
+    step:
+      title:
+        label: Step title
+        guidance: "Step title should start with a verb. For example: 'Check you're eligible'"
+      step_label:
+        label: Step label
+        number:
+          label: number
+          hint: "Use ‘number’ to show order of the steps"
+        and:
+          label: and
+          hint: "Use ‘and’ to show when you can (or need) to complete more than one step simultaneously."
+        or:
+          label: or
+          hint: "Use ‘or’ to show when there is an alternative way to complete a step or task."
+      view_broken_links: "View broken links"
+      content:
+        label: "Content, tasks and links"
+        guidance_title: "Describing a step"
+        guidance: |
+          A step can be a task or a group of related tasks. A task is an action the user needs to do, for example Check if you need to apply for a licence. Link the whole sentence - not just the action - and do not add a full stop.
+
+          Start a step with an action and explain the context in the link where possible, for example ‘Check what age you can drive’. Keep it short.
+
+          [The content patterns guidance](https://gov-uk.atlassian.net/wiki/spaces/MS/pages/416317515/Step+and+task+content+patterns)
+
+          ### Formatting
+
+          Links should be task focused. You cannot link only part of a sentence.
+
+          `[Task name](/link)`
+
+          For example: `[book your theory test](/book-theory-test)`
+
+          Only use bullets to show different ways you can perform the same task or different variables that change how you complete the task. Do not use bullets to list tasks that are all essential
+
+          `- [download option 1](/link)`
+          `- [download option 2](/link)`
     reorder:
       instructions_markdown: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
       automatically_updated_markdown: Step numbers will be automatically updated on save.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,21 +7,6 @@ en:
       approved_2i: Approved 2i
       scheduled: Scheduled
       published: Published
-  shared:
-    steps:
-      markdown_help:
-        formatting_guidance: |
-          Paragraphs are separated by empty lines.
-          Use non-bulleted lists for tasks. Add any costs after the link:
-
-           [task name](/link) £10 to £20
-           [task name](/link)
-
-          Only use bullets to show when a task has a number of options to choose from:
-
-          - [download form option 1](/link)
-          - [download form option 2](/link)
-          - bullet with no links
   step_by_step_pages:
     form:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,9 +24,18 @@ en:
           - bullet with no links
   step_by_step_pages:
     form:
+      title:
+        label: Title
+        guidance: "Add step by step after your title unless it will be inappropriate or make the title excessively long. Keep it under 85 characters"
       slug:
         label: Slug
-        hint: No slashes
+        guidance: "Slug is the link for your step by step. It should be lowercase and you should use hyphens to separate words. For example: get-driving-license"
+      introduction:
+        label: Introduction
+        guidance: "The introduction explains what the step by step helps the user do, or what it is. Keep it short. Tell users if it is not relevant to them. Do not include any important information in here that doesn’t exist elsewhere."
+      meta_description:
+        label: Meta description
+        guidance: "Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters."
     reorder:
       instructions_markdown: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
       automatically_updated_markdown: Step numbers will be automatically updated on save.

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -766,14 +766,12 @@ RSpec.feature "Managing step by step pages" do
     then_there_should_be_no_reorder_steps_tab
 
     when_I_view_the_step_by_step_page
-    then_I_can_see_the_steps
-    and_I_cannot_edit_any_steps
+    then_I_can_see_the_step_by_step_details
+    and_I_can_see_the_steps
+    and_I_cannot_edit_details_or_steps
     and_I_cannot_delete_any_steps
     and_I_cannot_add_new_steps
 
-    when_I_edit_the_step_by_step_page
-    then_I_can_see_the_step_by_step_details
-    and_I_cannot_edit_the_step_by_step_details
 
     when_I_visit_the_navigation_rules_page
     then_I_see_pages_included_in_navigation
@@ -794,11 +792,11 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to_not have_link("Reorder steps", :href => step_by_step_page_reorder_path(@step_by_step_page))
   end
 
-  def then_I_can_see_the_steps
+  def and_I_can_see_the_steps
     expect(find(".gem-c-summary-list#steps .govuk-summary-list__row:nth-child(1) .govuk-summary-list__value")).to have_content(@step_by_step_page.steps.first.title)
   end
 
-  def and_I_cannot_edit_any_steps
+  def and_I_cannot_edit_details_or_steps
     expect(page).to_not have_button("Edit")
   end
 
@@ -815,14 +813,6 @@ RSpec.feature "Managing step by step pages" do
     expect(page).to have_content("how-to-be-the-amazing-1")
     expect(page).to have_content("Find out the steps to become amazing")
     expect(page).to have_content("How to be amazing - find out the steps to become amazing")
-  end
-
-  def and_I_cannot_edit_the_step_by_step_details
-    expect(page).to_not have_field("step_by_step_page[title]")
-    expect(page).to_not have_field("step_by_step_page[slug]")
-    expect(page).to_not have_field("step_by_step_page[introduction]")
-    expect(page).to_not have_field("step_by_step_page[description]")
-    expect(page).to_not have_css("button", text: "Save")
   end
 
   def when_I_visit_the_navigation_rules_page

--- a/spec/features/managing_steps_spec.rb
+++ b/spec/features/managing_steps_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature "Managing step by step pages" do
   def and_I_fill_in_the_form_with_content
     fill_in "Step title", with: "Buy Mary Berry's 'Simple Cakes' book"
     choose "number"
-    fill_in "Content, tasks and links in this step", with: "* [Booky booky book book.com](http://bbbb.com)\n* [Words inside cardboard.com](http://wic.com)"
+    fill_in "Content, tasks and links", with: "* [Booky booky book book.com](http://bbbb.com)\n* [Words inside cardboard.com](http://wic.com)"
   end
 
   def and_I_fill_in_the_form


### PR DESCRIPTION
This adds contextual guidance to the add/edit step-by-step and add/edit step pages.

[Trello card - Add Contextual guidance to Add/Edit Content page](https://trello.com/c/nNcyHxaw)
[Trello card - Add Contextual guidance to Add/Edit Step page](https://trello.com/c/d9XCwVa2)