### PR TITLE
Increase publishing timeout

### DIFF
--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -16,8 +16,14 @@ class CoronavirusController < ApplicationController
       if valid_content?(corona_content)
         presenter = CoronavirusPagePresenter.new(corona_content)
 
-        Services.publishing_api.put_content(CONTENT_ID, presenter.payload)
-        flash["notice"] = "Draft content updated"
+        with_longer_timeout do
+          begin
+            Services.publishing_api.put_content(CONTENT_ID, presenter.payload)
+            flash["notice"] = "Draft content updated"
+          rescue GdsApi::HTTPGatewayTimeout
+            flash["alert"] = "Updating the draft timed out - please try again"
+          end
+        end
       end
     else
       flash["alert"] = "Error received from Github - #{response.code}"
@@ -39,6 +45,17 @@ class CoronavirusController < ApplicationController
   end
 
 private
+
+  def with_longer_timeout
+    prior_timeout = Services.publishing_api.client.options[:timeout]
+    Services.publishing_api.client.options[:timeout] = 10
+
+    begin
+      yield
+    ensure
+      Services.publishing_api.client.options[:timeout] = prior_timeout
+    end
+  end
 
   def update_type
     major_update? ? "major" : "minor"

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -22,6 +22,7 @@ class CoronavirusPagePresenter
       "rendering_app" => "collections",
       "publishing_app" => "collections-publisher",
       "routes" => [{ "path" => BASE_PATH, "type" => "exact" }],
+      "update_type" => "minor",
     }
   end
 end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe CoronavirusPagePresenter do
         "routes" => [
           { "path" => "/coronavirus", "type" => "exact" },
         ],
+        "update_type" => "minor",
       },
     )
   end


### PR DESCRIPTION
This is timing out on integration, so add some extra leeway and provide better feedback if it does fail.

Also adding a default "minor" update type to draft updating.  This is overridden by the value chosen at publish time, but publishing-api seems to need it.