### PR TITLE
Add education page

### DIFF
--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -118,7 +118,7 @@ private
     return false if content.nil?
 
     required_keys =
-      type == :landing ? required_landing_page_keys : required_business_page_keys
+      type == :landing ? required_landing_page_keys : required_hub_page_keys
     missing_keys = (required_keys - content.keys)
     if missing_keys.any?
       flash["alert"] = "Invalid content - please recheck GitHub and add #{missing_keys.join(', ')}."
@@ -155,16 +155,10 @@ private
     )
   end
 
-  def required_business_page_keys
+  def required_hub_page_keys
     %w(
       title
       header_section
-      guidance_section
-      related_links
-      announcements_label
-      announcements
-      other_announcements
-      guidance_section
       sections
       topic_section
       notifications

--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -189,6 +189,14 @@ private
           base_path: "/coronavirus/business-support",
           github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_business_page.yml",
         },
+      education:
+        {
+          name: "Education page",
+          content_id: "b350e61d-1db9-4cc2-bb44-fab02882ac25".freeze,
+          raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_education_page.yml".freeze,
+          base_path: "/coronavirus/education-and-childcare",
+          github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_education_page.yml",
+        },
     }
   end
 end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       when_i_visit_the_publish_coronavirus_page
       and_i_select_business_page
       and_i_push_a_new_draft_business_version_with_invalid_content
-      and_i_see_an_alert_for_missing_business_keys
+      and_i_see_an_alert_for_missing_hub_page_keys
     end
 
     scenario "Publishing business page" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -186,8 +186,8 @@ def and_i_see_an_alert
   expect(page).to have_text("Invalid content - please recheck GitHub and add title, stay_at_home, guidance, announcements_label, announcements, nhs_banner, sections, topic_section, notifications.")
 end
 
-def and_i_see_an_alert_for_missing_business_keys
-  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, guidance_section, related_links, announcements_label, announcements, other_announcements, guidance_section, sections, topic_section, notifications.")
+def and_i_see_an_alert_for_missing_hub_page_keys
+  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, sections, topic_section, notifications.")
 end
 
 def and_i_see_a_draft_updated_message


### PR DESCRIPTION
This adds the education hub page basic information.  We'll need to add the referenced yaml file