### PR TITLE
Update status on page refresh after update

### DIFF
--- a/app/controllers/secondary_content_links_controller.rb
+++ b/app/controllers/secondary_content_links_controller.rb
@@ -6,7 +6,7 @@ class SecondaryContentLinksController < ApplicationController
     @secondary_content_link = step_by_step_page.secondary_content_links.new(content_item)
 
     if @secondary_content_link.save
-      update_downstream
+      StepByStepUpdater.call(step_by_step_page, current_user)
 
       redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id), notice: "Secondary content was successfully linked."
     else
@@ -17,7 +17,7 @@ class SecondaryContentLinksController < ApplicationController
 
   def destroy
     if secondary_content_link.destroy
-      update_downstream
+      StepByStepUpdater.call(step_by_step_page, current_user)
 
       redirect_to step_by_step_page_secondary_content_links_path(step_by_step_page.id), notice: "Secondary content link was successfully deleted."
     else
@@ -38,10 +38,6 @@ private
 
   def secondary_content_link
     @secondary_content_link ||= step_by_step_page.secondary_content_links.find(params[:id])
-  end
-
-  def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id, current_user.name)
   end
 
   def content_item

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -10,7 +10,7 @@ class StepsController < ApplicationController
     @step = step_by_step_page.steps.new(step_params)
 
     if @step.save
-      update_downstream
+      StepByStepUpdater.call(step_by_step_page, current_user)
 
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: "Step was successfully created."
     else
@@ -24,7 +24,7 @@ class StepsController < ApplicationController
 
   def update
     if step.update(step_params)
-      update_downstream
+      StepByStepUpdater.call(step_by_step_page, current_user)
       redirect_to edit_step_by_step_page_step_path(step_by_step_page.id), notice: "Step was successfully updated."
     else
       render :edit
@@ -33,7 +33,7 @@ class StepsController < ApplicationController
 
   def destroy
     if step.destroy
-      update_downstream
+      StepByStepUpdater.call(step_by_step_page, current_user)
 
       redirect_to step_by_step_page_path(step_by_step_page.id), notice: "Step was successfully deleted."
     else
@@ -42,10 +42,6 @@ class StepsController < ApplicationController
   end
 
 private
-
-  def update_downstream
-    StepByStepDraftUpdateWorker.perform_async(step_by_step_page.id, current_user.name)
-  end
 
   def step_by_step_page
     @step_by_step_page ||= StepByStepPage.find(params[:step_by_step_page_id])

--- a/app/services/step_by_step_updater.rb
+++ b/app/services/step_by_step_updater.rb
@@ -1,0 +1,6 @@
+class StepByStepUpdater
+  def self.call(step_by_step, current_user)
+    step_by_step.mark_draft_updated unless %w(submitted_for_2i in_review approved_2i).include?(step_by_step.status)
+    StepByStepDraftUpdateWorker.perform_async(step_by_step.id, current_user.name)
+  end
+end

--- a/app/services/step_nav_publisher.rb
+++ b/app/services/step_nav_publisher.rb
@@ -1,7 +1,6 @@
 class StepNavPublisher
   def self.update(step_by_step_page, publish_intent = PublishIntent.minor_update)
-    step_by_step_page.refresh_auth_bypass_id if step_by_step_page.status == "published"
-    step_by_step_page.mark_draft_updated unless %w(submitted_for_2i in_review approved_2i).include?(step_by_step_page.status)
+    step_by_step_page.refresh_auth_bypass_id if step_by_step_page.status.published?
     presenter = StepNavPresenter.new(step_by_step_page)
     payload = presenter.render_for_publishing_api(publish_intent)
     Services.publishing_api.put_content(step_by_step_page.content_id, payload)

--- a/spec/services/step_by_step_updater_spec.rb
+++ b/spec/services/step_by_step_updater_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe StepByStepUpdater do
+  let(:current_user) { create(:user) }
+  let(:review_requester) { create(:user) }
+  let(:reviewer) { create(:user) }
+
+  before do
+    Sidekiq::Testing.fake!
+    allow(Services.publishing_api).to receive(:put_content)
+    allow(Services.publishing_api)
+      .to receive(:lookup_content_ids)
+      .and_return({})
+
+    StepByStepUpdater.call(step_by_step, current_user)
+  end
+
+  after do
+    expect(StepByStepDraftUpdateWorker.jobs.size).to eq(1)
+  end
+
+  subject(:step_by_step_status) { step_by_step.status }
+
+  context "does not revert to draft if a step by step in submitted_for_2i state is edited" do
+    let(:step_by_step) { create(:step_by_step_page_submitted_for_2i, review_requester_id: review_requester.uid, reviewer_id: reviewer.uid) }
+    it { is_expected.to eq "submitted_for_2i" }
+  end
+
+  context "does not revert to draft if a step by step in in_review state is edited" do
+    let(:step_by_step) { create(:step_by_step_page_claimed_for_2i, review_requester_id: review_requester.uid, reviewer_id: reviewer.uid) }
+    it { is_expected.to eq "in_review" }
+  end
+
+  context "does not revert to draft if a step by step in approved_2i state is edited" do
+    let(:step_by_step) { create(:step_by_step_page_2i_approved, review_requester_id: review_requester.uid, reviewer_id: reviewer.uid) }
+    it { is_expected.to eq "approved_2i" }
+  end
+
+  context "reverts to draft if a step by step in published state is edited" do
+    let(:step_by_step) { create(:published_step_by_step_page) }
+    it { is_expected.to eq "draft" }
+  end
+
+  context "reverts to draft if a step by step in scheduled state is edited" do
+    let(:step_by_step) { create(:scheduled_step_by_step_page) }
+    it { is_expected.to eq "draft" }
+  end
+end

