### PR TITLE
Livestream can be updated with new signon permission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?
+  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
@@ -19,6 +19,10 @@ private
 
   def coronavirus_editor?
     current_user.has_permission? "Coronavirus editor"
+  end
+
+  def livestream_editor?
+    current_user.has_permission? "Livestream editor"
   end
 
   # Can be overridden to allow controllers to choose the active menu item.
@@ -36,6 +40,10 @@ private
 
   def require_gds_editor_permissions!
     authorise_user!("GDS Editor")
+  end
+
+  def require_livestream_editor_permissions!
+    authorise_user!(any_of: ["Livestream editor", "Coronavirus editor"])
   end
 
   def require_skip_review_permissions!

--- a/app/controllers/coronavirus_controller.rb
+++ b/app/controllers/coronavirus_controller.rb
@@ -13,33 +13,6 @@ class CoronavirusController < ApplicationController
     render :index, locals: { links: links }
   end
 
-  def live_stream
-    @live_stream = updater.object
-  end
-
-  def update_live_stream
-    @live_stream = LiveStream.last
-    if @live_stream.update(url: url_params, formatted_stream_date: formatted_date)
-      if updater.update
-        flash[:notice] = "Draft live stream url updated!"
-      else
-        flash["alert"] = "Live stream url has not been updated - please try again"
-      end
-    else
-      flash[:notice] = @live_stream.errors.full_messages.join(", ")
-    end
-    redirect_to coronavirus_live_stream_path
-  end
-
-  def publish_live_stream
-    if updater.publish
-      flash[:notice] = "New live stream url published!"
-    else
-      flash["alert"] = "Live stream url has not been published - please try again"
-    end
-    redirect_to coronavirus_live_stream_path
-  end
-
   def show
     if page_config.nil?
       flash[:alert] = "'#{slug}' is not a valid page.  Please select from one of those below."
@@ -65,18 +38,6 @@ class CoronavirusController < ApplicationController
   end
 
 private
-
-  def updater
-    LiveStreamUpdater.new
-  end
-
-  def url_params
-    params[:url]
-  end
-
-  def formatted_date
-    DateTime.now.strftime("%-d %B %Y")
-  end
 
   def publish_page
     Services.publishing_api.publish(page_config[:content_id], update_type)

--- a/app/controllers/live_stream_controller.rb
+++ b/app/controllers/live_stream_controller.rb
@@ -1,0 +1,45 @@
+class LiveStreamController < ApplicationController
+  before_action :require_coronavirus_editor_permissions!
+  layout "admin_layout"
+
+  def index
+    @live_stream = updater.object
+  end
+
+  def update
+    @live_stream = LiveStream.last
+    if @live_stream.update(url: url_params, formatted_stream_date: formatted_date)
+      if updater.update
+        flash[:notice] = "Draft live stream url updated!"
+      else
+        flash["alert"] = "Live stream url has not been updated - please try again"
+      end
+    else
+      flash[:notice] = @live_stream.errors.full_messages.join(", ")
+    end
+    redirect_to live_stream_index_path
+  end
+
+  def publish
+    if updater.publish
+      flash[:notice] = "New live stream url published!"
+    else
+      flash["alert"] = "Live stream url has not been published - please try again"
+    end
+    redirect_to live_stream_index_path
+  end
+
+private
+
+  def updater
+    LiveStreamUpdater.new
+  end
+
+  def url_params
+    params[:url]
+  end
+
+  def formatted_date
+    DateTime.now.strftime("%-d %B %Y")
+  end
+end

--- a/app/controllers/live_stream_controller.rb
+++ b/app/controllers/live_stream_controller.rb
@@ -12,10 +12,10 @@ class LiveStreamController < ApplicationController
       if updater.update
         flash[:notice] = "Draft live stream url updated!"
       else
-        flash["alert"] = "Live stream url has not been updated - please try again"
+        flash[:alert] = "Live stream url has not been updated - please try again"
       end
     else
