### PR TITLE
Add guidance to the summary page

### DIFF
--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -1,6 +1,8 @@
 class StepByStepPagePresenter
   include Rails.application.routes.url_helpers
   include TimeOptionsHelper
+  include ActionView::Helpers::TagHelper
+
   attr_reader :step_by_step_page
 
   def initialize(step_by_step_page)
@@ -80,6 +82,7 @@ class StepByStepPagePresenter
   def sidebar_settings
     {
       field: "Sidebar settings",
+      value:  tag.span(I18n.t("guidance.summary_page.origin.sidebar_settings"), class: "govuk-hint"),
       edit: {
         link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
         href: step_by_step_page_navigation_rules_path(step_by_step_page),
@@ -93,6 +96,7 @@ class StepByStepPagePresenter
   def secondary_links_settings
     {
       field: "Secondary links",
+      value: tag.span(I18n.t("guidance.summary_page.origin.secondary_links"), class: "govuk-hint"),
       edit: {
         link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
         href: step_by_step_page_secondary_content_links_path(step_by_step_page),
@@ -108,6 +112,7 @@ class StepByStepPagePresenter
       borderless: true,
       id: "tags",
       title: "Tags",
+      block: tag.span(I18n.t("guidance.summary_page.origin.tags"), class: "govuk-hint"),
       edit: {
         link_text: "Edit",
         href: "#{Plek.find('content-tagger', external: true)}/taggings/#{step_by_step_page.content_id}",


### PR DESCRIPTION
Add guidance to sidebar setting, secondary links and tags as hint texts to differentiate it from filled in values (such as title, meta description or step title).

[Trello card](https://trello.com/c/xvy3LfAS)