### PR TITLE
Remove duplicated 2i reviewer name

### DIFF
--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -52,14 +52,14 @@
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <p class="govuk-body">Not yet claimed for 2i</p>
     <% if current_user.permissions.include?("2i reviewer") %>
-      <%= link_to "See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page) %>
+      <%= tag.p link_to("See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page), class: "govuk-link"), class: "govuk-body" %>
     <% end %>
   <% end %>
 <% elsif @step_by_step_page.status.in_review? %>
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <p class="govuk-body">The 2i reviewer is <%= @step_by_step_page.reviewer.name %></p>
     <% if current_user.permissions.include?("2i reviewer") %>
-      <%= link_to "See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page) %>
+      <%= tag.p link_to("See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page), class: "govuk-link"), class: "govuk-body" %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/step_by_step_pages/show/_required_actions.html.erb
+++ b/app/views/step_by_step_pages/show/_required_actions.html.erb
@@ -59,7 +59,7 @@
   <%= render "govuk_publishing_components/components/inset_text" do %>
     <p class="govuk-body">The 2i reviewer is <%= @step_by_step_page.reviewer.name %></p>
     <% if current_user.permissions.include?("2i reviewer") %>
-      <%= link_to "The 2i reviewer is #{@step_by_step_page.reviewer.name}. See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page) %>
+      <%= link_to "See guidance for doing 2i review.", step_by_step_page_guidance_path(@step_by_step_page) %>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The 2i reviewer name was appearing twice.  This removes the duplication, by removing the name from the link.

Example:
<img width="744" alt="Screen Shot 2019-10-21 at 10 52 07" src="https://user-images.githubusercontent.com/6329861/67195460-e1f2d800-f3f0-11e9-99a1-ab9e3ed48192.png">