### PR TITLE
Link directly to live streams page for Coronavirus daily update

### DIFF
--- a/app/views/coronavirus/live_stream.html.erb
+++ b/app/views/coronavirus/live_stream.html.erb
@@ -14,7 +14,7 @@
           </span>
         </summary>
         <div class="govuk-details__text">
-          <p>Every afternoon, No.10 adds a video link to the upcoming press conference to this <a href="https://www.youtube.com/user/Number10gov/">page.</a></p>
+          <p>Every afternoon, No.10 adds a video link to the upcoming press conference to this <a href="https://www.youtube.com/user/Number10gov/videos?view=2">page</a>.</p>
           <p>The video will appear in the 'Uploads' section of the page and is labelled as 'Live'.</p>
           <p>The video is added at around 4.30pm on weekdays, and 3.30pm on weekends.</p>
           <p>If the most recent video has yesterday's date, or there is no video labelled 'Live' check again in a few minutes.</p>


### PR DESCRIPTION
We are currently linking to the No 10 YouTube account page.  From here, you click 'Videos'.  This takes you to a page that only has pre-recorded videos and not upcoming live streams.  This has to be selected from a drop-down, which has caused confusion on multiple occassions.

Therefore updating the URL to link directly to No 10's live stream page.