### PR TITLE
Turn on coronavirus live streams from collections publisher

### DIFF
--- a/app/models/live_stream.rb
+++ b/app/models/live_stream.rb
@@ -1,0 +1,2 @@
+class LiveStream < ApplicationRecord
+end

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -15,7 +15,7 @@ class CoronavirusPagePresenter
       "description" => description,
       "document_type" => "coronavirus_landing_page",
       "schema_name" => "coronavirus_landing_page",
-      "details" => details,
+      "details" => details.merge(live_stream_state),
       "links" => {},
       "locale" => "en",
       "rendering_app" => "collections",
@@ -23,5 +23,15 @@ class CoronavirusPagePresenter
       "routes" => [{ "path" => path, "type" => "exact" }],
       "update_type" => "minor",
     }
+  end
+
+  def live_stream_state
+    {
+      "live_stream_enabled" => live_stream.state,
+    }
+  end
+
+  def live_stream
+    LiveStream.first_or_create
   end
 end

--- a/app/services/live_stream_updater.rb
+++ b/app/services/live_stream_updater.rb
@@ -42,7 +42,7 @@ private
         response =
           Services.publishing_api.put_content(landing_page_id, live_stream_payload)
         response.code == 200 ? response : object.toggle(:state)
-      rescue GdsApi::HTTPClientError
+      rescue GdsApi::HTTPErrorResponse
         object.toggle(:state)
       end
     end
@@ -54,7 +54,7 @@ private
         response =
           Services.publishing_api.publish(landing_page_id, "minor")
         response.code == 200 ? response : object.toggle(:state)
-      rescue GdsApi::HTTPClientError
+      rescue GdsApi::HTTPErrorResponse
         object.toggle(:state)
       end
     end

--- a/app/services/live_stream_updater.rb
+++ b/app/services/live_stream_updater.rb
@@ -1,0 +1,95 @@
+class LiveStreamUpdater
+  def initialize(object, state = nil)
+    @object = object
+    @state = state
+    @content_item = fetch_live_content_item
+  end
+
+  def updated?
+    update_object_and_content_item.try(:code) == 200
+  end
+
+  def published?
+    publish_content_item.try(:code) == 200
+  end
+
+  def resync
+    states_in_sync? ? object : object.toggle(:state)
+  end
+
+private
+
+  attr_reader :state, :live_stream, :content_item
+  attr_accessor :object
+
+  def states_in_sync?
+    live_state == object.state
+  end
+
+  def live_state
+    content_item["details"]["live_stream_enabled"]
+  end
+
+  def update_object_and_content_item
+    if object.update(state: state)
+      update_content_item
+    end
+  end
+
+  def update_content_item
+    with_longer_timeout do
+      begin
+        response =
+          Services.publishing_api.put_content(landing_page_id, live_stream_payload)
+        response.code == 200 ? response : object.toggle(:state)
+      rescue GdsApi::HTTPClientError
+        object.toggle(:state)
+      end
+    end
+  end
+
+  def publish_content_item
+    with_longer_timeout do
+      begin
+        response =
+          Services.publishing_api.publish(landing_page_id, "minor")
+        response.code == 200 ? response : object.toggle(:state)
+      rescue GdsApi::HTTPClientError
+        object.toggle(:state)
+      end
+    end
+  end
+
+  def fetch_live_content_item
+    content = Services.publishing_api.get_content(landing_page_id)
+    JSON.parse(content.raw_response_body)
+  end
+
+  def presenter
+    CoronavirusPagePresenter.new(content_item["details"], "/coronavirus")
+  end
+
+  def live_stream_payload
+    presenter.payload.merge(
+      {
+        "title" => "Coronavirus (COVID-19): what you need to do",
+        "description" => content_item["description"],
+      },
+    )
+  end
+
+  def landing_page_id
+    "774cee22-d896-44c1-a611-e3109cce8eae"
+  end
+
+  def with_longer_timeout
+    prior_timeout = Services.publishing_api.client.options[:timeout]
+    Services.publishing_api.client.options[:timeout] = 10
+
+    begin
+      yield
+    ensure
+      Services.publishing_api.client.options[:timeout] = prior_timeout
+    end
+  end
+end

