### PR TITLE
Live stream url updater

### DIFF
--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -19,20 +19,25 @@ class CoronavirusController < ApplicationController
     @live_stream = updater.object
   end
 
-  def publish_live_stream
+  def update_live_stream
     @live_stream = LiveStream.last
     if @live_stream.update(url: url_params)
       if updater.update?
-        if updater.publish?
-          flash[:notice] = "New live stream url published!"
-        else
-          flash["alert"] = "Live stream url has not been published - please try again"
-        end
+        flash[:notice] = "Draft live stream url updated!"
       else
         flash["alert"] = "Live stream url has not been updated - please try again"
       end
     else
       flash[:notice] = @live_stream.errors.full_messages.join(", ")
+    end
+    redirect_to coronavirus_live_stream_path
+  end
+
+  def publish_live_stream
+    if updater.publish?
+      flash[:notice] = "New live stream url published!"
+    else
+      flash["alert"] = "Live stream url has not been published - please try again"
     end
     redirect_to coronavirus_live_stream_path
   end

--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -22,7 +22,7 @@ class CoronavirusController < ApplicationController
   def update_live_stream
     @live_stream = LiveStream.last
     if @live_stream.update(url: url_params)
-      if updater.update?
+      if updater.update
         flash[:notice] = "Draft live stream url updated!"
       else
         flash["alert"] = "Live stream url has not been updated - please try again"
@@ -34,7 +34,7 @@ class CoronavirusController < ApplicationController
   end
 
   def publish_live_stream
-    if updater.publish?
+    if updater.publish
       flash[:notice] = "New live stream url published!"
     else
       flash["alert"] = "Live stream url has not been published - please try again"

--- a/app/models/live_stream.rb
+++ b/app/models/live_stream.rb
@@ -1,2 +1,3 @@
 class LiveStream < ApplicationRecord
+  validates :url, url: true, presence: true
 end

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -15,7 +15,7 @@ class CoronavirusPagePresenter
       "description" => description,
       "document_type" => "coronavirus_landing_page",
       "schema_name" => "coronavirus_landing_page",
-      "details" => details.merge(live_stream_state),
+      "details" => details.deep_merge(live_stream_url),
       "links" => {},
       "locale" => "en",
       "rendering_app" => "collections",
@@ -25,9 +25,11 @@ class CoronavirusPagePresenter
     }
   end
 
-  def live_stream_state
+  def live_stream_url
     {
-      "live_stream_enabled" => live_stream.state,
+      "live_stream" => {
+        "video_url" => live_stream.url,
+      },
     }
   end
 

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -29,8 +29,13 @@ class CoronavirusPagePresenter
     {
       "live_stream" => {
         "video_url" => live_stream.url,
+        "date" => todays_date,
       },
     }
+  end
+
+  def todays_date
+    DateTime.now.strftime("%-d %B %Y")
   end
 
   def live_stream

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,0 +1,36 @@
+class UrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    @record = record
+    @attribute = attribute
+    @value = value
+    if value.present?
+      code = response_code(parsed_url)
+      record_error("is not valid. Please check it and try again.") unless code == 200
+    end
+  end
+
+private
+
+  def record_error(msg)
+    @record.errors[@attribute] << msg
+  end
+
+  def parsed_url
+    uri = URI.parse(@value)
+    if uri.host == "www.youtube.com" && uri.scheme == "https"
+      uri.to_s
+    end
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def response_code(url = nil)
+    return if url.nil?
+
+    begin
+      RestClient.get(url).code
+    rescue RestClient::Exception => e
+      e.http_code
+    end
+  end
+end

--- a/app/views/coronavirus/index.html.erb
+++ b/app/views/coronavirus/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "What do you need to do?" %>
 
 <ul class="govuk-list">
+  <li><%= link_to "Update live stream", coronavirus_live_stream_path, class:"govuk-button" %></li>
 <% links.each do |link| %>
   <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-button" %></li>
 <% end %>

