### PR TITLE
Restructure locales YAML file

### DIFF
--- a/app/presenters/step_by_step_page_presenter.rb
+++ b/app/presenters/step_by_step_page_presenter.rb
@@ -82,7 +82,7 @@ class StepByStepPagePresenter
   def sidebar_settings
     {
       field: "Sidebar settings",
-      value:  tag.span(I18n.t("guidance.summary_page.origin.sidebar_settings"), class: "govuk-hint"),
+      value:  tag.span(I18n.t("guidance.summary_page.sidebar_settings"), class: "govuk-hint"),
       edit: {
         link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
         href: step_by_step_page_navigation_rules_path(step_by_step_page),
@@ -96,7 +96,7 @@ class StepByStepPagePresenter
   def secondary_links_settings
     {
       field: "Secondary links",
-      value: tag.span(I18n.t("guidance.summary_page.origin.secondary_links"), class: "govuk-hint"),
+      value: tag.span(I18n.t("guidance.summary_page.secondary_links"), class: "govuk-hint"),
       edit: {
         link_text: step_by_step_page.can_be_edited? ? "Edit" : "View",
         href: step_by_step_page_secondary_content_links_path(step_by_step_page),
@@ -112,7 +112,7 @@ class StepByStepPagePresenter
       borderless: true,
       id: "tags",
       title: "Tags",
-      block: tag.span(I18n.t("guidance.summary_page.origin.tags"), class: "govuk-hint"),
+      block: tag.span(I18n.t("guidance.summary_page.tags"), class: "govuk-hint"),
       edit: {
         link_text: "Edit",
         href: "#{Plek.find('content-tagger', external: true)}/taggings/#{step_by_step_page.content_id}",

--- a/app/views/navigation_rules/edit.html.erb
+++ b/app/views/navigation_rules/edit.html.erb
@@ -22,7 +22,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-    <%= render_markdown t("sidebar_settings.guidance_markdown") %>
+    <h3 class="govuk-heading-m"><%= t("sidebar_settings.header") %></h3>
+    <p class="govuk-body"><%= render_markdown t("guidance.sidebar_settings.guidance_markdown") %></p>
   </div>
 </div>
 

--- a/app/views/secondary_content_links/index.html.erb
+++ b/app/views/secondary_content_links/index.html.erb
@@ -21,7 +21,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-!-margin-bottom-6">
-      <%= render_markdown t("secondary_content_links.guidance_markdown") %>
+      <%= render_markdown t("guidance.secondary_content_links.guidance_markdown") %>
     </div>
 
     <% if @step_by_step_page.can_be_edited? %>

--- a/app/views/step_by_step_pages/_form.html.erb
+++ b/app/views/step_by_step_pages/_form.html.erb
@@ -4,7 +4,7 @@
   <%= render "govuk_publishing_components/components/contextual_guidance", {
     html_for: "step_by_step_page_title",
     title: t("step_by_step_pages.form.title.label"),
-    content: t("step_by_step_pages.form.title.guidance")
+    content: t("guidance.new_step_by_step.title")
   } do %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -20,7 +20,7 @@
   <%= render "govuk_publishing_components/components/contextual_guidance", {
     html_for: "step_by_step_page_slug",
     title: t("step_by_step_pages.form.slug.label"),
-    content: t("step_by_step_pages.form.slug.guidance")
+    content: t("guidance.new_step_by_step.slug")
   } do %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -36,7 +36,7 @@
   <%= render "govuk_publishing_components/components/contextual_guidance", {
     html_for: "step_by_step_page_introduction",
     title: t("step_by_step_pages.form.introduction.label"),
-    content: t("step_by_step_pages.form.introduction.guidance")
+    content: t("guidance.new_step_by_step.introduction")
   } do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
@@ -52,7 +52,7 @@
   <%= render "govuk_publishing_components/components/contextual_guidance", {
     html_for: "step_by_step_page_meta_description",
     title: t("step_by_step_pages.form.meta_description.label"),
-    content: t("step_by_step_pages.form.meta_description.guidance")
+    content: t("guidance.new_step_by_step.meta_description")
   } do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {

--- a/app/views/step_by_step_pages/guidance.html.erb
+++ b/app/views/step_by_step_pages/guidance.html.erb
@@ -46,4 +46,7 @@
 
     <h3 class="govuk-heading-m"><%= t("guidance.sidebar_settings.header") %></h3>
       <p class="govuk-body"><%= render_markdown(t("guidance.sidebar_settings.guidance_markdown")) %></p>
+
+    <h3 class="govuk-heading-m"><%= t("guidance.secondary_content_links.header") %></h3>
+      <p class="govuk-body"><%= render_markdown(t("guidance.secondary_content_links.guidance_markdown")) %></p>
 </div>

--- a/app/views/step_by_step_pages/guidance.html.erb
+++ b/app/views/step_by_step_pages/guidance.html.erb
@@ -40,4 +40,10 @@
         <%= t("guidance.new_step.step_label.or") %></p>
 
       <p class="govuk-body"><%= render_markdown(t("guidance.new_step.content_tasks_links_markdown")) %></p>
+
+    <h3 class="govuk-heading-m"><%= t("guidance.reorder.header") %></h3>
+      <p class="govuk-body"><%= t("guidance.reorder.order") %></p>
+
+    <h3 class="govuk-heading-m"><%= t("guidance.sidebar_settings.header") %></h3>
+      <p class="govuk-body"><%= render_markdown(t("guidance.sidebar_settings.guidance_markdown")) %></p>
 </div>

--- a/app/views/step_by_step_pages/guidance.html.erb
+++ b/app/views/step_by_step_pages/guidance.html.erb
@@ -29,4 +29,15 @@
 
       <h2 class="govuk-heading-s"><%= t("step_by_step_pages.form.meta_description.label") %></h2>
       <p class="govuk-body"><%= t("guidance.new_step_by_step.meta_description") %></p>
+
+    <h3 class="govuk-heading-m"><%= t("guidance.new_step.header") %></h3>
+      <h2 class="govuk-heading-s"><%= t("step_by_step_pages.step.title.label") %></h2>
+      <p class="govuk-body"><%= t("guidance.new_step.step_title") %></p>
+
+      <h2 class="govuk-heading-s"><%= t("step_by_step_pages.step.step_label.label") %></h2>
+      <p class="govuk-body"><%= t("guidance.new_step.step_label.number") %>
+        <%= t("guidance.new_step.step_label.and") %>
+        <%= t("guidance.new_step.step_label.or") %></p>
+
+      <p class="govuk-body"><%= render_markdown(t("guidance.new_step.content_tasks_links_markdown")) %></p>
 </div>

--- a/app/views/step_by_step_pages/guidance.html.erb
+++ b/app/views/step_by_step_pages/guidance.html.erb
@@ -15,34 +15,18 @@
 %>
 <%= render 'shared/steps/step_breadcrumb', links: links %>
 
-<% guidance = t("guidance") %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h3 class="govuk-heading-m"><%= guidance.keys[0].to_s.titleize %></h3>
-    <% guidance[:new_step_by_step][:shared].each do |title, content| %>
-      <h2 class="govuk-heading-s"><%= title.to_s.titleize %></h2>
-      <p class="govuk-body"><%= content %></p>
-    <% end %>
+    <h3 class="govuk-heading-m"><%= t("guidance.new_step_by_step.header") %></h3>
+      <h2 class="govuk-heading-s"><%= t("step_by_step_pages.form.title.label") %></h2>
+      <p class="govuk-body"><%= t("guidance.new_step_by_step.title") %></p>
 
-    <h3 class="govuk-heading-m"><%= guidance.keys[1].to_s.titleize %></h3>
-    <% guidance[:new_step][:shared].each do |title, content| %>
-      <% if content %><h2 class="govuk-heading-s"><%= title.to_s.titleize %></h2><% end %>
-      <p class="govuk-body"><%= render_markdown(content) %></p>
-    <% end %>
+      <h2 class="govuk-heading-s"><%= t("step_by_step_pages.form.slug.label") %></h2>
+      <p class="govuk-body"><%= t("guidance.new_step_by_step.slug") %></p>
 
-    <h3 class="govuk-heading-m"><%= guidance.keys[2].to_s.titleize %></h3>
-    <h2 class="govuk-heading-s"><%= guidance[:reorder_steps][:revewer_2i].to_s.titleize %></h2>
-    <p class="govuk-body"><%= guidance[:reorder_steps][:shared] %></p>
+      <h2 class="govuk-heading-s"><%= t("step_by_step_pages.form.introduction.label") %></h2>
+      <p class="govuk-body"><%= t("guidance.new_step_by_step.introduction") %></p>
 
-    <h3 class="govuk-heading-m"><%= guidance.keys[3].to_s.titleize %></h3>
-    <% guidance[:sidebar_settings][:shared].each do |title, content| %>
-      <% if content %><h2 class="govuk-heading-s"><%= title.to_s.titleize %></h2><% end %>
-      <p class="govuk-body"><%= content %></p>
-    <% end %>
-
-    <% guidance[:secondary_links][:shared].each do |title, content| %>
-      <h3 class="govuk-heading-m"><%= title.to_s.titleize %></h3>
-      <p class="govuk-body"><%= render_markdown(content) %></p>
-    <% end %>
-  </div>
+      <h2 class="govuk-heading-s"><%= t("step_by_step_pages.form.meta_description.label") %></h2>
+      <p class="govuk-body"><%= t("guidance.new_step_by_step.meta_description") %></p>
 </div>

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -3,7 +3,7 @@
 <%= render "govuk_publishing_components/components/contextual_guidance", {
   html_for: "step-title",
   title: t("step_by_step_pages.step.title.label"),
-  content: t("step_by_step_pages.step.title.guidance")
+  content: t("guidance.new_step.step_title")
 } do %>
   <%= render "govuk_publishing_components/components/input", {
     label: {
@@ -26,21 +26,21 @@
         {
           value: "number",
           text: t("step_by_step_pages.step.step_label.number.label"),
-          hint_text: t("step_by_step_pages.step.step_label.number.hint"),
+          hint_text: t("guidance.new_step.step_label.number"),
           bold: true,
           checked: !step.logic.present? || step.logic == "number"
         },
         {
           value: "and",
           text: t("step_by_step_pages.step.step_label.and.label"),
-          hint_text: t("step_by_step_pages.step.step_label.and.hint"),
+          hint_text: t("guidance.new_step.step_label.and"),
           bold: true,
           checked: step.logic == "and"
         },
         {
           value: "or",
           text: t("step_by_step_pages.step.step_label.or.label"),
-          hint_text: t("step_by_step_pages.step.step_label.or.hint"),
+          hint_text: t("guidance.new_step.step_label.or"),
           bold: true,
           checked: step.logic == "or"
         }
@@ -106,12 +106,11 @@
 
 <%= render "govuk_publishing_components/components/contextual_guidance", {
   html_for: "step-content",
-  title: t("step_by_step_pages.step.content.guidance_title"),
-  content: render_markdown(t("step_by_step_pages.step.content.guidance"))
+  content: render_markdown(t("guidance.new_step.content_tasks_links_markdown"))
 } do %>
   <%= render "components/markdown_editor", {
     label: {
-      text: t("step_by_step_pages.step.content.label"),
+      text: t("step_by_step_pages.step.content_tasks_links.label"),
       bold: true
     },
     textarea: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,21 +64,7 @@ en:
       time:
         label: Time
   sidebar_settings:
-    guidance_markdown: |
-      ## Showing or hiding the sidebar
-
-      ### Always show navigation
-
-      Sidebar will always show on the piece of content. Choose this option if the content is about a task that is always completed as part of the step by step journey. For example, booking a theory driving test is always part of the wider journey of learning to drive.
-
-      ### Show navigation if users comes from step by step
-
-      Sidebar will only show if you clicked on a link in the step by step to get there For example: If the page is part of multiple user journeys and showing step by steps risks limiting the way the page is used'.
-
-      ### Never show navigation
-
-      Chose this option when you're linking to a page that it would never be appropriate for the step by step side bar to appear on.
-
+    header: Showing or hiding the sidebar
   secondary_content_links:
     guidance_markdown: |
       Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
@@ -133,26 +119,24 @@ en:
           `- [download option 1](/link)`
 
           `- [download option 2](/link)`
-    reorder_steps:
-      revewer_2i:
-        Step order
-      shared:
+    reorder:
+      header: Order of steps
+      order:
         Steps and tasks should be listed in the order in which users need to complete them.
-      origin:
-        Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
-        Step numbers will be automatically updated on save.
     sidebar_settings:
-      shared:
-        Showing or hiding the sidebar:
+      header: Sidebar settings
+      guidance_markdown: |
+        ### Always show navigation
 
-        Always show navigation:
-          Sidebar will always show on the piece of content. Choose this option if the content is about a task that is always completed as part of the step by step journey. For example, booking a theory driving test is always part of the wider journey of learning to drive.
+        Sidebar will always show on the piece of content. Choose this option if the content is about a task that is always completed as part of the step by step journey. For example, booking a theory driving test is always part of the wider journey of learning to drive.
 
-        Show navigation if users comes from step by step: |
-          Sidebar will only show if you clicked on a link in the step by step to get there For example: If the page is part of multiple user journeys and showing step by steps risks limiting the way the page is used'.
+        ### Show navigation if users comes from step by step
 
-        Never show navigation:
-          Chose this option when you're linking to a page that it would never be appropriate for the step by step side bar to appear on.
+        Sidebar will only show if you clicked on a link in the step by step to get there For example: If the page is part of multiple user journeys and showing step by steps risks limiting the way the page is used'.
+
+        ### Never show navigation
+
+        Chose this option when you're linking to a page that it would never be appropriate for the step by step side bar to appear on.
     secondary_links:
       reviewer_2i:
         Secondary links

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,14 +66,6 @@ en:
   sidebar_settings:
     header: Showing or hiding the sidebar
   secondary_content_links:
-    guidance_markdown: |
-      Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
-
-      We use it for content which:
-
-      - could help you complete a task but is not the main piece of content included in the step by step
-      - is optional and not useful enough to be included in the step by step
-
     index:
       base_path:
         label: Add new secondary link
@@ -137,20 +129,15 @@ en:
         ### Never show navigation
 
         Chose this option when you're linking to a page that it would never be appropriate for the step by step side bar to appear on.
-    secondary_links:
-      reviewer_2i:
-        Secondary links
-      shared:
-        Secondary links: |
-          Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
+    secondary_content_links:
+      header: Secondary links
+      guidance_markdown: |
+        Secondary content is content which is not linked to in the step by step, but has the step by step sidebar showing on it.
 
-          We use it for content which:
+        We use it for content which:
 
-            - could help you complete a task but is not the main piece of content included in the step by step.
-            - is optional and not useful enough to be included in the step by step
-      origin:
-        Add new secondary link:
-          "[Remove the phrase “Base Path” so the only thing left is 'For example: https://www.gov.uk/pay-vat or /bank-holidays']"
+          - could help you complete a task but is not the main piece of content included in the step by step.
+          - is optional and not useful enough to be included in the step by step
     change_notes:
       origin:
         internal_notes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,23 +138,7 @@ en:
 
           - could help you complete a task but is not the main piece of content included in the step by step.
           - is optional and not useful enough to be included in the step by step
-    change_notes:
-      origin:
-        internal_notes:
-          "Add a summary of your changes and why. For example: what’s been added, removed or replaced. Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one."
-        submit_for_2i:
-          "Add a summary of your changes and why. For example: what’s been added, removed or replaced. Provide any context that helps understand what you’ve done. For example: a link to zendesk and trello ticket if there’s one."
-        request_changes:
-          Explain why the draft hasn't been approved. What needs to change and why.
-        change_note_when_Publishing_old_step_by_step_(if_users_should_be_notified):
-          Describe the change for users. This change note will be emailed to subscribers.
     summary_page:
-      origin:
-        sidebar_settings:
-          Choose to hide the sidebar on certain pages.
-
-        secondary_links:
-          Choose additional pages to show the step by step sidebar.
-
-        tags:
-          Tag the step by step to the GOV.UK taxonomy and mainstream browse pages.
+      sidebar_settings: Choose to hide the sidebar on certain pages.
+      secondary_links: Choose additional pages to show the step by step sidebar.
+      tags: Tag the step by step to the GOV.UK taxonomy and mainstream browse pages.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,54 +11,26 @@ en:
     form:
       title:
         label: Title
-        guidance: "Add step by step after your title unless it will be inappropriate or make the title excessively long. Keep it under 85 characters"
       slug:
         label: Slug
-        guidance: "Slug is the link for your step by step. It should be lowercase and you should use hyphens to separate words. For example: get-driving-license"
       introduction:
         label: Introduction
-        guidance: "The introduction explains what the step by step helps the user do, or what it is. Keep it short. Tell users if it is not relevant to them. Do not include any important information in here that doesn’t exist elsewhere."
       meta_description:
         label: Meta description
-        guidance: "Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters."
     step:
       title:
         label: Step title
-        guidance: "Step title should start with a verb. For example: 'Check you're eligible'"
       step_label:
         label: Step label
         number:
           label: number
-          hint: "Use ‘number’ to show order of the steps"
         and:
           label: and
-          hint: "Use ‘and’ to show when you can (or need) to complete more than one step simultaneously."
         or:
           label: or
-          hint: "Use ‘or’ to show when there is an alternative way to complete a step or task."
       view_broken_links: "View broken links"
-      content:
+      content_tasks_links:
         label: "Content, tasks and links"
-        guidance_title: "Describing a step"
-        guidance: |
-          A step can be a task or a group of related tasks. A task is an action the user needs to do, for example Check if you need to apply for a licence. Link the whole sentence - not just the action - and do not add a full stop.
-
-          Start a step with an action and keep it short, for example ‘Check what age you can drive’.
-
-          [The content patterns guidance](https://gov-uk.atlassian.net/wiki/spaces/MS/pages/416317515/Step+and+task+content+patterns)
-
-          ### Formatting
-
-          Links should be task focused. You cannot link only part of a sentence.
-
-          `[Task name](/link)`
-
-          For example: `[book your theory test](/book-theory-test)`
-
-          Only use bullets to show different ways you can perform the same task or different variables that change how you complete the task. Do not use bullets to list tasks that are all essential
-
-          `- [download option 1](/link)`
-          `- [download option 2](/link)`
     reorder:
       instructions_markdown: Use the up/down buttons on the right to reorder steps, or click and hold on a step to reorder using drag and drop.
       automatically_updated_markdown: Step numbers will be automatically updated on save.
@@ -122,15 +94,15 @@ en:
         hint: "For example: https://www.gov.uk/pay-vat or /bank-holidays"
   guidance:
     new_step_by_step:
-      shared:
-        title:
-          Add step by step after your title unless it will be inappropriate or make the title excessively long. Keep it under 85 characters
-        slug:
-          "Slug is the link for your step by step. It should be lowercase and you should use hyphens to separate words. For example: get-driving-license"
-        introduction:
-          The introduction explains what the step by step helps the user do, or what it is. Keep it short. Tell users if it is not relevant to them. Do not include any important information in here that doesn’t exist elsewhere.
-        meta_description:
-          Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters.
+      header: New step by step
+      title:
+        Add step by step after your title unless it will be inappropriate or make the title excessively long. Keep it under 85 characters
+      slug:
+        "Slug is the link for your step by step. It should be lowercase and you should use hyphens to separate words. For example: get-driving-license"
+      introduction:
+        The introduction explains what the step by step helps the user do, or what it is. Keep it short. Tell users if it is not relevant to them. Do not include any important information in here that doesn’t exist elsewhere.
+      meta_description:
+        Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters.
     new_step:
       shared:
         step_title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,29 +104,35 @@ en:
       meta_description:
         Meta description is shown in the GOV.UK search results. It should explain what the step by step helps the user do, or what it is. Keep it under 160 characters.
     new_step:
-      shared:
+        header: New step
         step_title:
           "Step title should start with a verb. For example: 'Check you're eligible'"
-        step_label: |
-          Use ‘number’
-          Use ‘and’ to show when you can (or need) to complete more than one step simultaneously.
-          Use ‘or’ to show when there is an alternative way to complete a step or task.
-        content,_tasks_and_links: |
-          ## Describing a step
-          A step can be a task or a group of related tasks. A task is an action the user needs to do, for example Check if you need to apply for a licence. Link the whole sentence - not just the action -  and do not add a full stop.
-          Start a step with an action and explain the context in the link where possible, for example 'Check what age you can drive'. Keep it short.
+        step_label:
+          number: Use ‘number’ to show order of the steps".
+          and: Use ‘and’ to show when you can (or need) to complete more than one step simultaneously.
+          or: Use ‘or’ to show when there is an alternative way to complete a step or task.
+        content_tasks_links_markdown: |
+          #### Describing a step
 
-          ## The content patterns guidance.
+          A step can be a task or a group of related tasks. A task is an action the user needs to do, for example Check if you need to apply for a licence. Link the whole sentence - not just the action - and do not add a full stop.
 
-          ## Formatting
+          Start a step with an action and keep it short, for example ‘Check what age you can drive’.
+
+          [The content patterns guidance](https://gov-uk.atlassian.net/wiki/spaces/MS/pages/416317515/Step+and+task+content+patterns)
+
+          #### Formatting
+
           Links should be task focused. You cannot link only part of a sentence.
 
-          `[Task name](/link)` For example: `[book your theory test](/book-theory-test)`
+          `[Task name](/link)`
+
+          For example: `[book your theory test](/book-theory-test)`
 
           Only use bullets to show different ways you can perform the same task or different variables that change how you complete the task. Do not use bullets to list tasks that are all essential
 
-          - `[download option 1](/link)`
-          - `[download option 2](/link)`
+          `- [download option 1](/link)`
+
+          `- [download option 2](/link)`
     reorder_steps:
       revewer_2i:
         Step order


### PR DESCRIPTION
## User story
**As a** Content Designer
**I want** to easily modify the contextual guidance and make sure it's consistent across the app
**So that** the various places the guidance appears remain synchronised

## What
- Shared contextual guidance is stored under `guidance` key, which removes repetition
- Rewrite guidance.html.erb so it doesn't rely on the structure of the YAML file
- Change formatting of the guidance page as shown below

| Before  | After |
| ------------- | ------------- |
| <img width="334" alt="guidance_before" src="https://user-images.githubusercontent.com/38078064/67223078-893e3200-f426-11e9-81a5-6134fe179af2.png">  | <img width="330" alt="new" src="https://user-images.githubusercontent.com/38078064/67266384-0bbb0600-f4a8-11e9-8397-eb709927c443.png">  |

[Trello card](https://trello.com/c/r0ycsFmz/177-change-the-structure-of-the-contextual-guidance-yaml-file-so-each-piece-of-guidance-only-appears-once-in-the-file)