--- a/app/views/coronavirus/index.html.erb
+++ b/app/views/coronavirus/index.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, "Which coronavirus page do you need to publish?" %>
+<% content_for :title, "What do you need to do?" %>
 
 <ul class="govuk-list">
+<li><%= link_to "Update live stream", coronavirus_live_stream_path, class:"govuk-button" %></li>
 <% links.each do |link| %>
-  <li><%= link_to link[:title], coronavirus_path(slug: link[:slug]), class:"govuk-button" %></li>
+  <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-button" %></li>
 <% end %>
 </ul>

--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, "Update live stream" %>
+<% content_for :context, "Turn the Number 10 live stream on or off" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <!-- turn livestream on/off buttons -->
+    <div>
+      <% if @live_stream.state %>
+        <%= link_to "Turn it off", coronavirus_publish_live_stream_path(on: false), method: :post, class: "govuk-button govuk-button--warning" %>
+      <% else %>
+        <%= link_to "Turn it on", coronavirus_publish_live_stream_path(on: true), method: :post, class: "govuk-button" %>
+      <% end %>
+    <div>
+    <!-- check live -->
+    <div class="govuk-!-padding-bottom-6">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Check live",
+        href: "https://www.gov.uk/coronavirus",
+        target: "_blank",
+        secondary: true
+      } %>
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: redirect("/step-by-step-pages", status: 302)
-
+  post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
+  get "/coronavirus/live_stream", to: "coronavirus#live_stream"
   resources :coronavirus, only: %i(index show update), param: :slug do
     post "publish", to: "coronavirus#publish"
   end

--- a/db/migrate/20200409194204_create_live_stream.rb
+++ b/db/migrate/20200409194204_create_live_stream.rb
@@ -1,0 +1,8 @@
+class CreateLiveStream < ActiveRecord::Migration[6.0]
+  def change
+    create_table :live_streams do |t|
+      t.boolean :state, default: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_09_091313) do
+ActiveRecord::Schema.define(version: 2020_04_09_194204) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -46,6 +46,12 @@ ActiveRecord::Schema.define(version: 2019_10_09_091313) do
     t.integer "index", default: 0, null: false
     t.integer "tag_id", null: false
     t.index ["tag_id"], name: "index_lists_on_tag_id"
+  end
+
+  create_table "live_streams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.boolean "state", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "navigation_rules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -149,7 +155,7 @@ ActiveRecord::Schema.define(version: 2019_10_09_091313) do
     t.string "content_id", null: false
     t.string "state", null: false
     t.boolean "dirty", default: false, null: false
-    t.text "published_groups", limit: 16777215
+    t.text "published_groups", size: :medium
     t.string "child_ordering", default: "alphabetical", null: false
     t.integer "index", default: 0, null: false
     t.index ["content_id"], name: "index_tags_on_content_id", unique: true

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       when_i_visit_the_publish_coronavirus_page
       i_see_a_landing_page_button
       i_see_a_business_page_button
+      i_see_livestream_button
     end
 
     scenario "User selects landing page" do
@@ -96,6 +97,32 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       when_i_visit_a_non_existent_page
       then_i_am_redirected_to_the_index_page
       and_i_see_a_message_telling_me_that_the_page_does_not_exist
+    end
+  end
+
+  context "Live stream updates" do
+    before do
+      given_i_am_a_coronavirus_editor
+      stub_coronavirus_publishing_api
+    end
+
+    scenario "Turn on the live stream" do
+      stub_live_content_request_stream_off
+      when_i_visit_the_publish_coronavirus_page
+      and_i_select_live_stream
+      given_the_live_stream_is_turned_off
+      and_i_select_turn_on_live_stream
+      the_payload_is_updated_to_on
+      and_i_see_live_stream_is_on_message
+    end
+
+    scenario "Turn off the live stream" do
+      stub_live_content_request_stream_on
+      when_i_visit_the_publish_coronavirus_page
+      and_i_select_live_stream
+      and_i_select_turn_off_live_stream
+      the_payload_is_updated_to_off
+      and_i_see_live_stream_is_off_message
     end
   end
 end