-      flash[:notice] = @live_stream.errors.full_messages.join(", ")
+      flash[:alert] = @live_stream.errors.full_messages.join(", ")
     end
     redirect_to live_stream_index_path
   end
@@ -24,7 +24,7 @@ class LiveStreamController < ApplicationController
     if updater.publish
       flash[:notice] = "New live stream url published!"
     else
-      flash["alert"] = "Live stream url has not been published - please try again"
+      flash[:alert] = "Live stream url has not been published - please try again"
     end
     redirect_to live_stream_index_path
   end

--- a/app/controllers/live_stream_controller.rb
+++ b/app/controllers/live_stream_controller.rb
@@ -1,5 +1,5 @@
 class LiveStreamController < ApplicationController
-  before_action :require_coronavirus_editor_permissions!
+  before_action :require_livestream_editor_permissions!
   layout "admin_layout"
 
   def index

--- a/app/views/coronavirus/index.html.erb
+++ b/app/views/coronavirus/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "What do you need to do?" %>
 
 <ul class="govuk-list">
-  <li><%= link_to "Update live stream", coronavirus_live_stream_path, class:"govuk-button" %></li>
+  <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-button" %></li>
 <% links.each do |link| %>
   <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-button" %></li>
 <% end %>

--- a/app/views/layouts/admin_layout.html.erb
+++ b/app/views/layouts/admin_layout.html.erb
@@ -22,6 +22,7 @@
         text: "Specialist sectors",
         href: topics_path,
         active: active_navigation_item == 'topics' ? 'active' : false,
