### PR TITLE
Add link to Content Tagger for step by steps

### DIFF
--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -103,6 +103,21 @@ class StepByStepPagePresenter
     }
   end
 
+  def tags_section
+    {
+      borderless: true,
+      id: "tags",
+      title: "Tags",
+      edit: {
+        link_text: "Edit",
+        href: "#{Plek.find('content-tagger', external: true)}/taggings/#{step_by_step_page.content_id}",
+        data_attributes: {
+          gtm: "edit-topics",
+        },
+      },
+    }
+  end
+
   def last_saved
     last_saved_time = format_full_date_and_time(step_by_step_page.updated_at)
     return "#{last_saved_time} by #{step_by_step_page.assigned_to}" if assigned?

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -76,6 +76,9 @@
         @step_by_step_page_presenter.secondary_links_settings
       ]
     }  %>
+
+    <%= render "govuk_publishing_components/components/summary_list", @step_by_step_page_presenter.tags_section %>
+
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_check_for_broken_links
     and_I_cannot_reorder_the_steps
     and_I_can_see_a_where_to_show_section_with_links "Edit"
+    and_I_can_see_a_tags_section_with_links "Edit"
     and_I_can_see_a_metadata_section
   end
 
@@ -39,6 +40,7 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_edit_and_delete_steps
     and_I_can_reorder_the_steps
     and_I_can_see_a_where_to_show_section_with_links "Edit"
+    and_I_can_see_a_tags_section_with_links "Edit"
     and_I_can_see_a_metadata_section
   end
 
@@ -199,6 +201,7 @@ RSpec.feature "Managing step by step pages" do
       but_I_cannot_edit_or_delete_steps
       and_I_cannot_reorder_the_steps
       and_I_can_see_a_where_to_show_section_with_links "Edit"
+      and_I_can_see_a_tags_section_with_links "Edit"
       then_I_can_preview_the_step_by_step
       and_the_steps_can_be_checked_for_broken_links
     end
@@ -526,6 +529,13 @@ RSpec.feature "Managing step by step pages" do
       expect(page).to have_content "Where to show this step by step"
       expect(page).to have_link(link_text, :href => step_by_step_page_navigation_rules_path(@step_by_step_page))
       expect(page).to have_link(link_text, :href => step_by_step_page_secondary_content_links_path(@step_by_step_page))
+    end
+  end
+
+  def and_I_can_see_a_tags_section_with_links(link_text)
+    within(".gem-c-summary-list#tags") do
+      expect(page).to have_content "Tags"
+      expect(page).to have_link(link_text, :href => "#{Plek.find('content-tagger', external: true)}/taggings/#{@step_by_step_page.content_id}")
     end
   end
 


### PR DESCRIPTION
Adds a link to the step by step in Content Tagger under a new "Tags" section.

The label will always say "Edit", since the tags can be changed regardless of whether the step by step is draft or published.
![Screen Shot 2019-10-11 at 15 20 33](https://user-images.githubusercontent.com/6329861/66661964-d3adfa80-ec3f-11e9-8cdd-a8153b493a1f.png)

Trello card: https://trello.com/c/uoBZfPNn