### PR TITLE
Add publish coronavirus page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,10 +11,14 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :active_navigation_item
+  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
+  end
+
+  def coronavirus_editor?
+    current_user.has_permission? "Coronavirus editor"
   end
 
   # Can be overridden to allow controllers to choose the active menu item.
@@ -24,6 +28,10 @@ private
 
   def require_2i_reviewer_permissions!
     authorise_user!("2i reviewer")
+  end
+
+  def require_coronavirus_editor_permissions!
+    authorise_user!("Coronavirus editor")
   end
 
   def require_gds_editor_permissions!

--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -1,0 +1,77 @@
+class CoronavirusController < ApplicationController
+  before_action :require_coronavirus_editor_permissions!
+  layout "admin_layout"
+
+  CONTENT_ID = "774cee22-d896-44c1-a611-e3109cce8eae".freeze
+  CONTENT_URL = "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml".freeze
+
+  def index; end
+
+  def update_draft
+    response = RestClient.get(CONTENT_URL)
+
+    if response.code == 200
+      corona_content = YAML.safe_load(response.body)["content"]
+
+      if valid_content?(corona_content)
+        presenter = CoronavirusPagePresenter.new(corona_content)
+
+        Services.publishing_api.put_content(CONTENT_ID, presenter.payload)
+        flash["notice"] = "Draft content updated"
+      end
+    else
+      flash["alert"] = "Error received from Github - #{response.code}"
+    end
+
+    redirect_to coronavirus_path
+  end
+
+  def publish
+    begin
+      Services.publishing_api.publish(CONTENT_ID, update_type)
+
+      flash["notice"] = "Page published!"
+    rescue GdsApi::HTTPConflict
+      flash["alert"] = "Page already published - update the draft first"
+    end
+
+    redirect_to coronavirus_path
+  end
+
+private
+
+  def update_type
+    major_update? ? "major" : "minor"
+  end
+
+  def major_update?
+    params["update-type"] == "major"
+  end
+
+  def valid_content?(content)
+    return false if content.nil?
+
+    missing_keys = (required_landing_page_keys - content.keys)
+    if missing_keys.any?
+      flash["alert"] = "Invalid content - please recheck Github and add #{missing_keys.join(', ')}."
+      return false
+    end
+
+    true
+  end
+
+  def required_landing_page_keys
+    %w(
+      title
+      meta_description
+      stay_at_home
+      guidance
+      announcements_label
+      announcements
+      nhs_banner
+      sections
+      topic_section
+      notifications
+    )
+  end
+end

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -1,0 +1,27 @@
+class CoronavirusPagePresenter
+  attr_reader :description, :details, :title
+
+  BASE_PATH = "/coronavirus".freeze
+
+  def initialize(corona_content)
+    @title = corona_content.delete("title")
+    @description = corona_content.delete("meta_description")
+    @details = corona_content
+  end
+
+  def payload
+    {
+      "base_path" => BASE_PATH,
+      "title" => title,
+      "description" => description,
+      "document_type" => "coronavirus_landing_page",
+      "schema_name" => "coronavirus_landing_page",
+      "details" => details,
+      "links" => {},
+      "locale" => "en",
+      "rendering_app" => "collections",
+      "publishing_app" => "collections-publisher",
+      "routes" => [{ "path" => BASE_PATH, "type" => "exact" }],
+    }
+  end
+end

--- a/app/views/coronavirus/index.html.erb
+++ b/app/views/coronavirus/index.html.erb
@@ -1,0 +1,57 @@
+<% content_for :title, "Publish gov.uk/coronavirus content" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div>
+      <p class="govuk-body">Updating coronavirus landing page content:</p>
+      <ol class="govuk-list govuk-list--number">
+        <li>Update the <a href="https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml">coronavirus content on Github</a></li>
+        <li>Get it reviewed and approved</li>
+        <li>Update the draft and check that it's OK</li>
+        <li>Publish!</li>
+      </ol>
+    </div>
+
+    <%= form_with(url: coronavirus_update_draft_path) do %>
+      <%= render "govuk_publishing_components/components/button", {
+          text: "Update draft",
+          margin_bottom: true
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Preview",
+        href: draft_govuk_url("/coronavirus"),
+        target: "_blank",
+        secondary: true
+      } %>
+    <% end %>
+
+    <%= form_with(url: coronavirus_publish_path) do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "update-type",
+        heading: "Update type",
+        heading_size: "s",
+        small: true,
+        items: [
+          {
+            value: "minor",
+            text: "Minor",
+            checked: true
+          },
+          {
+            value: "major",
+            text: "Major"
+          }
+        ]
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+          text: "Publish",
+          margin_bottom: true
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "View live version",
+        href: published_url("coronavirus"),
+        target: "_blank",
+        secondary: true
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -29,6 +29,12 @@
         active: active_navigation_item == 'step_by_step_pages' ? 'active' : false,
         user_has_permission_to_see: gds_editor?
       },