--- a/spec/fixtures/coronavirus_content_item.json
+++ b/spec/fixtures/coronavirus_content_item.json
@@ -1,0 +1,130 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/coronavirus",
+  "content_id": "774cee22-d896-44c1-a611-e3109cce8eae",
+  "document_type": "coronavirus_landing_page",
+  "first_published_at": "2020-03-20T14:29:42.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2020-03-30T16:57:50.000+00:00",
+  "publishing_app": "collections-publisher",
+  "publishing_scheduled_at": null,
+  "rendering_app": "collections",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "coronavirus_landing_page",
+  "title": "Coronavirus (COVID-19): what you need to do",
+  "updated_at": "2020-04-16T09:07:05.863Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "11053-1587028025.549-10.3.3.1-1694",
+  "links": {
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "514a6dd3-b7f2-4e0c-8018-c475840fb013",
+        "title": "Staying at home and away from others (social distancing)",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/full-guidance-on-staying-at-home-and-away-from-others",
+        "base_path": "/government/publications/full-guidance-on-staying-at-home-and-away-from-others",
+        "document_type": "guidance",
+        "public_updated_at": "2020-03-29T13:00:46Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/publications/full-guidance-on-staying-at-home-and-away-from-others",
+        "web_url": "https://www.gov.uk/government/publications/full-guidance-on-staying-at-home-and-away-from-others"
+      },
+      {
+        "content_id": "c3d303dd-c917-4769-a356-ce3d581e90fd",
+        "title": "COVID-19: guidance for employees, employers and businesses",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/guidance-to-employers-and-businesses-about-covid-19",
+        "base_path": "/government/publications/guidance-to-employers-and-businesses-about-covid-19",
+        "document_type": "guidance",
+        "public_updated_at": "2020-04-07T19:27:20Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/publications/guidance-to-employers-and-businesses-about-covid-19",
+        "web_url": "https://www.gov.uk/government/publications/guidance-to-employers-and-businesses-about-covid-19"
+      },
+      {
+        "content_id": "bd05a981-f046-4354-aff8-289462984fc5",
+        "title": "COVID-19: track coronavirus cases",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/covid-19-track-coronavirus-cases",
+        "base_path": "/government/publications/covid-19-track-coronavirus-cases",
+        "document_type": "guidance",
+        "public_updated_at": "2020-04-14T15:20:09Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/publications/covid-19-track-coronavirus-cases",
+        "web_url": "https://www.gov.uk/government/publications/covid-19-track-coronavirus-cases"
+      },
+      {
+        "content_id": "bfc9a804-8786-41ab-b642-06f256eda3ad",
+        "title": "Travel advice: coronavirus (COVID-19)",
+        "locale": "en",
+        "api_path": "/api/content/guidance/travel-advice-novel-coronavirus",
+        "base_path": "/guidance/travel-advice-novel-coronavirus",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2020-04-08T16:03:29Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/guidance/travel-advice-novel-coronavirus",
+        "web_url": "https://www.gov.uk/guidance/travel-advice-novel-coronavirus"
+      },
+      {
+        "content_id": "c957e925-4c4f-4c12-9d60-e639449e907d",
+        "title": "Claim for your employees' wages through the Coronavirus Job Retention Scheme",
+        "locale": "en",
+        "api_path": "/api/content/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme",
+        "base_path": "/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2020-04-15T12:39:46Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme",
+        "web_url": "https://www.gov.uk/guidance/claim-for-wage-costs-through-the-coronavirus-job-retention-scheme"
+      }
+    ],
+    "topical_events": [
+      {
+        "content_id": "c4cd0e8a-3ae1-4385-8936-1cfafe5031fb",
+        "title": "Coronavirus (COVID-19): UK government response",
+        "locale": "en",
+        "api_path": "/api/content/government/topical-events/coronavirus-covid-19-uk-government-response",
+        "base_path": "/government/topical-events/coronavirus-covid-19-uk-government-response",
+        "document_type": "topical_event",
+        "public_updated_at": "2020-03-20T08:30:26Z",
+        "schema_name": "placeholder",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/topical-events/coronavirus-covid-19-uk-government-response",
+        "web_url": "https://www.gov.uk/government/topical-events/coronavirus-covid-19-uk-government-response"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Coronavirus (COVID-19): what you need to do",
+        "public_updated_at": "2020-03-30T16:57:50Z",
+        "document_type": "coronavirus_landing_page",
+        "schema_name": "coronavirus_landing_page",
+        "base_path": "/coronavirus",
+        "api_path": "/api/content/coronavirus",
+        "withdrawn": false,
+        "content_id": "774cee22-d896-44c1-a611-e3109cce8eae",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/coronavirus",
+        "web_url": "https://www.gov.uk/coronavirus",
+        "links": {}
+      }
+    ]
+  },
+  "description": "Find out about the government response to coronavirus (COVID-19) and what you need to do.",
+  "details": {
+    "announcements_label": "Announcements",
+    "live_stream_enabled": false
+  }
+}

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -161,6 +161,7 @@ content:
         url: /search/news-and-communications?topical_events%5B%5D=coronavirus-covid-19-uk-government-response
       - label: "Guidance"
         url: /search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
