### PR TITLE
Use new auth_bypass_ids field in publishing-api

### DIFF
--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -46,7 +46,7 @@ private
 
   def optional_fields
     fields = {}
-    fields[:access_limited] = access_limited_tokens if step_nav.has_draft?
+    fields[:auth_bypass_ids] = [step_nav.auth_bypass_id] if step_nav.has_draft?
     fields
   end
 
@@ -102,10 +102,6 @@ private
 
   def secondary_to_step_nav_links
     step_nav.secondary_content_links.pluck(:content_id) + done_page_content_ids(base_paths_for_secondary_content_links)
-  end
-
-  def access_limited_tokens
-    { auth_bypass_ids: [step_nav.auth_bypass_id] }
   end
 
   def done_page_content_ids(base_paths)

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -64,11 +64,9 @@ RSpec.describe StepNavPresenter do
         step_nav.mark_draft_updated
 
         presented = subject.render_for_publishing_api
-        expected_access_limited_tokens = {
-          auth_bypass_ids: %w(123),
-        }
+        expected_auth_bypass_ids = %w(123)
 
-        expect(presented[:access_limited]).to eq(expected_access_limited_tokens)
+        expect(presented[:auth_bypass_ids]).to eq(expected_auth_bypass_ids)
       end
 
       it "doesn't add an access limiting token when publishing" do

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe StepNavPublisher do
     context "published step by step having a step edited" do
       let(:step_nav) { create(:published_step_by_step_page) }
 
-      it "defines :access_limited in the publishing-api payload" do
+      it "defines :auth_bypass_ids in the publishing-api payload" do
         StepNavPublisher.update(step_nav)
         content_id = /[0-9a-f]{5,40}/ # changes on each test run, as does Array value below
-        payload = hash_including(:access_limited => { :auth_bypass_ids => instance_of(Array) })
+        payload = hash_including(:auth_bypass_ids => instance_of(Array))
         expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/sUjBwDG0

Follows on from: 
* https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md
* https://github.com/alphagov/publishing-api/pull/1614

`auth_bypass_ids` have been separated from the `access_limited` hash in publishing-api.
This updates collections-publisher to send `auth_bypass_ids` to the new field.