+      {
+        text: "Coronavirus page",
+        href: coronavirus_path,
+        active: active_navigation_item == 'coronavirus' ? 'active' : false,
+        user_has_permission_to_see: coronavirus_editor?
+      },
       { text: current_user.name, href: Plek.new.external_url_for("signon") },
       { text: "Log out", href: gds_sign_out_path }
     ].delete_if{ |item| item[:user_has_permission_to_see] == false },

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,12 @@
       <%= link_to 'Step by step pages', step_by_step_pages_path %>
     </li>
   <% end %>
+
+  <% if coronavirus_editor? %>
+    <li class='<%= active_navigation_item == 'coronavirus' ? 'active' : nil %>'>
+      <%= link_to 'Coronavirus page', coronavirus_path %>
+    </li>
+  <% end %>
 <% end %>
 
 <% content_for :body_end do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
 
   root to: redirect("/step-by-step-pages", status: 302)
 
+  get "/coronavirus", to: "coronavirus#index"
+  post "/coronavirus/update_draft", to: "coronavirus#update_draft"
+  post "/coronavirus/publish", to: "coronavirus#publish"
+
   resources :step_by_step_pages, path: "step-by-step-pages" do
     get "approve-2i-review", to: "review#show_approve_2i_review_form"
     post "approve-2i-review", to: "review#approve_2i_review"

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+
+RSpec.feature "Publish updates to Coronavirus landing page" do
+  include CommonFeatureSteps
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    given_i_am_a_coronavirus_editor
+    stub_coronavirus_publishing_api
+    stub_github_request
+    stub_any_publishing_api_put_intent
+  end
+
+  scenario "User views the page" do
+    when_i_visit_the_publish_coronavirus_page
+    i_see_an_update_draft_button
+    and_a_preview_button
+    and_a_publish_button
+  end
+
+  scenario "Updating draft" do
+    when_i_visit_the_publish_coronavirus_page
+    and_i_push_a_new_draft_version
+    then_the_content_is_sent_to_publishing_api
+    and_i_see_a_draft_updated_message
+  end
+
+  scenario "Updating draft with invalid content" do
+    when_i_visit_the_publish_coronavirus_page
+    and_i_push_a_new_draft_version_with_invalid_content
+    and_i_see_an_alert
+  end
+
+  scenario "Publishing page" do
+    when_i_visit_the_publish_coronavirus_page
+    and_i_choose_a_major_update
+    and_i_publish_the_page
+    then_the_page_publishes
+    and_i_see_a_page_published_message
+  end
+
+  def given_i_am_a_coronavirus_editor
+    stub_user.permissions << "Coronavirus editor"
+    stub_user.name = "Test author"
+  end
+
+  def stub_coronavirus_publishing_api
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+  end
+
+  def stub_github_request
+    stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml")
+      .to_return(status: 200, body: github_response)
+  end
+
+  def github_response
+    File.read(Rails.root.join + "spec/fixtures/coronavirus_landing_page.yml")
+  end
+
+  def then_the_content_is_sent_to_publishing_api
+    assert_publishing_api_put_content(
+      "774cee22-d896-44c1-a611-e3109cce8eae",
+      request_json_includes(
+        "title" => "Coronavirus (COVID-19): what you need to do",
+      ),
+    )
+  end
+
+  def when_i_visit_the_publish_coronavirus_page
+    visit "/coronavirus"
+  end
+
+  def i_see_an_update_draft_button
+    expect(page).to have_button("Update draft")
+  end
+
+  def and_a_preview_button
+    expect(page).to have_link("Preview")
+    expect(find_link("Preview")[:target]).to eq("_blank")
+  end
+
+  def and_a_publish_button
+    expect(page).to have_button("Publish")
+  end
+
+  def and_i_push_a_new_draft_version
+    click_on("Update draft")
+  end
+
+  def and_i_push_a_new_draft_version_with_invalid_content
+    stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml")
+    .to_return(status: 200, body: invalid_github_response)
+
+    and_i_push_a_new_draft_version
+  end
+
+  def invalid_github_response
+    File.read(Rails.root.join + "spec/fixtures/invalid_corona_page.yml")
+  end
+
+  def and_i_see_an_alert
+    expect(page).to have_text("Invalid content - please recheck Github and add title, stay_at_home, guidance, announcements_label, announcements, nhs_banner, sections, topic_section, notifications.")
+  end
+
+  def and_i_see_a_draft_updated_message
+    expect(page).to have_text("Draft content updated")
+  end
+
+  def and_i_choose_a_major_update
+    choose("Major")
+  end
+
+  def and_i_publish_the_page
+    click_on("Publish")
+  end
+
+  def then_the_page_publishes
+    assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "major")
+  end
+
+  def and_i_see_a_page_published_message
+    expect(page).to have_text("Page published!")
+  end
+end

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -1,0 +1,166 @@
+content:
+  title: "Coronavirus (COVID-19): what you need to do"
+  meta_description: "Find out about the government response to coronavirus (COVID-19) and what you need to do."
+  stay_at_home:
+    pretext: Stay at home
+    list:
+      - Only go outside for food, health reasons or work (where this absolutely cannot be done from home)
+      - Stay 2 metres (6ft) away from other people
+      - Wash your hands as soon as you get home
+  guidance:
+    pretext: Anyone can spread the virus.
+    link:
+      href: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
+      text: Full guidance on staying at home and away from others
+  announcements_label: Announcements
+  announcements:
+    - text: You must stay at home apart from essential travel or you may be fined
+      href: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
+    - text: If you live in the UK and are currently abroad you are strongly advised to return now
+      href: /guidance/travel-advice-novel-coronavirus
+    - text: All non-essential shops and community spaces are closed
+      href: /government/publications/further-businesses-and-premises-to-close
+  nhs_banner:
+    heading: "Do not leave home if you or someone you live with has either:"
+    list:
+      - a high temperature
+      - a new, continuous cough
+    call_to_action:
+      title: Check the NHS website if you have symptoms
+      href: https://www.nhs.uk/conditions/coronavirus-covid-19/
+  sections:
+    - title: How to protect yourself and others
+      sub_sections:
+        - title:
+          list:
+            - label: Staying at home if you think you have coronavirus (self-isolating)
+              url: /government/publications/covid-19-stay-at-home-guidance
+            - label: Full guidance on staying at home and away from others
+              url: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
+            - label: How to protect extremely vulnerable people (shielding)
+              url: /government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19
+    - title: Employment and financial support
+      sub_sections:
+        - title:
+          list:
+            - label: Check if you can get statutory sick pay (SSP)
+              url: /statutory-sick-pay
+            - label: Check if you're eligible for Universal Credit
+              url: /universal-credit
+            - label: Check if you're eligible for Employment and Support Allowance (ESA)
+              url: /employment-support-allowance
+            - label: Your rights if your hours are cut or you’re laid off
+              url: /lay-offs-short-timeworking
+            - label: What to do if you cannot pay your tax bill on time
+              url: /difficulties-paying-hmrc
+    - title: School closures, education, and childcare
+      sub_sections:
+        - title:
+          list:
+            - label: What parents and carers need to know about closures
+              url: /government/publications/closure-of-educational-settings-information-for-parents-and-carers
+            - label: Guidance for schools and local authorities on closures
+              url: /government/publications/covid-19-school-closures
+            - label: "School opening for children of key workers"
+              url: /government/publications/coronavirus-covid-19-maintaining-educational-provision
+            - label: Cancelled exams
+              url: /government/publications/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020/coronavirus-covid-19-cancellation-of-gcses-as-and-a-levels-in-2020
+            - label: Dealing with COVID-19 in nurseries, schools and universities
+              url: /government/publications/guidance-to-educational-settings-about-covid-19
+            - label: Supporting vulnerable children
+              url: /government/publications/coronavirus-covid-19-guidance-on-vulnerable-children-and-young-people
+    - title: Businesses and other organisations
+      sub_sections:
+        - title:
+          list:
+            - label: How to keep your employees safe
+              url: /government/publications/guidance-to-employers-and-businesses-about-covid-19
+            - label: How to clean workplaces safely
+              url: /government/publications/covid-19-decontamination-in-non-healthcare-settings
+            - label: Check what you need to do about Statutory Sick Pay
+              url: /employers-sick-pay
+            - label: Find out what to do for different businesses and organisations
+              url: /government/collections/coronavirus-covid-19-list-of-guidance
+            - label: UK businesses trading internationally
+              url: /government/publications/coronavirus-covid-19-guidance-for-uk-businesses
+            - label: What the government is doing to support businesses
+              url: /government/publications/guidance-to-employers-and-businesses-about-covid-19
+    - title: Healthcare workers and carers
+      sub_sections:
+        - title:
+          list:
+            - label: NHS guidance for people working in healthcare
+              url: https://www.england.nhs.uk/coronavirus/
+            - label: How to protect people in residential care, supported living and home care
+              url: /government/publications/covid-19-residential-care-supported-living-and-home-care-guidance
+            - label: How to manage adult social care
+              url: /government/publications/covid-19-ethical-framework-for-adult-social-care
+            - label: How to protect extremely vulnerable people (shielding)
+              url: /government/publications/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19/guidance-on-shielding-and-protecting-extremely-vulnerable-persons-from-covid-19
+    - title: Travel
+      sub_sections:
+        - title:
+          list:
+            - label: Information for British citizens travelling abroad
+              url: /guidance/travel-advice-novel-coronavirus
+            - label: Foreign travel advice for each country
+              url: /foreign-travel-advice
+            - label: What to do if you're visiting the UK from China and you can't travel home
+              url: /guidance/coronavirus-immigration-guidance-if-youre-unable-to-return-to-china-from-the-uk
+            - label: Avoid travel to second homes, campsites and caravan parks
+              url: /government/news/covid-19-essential-travel-guidance
+    - title: How coronavirus is affecting public services
+      sub_sections:
+        - title: Benefits
+          list:
+            - label: Employment and Support Allowance (ESA)
+              url: /employment-support-allowance/your-esa-claim
+            - label: Personal Independence Payment (PIP)
+              url: /pip/how-to-claim
+            - label: Universal credit
+              url: /universal-credit/how-to-claim
+        - title: Crime, justice and the law
+          list:
+            - label: Court and tribunal cases
+              url: /guidance/coronavirus-covid-19-courts-and-tribunals-planning-and-preparation
+            - label: Visiting prisoners
+              url: /guidance/coronavirus-covid-19-and-prisons
+        - title: Driving and transport
+          list:
+            - label: Driving and theory tests suspended
+              url: /guidance/coronavirus-covid-19-driving-tests-and-theory-tests
+            - label: MOTs for heavy vehicles suspended
+              url: /guidance/coronavirus-covid-19-mots-for-lorries-buses-and-trailers
+            - label: Relaxation of drivers’ hours rules
+              url: /government/publications/covid-19-guidance-on-drivers-hours-relaxations/coronavirus-covid-19-guidance-on-drivers-hours-relaxations
+            - label: Vehicle approval tests suspended
+              url: /guidance/coronavirus-covid-19-vehicle-approval-tests
+        - title: Housing and local services
+          list:
+            - label: Planning inspections
+              url: /guidance/coronavirus-covid-19-planning-inspectorate-guidance
+    - title: How you can help
+      sub_sections:
+        - title:
+          list:
+            - label: Help produce ventilators and components
+              url: https://ventilator.herokuapp.com
+    - title: Coronavirus (COVID-19) cases in the UK
+      sub_sections:
+        - title:
+          list:
+            - label: Track coronavirus cases in the UK
+              url: /government/publications/covid-19-track-coronavirus-cases
+            - label: Latest number of coronavirus cases in the UK
+              url: /guidance/coronavirus-covid-19-information-for-the-public
+  topic_section:
+    header: "All coronavirus (COVID-19) information"
+    text: "Browse information related to coronavirus"
+    links:
+      - label: "News"
+        url: /search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response
+      - label: "Guidance"
+        url: /search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+  notifications:
+    intro: "Stay up to date with GOV.UK"
+    email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"

