### PR TITLE
Store the livestream date 

### DIFF
--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -1,5 +1,3 @@
-require_relative "../services/live_stream_updater.rb"
-
 class CoronavirusController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
   layout "admin_layout"
@@ -21,7 +19,7 @@ class CoronavirusController < ApplicationController
 
   def update_live_stream
     @live_stream = LiveStream.last
-    if @live_stream.update(url: url_params)
+    if @live_stream.update(url: url_params, formatted_stream_date: formatted_date)
       if updater.update
         flash[:notice] = "Draft live stream url updated!"
       else
@@ -74,6 +72,10 @@ private
 
   def url_params
     params[:url]
+  end
+
+  def formatted_date
+    DateTime.now.strftime("%-d %B %Y")
   end
 
   def publish_page

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -29,13 +29,9 @@ class CoronavirusPagePresenter
     {
       "live_stream" => {
         "video_url" => live_stream.url,
-        "date" => todays_date,
+        "date" => live_stream.formatted_stream_date,
       },
     }
-  end
-
-  def todays_date
-    DateTime.now.strftime("%-d %B %Y")
   end
 
   def live_stream

--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -35,6 +35,6 @@ class CoronavirusPagePresenter
   end
 
   def live_stream
-    LiveStream.first_or_create
+    LiveStreamUpdater.new.object
   end
 end

--- a/db/migrate/20200429150108_add_formatted_stream_date_to_live_stream.rb
+++ b/db/migrate/20200429150108_add_formatted_stream_date_to_live_stream.rb
@@ -1,0 +1,5 @@
+class AddFormattedStreamDateToLiveStream < ActiveRecord::Migration[6.0]
+  def change
+    add_column :live_streams, :formatted_stream_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_214202) do
+ActiveRecord::Schema.define(version: 2020_04_29_150108) do
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "author"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_04_24_214202) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "url", null: false
+    t.string "formatted_stream_date"
   end
 
   create_table "navigation_rules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_coronavirus_publishing_api
       stub_github_request
       stub_any_publishing_api_put_intent
+      stub_youtube
     end
 
     scenario "User views the page" do
@@ -58,6 +59,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_coronavirus_publishing_api
       stub_github_business_request
       stub_any_publishing_api_put_intent
+      stub_youtube
     end
 
     scenario "User selects business page" do
@@ -104,7 +106,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     before do
       given_i_am_a_coronavirus_editor
       stub_coronavirus_publishing_api
-      stub_restclient
+      stub_youtube
     end
 
     scenario "Publish a valid livestream url" do

--- a/spec/models/live_stream_spec.rb
+++ b/spec/models/live_stream_spec.rb
@@ -4,17 +4,23 @@ RSpec.describe LiveStream do
   describe "validations" do
     let(:bad_url) { "www.youtbe.co.uk/123" }
     let(:good_url) { "https://www.youtube.com/123" }
+    before do
+      stub_request(:get, bad_url).to_return(status: 404)
+      stub_request(:get, good_url)
+    end
 
     it "is invalid without a url" do
       expect(LiveStream.create).not_to be_valid
     end
 
     it "it requires a valid url" do
-      stub_request(:get, bad_url).to_return(status: 404)
       expect { LiveStream.create!(url: bad_url) }.to raise_error(ActiveRecord::RecordInvalid)
-
-      stub_request(:get, good_url)
       expect(LiveStream.create(url: good_url)).to be_valid
+    end
+
+    it "has a formatted_stream_date column that is neither required nor validated" do
+      expect(LiveStream.create(url: good_url, formatted_stream_date: "1 April 2020")).to be_valid
+      expect(LiveStream.create(url: good_url, formatted_stream_date: "")).to be_valid
     end
   end
 end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -12,41 +12,86 @@ RSpec.describe CoronavirusPagePresenter do
   }
 
   let(:landing_page_path) { "/coronavirus" }