+  live_stream:
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe CoronavirusPagePresenter do
         "schema_name" => "coronavirus_landing_page",
         "details" => {
           "sections" => "some sections",
+          "live_stream_enabled" => false,
         },
         "links" => {},
         "locale" => "en",

--- a/spec/services/live_stream_updater_spec.rb
+++ b/spec/services/live_stream_updater_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+
+RSpec.describe LiveStreamUpdater do
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+  end
+
+  context "Succesful interaction with publishing api" do
+    it "turns live stream on" do
+      stub_live_content_request
+      live_stream = LiveStream.create
+      expect(live_stream.state).to be false
+
+      updater = LiveStreamUpdater.new(live_stream, true)
+
+      expect(updater.updated?).to be true
+      expect(updater.published?).to be true
+      expect(live_stream.state).to be true
+      payload = updater.send(:live_stream_payload)
+      assert_publishing_api_put_content(landing_page_id, payload)
+    end
+
+    it "turns live stream off" do
+      stub_live_content_request
+      live_stream = LiveStream.create.toggle(:state)
+      expect(live_stream.state).to be true
+
+      updater = LiveStreamUpdater.new(live_stream, false)
+      payload = updater.send(:live_stream_payload)
+
+      expect(updater.updated?).to be true
+      expect(updater.published?).to be true
+      expect(live_stream.state).to be false
+      assert_publishing_api_put_content(landing_page_id, payload)
+    end
+  end
+
+  context "Unsuccesful interaction with publishing api" do
+    it "handles failure to update" do
+      stub_live_content_request
+      live_stream = LiveStream.create
+      updater = LiveStreamUpdater.new(live_stream, true)
+
+      stub_any_publishing_api_call_to_return_not_found
+      expect(updater.updated?).to be false
+      expect(live_stream.state).to be false
+    end
+
+    it "handles failure to publish " do
+      stub_live_content_request
+      live_stream = LiveStream.create
+      updater = LiveStreamUpdater.new(live_stream, true)
+      expect(updater.updated?).to be true
+      expect(live_stream.state).to be true
+
+      stub_any_publishing_api_call_to_return_not_found
+      expect(updater.published?).to be false
+      expect(live_stream.state).to be false
+    end
+  end
+
+  describe "#resync" do
+    it "database and content item out of sync" do
+      #stubbed content item contains { live_stream_enabled: false }
+      stub_live_content_request
+      live_stream = LiveStream.create.toggle(:state)
+      expect(live_stream.state).to be true
+      LiveStreamUpdater.new(live_stream).resync
+      expect(live_stream.state).to be false
+    end
+
+    it "database and content item in sync" do
+      stub_live_content_request
+      live_stream = LiveStream.create
+      expect(live_stream.state).to be false
+      LiveStreamUpdater.new(live_stream).resync
+      expect(live_stream.state).to be false
+    end
+  end
+
+  def live_content_item
+    File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
+  end
+
+  def stub_live_content_request
+    stub_publishing_api_has_item(JSON.parse(live_content_item))
+  end
+
+  def landing_page_id
+    "774cee22-d896-44c1-a611-e3109cce8eae"
+  end
+end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -3,9 +3,49 @@ def given_i_am_a_coronavirus_editor
   stub_user.name = "Test author"
 end
 