--- a/spec/fixtures/invalid_corona_page.yml
+++ b/spec/fixtures/invalid_corona_page.yml
@@ -1,0 +1,2 @@
+content:
+  meta_description: "Find out about the government response to coronavirus (COVID-19) and what you need to do."

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe CoronavirusPagePresenter do
+  include GovukContentSchemaTestHelpers
+
+  let(:content) {
+    {
+      "title" => "coronavirus",
+      "meta_description" => "details about the coronavirus response",
+      "sections" => "some sections",
+    }
+  }
+
+  subject { described_class.new(content) }
+
+  it "presents the payload correctly" do
+    presented = subject.payload
+    expect(presented).to be_valid_against_schema("coronavirus_landing_page")
+
+    expect(presented).to eq(
+      {
+        "base_path" => "/coronavirus",
+        "title" => "coronavirus",
+        "description" => "details about the coronavirus response",
+        "document_type" => "coronavirus_landing_page",
+        "schema_name" => "coronavirus_landing_page",
+        "details" => {
+          "sections" => "some sections",
+        },
+        "links" => {},
+        "locale" => "en",
+        "rendering_app" => "collections",
+        "publishing_app" => "collections-publisher",
+        "routes" => [
+          { "path" => "/coronavirus", "type" => "exact" },
+        ],
+      },
+    )
+  end
+end


### PR DESCRIPTION
This allows publishing of the page that is configured in [Github](https://github.com/alphagov/govuk-coronavirus-content)

The flow is:

- Update the yaml in github (and merge it)
- Update the draft in by hitting the button in this app
- Review the draft
- Update Github as necessary
- Publish

There is some basic yaml validation here, but mainly the hope is that changes
will generally be small enough to be eyeballed correctly.

![collections-publisher integration publishing service gov uk_coronavirus](https://user-images.githubusercontent.com/773037/77737533-1a34bd00-7006-11ea-8f82-c7c7b426e1c3.png)


https://trello.com/c/0uZVAYYt/35-look-at-options-for-publishers-to-update-page