### PR TITLE
Add contextual guidance for notes

### DIFF
--- a/app/views/review/submit_2i_verdict.erb
+++ b/app/views/review/submit_2i_verdict.erb
@@ -23,26 +23,31 @@
   <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 <% end %>
 
+<%
+  review_phrase = "2i_review_#{approved ? 'approved' : 'request_changes'}"
+  textarea_name = approved ? "additional_comment" : "requested_change"
+  button_text = approved ? "Yes, approve 2i" : "Send change request"
+%>
+
 <%= form_tag do %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "additional-comments",
+    title: t("step_by_step_pages.#{review_phrase}.title"),
+    content: t("step_by_step_pages.#{review_phrase}.guidance")
+  } do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: approved ? "Add a note (optional)" : "Describe changes required"
+          text: t("step_by_step_pages.#{review_phrase}.label")
         },
-        name: approved ? "additional_comment" : "requested_change",
+        id: "additional-comments",
+        name: textarea_name,
       } %>
-    </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
       <%= render "govuk_publishing_components/components/button", {
-        text: approved ? "Yes, approve 2i" : "Send change request"
+        text: button_text,
+        margin_bottom: true
       } %>
-    </div>
-    <div class="govuk-grid-column-full govuk-!-margin-top-3">
-      <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
-    </div>
-  </div>
+
+      <%= tag.p link_to("Cancel", @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
+    <% end %>
 <% end %>

--- a/app/views/review/submit_for_2i.html.erb
+++ b/app/views/review/submit_for_2i.html.erb
@@ -19,25 +19,24 @@
 <% content_for :context, 'Submit for 2i' %>
 
 <%= form_tag do %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Additional comments (optional)"
-        },
-        name: "additional_comments"
-      } %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "additional-comments",
+    title: t("step_by_step_pages.submit_for_2i.title"),
+    content: t("step_by_step_pages.submit_for_2i.guidance")
+  } do %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: t("step_by_step_pages.submit_for_2i.label"),
+        bold: true
+      },
+      id: "additional-comments",
+      name: "additional_comments"
+    } %>
+  <% end %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Submit for 2i"
-      } %>
-    </div>
-    <div class="govuk-grid-column-full govuk-!-margin-top-3">
-      <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link" %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Submit for 2i",
+    margin_bottom: true
+  } %>
+  <%= tag.p link_to("Cancel", @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
 <% end %>

--- a/app/views/step_by_step_pages/internal_change_notes.html.erb
+++ b/app/views/step_by_step_pages/internal_change_notes.html.erb
@@ -20,25 +20,31 @@
 
 <%= render 'nav', step_by_step_page: @step_by_step_page, active: "internal-change-notes" %>
 
+<%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
+  <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+  <%= render "govuk_publishing_components/components/contextual_guidance", {
+    html_for: "internal-change-note-description",
+    title: t("step_by_step_pages.internal_change_notes.label"),
+    content: t("step_by_step_pages.internal_change_notes.guidance")
+  } do %>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: t("step_by_step_pages.internal_change_notes.label"),
+        bold: true
+      },
+      id: "internal-change-note-description",
+      name: "internal_change_note[description]"
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Add internal note",
+    margin_bottom: true
+  } %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for(@internal_change_note, url: step_by_step_page_internal_change_notes_path) do |form| %>
-      <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Internal note",
-          bold: true
-        },
-        name: "internal_change_note[description]"
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Add internal note",
-        margin_bottom: true
-      } %>
-    <% end %>
-
     <%= render "govuk_publishing_components/components/accordion", {
       items: @step_by_step_page.internal_change_notes
         .group_by { |edition| edition.edition_number }

--- a/app/views/step_by_step_pages/publish.html.erb
+++ b/app/views/step_by_step_pages/publish.html.erb
@@ -25,14 +25,10 @@
 <%= form_tag do %>
   <%= render "step_by_step_pages/change_notes" %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Publish"
-      } %>
-    </div>
-    <div class="govuk-grid-column-full govuk-!-margin-top-3">
-      <%= link_to 'Cancel', @step_by_step_page, class: "govuk-link" %>
-    </div>
-  </div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Publish",
+    margin_bottom: true
+  } %>
+
+  <%= tag.p link_to('Cancel', @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
 <% end %>

--- a/app/views/step_by_step_pages/schedule.html.erb
+++ b/app/views/step_by_step_pages/schedule.html.erb
@@ -22,21 +22,13 @@
   <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
 <% end %>
 
-<div class="row">
-  <div class="col-md-7">
-    <%= form_tag(step_by_step_page_schedule_datetime_path(@step_by_step_page)) do %>
-      <%= render "step_by_step_pages/change_notes" %>
+<%= form_tag(step_by_step_page_schedule_datetime_path(@step_by_step_page)) do %>
+  <%= render "step_by_step_pages/change_notes" %>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Continue",
-          } %>
-        </div>
-        <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Continue",
+    margin_bottom: true
+  } %>
+
+  <%= tag.p link_to("Cancel", @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
+<% end %>

--- a/app/views/step_by_step_pages/schedule_datetime.html.erb
+++ b/app/views/step_by_step_pages/schedule_datetime.html.erb
@@ -26,62 +26,54 @@
   <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("step_by_step_pages.schedule_datetime.date.label") %></span>
 <% end %>
 
-<div class="row">
-  <div class="col-md-7">
-    <%= form_tag do %>
-      <%= render "govuk_publishing_components/components/date_input", {
-        legend_text: legend,
-        name: "schedule[date]",
-        hint: t("step_by_step_pages.schedule_datetime.date.hint"),
-        id: "date",
-        error_items: issues_for(:date),
-        items: [
-          {
-            name: "day",
-            width: 2,
-            value: @schedule_placeholder[:day]
-          },
-          {
-            name: "month",
-            width: 2,
-            value: @schedule_placeholder[:month]
-          },
-          {
-            name: "year",
-            width: 4,
-            value: @schedule_placeholder[:year]
-          }
-        ]
-      } %>
+<%= form_tag do %>
+  <%= render "govuk_publishing_components/components/date_input", {
+    legend_text: legend,
+    name: "schedule[date]",
+    hint: t("step_by_step_pages.schedule_datetime.date.hint"),
+    id: "date",
+    error_items: issues_for(:date),
+    items: [
+      {
+        name: "day",
+        width: 2,
+        value: @schedule_placeholder[:day]
+      },
+      {
+        name: "month",
+        width: 2,
+        value: @schedule_placeholder[:month]
+      },
+      {
+        name: "year",
+        width: 4,
+        value: @schedule_placeholder[:year]
+      }
+    ]
+  } %>
 
-      <%= render "components/autocomplete", {
-        id: "time",
-        name: "schedule[time]",
-        label: {
-          text: t("step_by_step_pages.schedule_datetime.date.label"),
-          bold: true,
-        },
-        input: {
-          options: time_options,
-          value: @schedule_placeholder[:time],
-        },
-        error_items: issues_for(:time),
-        data_attributes: {
-          "autocomplete-without-narrowing-results": true,
-        },
-        width: "narrow",
-      } %>
+  <%= render "components/autocomplete", {
+    id: "time",
+    name: "schedule[time]",
+    label: {
+      text: t("step_by_step_pages.schedule_datetime.date.label"),
+      bold: true,
+    },
+    input: {
+      options: time_options,
+      value: @schedule_placeholder[:time],
+    },
+    error_items: issues_for(:time),
+    data_attributes: {
+      "autocomplete-without-narrowing-results": true,
+    },
+    width: "narrow"
+  } %>
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Schedule to publish",
-          } %>
-        </div>
-        <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to "Cancel", @step_by_step_page, class: "govuk-link" %>
-        </div>
-      </div>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Schedule to publish",
+    margin_bottom: true
+  } %>
+
+  <%= tag.p link_to("Cancel", @step_by_step_page, class: "govuk-link"), class: "govuk-body" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,11 @@ en:
     reorder:
       instructions_markdown: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
       automatically_updated_markdown: Step numbers will be automatically updated on save.
