### PR TITLE
Add contextual guidance page

### DIFF
--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -162,6 +162,11 @@ class StepByStepPagesController < ApplicationController
     @parser.issues_for(namespace).map { |error| { text: error } }
   end
 
+  def guidance
+    set_current_page_as_step_by_step
+    render :guidance
+  end
+
 private
 
   def discard_draft

--- a/app/views/step_by_step_pages/guidance.html.erb
+++ b/app/views/step_by_step_pages/guidance.html.erb
@@ -1,0 +1,48 @@
+<%
+  links = [
+    {
+      text: 'Step by step publisher',
+      href: step_by_step_pages_path
+    },
+    {
+      text: @step_by_step_page.title,
+      href: @step_by_step_page
+    },
+    {
+      text: 'Guidance'
+    }
+  ]
+%>
+<%= render 'shared/steps/step_breadcrumb', links: links %>
+
+<% guidance = t("guidance") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3 class="govuk-heading-m"><%= guidance.keys[0].to_s.titleize %></h3>
+    <% guidance[:new_step_by_step][:shared].each do |title, content| %>
+      <h2 class="govuk-heading-s"><%= title.to_s.titleize %></h2>
+      <p class="govuk-body"><%= content %></p>
+    <% end %>
+
+    <h3 class="govuk-heading-m"><%= guidance.keys[1].to_s.titleize %></h3>
+    <% guidance[:new_step][:shared].each do |title, content| %>
+      <% if content %><h2 class="govuk-heading-s"><%= title.to_s.titleize %></h2><% end %>
+      <p class="govuk-body"><%= render_markdown(content) %></p>
+    <% end %>
+
+    <h3 class="govuk-heading-m"><%= guidance.keys[2].to_s.titleize %></h3>
+    <h2 class="govuk-heading-s"><%= guidance[:reorder_steps][:revewer_2i].to_s.titleize %></h2>
+    <p class="govuk-body"><%= guidance[:reorder_steps][:shared] %></p>
+
+    <h3 class="govuk-heading-m"><%= guidance.keys[3].to_s.titleize %></h3>
+    <% guidance[:sidebar_settings][:shared].each do |title, content| %>
+      <% if content %><h2 class="govuk-heading-s"><%= title.to_s.titleize %></h2><% end %>
+      <p class="govuk-body"><%= content %></p>
+    <% end %>
+
+    <% guidance[:secondary_links][:shared].each do |title, content| %>
+      <h3 class="govuk-heading-m"><%= title.to_s.titleize %></h3>
+      <p class="govuk-body"><%= render_markdown(content) %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -45,9 +45,15 @@
 <% if @step_by_step_page.status.submitted_for_2i? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <p class="govuk-body">Not yet claimed for 2i</p>
+    <% if current_user.permissions.include?("2i reviewer") %>
+      <%= link_to "See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page) %>
+    <% end %>
   <% end %>
 <% elsif @step_by_step_page.status.in_review? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <p class="govuk-body">The 2i reviewer is <%= @step_by_step_page.reviewer.name %></p>
+    <% if current_user.permissions.include?("2i reviewer") %>
+      <%= link_to "The 2i reviewer is #{@step_by_step_page.reviewer.name}. See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,3 +86,92 @@ en:
       base_path:
         label: Add new secondary link
         hint: "For example: https://www.gov.uk/pay-vat or /bank-holidays"