--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -3,14 +3,24 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <div class="govuk-form-group">
-      <%= form_with(url: "publish_live_stream", method: "post", local: true) do %>
+      <%= form_with(url: "update_live_stream", method: "post", local: true) do %>
         <%= label_tag(:url, "URL", class: "govuk-label" ) %>
         <%= text_field_tag(:url, nil,
           class: "govuk-input govuk-!-margin-bottom-6",
           placeholder: "eg. https://www.youtube.com/watch?v=d3ieIwP4FKg"
           ) %>
-        <%= submit_tag("Submit", class: "govuk-button") %>
+        <%= submit_tag("Update draft", class: "govuk-button") %>
       <% end %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Preview",
+        href: draft_govuk_url("/coronavirus"),
+        target: "_blank",
+        secondary: true
+      } %>
+      </div>
+      <div>
+        <%= link_to "Publish", coronavirus_publish_live_stream_path, method: :post, class: "govuk-button" %>
+      </div>
       <%= render "govuk_publishing_components/components/button", {
         text: "Check live",
         href: published_url("coronavirus"),

--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -21,7 +21,7 @@
           <p>Click on the video, and copy its URL.</p>
         </div>
       </details>
-      <%= form_with(url: "update_live_stream", method: "post", local: true) do %>
+      <%= form_with(url: "update_live_stream", method: "put", local: true) do %>
         <%= label_tag(:url, "YouTube URL", class: "govuk-label" ) %>
         <%= text_field_tag(:url, nil,
           class: "govuk-input govuk-!-margin-bottom-6",

--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -1,16 +1,39 @@
-<% content_for :title, "Add a new live stream URL" %>
-
+<% content_for :title, "Update live stream URL" %>
+<% content_for :context, "Make changes to the coronavirus landing page live stream" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <div class="govuk-form-group">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "1. Add the URL",
+        padding: true
+      } %>
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Help with YouTube
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>Every afternoon, No.10 adds a video link to the upcoming press conference to this <a href="https://www.youtube.com/user/Number10gov/">page.</a></p>
+          <p>The video will appear in the 'Uploads' section of the page and is labelled as 'Live'.</p>
+          <p>The video is added at around 4.30pm on weekdays, and 3.30pm on weekends.</p>
+          <p>If the most recent video has yesterday's date, or there is no video labelled 'Live' check again in a few minutes.</p>
+          <p>Click on the video, and copy its URL.</p>
+        </div>
+      </details>
       <%= form_with(url: "update_live_stream", method: "post", local: true) do %>
-        <%= label_tag(:url, "URL", class: "govuk-label" ) %>
+        <%= label_tag(:url, "YouTube URL", class: "govuk-label" ) %>
         <%= text_field_tag(:url, nil,
           class: "govuk-input govuk-!-margin-bottom-6",
           placeholder: "eg. https://www.youtube.com/watch?v=d3ieIwP4FKg"
           ) %>
+
         <%= submit_tag("Update draft", class: "govuk-button") %>
       <% end %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "2. Preview your changes",
+        padding: true
+      } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Preview",
         href: draft_govuk_url("/coronavirus"),
@@ -18,9 +41,17 @@
         secondary: true
       } %>
       </div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "3. Publish your changes",
+        padding: true
+      } %>
       <div>
         <%= link_to "Publish", coronavirus_publish_live_stream_path, method: :post, class: "govuk-button" %>
       </div>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "4. Check the live landing page",
+        padding: true
+      } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Check live",
         href: published_url("coronavirus"),

--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -1,18 +1,16 @@
-<% content_for :title, "Update live stream" %>
-<% content_for :context, "Turn the Number 10 live stream on or off" %>
+<% content_for :title, "Add a new live stream URL" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <!-- turn livestream on/off buttons -->
-    <div>
-      <% if @live_stream.state %>
-        <%= link_to "Turn it off", coronavirus_publish_live_stream_path(on: false), method: :post, class: "govuk-button govuk-button--warning" %>
-      <% else %>
-        <%= link_to "Turn it on", coronavirus_publish_live_stream_path(on: true), method: :post, class: "govuk-button" %>
+    <div class="govuk-form-group">
+      <%= form_with(url: "publish_live_stream", method: "post", local: true) do %>
+        <%= label_tag(:url, "URL", class: "govuk-label" ) %>
+        <%= text_field_tag(:url, nil,
+          class: "govuk-input govuk-!-margin-bottom-6",
+          placeholder: "eg. https://www.youtube.com/watch?v=d3ieIwP4FKg"
+          ) %>
+        <%= submit_tag("Submit", class: "govuk-button") %>
       <% end %>
