### PR TITLE
Allow users with permission to skip Step by Step 2i 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,6 +38,10 @@ private
     authorise_user!("GDS Editor")
   end
 
+  def require_skip_review_permissions!
+    authorise_user!("Skip review")
+  end
+
   def require_gds_editor_permissions_to_edit_browse_pages!
     require_gds_editor_permissions! if @tag.is_a?(MainstreamBrowsePage)
   end

--- a/app/helpers/step_nav_actions_helper.rb
+++ b/app/helpers/step_nav_actions_helper.rb
@@ -22,6 +22,10 @@ module StepNavActionsHelper
       step_by_step_page.review_requester_id == user.uid
   end
 
+  def can_skip_2i_review?(user)
+    user.has_permission?("Skip review")
+  end
+
 private
 
   def can_claim_first_review?(step_by_step_page, user)

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -55,6 +55,13 @@
         } %>
       <% end %>
       <%= preview_link %>
+      <% if can_skip_2i_review?(current_user) %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Publish without 2i review",
+          href: step_by_step_page_publish_without_2i_review_path(@step_by_step_page),
+          destructive: true
+        } %>
+      <% end %>
     <% end %>
 
     <% if can_revert_to_draft?(@step_by_step_page, current_user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
     put "navigation-rules", to: "navigation_rules#update"
     get :publish
     post :publish
+    get :publish_without_2i_review
+    post :publish_without_2i_review
     get :reorder
     post :reorder
     get "request-change-2i-review", to: "review#show_request_change_2i_review_form"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ if User.where(name: "Test user").blank?
   User.create!(
     uid: user_id,
     name: "Test user",
-    permissions: ["signin", "GDS Editor", "Coronavirus editor"],
+    permissions: ["signin", "GDS Editor", "Coronavirus editor", "Skip review"],
     organisation_content_id: gds_organisation_id,
   )
 end

--- a/spec/features/step_by_step_actions_spec.rb
+++ b/spec/features/step_by_step_actions_spec.rb
@@ -15,6 +15,17 @@ RSpec.feature "Contextual action buttons for step by step pages" do
       given_there_is_a_step_by_step_page_with_a_link_report
       when_i_visit_the_step_by_step_page
       then_the_primary_action_should_be "Submit for 2i review"
+      and_there_should_not_be_a_warning_action_to "Publish without 2i review"
+      and_there_should_be_secondary_actions_to %w[Preview]
+      and_there_should_be_tertiary_actions_to %w[Delete]
+    end
+
+    scenario "show the relevant actions to a user with Skip review permissions" do
+      given_i_can_skip_review
+      given_there_is_a_step_by_step_page_with_a_link_report
+      when_i_visit_the_step_by_step_page
+      then_the_primary_action_should_be "Submit for 2i review"
+      and_there_should_be_a_warning_action_to "Publish without 2i review"
       and_there_should_be_secondary_actions_to %w[Preview]
       and_there_should_be_tertiary_actions_to %w[Delete]
     end
@@ -133,8 +144,17 @@ RSpec.feature "Contextual action buttons for step by step pages" do
     end
   end
 
+  def and_there_should_not_be_a_warning_action_to(action_text)
+    expect(page).not_to have_css(warning_action_selector, text: action_text)
+  end
+
+  def and_there_should_be_a_warning_action_to(action_text)
+    expect(page).to have_css(warning_action_selector, count: 1)
+    expect(page).to have_css(warning_action_selector, text: action_text), "Couldn't find '#{action_text}' as a primary action in: \n #{action_html}"
+  end
+
   def primary_action_selector
-    ".app-side__actions .gem-c-button:not(.gem-c-button--secondary)"
+    ".app-side__actions .gem-c-button:not(.gem-c-button--secondary):not(.govuk-button--warning)"
   end
 
   def secondary_action_selector
@@ -143,6 +163,10 @@ RSpec.feature "Contextual action buttons for step by step pages" do
 
   def tertiary_action_selector
     ".app-side__actions .govuk-link"
+  end
+
+  def warning_action_selector
+    ".app-side__actions .govuk-button--warning"
   end
 
   def action_html

--- a/spec/helpers/step_nav_actions_helper_spec.rb
+++ b/spec/helpers/step_nav_actions_helper_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe StepNavActionsHelper do
   let(:reviewer_user) { create(:user, permissions: required_permissions_for_2i) }
   let(:second_reviewer_user) { create(:user, permissions: required_permissions_for_2i) }
   let(:non_2i_user) { create(:user, permissions: required_permissions_for_2i - ["2i reviewer"]) }
+  let(:skip_2i_user) { create(:user, permissions: required_permissions_to_skip_2i) }
 
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
@@ -154,6 +155,16 @@ RSpec.describe StepNavActionsHelper do
 
         expect(can_revert_to_draft?(step_by_step_page, user)).to be false
       end
+    end
+  end
+
+  describe "#can_skip_2i_review?" do
+    it "returns false if the user can not skip 2i review" do
+      expect(helper.can_skip_2i_review?(reviewer_user)).to be false
+    end
+
+    it "returns true if the user can skip 2i review" do
+      expect(helper.can_skip_2i_review?(skip_2i_user)).to be true
     end
   end
 end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -21,6 +21,10 @@ module CommonFeatureSteps
     stub_user.permissions << "2i reviewer"
   end
 
+  def given_i_can_skip_review
+    stub_user.permissions << "Skip review"
+  end
+
   def required_permissions_for_2i
     ["signin", "GDS Editor", "2i reviewer"]
   end

--- a/spec/support/common_feature_steps.rb
+++ b/spec/support/common_feature_steps.rb
@@ -25,6 +25,10 @@ module CommonFeatureSteps
     ["signin", "GDS Editor", "2i reviewer"]
   end
 
+  def required_permissions_to_skip_2i
+    ["signin", "GDS Editor", "2i reviewer", "Skip review"]
+  end
+
   def then_i_can_see_a_success_message(message)
     within(".gem-c-success-alert") do
       expect(page).to have_content message


### PR DESCRIPTION
This changes allows user's with the `Skip review` permission to publish Step by Step pages
without first receiving a "two eye" review from another content designer.

When permission is granted, a red "Publish without 2i" button is available on the Step by Step page, and the internal change note details if the change was made without review.

<img width="319" alt="Screenshot 2020-05-28 at 16 26 55" src="https://user-images.githubusercontent.com/13475227/83162117-384f9400-a101-11ea-85f7-cf85fc581f46.png">

<img width="603" alt="Screenshot 2020-05-28 at 16 10 49" src="https://user-images.githubusercontent.com/13475227/83159466-e9542f80-a0fd-11ea-9138-1eb41fbfb1c1.png">

[Trello](https://trello.com/c/nRiaTxuK/2003-3-add-skip-review-permission-to-collections-publisher)