+    internal_change_notes:
+      label: Internal note
+      guidance: |
+        Add a summary of your changes and why. For example: what’s been added, removed or replaced.
+        Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one.
     change_notes:
       title: Notify users about this change?
       label: Public change note

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,12 @@ en:
       title: Notify users about this change?
       label: Public change note
       hint: Describe the change for users. This change note will be emailed to subscribers.
+    submit_for_2i:
+      label: Additional comments (optional)
+      title: Submit for 2i
+      guidance: |
+        Add a summary of your changes and why. For example: what’s been added, removed or replaced.
+        Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one.
     schedule_datetime:
       date:
         label: Date
@@ -134,7 +140,7 @@ en:
 
           ## Formatting
           Links should be task focused. You cannot link only part of a sentence.
-          
+
           `[Task name](/link)` For example: `[book your theory test](/book-theory-test)`
 
           Only use bullets to show different ways you can perform the same task or different variables that change how you complete the task. Do not use bullets to list tasks that are all essential

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,6 +77,14 @@ en:
       guidance: |
         Add a summary of your changes and why. For example: what’s been added, removed or replaced.
         Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one.
+    2i_review_approved:
+      label: Add a note (optional)
+      title: Approve step by step
+      guidance: Leave a note if something needs to be changed before publishing.
+    2i_review_request_changes:
+      label: Describe changes required
+      title: Request changes to step by step
+      guidance: Explain why the draft hasn't been approved. What needs to change and why.
     schedule_datetime:
       date:
         label: Date


### PR DESCRIPTION
Add Contextual guidance to change notes:
- internal change notes (on history page)
- notes when submitting for 2i
- notes when requesting changes or approving
- notes when publishing or scheduling

[Trello card](https://trello.com/c/EOm5X8Mp)