### PR TITLE
Replace govuk-lint(-sass) with scss-govuk

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ['scss_lint-govuk']

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :development, :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "govuk-content-schema-test-helpers"
-  gem "govuk-lint", "~> 4.3.0"
   gem "govuk_test"
   gem "jasmine", "~> 3.5"
   gem "jasmine_selenium_runner", "~> 3", require: false
@@ -37,6 +36,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rubocop-govuk"
+  gem "scss_lint-govuk"
   gem "shoulda-matchers", "~> 4.1"
   gem "timecop"
   gem "webmock", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,10 +59,10 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    brakeman (4.7.1)
+    brakeman (4.7.2)
     builder (3.2.4)
     byebug (11.0.1)
-    capybara (3.29.0)
+    capybara (3.30.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -112,11 +112,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -341,6 +336,8 @@ GEM
       tilt
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     select2-rails (3.5.10)
       thor (~> 0.14)
     selenium-webdriver (3.142.6)
@@ -387,7 +384,7 @@ GEM
       rack (>= 2.0.6)
     warden-oauth2 (0.0.1)
       warden
-    webdrivers (4.1.3)
+    webdrivers (4.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -415,7 +412,6 @@ DEPENDENCIES
   gds-sso (~> 14.2)
   generic_form_builder (~> 0.13)
   govuk-content-schema-test-helpers
-  govuk-lint (~> 4.3.0)
   govuk_admin_template (~> 6.7)
   govuk_app_config (~> 2.0)
   govuk_publishing_components (~> 21.17)
@@ -432,6 +428,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sass-rails (~> 5.0)
+  scss_lint-govuk
   select2-rails (~> 3.5.9)
   shoulda-matchers (~> 4.1)
   timecop

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ node {
     beforeTest: {
       sh("yarn install")
     },
-    sassLint: false,
     rubyLintDirs: "",
     publishingE2ETests: true,
     brakeman: true

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,5 @@
 desc "Run govuk-lint on all files"
 task "lint" do
   sh "rubocop"
-  sh "govuk-lint-sass app/assets/stylesheets"
+  sh "scss-lint app/assets/stylesheets"
 end


### PR DESCRIPTION
https://trello.com/c/EcitEsfK/1297-audit-dependabot-for-collections-publisher

Previously we replaced govuk-lint-ruby with rubocop-govuk. This completely
removes govuk-lint by replacing govuk-lint-sass with using scss-lint
directly, ensuring we're linting locally and in Jenkins.