--- a/spec/services/step_nav_publisher_spec.rb
+++ b/spec/services/step_nav_publisher_spec.rb
@@ -25,59 +25,26 @@ RSpec.describe StepNavPublisher do
       let(:step_nav) { create(:published_step_by_step_page) }
 
       it "defines :auth_bypass_ids in the publishing-api payload" do
+        step_nav.mark_draft_updated
         StepNavPublisher.update(step_nav)
-        content_id = /[0-9a-f]{5,40}/ # changes on each test run, as does Array value below
         payload = hash_including(:auth_bypass_ids => instance_of(Array))
-        expect(Services.publishing_api).to have_received(:put_content).with(content_id, payload)
+        expect(Services.publishing_api).to have_received(:put_content).with(step_nav.content_id, payload)
       end
     end
 
     context "step by step being edited" do
-      let(:step_nav) { create(:step_by_step_page_with_steps) }
-
-      before do
-        allow(SecureRandom).to receive(:uuid).and_return("bd814775-304c-46d0-919f-f9e0f6cba4e9")
-      end
-
-      it "does not revert to draft if a step by step in submitted_for_2i state is edited" do
-        step_nav.update_attributes(status: "submitted_for_2i", review_requester_id: review_requester_user.uid, reviewer_id: reviewer_user.uid)
-        StepNavPublisher.update(step_nav)
-        expect(step_nav.status).to eq "submitted_for_2i"
-      end
-
-      it "does not revert to draft if a step by step in in_review state is edited" do
-        step_nav.update_attributes(status: "in_review", review_requester_id: review_requester_user.uid, reviewer_id: reviewer_user.uid)
-        StepNavPublisher.update(step_nav)
-        expect(step_nav.status).to eq "in_review"
-      end
-
-      it "does not revert to draft if a step by step in approved_2i state is edited" do
-        step_nav.update_attributes(status: "approved_2i", review_requester_id: review_requester_user.uid, reviewer_id: reviewer_user.uid)
-        StepNavPublisher.update(step_nav)
-        expect(step_nav.status).to eq "approved_2i"
-      end
-
-      it "reverts to draft if a step by step in published state is edited" do
-        step_nav.update_attributes(status: "published")
-        StepNavPublisher.update(step_nav)
-        expect(step_nav.status).to eq "draft"
-      end
-
-      it "reverts to draft if a step by step in scheduled state is edited" do
-        step_nav.update_attributes(status: "scheduled")
-        StepNavPublisher.update(step_nav)
-        expect(step_nav.status).to eq "draft"
-      end
-
       it "does not change the auth_bypass_id when step by step in draft state is edited" do
         StepNavPublisher.update(step_nav)
         expect(step_nav.auth_bypass_id).to eq "33ac75d8-4adf-48a7-acb2-bbf4e7f644a3"
       end
 
       it "changes the auth_bypass_id when step by step in published state is edited" do
+        content_id = "bd814775-304c-46d0-919f-f9e0f6cba4e9"
+        allow(SecureRandom).to receive(:uuid).and_return(content_id)
+
         step_nav.update_attributes(status: "published")
         StepNavPublisher.update(step_nav)
-        expect(step_nav.auth_bypass_id).to eq "bd814775-304c-46d0-919f-f9e0f6cba4e9"
+        expect(step_nav.auth_bypass_id).to eq content_id
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,5 +92,6 @@ RSpec.configure do |config|
 
   config.before(:each) do
     Sidekiq::Worker.clear_all
+    Sidekiq::Testing.inline!
   end
 end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,4 +1,2 @@
 require "sidekiq"
 require "govuk_sidekiq/testing"
-
-Sidekiq::Testing.inline!


### PR DESCRIPTION
This commit makes sure the status of the step by step is in the correct
state after an edit has been made. Previously, the code to update the
state was inside a sidekiq worker which may not have completed upon the
new page being loaded. This led to the wrong links being displayed until
the worker has processed the job.

Trello:
https://trello.com/c/L4IbSFuv/111-status-doesnt-update-to-draft-until-page-is-refreshed