### PR TITLE
Broken links bug

### DIFF
--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -9,6 +9,12 @@ module StepNavActionsHelper
       step_by_step_page.reviewer_id == user.uid
   end
 
+  def must_check_for_broken_links?(step_by_step_page)
+    step_by_step_page.steps.any? &&
+      !step_by_step_page.links_checked_since_last_update? &&
+      !step_by_step_page.broken_links_found?
+  end
+
 private
 
   def can_claim_first_review?(step_by_step_page, user)

--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -11,6 +11,7 @@ module StepNavActionsHelper
 
   def must_check_for_broken_links?(step_by_step_page)
     step_by_step_page.steps.any? &&
+      contains_links?(step_by_step_page) &&
       !step_by_step_page.links_checked_since_last_update? &&
       !step_by_step_page.broken_links_found?
   end
@@ -28,5 +29,13 @@ private
       step_by_step_page.review_requester_id != user.uid &&
       step_by_step_page.reviewer_id != user.uid &&
       user.has_permission?("2i reviewer")
+  end
+
+  def contains_links?(step_by_step_page)
+    step_by_step_page.steps.each do |step|
+      return true if StepContentParser.new.all_paths(step.contents).any?
+    end
+
+    false
   end
 end

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -15,7 +15,7 @@
         </li>
       <% end %>
 
-      <% if @step_by_step_page.steps.any? && !@step_by_step_page.links_checked_since_last_update? && !@step_by_step_page.broken_links_found? %>
+      <% if must_check_for_broken_links?(@step_by_step_page) %>
         <li>
           Check for broken links
         </li>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -9,7 +9,7 @@
         </li>
       <% end %>
 
-      <% if @step_by_step_page.steps.any? && !@step_by_step_page.steps_have_content? %>
+      <% if !@step_by_step_page.steps_have_content? %>
         <li>
           Add content to all your steps
         </li>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -44,6 +44,13 @@ RSpec.feature "Managing step by step pages" do
     and_I_can_see_a_metadata_section
   end
 
+  scenario "User visits a step by step page with steps with no links" do
+    given_there_is_a_step_by_step_page_with_steps_without_links
+    when_I_view_the_step_by_step_page
+    then_I_should_see_an_inset_prompt
+    and_the_prompt_should_not_contain "Check for broken links"
+  end
+
   scenario "User edits step by step information" do
     given_there_is_a_step_by_step_page
     when_I_edit_the_step_by_step_page

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe StepNavActionsHelper do
       expect(helper.must_check_for_broken_links?(step_by_step_page)).to be false
     end
 
+    it "returns false if there aren't any steps with links" do
+      step_by_step_page = create(:step_by_step_page)
+      create(:or_step, step_by_step_page: step_by_step_page)
+
+      expect(helper.must_check_for_broken_links?(step_by_step_page)).to be false
+    end
+
     context "steps with links" do
       it "returns true if there are internal links and link checker hasn't been run" do
         step_by_step_page = create(:draft_step_by_step_page)

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -168,6 +168,11 @@ module StepNavSteps
     create(:step, step_by_step_page: @step_by_step_page, contents: "")
   end
 
+  def given_there_is_a_step_by_step_page_with_steps_without_links
+    @step_by_step_page = create(:step_by_step_page)
+    create(:step, step_by_step_page: @step_by_step_page, contents: "content here but no links")
+  end
+
   def given_there_are_step_by_step_pages
     @step_by_step_pages = [
       create(:draft_step_by_step_page, title: "A draft step nav", slug: "a-draft-step-nav"),


### PR DESCRIPTION
Trello - https://trello.com/c/XM016j2s/149-bug-check-for-broken-links-when-there-are-no-links

## What's changed and why?
Stops a message from appearing at the top of the page asking the user to "Check for broken links" if the step-by-step doesn't contain any links.

