### PR TITLE
Fix bug that caused box to appear with no suggestions

### DIFF
--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -38,6 +38,12 @@
           </li>
         <% end %>
       <% end %>
+
+      <% if @step_by_step_page.status.draft? || @step_by_step_page.status.submitted_for_2i? %>
+        <li>
+          <p class="govuk-body">Get 2i approval</p>
+        </li>
+      <% end %>
     </ul>
   <% end %>
 <% end %>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -272,6 +272,7 @@ RSpec.feature "Managing step by step pages" do
     when_I_view_the_step_by_step_page
     then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_prompt_text "Add content to all your steps"
+    and_the_prompt_should_contain_prompt_text "Get 2i approval"
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
@@ -357,6 +358,7 @@ RSpec.feature "Managing step by step pages" do
     then_I_should_see_an_inset_prompt
     and_the_prompt_should_contain_prompt_text "Add content to all your steps"
     and_the_prompt_should_contain_prompt_text "Check for broken links"
+    and_the_prompt_should_contain_prompt_text "Get 2i approval"
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 


### PR DESCRIPTION
Adds in a check for the status of a SBS and provides guidance accordingly. This should stop a bug where the "To publish this SBS you need to" box appeared without giving any suggestions.

Trello - https://trello.com/c/7IzRnut3/163-to-publish-this-sbs-you-need-to-doesnt-list-any-things-the-user-needs-to-do