-    <div>
-    <!-- check live -->
-    <div class="govuk-!-padding-bottom-6">
       <%= render "govuk_publishing_components/components/button", {
         text: "Check live",
         href: published_url("coronavirus"),
@@ -20,6 +18,5 @@
         secondary: true
       } %>
     </div>
-
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: redirect("/step-by-step-pages", status: 302)
+  post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
+  get "/coronavirus/live_stream", to: "coronavirus#live_stream"
 
   resources :coronavirus, only: %i(index show update), param: :slug do
     post "publish", to: "coronavirus#publish"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   root to: redirect("/step-by-step-pages", status: 302)
   get "/coronavirus/live_stream", to: "coronavirus#live_stream"
-  post "/coronavirus/update_live_stream", to: "coronavirus#update_live_stream"
+  put "/coronavirus/update_live_stream", to: "coronavirus#update_live_stream"
   post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: redirect("/step-by-step-pages", status: 302)
-  post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
   get "/coronavirus/live_stream", to: "coronavirus#live_stream"
+  post "/coronavirus/update_live_stream", to: "coronavirus#update_live_stream"
+  post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
+
 
   resources :coronavirus, only: %i(index show update), param: :slug do
     post "publish", to: "coronavirus#publish"

--- a/db/migrate/20200424104605_add_url_to_live_stream.rb
+++ b/db/migrate/20200424104605_add_url_to_live_stream.rb
@@ -1,0 +1,5 @@
+class AddUrlToLiveStream < ActiveRecord::Migration[6.0]
+  def change
+    add_column :live_streams, :url, :string, null: false
+  end
+end

--- a/db/migrate/20200424214202_remove_state_from_live_stream.rb
+++ b/db/migrate/20200424214202_remove_state_from_live_stream.rb
@@ -1,0 +1,5 @@
+class RemoveStateFromLiveStream < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :live_streams, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_09_194204) do
+ActiveRecord::Schema.define(version: 2020_04_24_214202) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -49,9 +49,9 @@ ActiveRecord::Schema.define(version: 2020_04_09_194204) do
   end
 
   create_table "live_streams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.boolean "state", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url", null: false
   end
 
   create_table "navigation_rules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,6 @@ user_id = "026530a0-750f-41e6-8863-b539d1467145"
 User.create!(
   uid: user_id,
   name: "Test user",
-  permissions: ["signin", "GDS Editor"],
+  permissions: ["signin", "GDS Editor", "Coronavirus editor"],
   organisation_content_id: gds_organisation_id,
 )

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -107,16 +107,17 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_restclient
     end
 
-    scenario "Add a valid livestream url" do
+    scenario "Publish a valid livestream url" do
       when_i_visit_the_publish_coronavirus_page
       and_i_select_live_stream
-      i_am_able_to_submit_a_valid_url
-      the_payload_contains_the_valid_url
-      and_i_see_live_stream_is_published_message
+      i_am_able_to_update_draft_content_with_valid_url
+      and_i_see_live_stream_is_updated_message
+      and_i_can_check_the_preview
+      and_i_can_publish_the_url
       and_i_see_a_link_to_the_landing_page
     end
 
-    scenario "Add an invalid livestream url" do
+    scenario "Adding an invalid livestream url" do
       when_i_visit_the_publish_coronavirus_page
       and_i_select_live_stream
       i_am_able_to_submit_an_invalid_url

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -99,4 +99,29 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       and_i_see_a_message_telling_me_that_the_page_does_not_exist
     end
   end
