### PR TITLE
Fix flash messages not appearing

### DIFF
--- a/app/views/coronavirus/shared/_draft.html.erb
+++ b/app/views/coronavirus/shared/_draft.html.erb
@@ -3,7 +3,7 @@
     text: "3. Update draft",
     padding: true
   } %>
-  <%= form_with(url: coronavirus_path, method: "put") do %>
+  <%= form_with(url: coronavirus_path, method: "put", local: true) do %>
     <%= render "govuk_publishing_components/components/button", {
         text: "Update draft",
         margin_bottom: false

--- a/app/views/coronavirus/shared/_publish.html.erb
+++ b/app/views/coronavirus/shared/_publish.html.erb
@@ -3,7 +3,7 @@
       text: "5. Publish changes to production",
       padding: true
     } %>
-    <%= form_with(url: coronavirus_publish_path(coronavirus_slug: params[:slug])) do %>
+    <%= form_with(url: coronavirus_publish_path(coronavirus_slug: params[:slug]), local: true) do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "update-type",
         heading: "Update type",


### PR DESCRIPTION
form_with now assumes an xhr request unless you specify `local: true`

The flash message was being rendered and returned to the browser as an AJAX response, so the client page never updated.