### PR TITLE
Update coronavirus landing page publishing tool

### DIFF
--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -156,8 +156,7 @@ private
     %w[
       title
       meta_description
-      stay_at_home
-      guidance
+      header_section
       announcements_label
       announcements
       nhs_banner

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -8,13 +8,9 @@ RSpec.describe "Markdown editor", type: :view do
   end
 
   it "renders a textarea with a label and toolbar" do
-    render "components/markdown_editor",  label: {
-                                            text: "Body",
-                                          },
-                                          textarea: {
-                                            name: "markdown-editor",
-                                            id: "markdown-editor",
-                                          }
+    render "components/markdown_editor",
+           label: { text: "Body" },
+           textarea: { name: "markdown-editor", id: "markdown-editor" }
 
     assert_select ".govuk-label[for='markdown-editor']", text: "Body"
     assert_select ".app-c-markdown-editor__toolbar-group[for='markdown-editor']"

--- a/spec/features/curating_topic_contents_spec.rb
+++ b/spec/features/curating_topic_contents_spec.rb
@@ -106,11 +106,11 @@ RSpec.feature "Curating topic contents" do
                 "contents" => [
                   "/oil-rig-staffing",
                   "/oil-rig-safety-requirements",
-              ] },
+                ] },
               { "name" => "Piping",
                 "contents" => [
                   "/undersea-piping-restrictions",
-              ] },
+                ] },
             ],
             "internal_name" => "Oil and Gas / Offshore",
           },
@@ -188,11 +188,11 @@ RSpec.feature "Curating topic contents" do
                 "contents" => [
                   "/oil-rig-safety-requirements",
                   "/oil-rig-staffing",
-              ] },
+                ] },
               { "name" => "Piping",
                 "contents" => [
                   "/undersea-piping-restrictions",
-              ] },
+                ] },
             ],
             "internal_name" => "Oil and Gas / Offshore",
           },

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -1,14 +1,13 @@
 content:
   title: "Coronavirus (COVID-19): what you need to do"
   meta_description: "Find out about the government response to coronavirus (COVID-19) and what you need to do."
-  stay_at_home:
-    pretext: Stay at home
+  header_section:
+    pretext-1: Stay alert
+    pretext-2: Anyone can spread the virus.
     list:
       - Only go outside for food, health reasons or work (where this absolutely cannot be done from home)
       - Stay 2 metres (6ft) away from other people
       - Wash your hands as soon as you get home
-  guidance:
-    pretext: Anyone can spread the virus.
     link:
       href: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
       text: Full guidance on staying at home and away from others

--- a/spec/presenters/groups_presenter_spec.rb
+++ b/spec/presenters/groups_presenter_spec.rb
@@ -31,20 +31,20 @@ RSpec.describe GroupsPresenter do
 
         expect(GroupsPresenter.new(tag).groups).to eq(
           [
-              {
-                name: "Piping",
-                contents: [
-                  "/undersea-piping-restrictions",
-                ],
-              },
-              {
-                name: "Oil rigs",
-                contents: [
-                  "/oil-rig-safety-requirements",
-                  "/oil-rig-staffing",
-                ],
-              },
-            ],
+            {
+              name: "Piping",
+              contents: [
+                "/undersea-piping-restrictions",
+              ],
+            },
+            {
+              name: "Oil rigs",
+              contents: [
+                "/oil-rig-safety-requirements",
+                "/oil-rig-staffing",
+              ],
+            },
+          ],
         )
       end
     end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -189,7 +189,7 @@ def live_content_item
 end
 
 def and_i_see_an_alert
-  expect(page).to have_text("Invalid content - please recheck GitHub and add title, stay_at_home, guidance, announcements_label, announcements, nhs_banner, sections, topic_section, notifications.")
+  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, announcements_label, announcements, nhs_banner, sections, topic_section, notifications.")
 end
 
 def and_i_see_an_alert_for_missing_hub_page_keys


### PR DESCRIPTION
We have [changed the structure](https://github.com/alphagov/govuk-coronavirus-content/pull/219) of the content item. The publishing tool needs to know about it.
