### PR TITLE
coronavirus: Remove 'to production' wording from '5. Publish changes'

### DIFF
--- a/app/views/coronavirus/shared/_publish.html.erb
+++ b/app/views/coronavirus/shared/_publish.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-padding-bottom-4">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "5. Publish changes to production",
+      text: "5. Publish changes",
       padding: true
     } %>
     <%= form_with(url: coronavirus_publish_path(coronavirus_slug: params[:slug]), local: true) do %>


### PR DESCRIPTION
- This isn't a code change, just a words change for step 5 of the coronavirus 'publish a draft onto the website' workflow.
- I was testing a thing in integration and having it say 'production' even though I was in integration made me hesitate and look at the code to make sure it wasn't hardcoded to production.
- I tried to make the environment it specified match the currently deployed environment (`GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment`), but I'm too tired to make the interpolation work properly in the component.