### PR TITLE
Add guidance to sidebar settings and secondary links pages

### DIFF
--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -21,67 +21,64 @@
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
 <div class="govuk-grid-row">
-    <%= form_for(step_by_step_page_navigation_rules_path(@step_by_step_page), method: :put) do |form| %>
-      <div class="govuk-grid-column-full">
-        <table class="govuk-table table-stepnav-rules" data-module="filterable-table">
-          <thead class="govuk-table__head">
-            <tr>
-              <th class="govuk-table__header" scope="col">Page title</th>
-              <th class="govuk-table__header" scope="col">Path</th>
-              <th class="govuk-table__header" scope="col">Sidebar content of page</th>
-            </tr>
-          </thead>
+  <%= form_for(step_by_step_page_navigation_rules_path(@step_by_step_page), method: :put) do |form| %>
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table table-stepnav-rules">
+        <thead class="govuk-table__head">
+          <tr>
+            <th class="govuk-table__header" scope="col">Page title</th>
+            <th class="govuk-table__header" scope="col">Path</th>
+            <th class="govuk-table__header" scope="col">Sidebar content of page</th>
+          </tr>
+        </thead>
 
-          <tbody class="govuk-table__body">
-            <% if @step_by_step_page.navigation_rules.present? %>
-              <% @step_by_step_page.navigation_rules.each do |navigation_rule| %>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell"><%= link_to(navigation_rule.title, draft_govuk_url(navigation_rule.base_path), class: "govuk-link") %></td>
-                  <td class="govuk-table__cell"><%= navigation_rule.base_path %></td>
-                  <td class="govuk-table__cell">
-                    <% if @step_by_step_page.can_be_edited? %>
-                      <%= render "govuk_publishing_components/components/select", {
-                        id: "navigation_rules[#{navigation_rule.content_id}]",
-                        label: "",
-                        options: [
-                          {
-                            text: navigation_rule.display_text("always"),
-                            value: "always",
-                            selected: true
-                          },
-                          {
-                            text: navigation_rule.display_text("conditionally"),
-                            value: "conditionally",
-                          },
-                          {
-                            text: navigation_rule.display_text("never"),
-                            value: "never"
-                          }
-                        ].each{ |item| item[:selected] = item[:value] == navigation_rule.include_in_links }
-                      } %>
-                    <% else %>
-                      <%= tag.p navigation_rule.display_text(navigation_rule.include_in_links), id: "navigation_rules[#{navigation_rule.content_id}]" %>
-                    <% end %>
-                  </td>
-                </tr>
-              <% end %>
-            <% else %>
+        <tbody class="govuk-table__body">
+          <% if @step_by_step_page.navigation_rules.present? %>
+            <% @step_by_step_page.navigation_rules.each do |navigation_rule| %>
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell" colspan="3">
-                  <p class="govuk-hint">No links exist</p>
-                </tr>
+                <td class="govuk-table__cell"><%= link_to(navigation_rule.title, draft_govuk_url(navigation_rule.base_path), class: "govuk-link") %></td>
+                <td class="govuk-table__cell"><%= navigation_rule.base_path %></td>
+                <td class="govuk-table__cell">
+                  <% if @step_by_step_page.can_be_edited? %>
+                    <%= render "govuk_publishing_components/components/select", {
+                      id: "navigation_rules[#{navigation_rule.content_id}]",
+                      label: "",
+                      options: [
+                        {
+                          text: navigation_rule.display_text("always"),
+                          value: "always",
+                          selected: true
+                        },
+                        {
+                          text: navigation_rule.display_text("conditionally"),
+                          value: "conditionally",
+                        },
+                        {
+                          text: navigation_rule.display_text("never"),
+                          value: "never"
+                        }
+                      ].each{ |item| item[:selected] = item[:value] == navigation_rule.include_in_links }
+                    } %>
+                  <% else %>
+                    <%= tag.p navigation_rule.display_text(navigation_rule.include_in_links), id: "navigation_rules[#{navigation_rule.content_id}]" %>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
-          </tbody>
-        </table>
-      </div>
-      <% if @step_by_step_page.navigation_rules.present? && @step_by_step_page.can_be_edited?%>
-        <div class="govuk-grid-column-full">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Save"
-          } %>
-        </div>
-      <% end %>
+          <% else %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell" colspan="3">
+                <p class="govuk-hint">No links exist</p>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+    <% if @step_by_step_page.navigation_rules.present? && @step_by_step_page.can_be_edited?%>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save"
+      } %>
     <% end %>
