### PR TITLE
Uniqueness validator explicitly uses case sensitivity

### DIFF
--- a/app/models/secondary_content_link.rb
+++ b/app/models/secondary_content_link.rb
@@ -3,7 +3,7 @@ class SecondaryContentLink < ApplicationRecord
   validates_presence_of :step_by_step_page
 
   validates :title, :base_path, :content_id, :publishing_app, :schema_name, :step_by_step_page_id, presence: true
-  validates_uniqueness_of :base_path, scope: :step_by_step_page_id
+  validates_uniqueness_of :base_path, scope: :step_by_step_page_id, case_sensitive: false
 
   def smartanswer?
     schema_name == "transaction" && publishing_app == "smartanswers"

--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -18,7 +18,7 @@ class StepByStepPage < ApplicationRecord
 
   validates :title, :slug, :introduction, :description, presence: true
   validates :scheduled_at, in_future: true
-  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: true
+  validates :slug, format: { with: /\A([a-z0-9]+-)*[a-z0-9]+\z/ }, uniqueness: { case_sensitive: false }
   validates :slug, slug: true, on: :create
   validates :status, inclusion: { in: STATUSES }, presence: true
   validates :status, status_prerequisite: true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,7 +17,7 @@ class Tag < ApplicationRecord
   has_many :redirect_routes
 
   validates :slug, :title, :content_id, presence: true
-  validates :slug, uniqueness: { scope: %w(parent_id) }, format: { with: /\A[a-z0-9-]*\z/ }
+  validates :slug, uniqueness: { scope: %w(parent_id), case_sensitive: false }, format: { with: /\A[a-z0-9-]*\z/ }
   validates :child_ordering, inclusion: { in: ORDERING_TYPES }
   validate :parent_is_not_a_child
   validate :cannot_change_slug


### PR DESCRIPTION
Fixes Rail 6.1 deprecation warnings

```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :slug attribute in StepByStepPage model, pass `case_sensitive: true` option explicitly to the uniqueness validator

DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :slug attribute in Tag model, pass `case_sensitive: true` option explicitly to the uniqueness validator

DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :base_path attribute in SecondaryContentLink model, pass `case_sensitive: true` option explicitly to the uniqueness validator

```