+
+  context "Live stream updates" do
+    before do
+      given_i_am_a_coronavirus_editor
+      stub_coronavirus_publishing_api
+      stub_restclient
+    end
+
+    scenario "Add a valid livestream url" do
+      when_i_visit_the_publish_coronavirus_page
+      and_i_select_live_stream
+      i_am_able_to_submit_a_valid_url
+      the_payload_contains_the_valid_url
+      and_i_see_live_stream_is_published_message
+      and_i_see_a_link_to_the_landing_page
+    end
+
+    scenario "Add an invalid livestream url" do
+      when_i_visit_the_publish_coronavirus_page
+      and_i_select_live_stream
+      i_am_able_to_submit_an_invalid_url
+      and_i_see_the_error_message
+      and_nothing_is_sent_publishing_api
+    end
+  end
 end

--- a/spec/fixtures/coronavirus_content_item.json
+++ b/spec/fixtures/coronavirus_content_item.json
@@ -125,6 +125,13 @@
   "description": "Find out about the government response to coronavirus (COVID-19) and what you need to do.",
   "details": {
     "announcements_label": "Announcements",
-    "live_stream_enabled": false
+    "live_stream": {
+      "video_url" : "https://www.youtube.com/watch?v=UF8mC-T0u6k",
+      "date" : "1 April 2020",
+      "date_text": "Live streamed",
+      "previous_videos": {
+        "url": "https://www.youtube.com/user/Number10gov/videos"
+      }
+    }
   }
 }

--- a/spec/models/live_stream_spec.rb
+++ b/spec/models/live_stream_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe LiveStream do
-
   describe "validations" do
     let(:bad_url) { "www.youtbe.co.uk/123" }
     let(:good_url) { "https://www.youtube.com/123" }

--- a/spec/models/live_stream_spec.rb
+++ b/spec/models/live_stream_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe LiveStream do
+
+  describe "validations" do
+    let(:bad_url) { "www.youtbe.co.uk/123" }
+    let(:good_url) { "https://www.youtube.com/123" }
+
+    it "is invalid without a url" do
+      expect(LiveStream.create).not_to be_valid
+    end
+
+    it "it requires a valid url" do
+      stub_request(:get, bad_url).to_return(status: 404)
+      expect { LiveStream.create!(url: bad_url) }.to raise_error(ActiveRecord::RecordInvalid)
+
+      stub_request(:get, good_url)
+      expect(LiveStream.create(url: good_url)).to be_valid
+    end
+  end
+end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -16,9 +16,14 @@ RSpec.describe CoronavirusPagePresenter do
   subject { described_class.new(content, landing_page_path) }
 
   it "presents the payload correctly" do
-    presented = subject.payload
-    expect(presented).to be_valid_against_schema("coronavirus_landing_page")
+    url = "https://www.youtube.com/123"
+    stub_request(:get, url)
 
