### PR TITLE
Deal with internal step links without a protocol

### DIFF
--- a/app/services/step_content_parser.rb
+++ b/app/services/step_content_parser.rb
@@ -66,7 +66,7 @@ private
   end
 
   def external_links(content)
-    all_links_in_content(content) - relative_paths(content)
+    all_links_in_content(content).reject { |href| href.match?(GOVUK_DOMAIN_REGEX) } - relative_paths(content)
   end
 
   def internal_links(content)

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -532,15 +532,15 @@ RSpec.describe StepContentParser do
         expect(subject.all_paths(test_text)).to be_empty
       end
     end
-    context "when there is one relative and one absolute path" do
-      test_text = "[Learn to drive](/learn-to-drive)\n[Google it](https://www.google.com)"
+    context "when there is one relative, one absolute path with protocol and one absolute path without protocol" do
+      test_text = "[Learn to drive](/learn-to-drive)\n[Google it](https://www.google.com)\n[Random page](www.gov.uk/random)"
       it "should return an array of URLs" do
         links = subject.all_paths(test_text)
         expect(links).to all(start_with("https:"))
       end
-      it "should have a length of two" do
+      it "should have a length of three" do
         links = subject.all_paths(test_text)
-        expect(links.length).to eql 2
+        expect(links.length).to eql 3
       end
     end
   end

--- a/spec/services/step_content_parser_spec.rb
+++ b/spec/services/step_content_parser_spec.rb
@@ -371,6 +371,20 @@ RSpec.describe StepContentParser do
       )
     end
 
+    it "allows GOV.UK urls without protocols" do
+      step_text = <<~HEREDOC
+        - [Link without www ](gov.uk/link)
+        - [Link with www    ](www.gov.uk/link-with-www)
+      HEREDOC
+
+      expect(subject.base_paths(step_text)).to eq(
+        %w(
+          /link
+          /link-with-www
+        ),
+      )
+    end
+
     it "rejects invalid URLs" do
       step_text = <<~HEREDOC
         [All the prizes](/all-the-prizes)


### PR DESCRIPTION
We are currently treating step links with a URL that has no protocol (e.g. `www.gov.uk/random` or `gov.uk/random`) as external links and therefore sending the URL as-is to link checker.  The link check fails due to no protocol.

This change removes these URLs from the external links array, so they get treated as internal links.

Trello card: https://trello.com/c/yRlt59zb