### PR TITLE
Re-style coronavirus index page

### DIFF
--- a/app/assets/stylesheets/admin_layout.scss
+++ b/app/assets/stylesheets/admin_layout.scss
@@ -5,4 +5,4 @@
 @import "./objects/side";
 @import "./utilities/overrides";
 @import "./steps";
-@import "./views/coronavirus_manage_page";
+@import "./views/coronavirus_manage_pages";

--- a/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
+++ b/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
@@ -11,3 +11,7 @@
     width: 30%;
   }
 }
+
+.covid__spaced-list .covid__spaced-list-item:nth-of-type(2n) {
+  margin-bottom: govuk-spacing(4);
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?
+  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?, :unreleased_feature_user?
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
@@ -23,6 +23,10 @@ private
 
   def livestream_editor?
     current_user.has_permission? "Livestream editor"
+  end
+
+  def unreleased_feature_user?
+    current_user.has_permission? "Unreleased feature"
   end
 
   # Can be overridden to allow controllers to choose the active menu item.

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -2,24 +2,17 @@ class CoronavirusPagesController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
   before_action :require_unreleased_feature_permissions!, only: %w[show]
   before_action :redirect_to_index_if_slug_unknown, only: %w[prepare show]
+  before_action :initialise_coronavirus_pages, only: %w[index]
   layout "admin_layout"
 
-  def index
-    topic_links = topic_pages_configuration.keys.map do |page|
-      {
-        slug: page.to_s,
-        title: topic_pages_configuration[page][:name],
-      }
-    end
+  def index; end
 
-    subtopic_links = subtopic_pages_configuration.keys.map do |page|
-      {
-        slug: page.to_s,
-        title: subtopic_pages_configuration[page][:name],
-      }
-    end
-
-    render :index, locals: { topic_links: topic_links, subtopic_links: subtopic_links }
+  def initialise_coronavirus_pages
+    pages = page_configs.keys
+    @coronavirus_pages =
+      pages.map do |page|
+        CoronavirusPages::Updater.new(page.to_s).page
+      end
   end
 
   def prepare

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -5,14 +5,21 @@ class CoronavirusPagesController < ApplicationController
   layout "admin_layout"
 
   def index
-    links = page_configs.keys.map do |page|
+    topic_links = topic_pages_configuration.keys.map do |page|
       {
         slug: page.to_s,
-        title: page_configs[page][:name],
+        title: topic_pages_configuration[page][:name],
       }
     end
 
-    render :index, locals: { links: links }
+    subtopic_links = subtopic_pages_configuration.keys.map do |page|
+      {
+        slug: page.to_s,
+        title: subtopic_pages_configuration[page][:name],
+      }
+    end
+
+    render :index, locals: { topic_links: topic_links, subtopic_links: subtopic_links }
   end
 
   def prepare

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -5,14 +5,9 @@ class CoronavirusPagesController < ApplicationController
   before_action :initialise_coronavirus_pages, only: %w[index]
   layout "admin_layout"
 
-  def index; end
-
-  def initialise_coronavirus_pages
-    pages = page_configs.keys
-    @coronavirus_pages =
-      pages.map do |page|
-        CoronavirusPages::Updater.new(page.to_s).page
-      end
+  def index
+    @topic_page = CoronavirusPage.topic_page.first
+    @subtopic_pages = CoronavirusPage.subtopic_pages
   end
 
   def prepare
@@ -39,6 +34,12 @@ class CoronavirusPagesController < ApplicationController
   end
 
 private
+
+  def initialise_coronavirus_pages
+    page_configs.keys.map do |page|
+      CoronavirusPages::Updater.new(page.to_s).page
+    end
+  end
 
   def coronavirus_page
     @coronavirus_page ||= updater.page

--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -1,3 +1,5 @@
 class CoronavirusPage < ApplicationRecord
   has_many :sub_sections
+  scope :topic_page, -> { where(slug: "landing") }
+  scope :subtopic_pages, -> { where.not(slug: "landing") }
 end

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -3,13 +3,17 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
 <ul class="govuk-list">
-  <li><%= link_to "Edit #{@topic_page.name} '#{@topic_page.sections_title.downcase}' accordion", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <% if unreleased_feature_user? %>
+    <li><%= link_to "Edit #{@topic_page.name} '#{@topic_page.sections_title.downcase}' accordion", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <% end %>
   <li><%= link_to "Publish #{@topic_page.name}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
   <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
   <br>
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
   <% @subtopic_pages.each do |page| %>
+  <% if unreleased_feature_user? %>
     <li><%= link_to "Edit #{page.name} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
+  <% end %>
     <li><%= link_to "Publish #{page.name}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
     <br>
   <% end %>

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -8,13 +8,14 @@
   <% end %>
   <li><%= link_to "Publish #{@topic_page.name}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
   <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
-  <br>
+</ul>
+
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
+<ul class="govuk-list covid__spaced-list">
   <% @subtopic_pages.each do |page| %>
   <% if unreleased_feature_user? %>
-    <li><%= link_to "Edit #{page.name} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
   <% end %>
-    <li><%= link_to "Publish #{page.name}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
-    <br>
+    <li class="covid__spaced-list-item"><%= link_to "Publish #{page.name}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   <% end %>
 </ul>

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -1,17 +1,11 @@
+
 <% content_for :title, "Coronavirus topic pages" %>
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
 <ul class="govuk-list">
   <li><%= link_to "Edit landing page ‘guidance and support’ accordion", "#test", class:"govuk-link" %></li>
   <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
-  <% topic_links.each do |link| %>
-    <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-link" %></li>
-  <% end %>
-</ul>
-
-<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
-<ul class="govuk-list">
-  <% subtopic_links.each do |link| %>
-  <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-link" %></li>
+  <% @coronavirus_pages.each do |page| %>
+    <li><%= link_to "Publish #{page.name}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   <% end %>
 </ul>

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -1,8 +1,17 @@
-<% content_for :title, "What do you need to do?" %>
+<% content_for :title, "Coronavirus topic pages" %>
 
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
 <ul class="govuk-list">
-  <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-button" %></li>
-<% links.each do |link| %>
-  <li><%= link_to "Publish #{link[:title]}", prepare_coronavirus_page_path(slug: link[:slug]), class:"govuk-button" %></li>
-<% end %>
+  <li><%= link_to "Edit landing page ‘guidance and support’ accordion", "#test", class:"govuk-link" %></li>
+  <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
+  <% topic_links.each do |link| %>
+    <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-link" %></li>
+  <% end %>
+</ul>
+
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
+<ul class="govuk-list">
+  <% subtopic_links.each do |link| %>
+  <li><%= link_to "Publish #{link[:title]}", coronavirus_path(slug: link[:slug]), class:"govuk-link" %></li>
+  <% end %>
 </ul>

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -3,9 +3,14 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
 <ul class="govuk-list">
-  <li><%= link_to "Edit landing page ‘guidance and support’ accordion", "#test", class:"govuk-link" %></li>
+  <li><%= link_to "Edit #{@topic_page.name} '#{@topic_page.sections_title.downcase}' accordion", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <li><%= link_to "Publish #{@topic_page.name}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
   <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
-  <% @coronavirus_pages.each do |page| %>
+  <br>
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
+  <% @subtopic_pages.each do |page| %>
+    <li><%= link_to "Edit #{page.name} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
     <li><%= link_to "Publish #{page.name}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
+    <br>
   <% end %>
 </ul>

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -7,11 +7,23 @@ RSpec.describe CoronavirusPagesController, type: :controller do
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
   let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
+  let(:all_content_urls) do
+    CoronavirusPages::Configuration.all_pages.map do |config|
+      config.second[:raw_content_url]
+    end
+  end
+  let(:stub_all_content_urls) do
+    all_content_urls.each do |url|
+      stub_request(:get, url)
+        .to_return(status: 200, body: raw_content)
+    end
+  end
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:raw_content) { File.read(Rails.root.join + fixture_path) }
 
   describe "GET /coronavirus" do
     it "renders page successfully" do