+def given_the_live_stream_is_turned_off
+  expect(LiveStream.last.state).to be false
+end
+
+def given_the_live_stream_is_turned_on
+  expect(LiveStream.last.state).to be true
+end
+
+def the_payload_is_updated_to_on
+  assert_publishing_api_put_content(
+    "774cee22-d896-44c1-a611-e3109cce8eae",
+    request_json_includes(
+      "details" => {
+        "announcements_label" => "Announcements",
+        "live_stream_enabled" => true,
+      },
+    ),
+  )
+end
+
+def the_payload_is_updated_to_off
+  assert_publishing_api_put_content(
+    "774cee22-d896-44c1-a611-e3109cce8eae",
+    request_json_includes(
+      "details" => {
+        "announcements_label" => "Announcements",
+        "live_stream_enabled" => false,
+      },
+    ),
+  )
+end
+
 def stub_coronavirus_publishing_api
   stub_any_publishing_api_put_content
   stub_any_publishing_api_publish
+end
+
+def stub_live_content_request_stream_off
+  stub_publishing_api_has_item(JSON.parse(live_content_item_live_stream_off))
+end
+
+def stub_live_content_request_stream_on
+  stub_publishing_api_has_item(JSON.parse(live_content_item_live_stream_on))
 end
 
 def stub_github_request
@@ -52,12 +92,28 @@ def i_see_a_business_page_button
   expect(page).to have_link("Business support page")
 end
 
+def i_see_livestream_button
+  expect(page).to have_link("Update live stream")
+end
+
 def and_i_select_landing_page
   click_on("Coronavirus landing page")
 end
 
 def and_i_select_business_page
   click_on("Business support page")
+end
+
+def and_i_select_live_stream
+  click_on("Update live stream")
+end
+
+def and_i_select_turn_on_live_stream
+  click_on("Turn it on")
+end
+
+def and_i_select_turn_off_live_stream
+  click_on("Turn it off")
 end
 
 def when_i_visit_the_publish_coronavirus_page
@@ -111,6 +167,17 @@ def invalid_github_response
   File.read(Rails.root.join + "spec/fixtures/invalid_corona_page.yml")
 end
 
+def live_content_item_live_stream_off
+  File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
+end
+
+def live_content_item_live_stream_on
+  f = File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
+  h = JSON.parse(f)
+  h["details"]["live_stream_enabled"] = true
+  h.to_json
+end
+
 def and_i_see_an_alert
   expect(page).to have_text("Invalid content - please recheck GitHub and add title, stay_at_home, guidance, announcements_label, announcements, nhs_banner, sections, topic_section, notifications.")
 end
@@ -141,4 +208,12 @@ end
 
 def and_i_see_a_page_published_message
   expect(page).to have_text("Page published!")
+end
+
+def and_i_see_live_stream_is_on_message
+  expect(page).to have_text("Live stream turned on")
+end
+
+def and_i_see_live_stream_is_off_message
+  expect(page).to have_text("Live stream turned off")
 end


### PR DESCRIPTION
## What
- first attempt at adding a button to the coronavirus pages tab in collections publisher so that content designers/others can activate the livestream without dev input. 
## How
- Set the livestream state (on or off) in collections publisher instead of in the [yaml](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml) file in the govuk-coronavirus-content repo
- Persist live stream state in database
- Read from database when creating payload for publishing api

[Trello card](https://trello.com/c/tsal0J9i/158-create-a-way-for-content-designers-to-switch-the-livestream-on-and-off)