### PR TITLE
Add the worker support hub page

### DIFF
--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -202,6 +202,14 @@ private
           base_path: "/coronavirus/education-and-childcare",
           github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_education_page.yml",
         },
+      employees:
+        {
+          name: "Worker page",
+          content_id: "5ebf285a-9165-476c-be90-66b9729f50da".freeze,
+          raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_worker_page.yml".freeze,
+          base_path: "/coronavirus/worker-support",
+          github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_worker_page.yml",
+        },
     }
   end
 end


### PR DESCRIPTION
The paths here should match the file in https://github.com/alphagov/govuk-coronavirus-content/pull/275

https://trello.com/c/Pd19z0rM/326-add-employee-hub-configuration-to-collections-publisher