+  guidance:
+    new_step_by_step:
+      shared:
+        title:
+          Add step by step after your title unless it will be inappropriate or make the title excessively long. Keep it under 85 characters
+        slug:
+          "Slug is the link for your step by step. It should be lowercase and you should use hyphens to separate words. For example: get-driving-license"
+        introduction:
+          The introduction explains what the step by step helps the user do, or what it is. Keep it short. Tell users if it is not relevant to them. Do not include any important information in here that doesn’t exist elsewhere.
+        meta_description:
+          Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters.
+    new_step:
+      shared:
+        step_title:
+          "Step title should start with a verb. For example: 'Check you're eligible'"
+        step_label: |
+          Use ‘number’
+          Use ‘and’ to show when you can (or need) to complete more than one step simultaneously.
+          Use ‘or’ to show when there is an alternative way to complete a step or task.
+        content,_tasks_and_links: |
+          ## Describing a step
+          A step can be a task or a group of related tasks. A task is an action the user needs to do, for example Check if you need to apply for a licence. Link the whole sentence - not just the action -  and do not add a full stop.
+          Start a step with an action and explain the context in the link where possible, for example 'Check what age you can drive'. Keep it short.
+
+          ## The content patterns guidance.
+
+          ## Formatting
+          Links should be task focused. You cannot link only part of a sentence.
+          
+          `[Task name](/link)` For example: `[book your theory test](/book-theory-test)`
+
+          Only use bullets to show different ways you can perform the same task or different variables that change how you complete the task. Do not use bullets to list tasks that are all essential
+
+          - `[download option 1](/link)`
+          - `[download option 2](/link)`
+    reorder_steps:
+      revewer_2i:
+        Step order
+      shared:
+        Steps and tasks should be listed in the order in which users need to complete them.
+      origin:
+        Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
+        Step numbers will be automatically updated on save.
+    sidebar_settings:
+      shared:
+        Showing or hiding the sidebar:
+
+        Always show navigation:
+          Sidebar will always show on the piece of content. Choose this option if the content is about a task that is always completed as part of the step by step journey. For example, booking a theory driving test is always part of the wider journey of learning to drive.
+
+        Show navigation if users comes from step by step: |
+          Sidebar will only show if you clicked on a link in the step by step to get there For example: If the page is part of multiple user journeys and showing step by steps risks limiting the way the page is used'.
+
+        Never show navigation:
+          Chose this option when you're linking to a page that it would never be appropriate for the step by step side bar to appear on.
+    secondary_links:
+      reviewer_2i:
+        Secondary links
+      shared:
+        Secondary links: |
+          Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
+
+          We use it for content which:
+
+            - could help you complete a task but is not the main piece of content included in the step by step.
+            - is optional and not useful enough to be included in the step by step
+      origin:
+        Add new secondary link:
+          "[Remove the phrase “Base Path” so the only thing left is 'For example: https://www.gov.uk/pay-vat or /bank-holidays']"
+    change_notes:
+      origin:
+        internal_notes:
+          "Add a summary of your changes and why. For example: what’s been added, removed or replaced. Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one."
+        submit_for_2i:
+          "Add a summary of your changes and why. For example: what’s been added, removed or replaced. Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one."
+        request_changes:
+          Explain why the draft hasn't been approved. What needs to change and why.
+        change_note_when_Publishing_old_step_by_step_(if_users_should_be_notified):
+          Describe the change for users. This change note will be emailed to subscribers.
+    summary_page:
+      origin:
+        sidebar_settings:
+          Choose to hide the sidebar on certain pages.
+
+        secondary_links:
+          Choose additional pages to show the step by step sidebar.
+
+        tags:
+          Tag the step by step to the GOV.UK taxonomy and mainstream browse pages.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     post "approve-2i-review", to: "review#approve_2i_review"
     post :check_links
     post "claim-2i-review", to: "review#claim_2i_review"
+    get :guidance
     get "internal-change-notes"
     post "internal-change-notes", to: "internal_change_notes#create"
     get "navigation-rules", to: "navigation_rules#edit"

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Contextual action buttons for step by step pages" do
       then_the_primary_action_should_be "Claim for 2i review"
       and_there_should_be_secondary_actions_to %w(Preview)
       and_there_should_be_tertiary_actions_to %w(Delete)
+      and_there_should_be_a_guidance_link
     end
   end
 
@@ -61,6 +62,7 @@ RSpec.feature "Contextual action buttons for step by step pages" do
       then_the_primary_action_should_be "Approve"
       and_there_should_be_secondary_actions_to ["Request changes", "Preview"]
       and_there_should_be_tertiary_actions_to %w(Delete)
+      and_there_should_be_a_guidance_link
     end
   end
 
@@ -145,5 +147,9 @@ RSpec.feature "Contextual action buttons for step by step pages" do
 
   def action_html
     find(".app-side__actions").native.inner_html.strip
+  end
+
+  def and_there_should_be_a_guidance_link
+    expect(page).to have_link("See guidance for doing 2i review.")
   end
 end


### PR DESCRIPTION
This adds the contextual guidance page, links to it from SBS's that are in review and tests for same. This will provide a place where 2i reviewers can go to see guidance on what the intended use of attributes are.

Trello - https://trello.com/c/K4Uyg9m6/127-add-a-view-giving-some-contextual-guidance-to-2i-reviewers