+    LiveStream.create(url: url)
+    date = subject.todays_date
+    presented = subject.payload
+
+    expect(presented).to be_valid_against_schema("coronavirus_landing_page")
     expect(presented).to eq(
       {
         "base_path" => landing_page_path,
@@ -28,7 +33,10 @@ RSpec.describe CoronavirusPagePresenter do
         "schema_name" => "coronavirus_landing_page",
         "details" => {
           "sections" => "some sections",
-          "live_stream"=>{"video_url"=>nil},
+          "live_stream" => {
+            "video_url" => LiveStream.last.url,
+            "date" => date,
+},
         },
         "links" => {},
         "locale" => "en",

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CoronavirusPagePresenter do
         "schema_name" => "coronavirus_landing_page",
         "details" => {
           "sections" => "some sections",
-          "live_stream_enabled" => false,
+          "live_stream"=>{"video_url"=>nil},
         },
         "links" => {},
         "locale" => "en",

--- a/spec/services/live_stream_updater_spec.rb
+++ b/spec/services/live_stream_updater_spec.rb
@@ -9,76 +9,45 @@ RSpec.describe LiveStreamUpdater do
     stub_any_publishing_api_publish
   end
 
-  context "Succesful interaction with publishing api" do
-    it "turns live stream on" do
+  describe "#initialize" do
+    it "finds or creates a livestream object" do
       stub_live_content_request
-      live_stream = LiveStream.create
-      expect(live_stream.state).to be false
+      stub_youtube_link
 
-      updater = LiveStreamUpdater.new(live_stream, true)
-
-      expect(updater.updated?).to be true
-      expect(updater.published?).to be true
-      expect(live_stream.state).to be true
-      payload = updater.send(:live_stream_payload)
-      assert_publishing_api_put_content(landing_page_id, payload)
+      live_stream = LiveStreamUpdater.new.object
+      expect(live_stream.url).to eq live_url
     end
+  end
 
-    it "turns live stream off" do
+  context "Succesful interaction with publishing api" do
+    it "#update and #publish?" do
       stub_live_content_request
-      live_stream = LiveStream.create.toggle(:state)
-      expect(live_stream.state).to be true
+      stub_youtube_link
 
-      updater = LiveStreamUpdater.new(live_stream, false)
-      payload = updater.send(:live_stream_payload)
-
-      expect(updater.updated?).to be true
-      expect(updater.published?).to be true
-      expect(live_stream.state).to be false
-      assert_publishing_api_put_content(landing_page_id, payload)
+      updater = LiveStreamUpdater.new
+      expect(updater.update?).to be true
+      expect(updater.publish?).to be true
     end
   end
 
   context "Unsuccesful interaction with publishing api" do
-    it "handles failure to update" do
+    it "#update?" do
       stub_live_content_request
-      live_stream = LiveStream.create
-      updater = LiveStreamUpdater.new(live_stream, true)
+      stub_youtube_link
 
+      updater = LiveStreamUpdater.new
       stub_any_publishing_api_call_to_return_not_found
-      expect(updater.updated?).to be false
-      expect(live_stream.state).to be false
+      expect(updater.update?).to be false
     end
 
-    it "handles failure to publish " do
+    it "#publish? " do
       stub_live_content_request
-      live_stream = LiveStream.create
-      updater = LiveStreamUpdater.new(live_stream, true)
-      expect(updater.updated?).to be true
-      expect(live_stream.state).to be true
+      stub_youtube_link
 
+      updater = LiveStreamUpdater.new
+      expect(updater.update?).to be true
       stub_any_publishing_api_call_to_return_not_found
-      expect(updater.published?).to be false
-      expect(live_stream.state).to be false
-    end
-  end
-
-  describe "#resync" do
-    it "database and content item out of sync" do
-      #stubbed content item contains { live_stream_enabled: false }
-      stub_live_content_request
-      live_stream = LiveStream.create.toggle(:state)
-      expect(live_stream.state).to be true
-      LiveStreamUpdater.new(live_stream).resync
-      expect(live_stream.state).to be false
-    end
-
-    it "database and content item in sync" do
-      stub_live_content_request
-      live_stream = LiveStream.create
-      expect(live_stream.state).to be false
-      LiveStreamUpdater.new(live_stream).resync
-      expect(live_stream.state).to be false
+      expect(updater.publish?).to be false
     end
   end
 
@@ -86,11 +55,16 @@ RSpec.describe LiveStreamUpdater do
     File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
   end
 
+  def live_url
+    h = JSON.parse(live_content_item)
+    h["details"]["live_stream"]["video_url"]
+  end
+
   def stub_live_content_request
     stub_publishing_api_has_item(JSON.parse(live_content_item))
   end
 
-  def landing_page_id
-    "774cee22-d896-44c1-a611-e3109cce8eae"
+  def stub_youtube_link
+    stub_request(:get, live_url )
   end
 end

--- a/spec/services/live_stream_updater_spec.rb
+++ b/spec/services/live_stream_updater_spec.rb
@@ -65,6 +65,6 @@ RSpec.describe LiveStreamUpdater do
   end
 
   def stub_youtube_link
-    stub_request(:get, live_url )
+    stub_request(:get, live_url)
   end
 end

--- a/spec/services/live_stream_updater_spec.rb
+++ b/spec/services/live_stream_updater_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe LiveStreamUpdater do
       stub_youtube_link
 
       updater = LiveStreamUpdater.new
-      expect(updater.update?).to be true
-      expect(updater.publish?).to be true
+      expect(updater.update).to be true
+      expect(updater.publish).to be true
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe LiveStreamUpdater do
 
       updater = LiveStreamUpdater.new
       stub_any_publishing_api_call_to_return_not_found
-      expect(updater.update?).to be false
+      expect(updater.update).to be false
     end
 
     it "#publish? " do
@@ -45,9 +45,9 @@ RSpec.describe LiveStreamUpdater do
       stub_youtube_link
 
       updater = LiveStreamUpdater.new
-      expect(updater.update?).to be true
+      expect(updater.update).to be true
       stub_any_publishing_api_call_to_return_not_found
-      expect(updater.publish?).to be false
+      expect(updater.publish).to be false
     end
   end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -11,7 +11,7 @@ def the_payload_contains_the_valid_url
         "announcements_label" => "Announcements",
         "live_stream" => {
           "video_url" => valid_url,
-          "date" => "1 April 2020",
+          "date" => todays_date,
           "date_text" => "Live streamed",
           "previous_videos" => {
             "url" => "https://www.youtube.com/user/Number10gov/videos",
@@ -24,6 +24,10 @@ end
 
 def stub_publishing_api_live_content_request
   stub_publishing_api_has_item(JSON.parse(live_content_item))
+end
+
+def todays_date
+  DateTime.now.strftime("%-d %B %Y")
 end
 
 def invalid_url

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -106,7 +106,7 @@ end
 
 def and_i_select_live_stream
   click_on("Update live stream")
-  expect(page).to have_text("Add a new live stream URL")
+  expect(page).to have_text("Update live stream URL")
 end
 
 def i_am_able_to_update_draft_content_with_valid_url
@@ -164,11 +164,6 @@ end
 
 def and_i_push_a_new_draft_version
   click_on("Update draft")
-end
-
-def i_am_able_to_enter_a_new_url
-  expect(page).to have_text("Add a new live stream URL")
-  e
 end
 
 def and_i_push_a_new_draft_version_with_invalid_content

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -109,14 +109,24 @@ def and_i_select_live_stream
   expect(page).to have_text("Add a new live stream URL")
 end
 
-def i_am_able_to_submit_a_valid_url
+def i_am_able_to_update_draft_content_with_valid_url
   fill_in("url", with: valid_url)
-  click_on("Submit")
+  click_on("Update draft")
+  the_payload_contains_the_valid_url
+end
+
+def and_i_can_publish_the_url
+  click_on("Publish")
+  assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
+end
+
+def and_i_can_check_the_preview
+  expect(page).to have_link("Preview", href: "https://draft-origin.test.gov.uk/coronavirus")
 end
 
 def i_am_able_to_submit_an_invalid_url
   fill_in("url", with: invalid_url)
-  click_on("Submit")
+  click_on("Update draft")
 end
 
 def when_i_visit_the_publish_coronavirus_page
@@ -213,6 +223,10 @@ end
 
 def and_i_see_a_page_published_message
   expect(page).to have_text("Page published!")
+end
+
+def and_i_see_live_stream_is_updated_message
+  expect(page).to have_text("Draft live stream url updated!")
 end
 
 def and_i_see_live_stream_is_published_message


### PR DESCRIPTION
[trello](https://trello.com/c/PdKUXgfr/216-update-the-landing-page-publishing-tool-to-allow-content-designers-to-add-a-specific-youtube-url)

<img width="772" alt="Screenshot 2020-04-28 at 13 43 12" src="https://user-images.githubusercontent.com/17908089/80488433-3ce42980-8956-11ea-8ddf-1e73d70356e3.png">

Once this is merged we can remove some keys from the [coronavirus landing page yaml](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml)

https://github.com/alphagov/govuk-coronavirus-content/blob/5142f9c856d4e798a68fbcab2bfa40d94245218a/content/coronavirus_landing_page.yml#L236-L237

https://github.com/alphagov/govuk-coronavirus-content/blob/5142f9c856d4e798a68fbcab2bfa40d94245218a/content/coronavirus_landing_page.yml#L219-L220 we should probably leave these in but set the values to nil 