### PR TITLE
Remove fix broken links requirement

### DIFF
--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -12,8 +12,7 @@ module StepNavActionsHelper
   def must_check_for_broken_links?(step_by_step_page)
     step_by_step_page.steps.any? &&
       contains_links?(step_by_step_page) &&
-      !step_by_step_page.links_checked_since_last_update? &&
-      !step_by_step_page.broken_links_found?
+      !step_by_step_page.links_checked_since_last_update?
   end
 
 private

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -141,10 +141,6 @@ class StepByStepPage < ApplicationRecord
     (has_draft? && !scheduled_for_publishing? && !can_be_published?) || status.in_review?
   end
 
-  def broken_links_found?
-    steps.any?(&:broken_links?)
-  end
-
   def links_checked_since_last_update?
     (links_checked? && links_last_checked_date > draft_updated_at) || status.approved_2i?
   end

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -110,7 +110,6 @@ class StepByStepPage < ApplicationRecord
       !scheduled_for_publishing? &&
       steps_have_content? &&
       links_checked_since_last_update? &&
-      !broken_links_found? &&
       status.approved_2i?
   end
 

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -21,12 +21,6 @@
         </li>
       <% end %>
 
-      <% if @step_by_step_page.broken_links_found? %>
-        <li>
-          Fix broken links
-        </li>
-      <% end %>
-
       <% if @step_by_step_page.status.in_review? %>
         <% if current_user.uid == @step_by_step_page.reviewer_id %>
           <li>

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -342,15 +342,6 @@ RSpec.feature "Managing step by step pages" do
     and_I_cannot_publish_or_schedule_the_step_by_step
   end
 
-  scenario "Step by step contains broken links" do
-    given_there_is_a_step_by_step_page_with_broken_links_and_unpublished_changes
-    when_I_view_the_step_by_step_page
-    then_I_should_see_an_inset_prompt
-    and_the_prompt_should_contain_prompt_text "Fix broken links"
-    and_the_prompt_should_not_contain "Check for broken links"
-    and_I_cannot_publish_or_schedule_the_step_by_step
-  end
-
   scenario "Step by step has been updated since it was last checked for broken links" do
     given_a_step_by_step_has_been_updated_after_links_last_checked
     when_I_view_the_step_by_step_page

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe StepNavActionsHelper do
         expect(helper.must_check_for_broken_links?(step_by_step_page)).to be true
       end
 
-      it "returns false if link checker has been run and there are no broken links" do
+      it "returns false if link checker has been run since the last update" do
         step_by_step_page = create(:draft_step_by_step_page)
-        stub_link_checker_report_success(step_by_step_page.steps.first)
+        stub_link_checker_report_broken_link(step_by_step_page.steps.first)
 
         expect(helper.must_check_for_broken_links?(step_by_step_page)).to be false
       end

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -306,28 +306,6 @@ RSpec.describe StepByStepPage do
     end
   end
 
-  describe "broken_links_found?" do
-    let(:step_by_step_page) { create(:step_by_step_page_with_steps) }
-
-    it "returns false if links have not been checked" do
-      allow(step_by_step_page).to receive(:links_checked?).and_return(false)
-
-      expect(step_by_step_page.broken_links_found?).to be false
-    end
-
-    it "returns false if links have been checked and there were no broken links" do
-      stub_link_checker_report_success(step_by_step_page.steps.first)
-
-      expect(step_by_step_page.broken_links_found?).to be false
-    end
-
-    it "returns true if broken links were found" do
-      stub_link_checker_report_multiple_broken_links(step_by_step_page.steps.first)
-
-      expect(step_by_step_page.broken_links_found?).to be true
-    end
-  end
-
   describe "links_checked?" do
     it "returns true if links have been checked" do
       step_by_step_with_step = create(:step_by_step_page)

--- a/spec/models/step_by_step_page_spec.rb
+++ b/spec/models/step_by_step_page_spec.rb
@@ -513,13 +513,6 @@ RSpec.describe StepByStepPage do
       expect(step_by_step_page.can_be_published?).to be false
     end
 
-    it "cannot be published if broken links were found when links were checked" do
-      step_by_step_page.mark_draft_updated
-      stub_link_checker_report_broken_link(step_by_step_page.steps.first)
-
-      expect(step_by_step_page.can_be_published?).to be false
-    end
-
     it "cannot be published if it is not 2i approved" do
       step_by_step_page.mark_draft_updated
       step_by_step_page.status = "in_review"

--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -115,12 +115,6 @@ module StepNavSteps
 
   alias_method :given_there_is_an_approved_2i_step_that_has_no_broken_links, :given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
 
-  def given_there_is_a_step_by_step_page_with_broken_links_and_unpublished_changes
-    step = create(:step)
-    stub_link_checker_report_broken_link(step)
-    @step_by_step_page = create(:step_by_step_page, steps: [step], draft_updated_at: Time.zone.now, slug: "step-by-step-with-broken-links-and-unpublished-changes")
-  end
-
   def given_there_is_a_step_by_step_page_with_unpublished_changes_whose_links_have_been_checked
     step = create(:step)
     stub_link_checker_report_success(step)


### PR DESCRIPTION
Trello: https://trello.com/c/t2MylOor
Reverts changes made in PR #754 

## What's changed?

Remove the requirement that forced users to fix all of the broken links before they can publish step-by-steps.

## Why?

In many cases step-by-steps contain links to draft content or other draft step-by-steps. It's also possible to for draft step-by-steps to be linked to each other. As Link Checker API doesn't handle draft content, and can only check links that are publicly accessible, publishers could end up in a chicken or egg situation where they can't publish any step-by-steps.

## Expected changes
### Before
![Screen Shot 2019-10-18 at 15 42 34](https://user-images.githubusercontent.com/5793815/67103932-f733f080-f1bd-11e9-9832-97c13d63efc6.png)

### After
![Screen Shot 2019-10-18 at 15 42 44](https://user-images.githubusercontent.com/5793815/67103941-fbf8a480-f1bd-11e9-8054-db5d2225adc2.png)