+      stub_all_content_urls
       get :index
       expect(response).to have_http_status(:success)
     end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     before do
       given_i_am_a_coronavirus_editor
       stub_coronavirus_publishing_api
-      stub_github_request
+      stub_all_github_requests
       stub_any_publishing_api_put_intent
       stub_youtube
     end
@@ -57,7 +57,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     before do
       given_i_am_a_coronavirus_editor
       stub_coronavirus_publishing_api
-      stub_github_business_request
+      stub_all_github_requests
       stub_any_publishing_api_put_intent
       stub_youtube
     end
@@ -74,6 +74,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     scenario "Updating draft business page" do
       when_i_visit_the_publish_coronavirus_page
       and_i_select_business_page
+      stub_github_business_request
       and_i_push_a_new_draft_version
       then_the_business_content_is_sent_to_publishing_api
       and_i_see_a_draft_updated_message

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -15,13 +15,13 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "User views the page" do
-      when_i_visit_the_publish_coronavirus_page
-      i_see_a_landing_page_button
-      i_see_a_business_page_button
+      when_i_visit_the_coronavirus_index_page
+      i_see_a_publish_landing_page_link
+      i_see_a_publish_business_page_link
     end
 
     scenario "User selects landing page" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_landing_page
       i_see_an_update_draft_button
       and_a_preview_button
@@ -29,7 +29,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Updating draft landing page" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_landing_page
       and_i_push_a_new_draft_version
       then_the_content_is_sent_to_publishing_api
@@ -37,14 +37,14 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Updating landing draft with invalid content" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_landing_page
       and_i_push_a_new_draft_version_with_invalid_content
       and_i_see_an_alert
     end
 
     scenario "Publishing landing page" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_landing_page
       and_i_choose_a_major_update
       and_i_publish_the_page
@@ -63,7 +63,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "User selects business page" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_business_page
       i_see_an_update_draft_button
       and_a_preview_button
