### PR TITLE
Show Revert to draft link when step by step is submitted for 2i and in review

### DIFF
--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -16,6 +16,13 @@ module StepNavActionsHelper
       !step_by_step_page.broken_links_found?
   end
 
+  def can_revert_to_draft?(step_by_step_page, user)
+    return true if step_by_step_page.status.approved_2i?
+
+    %w[submitted_for_2i in_review].include?(step_by_step_page.status) &&
+      step_by_step_page.review_requester_id == user.uid
+  end
+
 private
 
   def can_claim_first_review?(step_by_step_page, user)

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -57,7 +57,7 @@
       <%= preview_link %>
     <% end %>
 
-    <% if @step_by_step_page.status.approved_2i? %>
+    <% if can_revert_to_draft?(@step_by_step_page, current_user) %>
       <%= link_to 'Revert to draft', { controller: "review", action: "revert_to_draft", step_by_step_page_id: @step_by_step_page.id }, method: :post, data: { confirm: 'This will remove existing 2i approval. Do you want to revert to draft?' }, class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
     <% end %>
 

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Contextual action buttons for step by step pages" do
       when_I_visit_the_step_by_step_page
       then_there_should_be_no_primary_action
       and_there_should_be_secondary_actions_to %w(Preview)
-      and_there_should_be_tertiary_actions_to %w(Delete)
+      and_there_should_be_tertiary_actions_to ["Revert to draft", "Delete"]
     end
 
     scenario "show the relevant actions to the step by step 2i reviewer" do
@@ -53,7 +53,7 @@ RSpec.feature "Contextual action buttons for step by step pages" do
       when_I_visit_the_step_by_step_page
       then_there_should_be_no_primary_action
       and_there_should_be_secondary_actions_to %w(Preview)
-      and_there_should_be_tertiary_actions_to %w(Delete)
+      and_there_should_be_tertiary_actions_to ["Revert to draft", "Delete"]
     end
 
     scenario "show the relevant actions to the step by step 2i reviewer" do


### PR DESCRIPTION
This allows the author to revert to draft when the Step by step is in `submitted_for_2i` state or in `in_review` state.

**Before**
<img width="733" alt="before" src="https://user-images.githubusercontent.com/38078064/66897137-43c8d180-efee-11e9-9aaf-3ccd4565faf1.png">

**After**
<img width="787" alt="after" src="https://user-images.githubusercontent.com/38078064/66901685-13d1fc00-eff7-11e9-952d-3a7a57d6562a.png">

[Trello card](https://trello.com/c/FoRZjA0I/164-when-a-sbs-is-submitted-for-2i-theres-no-revert-to-draft-link-only-an-unpublish-option)

_Note:_ Functionality that allows the reviewer to abandon review will be added as a separate PR. 