+        user_has_permission_to_see: !livestream_editor?
       },
       {
         text: "Step by steps",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,25 +8,25 @@
 
 <% content_for :navbar_items do %>
   <% if gds_editor? %>
-    <li class='<%= active_navigation_item == 'mainstream_browse_pages' ? 'active' : nil %>'>
+    <li class="<%= active_navigation_item == 'mainstream_browse_pages' ? 'active' : nil %>">
       <%= link_to 'Mainstream browse pages', mainstream_browse_pages_path %>
     </li>
   <% end %>
 
   <% unless livestream_editor? %>
-    <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
+    <li class="<%= active_navigation_item == 'topics' ? 'active' : nil %>">
       <%= link_to 'Specialist sector pages', topics_path %>
     </li>
   <% end %>
 
   <% if gds_editor? %>
-    <li class='<%= active_navigation_item == 'step_by_step_pages' ? 'active' : nil %>'>
+    <li class="<%= active_navigation_item == 'step_by_step_pages' ? 'active' : nil %>">
       <%= link_to 'Step by step pages', step_by_step_pages_path %>
     </li>
   <% end %>
 
   <% if coronavirus_editor? %>
-    <li class='<%= active_navigation_item == 'coronavirus' ? 'active' : nil %>'>
+    <li class="<%= active_navigation_item == 'coronavirus' ? 'active' : nil %>">
       <%= link_to 'Coronavirus pages', coronavirus_index_path %>
     </li>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,11 @@
     </li>
   <% end %>
 
-  <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
-    <%= link_to 'Specialist sector pages', topics_path %>
-  </li>
+  <% unless livestream_editor? %>
+    <li class='<%= active_navigation_item == 'topics' ? 'active' : nil %>'>
+      <%= link_to 'Specialist sector pages', topics_path %>
+    </li>
+  <% end %>
 
   <% if gds_editor? %>
     <li class='<%= active_navigation_item == 'step_by_step_pages' ? 'active' : nil %>'>

--- a/app/views/live_stream/index.html.erb
+++ b/app/views/live_stream/index.html.erb
@@ -7,21 +7,22 @@
         text: "1. Add the URL",
         padding: true
       } %>
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Help with YouTube
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <p>Every afternoon, No.10 adds a video link to the upcoming press conference to this <a href="https://www.youtube.com/user/Number10gov/videos?view=2">page</a>.</p>
-          <p>The video will appear in the 'Uploads' section of the page and is labelled as 'Live'.</p>
-          <p>The video is added at around 4.30pm on weekdays, and 3.30pm on weekends.</p>
-          <p>If the most recent video has yesterday's date, or there is no video labelled 'Live' check again in a few minutes.</p>
-          <p>Click on the video, and copy its URL.</p>
-        </div>
-      </details>
-
+      <% unless livestream_editor? %>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Help with YouTube
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p>Every afternoon, No.10 adds a video link to the upcoming press conference to this <a href="https://www.youtube.com/user/Number10gov/videos?view=2">page</a>.</p>
+            <p>The video will appear in the 'Uploads' section of the page and is labelled as 'Live'.</p>
+            <p>The video is added at around 4.30pm on weekdays, and 3.30pm on weekends.</p>
+            <p>If the most recent video has yesterday's date, or there is no video labelled 'Live' check again in a few minutes.</p>
+            <p>Click on the video, and copy its URL.</p>
+          </div>
+        </details>
+      <% end %>
       <%= form_with(url: live_stream_path(@live_stream), method: "put", local: true) do %>
         <%= label_tag(:url, "YouTube URL", class: "govuk-label" ) %>
         <%= text_field_tag(:url, nil,

--- a/app/views/live_stream/index.html.erb
+++ b/app/views/live_stream/index.html.erb
@@ -21,7 +21,8 @@
           <p>Click on the video, and copy its URL.</p>
         </div>
       </details>
-      <%= form_with(url: "update_live_stream", method: "put", local: true) do %>
+
+      <%= form_with(url: live_stream_path(@live_stream), method: "put", local: true) do %>
         <%= label_tag(:url, "YouTube URL", class: "govuk-label" ) %>
         <%= text_field_tag(:url, nil,
           class: "govuk-input govuk-!-margin-bottom-6",
@@ -46,7 +47,7 @@
         padding: true
       } %>
       <div>
-        <%= link_to "Publish", coronavirus_publish_live_stream_path, method: :post, class: "govuk-button" %>
+        <%= link_to "Publish", live_stream_publish_path(@live_stream), method: :post, class: "govuk-button" %>
       </div>
       <%= render "govuk_publishing_components/components/heading", {
         text: "4. Check the live landing page",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,16 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  class RoleConstraint
+    def initialize(role)
+      @role = role
+    end
+    def matches?(request)
+      user = request.env["warden"].user
+      user && user.has_permission?(@role)
+    end
+  end
+
+  root to: "live_stream#index", constraints: RoleConstraint.new("Livestream editor"), as: nil
   root to: redirect("/step-by-step-pages", status: 302)
 
   resources :live_stream, only: %i[index update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-
   root to: redirect("/step-by-step-pages", status: 302)
-  get "/coronavirus/live_stream", to: "coronavirus#live_stream"
-  put "/coronavirus/update_live_stream", to: "coronavirus#update_live_stream"
-  post "/coronavirus/publish_live_stream", to: "coronavirus#publish_live_stream"
+
+  resources :live_stream, only: %i[index update] do
+    post "publish", to: "live_stream#publish"
+  end
 
   resources :coronavirus, only: %i[index show update], param: :slug do
     post "publish", to: "coronavirus#publish"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     def initialize(role)
       @role = role
     end
+
     def matches?(request)
       user = request.env["warden"].user
       user && user.has_permission?(@role)

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -4,14 +4,34 @@ RSpec.feature "Access control" do
   include CommonFeatureSteps
   include NavigationSteps
 
-  scenario "Non-GDS editor can't navigate to browse pages" do
+  scenario "Non-GDS Editor can't navigate to browse pages" do
     given_i_am_not_a_gds_editor
     when_i_visit_the_browse_pages_index
     then_i_am_informed_i_dont_have_access
   end
 
+  describe "Landing page" do
+    scenario "A Non-GDS editor cannot access this application" do
+      given_i_am_not_a_gds_editor
+      when_i_visit_the_root_path
+      then_i_am_informed_i_dont_have_access
+    end
+
+    scenario "A GDS Editor accessing this application sees step by step page" do
+      given_i_am_a_gds_editor
+      when_i_visit_the_root_path
+      i_see_the_step_by_step_index_page
+    end
+  end
+
   def then_i_am_informed_i_dont_have_access
     expect(page).to have_content "Sorry, you don't seem to have the GDS Editor permission for this app"
     expect(page.status_code).to eql(403)
+  end
+
+  def i_see_the_step_by_step_index_page
+    expect(page).to have_content "Step by steps"
+    expect(page).to have_link "Create new step by step"
+    expect(page.status_code).to eql(200)
   end
 end

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
 
 RSpec.feature "Access control" do
   include CommonFeatureSteps
   include NavigationSteps
+  include GdsApi::TestHelpers::PublishingApi
 
   scenario "Non-GDS Editor can't navigate to browse pages" do
     given_i_am_not_a_gds_editor
@@ -11,7 +13,13 @@ RSpec.feature "Access control" do
   end
 
   describe "Landing page" do
-    scenario "A Non-GDS editor cannot access this application" do
+    before do
+      stub_youtube
+      stub_live_coronavirus_content_request
+      stub_yesterdays_youtube_link
+    end
+
+    scenario "A Non-GDS Editor cannot access this application" do
       given_i_am_not_a_gds_editor
       when_i_visit_the_root_path
       then_i_am_informed_i_dont_have_access
@@ -22,6 +30,18 @@ RSpec.feature "Access control" do
       when_i_visit_the_root_path
       i_see_the_step_by_step_index_page
     end
+
+    scenario "A Livestream Editor accessing this application sees the livestream page" do
+      given_i_am_a_livestream_editor
+      when_i_visit_the_root_path
+      i_see_the_live_stream_page
+    end
+  end
+
+  def given_i_am_a_livestream_editor
+    user = create(:user, permissions: ["signin", "Livestream editor"])
+    GDS::SSO.test_user = user
+    allow_any_instance_of(Warden::Proxy).to receive(:user).and_return(user)
   end
 
   def then_i_am_informed_i_dont_have_access
@@ -32,6 +52,11 @@ RSpec.feature "Access control" do
   def i_see_the_step_by_step_index_page
     expect(page).to have_content "Step by steps"
     expect(page).to have_link "Create new step by step"
+    expect(page.status_code).to eql(200)
+  end
+
+  def i_see_the_live_stream_page
+    expect(page).to have_content "Update live stream URL"
     expect(page.status_code).to eql(200)
   end
 end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -101,30 +101,4 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       and_i_see_a_message_telling_me_that_the_page_does_not_exist
     end
   end
-
-  context "Live stream updates" do
-    before do
-      given_i_am_a_coronavirus_editor
-      stub_coronavirus_publishing_api
-      stub_youtube
-    end
-
-    scenario "Publish a valid livestream url" do
-      when_i_visit_the_publish_coronavirus_page
-      and_i_select_live_stream
-      i_am_able_to_update_draft_content_with_valid_url
-      and_i_see_live_stream_is_updated_message
-      and_i_can_check_the_preview
-      and_i_can_publish_the_url
-      and_i_see_a_link_to_the_landing_page
-    end
-
-    scenario "Adding an invalid livestream url" do
-      when_i_visit_the_publish_coronavirus_page
-      and_i_select_live_stream
-      i_am_able_to_submit_an_invalid_url
-      and_i_see_the_error_message
-      and_nothing_is_sent_publishing_api
-    end
-  end
 end

--- a/spec/features/live_stream_page_spec.rb
+++ b/spec/features/live_stream_page_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+
+RSpec.feature "Make changes to the live stream URL" do
+  include CommonFeatureSteps
+  include GdsApi::TestHelpers::PublishingApi
+
+  before do
+    given_i_am_a_coronavirus_editor
+    stub_coronavirus_publishing_api
+    stub_youtube
+  end
+
+  scenario "Publish a valid livestream url" do
+    when_i_visit_the_publish_coronavirus_page
+    and_i_select_live_stream
+    i_am_able_to_update_draft_content_with_valid_url
+    and_i_see_live_stream_is_updated_message
+    and_i_can_check_the_preview
+    and_i_can_publish_the_url
+    and_i_see_a_link_to_the_landing_page
+  end
+
+  scenario "Adding an invalid livestream url" do
+    when_i_visit_the_publish_coronavirus_page
+    and_i_select_live_stream
+    i_am_able_to_submit_an_invalid_url
+    and_i_see_the_error_message
+    and_nothing_is_sent_publishing_api
+  end
+end

--- a/spec/services/live_stream_updater_spec.rb
+++ b/spec/services/live_stream_updater_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LiveStreamUpdater do
   before do
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
-    stub_live_content_request
+    stub_live_coronavirus_content_request
     stub_yesterdays_youtube_link
     stub_todays_youtube_link
   end
@@ -62,39 +62,5 @@ RSpec.describe LiveStreamUpdater do
       stub_any_publishing_api_call_to_return_not_found
       expect(updater.publish).to be false
     end
-  end
-
-  def live_content_item
-    File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
-  end
-
-  def yesterdays_link
-    h = JSON.parse(live_content_item)
-    h["details"]["live_stream"]["video_url"]
-  end
-
-  def yesterdays_date
-    h = JSON.parse(live_content_item)
-    h["details"]["live_stream"]["date"]
-  end
-
-  def todays_link
-    "https://www.youtube.com/watch?yesterdays-link"
-  end
-
-  def todays_date
-    "31 March 2020"
-  end
-
-  def stub_live_content_request
-    stub_publishing_api_has_item(JSON.parse(live_content_item))
-  end
-
-  def stub_todays_youtube_link
-    stub_request(:get, todays_link)
-  end
-
-  def stub_yesterdays_youtube_link
-    stub_request(:get, yesterdays_link)
   end
 end

--- a/spec/support/aaa_database_cleaner.rb
+++ b/spec/support/aaa_database_cleaner.rb
@@ -5,6 +5,7 @@ require "database_cleaner"
 
 RSpec.configure do |config|
   config.before(:suite) do
+    DatabaseCleaner.allow_remote_database_url = true
     DatabaseCleaner.clean_with :truncation
   end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -23,21 +23,23 @@ def the_payload_contains_the_valid_url
 end
 
 def stub_live_coronavirus_content_request
-  stub_publishing_api_has_item(JSON.parse(live_coronavirus_content_item))
+  stub_publishing_api_has_item(coronavirus_content_json)
 end
 
 def live_coronavirus_content_item
-  File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
+  File.read(Rails.root.join("spec/fixtures/coronavirus_content_item.json"))
+end
+
+def coronavirus_content_json
+  @coronavirus_content_json ||= JSON.parse(live_coronavirus_content_item)
 end
 
 def coronavirus_live_stream_hash
-  h = JSON.parse(live_coronavirus_content_item)
-  h["details"]["live_stream"]
+  coronavirus_content_json.dig("details", "live_stream")
 end
 
 def coronavirus_content_id
-  h = JSON.parse(live_coronavirus_content_item)
-  h["content_id"]
+  coronavirus_content_json["content_id"]
 end
 
 def todays_date

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -4,26 +4,40 @@ def given_i_am_a_coronavirus_editor
 end
 
 def the_payload_contains_the_valid_url
+  live_stream_payload = coronavirus_live_stream_hash.merge(
+    {
+      "video_url" => valid_url,
+      "date" => todays_date,
+    },
+  )
+
   assert_publishing_api_put_content(
-    "774cee22-d896-44c1-a611-e3109cce8eae",
+    coronavirus_content_id,
     request_json_includes(
       "details" => {
         "announcements_label" => "Announcements",
-        "live_stream" => {
-          "video_url" => valid_url,
-          "date" => todays_date,
-          "date_text" => "Live streamed",
-          "previous_videos" => {
-            "url" => "https://www.youtube.com/user/Number10gov/videos",
-          },
-        },
+        "live_stream" => live_stream_payload,
       },
     ),
   )
 end
 
-def stub_publishing_api_live_content_request
-  stub_publishing_api_has_item(JSON.parse(live_content_item))
+def stub_live_coronavirus_content_request
+  stub_publishing_api_has_item(JSON.parse(live_coronavirus_content_item))
+end
+
+def live_coronavirus_content_item
+  File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
+end
+
+def coronavirus_live_stream_hash
+  h = JSON.parse(live_coronavirus_content_item)
+  h["details"]["live_stream"]
+end
+
+def coronavirus_content_id
+  h = JSON.parse(live_coronavirus_content_item)
+  h["content_id"]
 end
 
 def todays_date
@@ -43,9 +57,9 @@ def stub_youtube
 end
 
 def stub_coronavirus_publishing_api
+  stub_live_coronavirus_content_request
   stub_any_publishing_api_put_content
   stub_any_publishing_api_publish
-  stub_publishing_api_live_content_request
 end
 
 def stub_github_request
@@ -182,10 +196,6 @@ end
 
 def invalid_github_response
   File.read(Rails.root.join + "spec/fixtures/invalid_corona_page.yml")
-end
-
-def live_content_item
-  File.read(Rails.root.join + "spec/fixtures/coronavirus_content_item.json")
 end
 
 def and_i_see_an_alert

--- a/spec/support/livestream_helpers.rb
+++ b/spec/support/livestream_helpers.rb
@@ -7,13 +7,11 @@ def stub_yesterdays_youtube_link
 end
 
 def yesterdays_link
-  h = JSON.parse(live_coronavirus_content_item)
-  h["details"]["live_stream"]["video_url"]
+  coronavirus_content_json.dig("details", "live_stream", "video_url")
 end
 
 def yesterdays_date
-  h = JSON.parse(live_coronavirus_content_item)
-  h["details"]["live_stream"]["date"]
+  coronavirus_content_json.dig("details", "live_stream", "date")
 end
 
 def todays_link

--- a/spec/support/livestream_helpers.rb
+++ b/spec/support/livestream_helpers.rb
@@ -1,0 +1,21 @@
+def stub_todays_youtube_link
+  stub_request(:get, todays_link)
+end
+
+def stub_yesterdays_youtube_link
+  stub_request(:get, yesterdays_link)
+end
+
+def yesterdays_link
+  h = JSON.parse(live_coronavirus_content_item)
+  h["details"]["live_stream"]["video_url"]
+end
+
+def yesterdays_date
+  h = JSON.parse(live_coronavirus_content_item)
+  h["details"]["live_stream"]["date"]
+end
+
+def todays_link
+  "https://www.youtube.com/watch?todays_link"
+end

--- a/spec/support/navigation_steps.rb
+++ b/spec/support/navigation_steps.rb
@@ -34,4 +34,8 @@ module NavigationSteps
   def when_i_visit_the_step_by_step_page
     visit step_by_step_page_path(@step_by_step_page)
   end
+
+  def when_i_visit_the_root_path
+    visit root_path
+  end
 end


### PR DESCRIPTION
## What
Allow users with a new signon permission `Livestream editor` access to edit the daily livestream URL.

## Why
So that we can hand over control of updating the livestream URL to Cabinet Office/number 10.

## Before PR
Currently to edit the livestream you need both GDS editor and Coronavirus editor permissions:
- GDS Editor permissions required to access the landing page of Collections Publisher (root is step by step index page). 
- From landing page, navigate to Coronavirus Pages, which requires Coronavirus Editor permissions. 

## After PR
- If user has only Livestream Editor permissions, accessing the app they will now be routed to the livestream edit page. 
- This is the only page they can access.
- Coronavirus editors accessing the app will see no change in their flow.

[trello](https://trello.com/c/sRpPbpqM/323-enable-co-no10-to-update-the-livestream)