### PR TITLE
Fix a couple of coronavirus issues 

### DIFF
--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -15,7 +15,7 @@
     <div class="govuk-!-padding-bottom-6">
       <%= render "govuk_publishing_components/components/button", {
         text: "Check live",
-        href: "https://www.gov.uk/coronavirus",
+        href: published_url("coronavirus"),
         target: "_blank",
         secondary: true
       } %>

--- a/app/views/coronavirus/shared/_live.html.erb
+++ b/app/views/coronavirus/shared/_live.html.erb
@@ -4,7 +4,7 @@
 } %>
 <%= render "govuk_publishing_components/components/button", {
     text: "View live version",
-    href: published_url(path),
+    href: published_url(path.delete_prefix("/")),
     target: "_blank",
     secondary: true
   } %>

--- a/app/views/coronavirus/show.html.erb
+++ b/app/views/coronavirus/show.html.erb
@@ -6,6 +6,6 @@
     <%= render partial: "coronavirus/shared/draft" %>
     <%= render partial: "coronavirus/shared/preview", locals: { path: page[:base_path] } %>
     <%= render partial: "coronavirus/shared/publish" %>
-    <%= render partial: "coronavirus/shared/live", locals: { path: "coronavirus" } %>
+    <%= render partial: "coronavirus/shared/live", locals: { path: page[:base_path] } %>
   </div>
 </div>

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -114,6 +114,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       and_i_select_turn_on_live_stream
       the_payload_is_updated_to_on
       and_i_see_live_stream_is_on_message
+      and_i_see_a_link_to_the_landing_page
     end
 
     scenario "Turn off the live stream" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -66,7 +66,8 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       and_i_select_business_page
       i_see_an_update_draft_button
       and_a_preview_button
-      # and_a_publish_button
+      and_a_publish_button
+      and_a_view_live_business_content_button
     end
 
     scenario "Updating draft business page" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -145,6 +145,10 @@ def and_a_publish_button
   expect(page).to have_button("Publish")
 end
 
+def and_a_view_live_business_content_button
+  expect(page).to have_link("View live version", href: "https://www.test.gov.uk/coronavirus/business-support")
+end
+
 def and_i_push_a_new_draft_version
   click_on("Update draft")
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -217,3 +217,7 @@ end
 def and_i_see_live_stream_is_off_message
   expect(page).to have_text("Live stream turned off")
 end
+
+def and_i_see_a_link_to_the_landing_page
+  expect(page).to have_link("Check live", href: "https://www.test.gov.uk/coronavirus")
+end


### PR DESCRIPTION
Fixes: 
- [The livestream toggle page](https://collections-publisher.publishing.service.gov.uk/coronavirus/live_stream) "Check live" link that is not currently environment specific
- [The business support page](https://collections-publisher.publishing.service.gov.uk/coronavirus/business) has a "View live version" link that points to the /coronavirus page
