### PR TITLE
Use update_column for backfilling auth_bypass_id values

### DIFF
--- a/db/migrate/20191008113036_populate_auth_bypass_id.rb
+++ b/db/migrate/20191008113036_populate_auth_bypass_id.rb
@@ -4,7 +4,7 @@ class PopulateAuthBypassId < ActiveRecord::Migration[5.2]
   def up
     StepByStepPage.find_each do |step_by_step|
       auth_bypass_id = generate_legacy_auth_bypass_id(step_by_step.content_id)
-      step_by_step.update(auth_bypass_id: auth_bypass_id)
+      step_by_step.update_column(:auth_bypass_id, auth_bypass_id)
     end
   end
 


### PR DESCRIPTION
This migration was written to use `update`.  This changes the `updated_at` field during the migration (making it look like all step by steps have been modified by a content designer).  Changing to `update_column` so this time is not changed.

This migration has not yet been deployed to production.

Trello card: https://trello.com/c/jKRvjyAe