-  </div>
+  <% end %>
 </div>

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -21,6 +21,12 @@
 <%= render 'shared/steps/form_notice', message: notice, status: "success" %>
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+    <%= render_markdown t("sidebar_settings.guidance_markdown") %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
   <%= form_for(step_by_step_page_navigation_rules_path(@step_by_step_page), method: :put) do |form| %>
     <div class="govuk-grid-column-full">
       <table class="govuk-table table-stepnav-rules">

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -19,41 +19,32 @@
 <% content_for :context, 'Secondary links' %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <%= render_markdown t("secondary_content_links.guidance_markdown") %>
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-!-margin-bottom-6">
+      <%= render_markdown t("secondary_content_links.guidance_markdown") %>
+    </div>
+
+    <% if @step_by_step_page.can_be_edited? %>
+      <%= form_for(@secondary_content_link, url: step_by_step_page_secondary_content_links_path) do |form| %>
+        <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: t("secondary_content_links.index.base_path.label")
+          },
+          hint: t("secondary_content_links.index.base_path.hint"),
+          name: "base_path",
+          heading_size: "m"
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Add secondary link"
+        } %>
+      <% end %>
+    <% end %>
   </div>
 </div>
 
-<% if @step_by_step_page.can_be_edited? %>
-  <div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-    <div class="govuk-grid-column-full">
-      <%= form_for(@secondary_content_link, url: step_by_step_page_secondary_content_links_path) do |form| %>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <%= render "shared/steps/form_errors", resource: @step_by_step_page %>
-
-            <%= render "govuk_publishing_components/components/input", {
-              label: {
-                text: t("secondary_content_links.index.base_path.label")
-              },
-              hint: t("secondary_content_links.index.base_path.hint"),
-              name: "base_path",
-              heading_size: "m"
-            } %>
-          </div>
-        </div>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-full">
-            <%= render "govuk_publishing_components/components/button", {
-              text: "Add secondary link"
-            } %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
-  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-<% end %>
+<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
 <div class="govuk-grid-row secondary-links govuk-!-margin-top-6">
   <div class="govuk-grid-column-full">
@@ -90,7 +81,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" colspan="3">
             <p class="govuk-hint">No secondary links have been added yet.</p>
-          </tr>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,14 +90,13 @@ en:
 
   secondary_content_links:
     guidance_markdown: |
-      ##What is secondary content?
-
       Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
 
       We use it for content which:
 
       - could help you complete a task but is not the main piece of content included in the step by step
       - is optional and not useful enough to be included in the step by step
+
     index:
       base_path:
         label: Add new secondary link

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,22 @@ en:
         hint: For example, 01 08 2027
       time:
         label: Time
+  sidebar_settings:
+    guidance_markdown: |
+      ## Showing or hiding the sidebar
+
+      ### Always show navigation
+
+      Sidebar will always show on the piece of content. Choose this option if the content is about a task that is always completed as part of the step by step journey. For example, booking a theory driving test is always part of the wider journey of learning to drive.
+
+      ### Show navigation if users comes from step by step
+
+      Sidebar will only show if you clicked on a link in the step by step to get there For example: If the page is part of multiple user journeys and showing step by steps risks limiting the way the page is used'.
+
+      ### Never show navigation
+
+      Chose this option when you're linking to a page that it would never be appropriate for the step by step side bar to appear on.
+
   secondary_content_links:
     guidance_markdown: |
       ##What is secondary content?


### PR DESCRIPTION
This PR
 - adds guidance to sidebar settings page and fixes broken markup
 - adds guidance to secondary links page and fixes broken markup

[Trello card](https://trello.com/c/ij0U9BPn)