@@ -72,7 +72,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Updating draft business page" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_business_page
       stub_github_business_request
       and_i_push_a_new_draft_version
@@ -81,14 +81,14 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Updating business draft with invalid content" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_business_page
       and_i_push_a_new_draft_business_version_with_invalid_content
       and_i_see_an_alert_for_missing_hub_page_keys
     end
 
     scenario "Publishing business page" do
-      when_i_visit_the_publish_coronavirus_page
+      when_i_visit_the_coronavirus_index_page
       and_i_select_business_page
       and_i_choose_a_major_update
       and_i_publish_the_page

--- a/spec/features/live_stream_page_spec.rb
+++ b/spec/features/live_stream_page_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "Make changes to the live stream URL" do
   before do
     given_i_am_a_coronavirus_editor
     stub_coronavirus_publishing_api
+    stub_all_github_requests
     stub_youtube
   end
 

--- a/spec/features/live_stream_page_spec.rb
+++ b/spec/features/live_stream_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Make changes to the live stream URL" do
   end
 
   scenario "Publish a valid livestream url" do
-    when_i_visit_the_publish_coronavirus_page
+    when_i_visit_the_coronavirus_index_page
     and_i_select_live_stream
     i_am_able_to_update_draft_content_with_valid_url
     and_i_see_live_stream_is_updated_message
@@ -23,7 +23,7 @@ RSpec.feature "Make changes to the live stream URL" do
   end
 
   scenario "Adding an invalid livestream url" do
-    when_i_visit_the_publish_coronavirus_page
+    when_i_visit_the_coronavirus_index_page
     and_i_select_live_stream
     i_am_able_to_submit_an_invalid_url
     and_i_see_the_error_message

--- a/spec/models/coronavirus_page_spec.rb
+++ b/spec/models/coronavirus_page_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CoronavirusPage do
+  describe "scopes" do
+    let!(:business) { create :coronavirus_page, :business }
+    let!(:landing) { create :coronavirus_page, :landing }
+    let!(:education) { create :coronavirus_page, :education }
+    let!(:employees) { create :coronavirus_page, :employees }
+
+    it "topic_page" do
+      expect(CoronavirusPage.topic_page.first).to eq landing
+    end
+
+    it "sub_topics" do
+      expect(CoronavirusPage.subtopic_pages).to eq [business, education, employees]
+    end
+  end
+end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -109,12 +109,12 @@ def then_the_business_content_is_sent_to_publishing_api
   )
 end
 
-def i_see_a_landing_page_button
-  expect(page).to have_link("Coronavirus landing page")
+def i_see_a_publish_landing_page_link
+  expect(page).to have_link("Publish Coronavirus landing page")
 end
 
-def i_see_a_business_page_button
-  expect(page).to have_link("Business support page")
+def i_see_a_publish_business_page_link
+  expect(page).to have_link("Publish Business support page")
 end
 
 def i_see_livestream_button
@@ -122,15 +122,15 @@ def i_see_livestream_button
 end
 
 def and_i_select_landing_page
-  click_on("Coronavirus landing page")
+  click_link("Publish Coronavirus landing page")
 end
 
 def and_i_select_business_page
-  click_on("Business support page")
+  click_link("Publish Business support page")
 end
 
 def and_i_select_live_stream
-  click_on("Update live stream")
+  click_link("Update live stream")
   expect(page).to have_text("Update live stream URL")
 end
 
@@ -154,7 +154,7 @@ def i_am_able_to_submit_an_invalid_url
   click_on("Update draft")
 end
 
-def when_i_visit_the_publish_coronavirus_page
+def when_i_visit_the_coronavirus_index_page
   visit "/coronavirus"
 end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -64,9 +64,18 @@ def stub_coronavirus_publishing_api
   stub_any_publishing_api_publish
 end
 
-def stub_github_request
-  stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml")
-    .to_return(status: 200, body: github_response)
+def raw_content_urls
+  @raw_content_urls ||=
+    CoronavirusPages::Configuration.all_pages.map do |config|
+      config.second[:raw_content_url]
+    end
+end
+
+def stub_all_github_requests
+  raw_content_urls.each do |url|
+    stub_request(:get, url)
+      .to_return(status: 200, body: github_response)
+  end
 end
 
 def stub_github_business_request


### PR DESCRIPTION
Pair programming effort between @danacotoran and @hannako 

## What
Frontend: Implement the design of the new index page for the coronavirus publishing tool.
Backend: Wire up the index page to read from database objects passed through from the controller.

## Before
<img width="1039" alt="Screenshot 2020-06-23 at 11 03 39" src="https://user-images.githubusercontent.com/17908089/85390841-4b5b5580-b541-11ea-9e7d-eecc381631ab.png">

## After
<img width="1061" alt="Screenshot 2020-06-23 at 11 04 57" src="https://user-images.githubusercontent.com/17908089/85390924-65953380-b541-11ea-8877-b456d1929233.png">






https://trello.com/c/u16kFlyh