### PR TITLE
Hide the Update Live Stream button

### DIFF
--- a/app/views/coronavirus/index.html.erb
+++ b/app/views/coronavirus/index.html.erb
@@ -1,7 +1,6 @@
 <% content_for :title, "What do you need to do?" %>
 
 <ul class="govuk-list">
-<li><%= link_to "Update live stream", coronavirus_live_stream_path, class:"govuk-button" %></li>
 <% links.each do |link| %>
   <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-button" %></li>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: redirect("/step-by-step-pages", status: 302)
-  post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
-  get "/coronavirus/live_stream", to: "coronavirus#live_stream"
+
   resources :coronavirus, only: %i(index show update), param: :slug do
     post "publish", to: "coronavirus#publish"
   end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       when_i_visit_the_publish_coronavirus_page
       i_see_a_landing_page_button
       i_see_a_business_page_button
-      i_see_livestream_button
     end
 
     scenario "User selects landing page" do
@@ -98,33 +97,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       when_i_visit_a_non_existent_page
       then_i_am_redirected_to_the_index_page
       and_i_see_a_message_telling_me_that_the_page_does_not_exist
-    end
-  end
-
-  context "Live stream updates" do
-    before do
-      given_i_am_a_coronavirus_editor
-      stub_coronavirus_publishing_api
-    end
-
-    scenario "Turn on the live stream" do
-      stub_live_content_request_stream_off
-      when_i_visit_the_publish_coronavirus_page
-      and_i_select_live_stream
-      given_the_live_stream_is_turned_off
-      and_i_select_turn_on_live_stream
-      the_payload_is_updated_to_on
-      and_i_see_live_stream_is_on_message
-      and_i_see_a_link_to_the_landing_page
-    end
-
-    scenario "Turn off the live stream" do
-      stub_live_content_request_stream_on
-      when_i_visit_the_publish_coronavirus_page
-      and_i_select_live_stream
-      and_i_select_turn_off_live_stream
-      the_payload_is_updated_to_off
-      and_i_see_live_stream_is_off_message
     end
   end
 end


### PR DESCRIPTION
Because we are no longer toggling the live stream
video component (ref: https://github.com/alphagov/collections/pull/1694#pullrequestreview-399998300)
we no longer need this button. A separate PR will
contain the work needed to allow content designers to
publish the daily live stream url via this interface.