+  let(:payload) {
+    {
+      "base_path" => landing_page_path,
+      "title" => "coronavirus",
+      "description" => "details about the coronavirus response",
+      "document_type" => "coronavirus_landing_page",
+      "schema_name" => "coronavirus_landing_page",
+      "details" => {},
+      "links" => {},
+      "locale" => "en",
+      "rendering_app" => "collections",
+      "publishing_app" => "collections-publisher",
+      "routes" => [
+        { "path" => landing_page_path, "type" => "exact" },
+      ],
+      "update_type" => "minor",
+    }
+  }
+
+  let(:new_url) { "https://www.youtube.com/123" }
+  let(:new_date) { "2 April 2020" }
 
   subject { described_class.new(content, landing_page_path) }
 
-  it "presents the payload correctly" do
-    url = "https://www.youtube.com/123"
-    stub_request(:get, url)
+  before do
+    stub_request(:get, video_url_from_content_item)
+    stub_request(:get, new_url)
+    stub_publishing_api_has_item(JSON.parse(live_content_item))
+  end
 
-    LiveStream.create(url: url)
-    date = subject.todays_date
-    presented = subject.payload
+  describe "#payload" do
+    # this situation will only arise the first time the application is deployed,
+    # and if a content change is published before a livestream is created.
+    context "when no livestream objects exist in the database" do
+      it "presents the payload correctly" do
+        presented = subject.payload
+        details = {
+          "details" => {
+            "sections" => "some sections",
+            "live_stream" => {
+              "video_url" => video_url_from_content_item,
+              "date" => date_from_content_item,
+            },
+          },
+        }
+        expect(presented).to be_valid_against_schema("coronavirus_landing_page")
+        expect(presented).to eq payload.merge(details)
+      end
+    end
 
-    expect(presented).to be_valid_against_schema("coronavirus_landing_page")
-    expect(presented).to eq(
-      {
-        "base_path" => landing_page_path,
-        "title" => "coronavirus",
-        "description" => "details about the coronavirus response",
-        "document_type" => "coronavirus_landing_page",
-        "schema_name" => "coronavirus_landing_page",
-        "details" => {
-          "sections" => "some sections",
-          "live_stream" => {
-            "video_url" => LiveStream.last.url,
-            "date" => date,
-},
-        },
-        "links" => {},
-        "locale" => "en",
-        "rendering_app" => "collections",
-        "publishing_app" => "collections-publisher",
-        "routes" => [
-          { "path" => landing_page_path, "type" => "exact" },
-        ],
-        "update_type" => "minor",
-      },
-    )
+    context "when a livestream object exists in the database" do
+      it "presents the payload correctly" do
+        LiveStream.create(url: new_url, formatted_stream_date: new_date)
+        presented = subject.payload
+        details = {
+          "details" => {
+            "sections" => "some sections",
+            "live_stream" => {
+              "video_url" => new_url,
+              "date" => new_date,
+            },
+          },
+        }
+        expect(presented).to be_valid_against_schema("coronavirus_landing_page")
+        expect(presented).to eq payload.merge(details)
+      end
+    end
+  end
+
+  def live_content_item
+    File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
+  end
+
+  def video_url_from_content_item
+    h = JSON.parse(live_content_item)
+    h["details"]["live_stream"]["video_url"]
+  end
+
+  def date_from_content_item
+    h = JSON.parse(live_content_item)
+    h["details"]["live_stream"]["date"]
   end
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -38,7 +38,7 @@ def valid_url
   "https://www.youtube.com/watch?v=UF8mC-T0u6k"
 end
 
-def stub_restclient
+def stub_youtube
   stub_request(:get, valid_url)
 end
 


### PR DESCRIPTION
This is follow up work to [the Live stream url updater PR](https://trello.com/c/PdKUXgfr/216-update-the-landing-page-publishing-tool-to-allow-content-designers-to-add-a-specific-youtube-url) which contains a bug.

**Bug**:
Updating the content item updated the value of livestream date in the payload for publishing api. 

**Fix**:
Persist the date of the live stream so that the field isn't overwritten each time the content item is updated. 

A remaining issue is that if someone updates the link to the livestream and makes a mistake, for example they publish yesterday's livestream again rather than today's live video, the date field is still programatically updated to todays date. So whilst we could reset the url, we can't easily undo the date change through the UI. We could add another text field to the form so that it's possible to manually set a date. I'll check in with @samdub to see if he thinks it's worth it.
