### PR TITLE
Coronavirus publishing tool: Reordering subsections

### DIFF
--- a/app/assets/javascripts/admin_layout.js
+++ b/app/assets/javascripts/admin_layout.js
@@ -14,8 +14,8 @@
 //= require @webcomponents/custom-elements/custom-elements.min.js
 
 //= require components/markdown-editor.js
-//= require steps.js
+//= require sections.js
 
 $(document).ready(function() {
-  GOVUK.stepByStepPublisher.init();
+  GOVUK.sectionPublisher.init();
 });

--- a/app/assets/javascripts/sections.js
+++ b/app/assets/javascripts/sections.js
@@ -6,7 +6,7 @@
   window.GOVUK = window.GOVUK || {};
   var $ = window.jQuery;
 
-  GOVUK.stepByStepPublisher = {
+  GOVUK.sectionPublisher = {
     init: function() {
       this.addReorderButtons();
       this.bindReorderButtonClicks();
@@ -55,12 +55,12 @@
           $parent.insertAfter($next);
         }
 
-        GOVUK.stepByStepPublisher.setOrder();
+        GOVUK.sectionPublisher.setOrder();
       });
     },
 
     setOrder: function() {
-      var $orderVal = $('#step_order_save');
+      var $orderVal = $('#js_order_save');
       var order = [];
 
       $('.js-reorder').each(function(i) {
@@ -79,7 +79,7 @@
           ui.placeholder.height(ui.item.height());
         },
         update: function(){
-          GOVUK.stepByStepPublisher.setOrder();
+          GOVUK.sectionPublisher.setOrder();
         }
       });
 

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -37,6 +37,20 @@ class CoronavirusPagesController < ApplicationController
 
   def reorder
     coronavirus_page
+    if request.post? && params.key?(:section_order_save)
+      reordered_sections = JSON.parse(params[:section_order_save])
+      reordered_sections.each do |section_data|
+        sub_section = @coronavirus_page.sub_sections.find(section_data["id"])
+        sub_section.update(position: section_data["position"])
+      end
+      message = if draft_updater.send
+                  { notice: "Steps were successfully reordered." }
+                else
+                  { alert: draft_updater.errors.to_sentence }
+                  # #undo_order_change
+                end
+      redirect_to coronavirus_page_path(slug), message
+    end
   end
 
 private

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -1,6 +1,6 @@
 class CoronavirusPagesController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
-  before_action :require_unreleased_feature_permissions!, only: %w[show reorder]
+  before_action :require_unreleased_feature_permissions!, only: %w[show]
   before_action :redirect_to_index_if_slug_unknown, only: %w[prepare show]
   before_action :initialise_coronavirus_pages, only: %w[index]
   layout "admin_layout"
@@ -35,35 +35,7 @@ class CoronavirusPagesController < ApplicationController
     end
   end
 
-  def reorder
-    coronavirus_page
-    @old_positions = positions
-    if request.post? && params.key?(:section_order_save)
-      @new_positions = JSON.parse(params[:section_order_save])
-      set_positions(@new_positions)
-      if draft_updater.send
-        message = { notice: "Sections were successfully reordered." }
-      else
-        set_positions(@old_positions)
-        message = { alert: "Sorry! Sections have not been reordered: " + draft_updater.errors.to_sentence }
-      end
-      redirect_to coronavirus_page_path(slug), message
-    end
-  end
-
 private
-
-  def positions
-    coronavirus_page.sub_sections.each_with_object([]) do |sub_section, array|
-      array << { "id" => sub_section.id, "position" => sub_section.position }
-    end
-  end
-
-  def set_positions(positions)
-    positions.each do |sub_section|
-      SubSection.find(sub_section["id"]).update(position: sub_section["position"])
-    end
-  end
 
   def initialise_coronavirus_pages
     page_configs.keys.map do |page|

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -1,6 +1,6 @@
 class CoronavirusPagesController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
-  before_action :require_unreleased_feature_permissions!, only: %w[show]
+  before_action :require_unreleased_feature_permissions!, only: %w[show reorder]
   before_action :redirect_to_index_if_slug_unknown, only: %w[prepare show]
   before_action :initialise_coronavirus_pages, only: %w[index]
   layout "admin_layout"
@@ -33,6 +33,10 @@ class CoronavirusPagesController < ApplicationController
     else
       redirect_to coronavirus_page_path(slug)
     end
+  end
+
+  def reorder
+    coronavirus_page
   end
 
 private

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -12,13 +12,11 @@ class ReorderSubSectionsController < ApplicationController
     current_positions
     set_positions(submitted_positions)
     if draft_updater.send
-      message = { notice: "Sections were successfully reordered." }
+      redirect_to coronavirus_page_path(slug), notice: "Sections were successfully reordered."
     else
-      current_positions
-      set_positions(current_positions)
-      message = { alert: "Sorry! Sections have not been reordered: " + draft_updater.errors.to_sentence }
+      message = "Sorry! Sections have not been reordered: #{draft_updater.errors.to_sentence}. Please try saving again."
+      redirect_to reorder_coronavirus_page_sub_sections_path(slug), alert: message
     end
-    redirect_to coronavirus_page_path(slug), message
   end
 
 private

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -1,0 +1,68 @@
+class ReorderSubSectionsController < ApplicationController
+  before_action :require_coronavirus_editor_permissions!
+  before_action :require_unreleased_feature_permissions!
+  before_action :redirect_to_index_if_slug_unknown
+  layout "admin_layout"
+
+  def index
+    coronavirus_page
+  end
+
+  def update
+    current_positions
+    set_positions(submitted_positions)
+    if draft_updater.send
+      message = { notice: "Sections were successfully reordered." }
+    else
+      current_positions
+      set_positions(current_positions)
+      message = { alert: "Sorry! Sections have not been reordered: " + draft_updater.errors.to_sentence }
+    end
+    redirect_to coronavirus_page_path(slug), message
+  end
+
+private
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPages::ModelBuilder.call(slug)
+  end
+
+  def current_positions
+    @current_positions ||= coronavirus_page.sub_sections.map do |sub_section|
+      { "id" => sub_section.id, "position" => sub_section.position }
+    end
+  end
+
+  def submitted_positions
+    JSON.parse(params[:section_order_save])
+  end
+
+  def set_positions(positions)
+    positions.each do |sub_section|
+      SubSection.find(sub_section["id"]).update(position: sub_section["position"])
+    end
+  end
+
+  def draft_updater
+    @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
+  end
+
+  def redirect_to_index_if_slug_unknown
+    if slug_unknown?
+      flash[:alert] = "'#{slug}' is not a valid page.  Please select from one of those below."
+      redirect_to coronavirus_pages_path
+    end
+  end
+
+  def slug
+    params[:slug] || params[:coronavirus_page_slug]
+  end
+
+  def slug_unknown?
+    !page_configs.key?(slug.to_sym)
+  end
+
+  def page_configs
+    CoronavirusPages::Configuration.all_pages
+  end
+end

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -77,7 +77,7 @@ class CoronavirusPages::ContentBuilder
   end
 
   def sub_sections_data
-    coronavirus_page.sub_sections.map do |sub_section|
+    coronavirus_page.sub_sections.order(:position).map do |sub_section|
       presenter = SubSectionJsonPresenter.new(sub_section)
       add_error(presenter.errors) unless presenter.success?
       presenter.output

--- a/app/services/coronavirus_pages/model_builder.rb
+++ b/app/services/coronavirus_pages/model_builder.rb
@@ -39,12 +39,13 @@ module CoronavirusPages
     end
 
     def sub_sections
-      parsed_sub_sections.map do |sub_section|
-        SubSection.new(sub_section)
+      sub_section_attributes.each_with_index.map do |attributes, i|
+        attributes["position"] = i
+        SubSection.new(attributes)
       end
     end
 
-    def parsed_sub_sections
+    def sub_section_attributes
       SectionsPresenter.new(yaml_data.dig("content", "sections")).output
     end
 

--- a/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
@@ -1,8 +1,9 @@
-
+<% reorder ||= false %>
 <% sub_sections =
  @coronavirus_page.sub_sections.map do |sub_section|
    {
-     field: sub_section.title ,
+     id: rand(10000),
+     field: sub_section.title,
      edit: { href: edit_coronavirus_page_sub_section_path(@coronavirus_page.slug, sub_section) },
      delete: {
        href: coronavirus_page_sub_section_path(@coronavirus_page.slug, sub_section),
@@ -13,9 +14,28 @@
      }
    }
  end %>
-<div class="covid-manage-page__accordion-summary-list">
-  <%= render "govuk_publishing_components/components/summary_list", {
-    title: @coronavirus_page.sections_title,
-    items: sub_sections
-  } %>
+
+<% if reorder  %>
+  <div class="covid-manage-page__accordion-summary-list">
+    <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
+      <% sub_sections.each_with_index do |accordion, index| %>
+        <li class="js-reorder" data-id="<%= accordion[:id] %>">
+          <div class="govuk-grid-row" id="step-<%= index %>">
+            <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
+              <%= accordion[:field] %>
+            </div>
+            <div class="govuk-grid-column-one-quarter js-order-controls">
+            </div>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% else %>
+  <div class="covid-manage-page__accordion-summary-list">
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: @coronavirus_page.sections_title,
+      items: sub_sections
+    } %>
+<% end %>
 </div>

--- a/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
@@ -1,4 +1,3 @@
-<% reorder ||= false %>
 <% sub_sections =
  @coronavirus_page.sub_sections.order(:position).map do |sub_section|
    {
@@ -15,27 +14,9 @@
    }
  end %>
 
-<% if reorder  %>
-  <div class="covid-manage-page__accordion-summary-list">
-    <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
-      <% sub_sections.each_with_index do |accordion, index| %>
-        <li class="js-reorder" data-id="<%= accordion[:id] %>">
-          <div class="govuk-grid-row" id="step-<%= index %>">
-            <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
-              <%= accordion[:field] %>
-            </div>
-            <div class="govuk-grid-column-one-quarter js-order-controls">
-            </div>
-          </div>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-<% else %>
-  <div class="covid-manage-page__accordion-summary-list">
-    <%= render "govuk_publishing_components/components/summary_list", {
-      title: @coronavirus_page.sections_title,
-      items: sub_sections
-    } %>
-<% end %>
+<div class="covid-manage-page__accordion-summary-list">
+  <%= render "govuk_publishing_components/components/summary_list", {
+    title: @coronavirus_page.sections_title,
+    items: sub_sections
+  } %>
 </div>

--- a/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
@@ -1,8 +1,8 @@
 <% reorder ||= false %>
 <% sub_sections =
- @coronavirus_page.sub_sections.map do |sub_section|
+ @coronavirus_page.sub_sections.order(:position).map do |sub_section|
    {
-     id: rand(10000),
+     id: sub_section.id,
      field: sub_section.title,
      edit: { href: edit_coronavirus_page_sub_section_path(@coronavirus_page.slug, sub_section) },
      delete: {

--- a/app/views/coronavirus_pages/reorder.html.erb
+++ b/app/views/coronavirus_pages/reorder.html.erb
@@ -2,7 +2,7 @@
   links = [
     {
       text: 'Coronavirus topic pages',
-      href: coronavirus_index_path
+      href: coronavirus_pages_path
     },
     {
       text: "Coronavirus (COVID-19)"
@@ -12,12 +12,12 @@
 %>
 
 <% content_for :title, "Coronavirus (COVID-19)" %>
-<% content_for :context, 'Reorder guidance and support accordion' %>
+<% content_for :context, "Reorder #{@coronavirus_page.sections_title.downcase} accordion" %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown "Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop." %>
-    <%= render "coronavirus_pages/accordion_summary_list", { reorder: true } %>
+    <%= render "coronavirus_pages/sub_sections_summary_list", { reorder: true } %>
 
     <%= form_for("reorder_guidance_accordion", url: "/test/covid/managepage/reorder", method: :post) do |form| %>
       <input type="hidden" name="section_order_save" id="js_order_save" value="" />
@@ -26,12 +26,9 @@
           <%= render "govuk_publishing_components/components/button", {
             text: "Save"
           } %>
-        </div>
-        <div class="govuk-grid-column-full govuk-!-margin-top-3">
-          <%= link_to 'Cancel', test_covid_managepage_path, class: "govuk-link" %>
+          <%= link_to 'Cancel', coronavirus_page_path(@coronavirus_page.slug), class: "govuk-link govuk-button" %>
         </div>
       </div>
     <% end %>
   </div>
-
 </div>

--- a/app/views/coronavirus_pages/reorder.html.erb
+++ b/app/views/coronavirus_pages/reorder.html.erb
@@ -19,7 +19,7 @@
     <%= render_markdown "Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop." %>
     <%= render "coronavirus_pages/sub_sections_summary_list", { reorder: true } %>
 
-    <%= form_for("reorder_guidance_accordion", url: "/test/covid/managepage/reorder", method: :post) do |form| %>
+    <%= form_for(@coronavirus_page, url: reorder_coronavirus_page_path, method: :post) do |form| %>
       <input type="hidden" name="section_order_save" id="js_order_save" value="" />
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/app/views/coronavirus_pages/reorder.html.erb
+++ b/app/views/coronavirus_pages/reorder.html.erb
@@ -1,0 +1,37 @@
+<%
+  links = [
+    {
+      text: 'Coronavirus topic pages',
+      href: coronavirus_index_path
+    },
+    {
+      text: "Coronavirus (COVID-19)"
+    }
+  ]
+
+%>
+
+<% content_for :title, "Coronavirus (COVID-19)" %>
+<% content_for :context, 'Reorder guidance and support accordion' %>
+
+<div class="covid-manage-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_markdown "Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop." %>
+    <%= render "coronavirus_pages/accordion_summary_list", { reorder: true } %>
+
+    <%= form_for("reorder_guidance_accordion", url: "/test/covid/managepage/reorder", method: :post) do |form| %>
+      <input type="hidden" name="section_order_save" id="js_order_save" value="" />
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save"
+          } %>
+        </div>
+        <div class="govuk-grid-column-full govuk-!-margin-top-3">
+          <%= link_to 'Cancel', test_covid_managepage_path, class: "govuk-link" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+</div>

--- a/app/views/reorder_sub_sections/_reorder_list.html.erb
+++ b/app/views/reorder_sub_sections/_reorder_list.html.erb
@@ -1,0 +1,17 @@
+<% sub_sections = @coronavirus_page.sub_sections.order(:position) %>
+
+<div class="covid-manage-page__accordion-summary-list">
+  <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
+    <% sub_sections.each_with_index do |sub_section, index| %>
+      <li class="js-reorder" data-id="<%= sub_section.id %>">
+        <div class="govuk-grid-row" id="step-<%= index %>">
+          <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
+            <%= sub_section.title %>
+          </div>
+          <div class="govuk-grid-column-one-quarter js-order-controls">
+          </div>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/reorder_sub_sections/index.html.erb
+++ b/app/views/reorder_sub_sections/index.html.erb
@@ -1,25 +1,12 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus topic pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: "Coronavirus (COVID-19)"
-    }
-  ]
-
-%>
-
 <% content_for :title, "Coronavirus (COVID-19)" %>
 <% content_for :context, "Reorder #{@coronavirus_page.sections_title.downcase} accordion" %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown "Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop." %>
-    <%= render "coronavirus_pages/sub_sections_summary_list", { reorder: true } %>
+    <%= render "reorder_list" %>
 
-    <%= form_for(@coronavirus_page, url: reorder_coronavirus_page_path, method: :post) do |form| %>
+    <%= form_for(@coronavirus_page, url: reorder_coronavirus_page_sub_sections_path, method: :put) do |form| %>
       <input type="hidden" name="section_order_save" id="js_order_save" value="" />
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">

--- a/app/views/step_by_step_pages/reorder.html.erb
+++ b/app/views/step_by_step_pages/reorder.html.erb
@@ -50,7 +50,7 @@
       </ul>
 
       <%= form_for(@step_by_step_page, url: step_by_step_page_reorder_path(@step_by_step_page), method: :post) do |form| %>
-        <input type="hidden" name="step_order_save" id="step_order_save" value="" />
+        <input type="hidden" name="step_order_save" id="js_order_save" value="" />
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
             <%= render "govuk_publishing_components/components/button", {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,10 +20,13 @@ Rails.application.routes.draw do
 
   resources :coronavirus_pages, path: "coronavirus", only: %i[index show update], param: :slug do
     get "prepare", on: :member
-    get "reorder", on: :member
-    post "reorder", on: :member
     post "publish", to: "coronavirus_pages#publish"
-    resources :sub_sections
+    resources :sub_sections do
+      collection do
+        get "reorder", to: "reorder_sub_sections#index"
+        put "reorder", to: "reorder_sub_sections#update"
+      end
+    end
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
   resources :coronavirus_pages, path: "coronavirus", only: %i[index show update], param: :slug do
     get "prepare", on: :member
+    get "reorder", on: :member
     post "publish", to: "coronavirus_pages#publish"
     resources :sub_sections
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   resources :coronavirus_pages, path: "coronavirus", only: %i[index show update], param: :slug do
     get "prepare", on: :member
     get "reorder", on: :member
+    post "reorder", on: :member
     post "publish", to: "coronavirus_pages#publish"
     resources :sub_sections
   end

--- a/db/migrate/20200701141142_add_position_to_sub_section.rb
+++ b/db/migrate/20200701141142_add_position_to_sub_section.rb
@@ -1,0 +1,5 @@
+class AddPositionToSubSection < ActiveRecord::Migration[6.0]
+  def change
+    add_column :sub_sections, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_165045) do
+ActiveRecord::Schema.define(version: 2020_07_01_141142) do
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sections_title"
@@ -155,6 +155,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_165045) do
     t.bigint "coronavirus_page_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position"
     t.index ["coronavirus_page_id"], name: "index_sub_sections_on_coronavirus_page_id"
   end
 

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
     let!(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page }
 
     let(:section_params) { "[{\"id\":#{sub_section_0.id}, \"position\":1},{\"id\":#{sub_section_1.id},\"position\":0}]" }
-    let!(:subject) { post :reorder, params: { slug: coronavirus_page.slug, section_order_save: section_params } }
+    let(:subject) { post :reorder, params: { slug: coronavirus_page.slug, section_order_save: section_params } }
 
     it "redirects to coronavirus page on success" do
       expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
@@ -118,6 +118,14 @@ RSpec.describe CoronavirusPagesController, type: :controller do
       subject
       expect(sub_section_0.reload.position).to eq 1
       expect(sub_section_1.reload.position).to eq 0
+    end
+
+    it "reinstates the previous order if draft updater fails" do
+      stub_any_publishing_api_put_content
+        .to_return(status: 500)
+      subject
+      expect(sub_section_0.reload.position).to eq 0
+      expect(sub_section_1.reload.position).to eq 1
     end
   end
 end

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe CoronavirusPagesController, type: :controller do
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
-  let!(:live_stream) { create :live_stream, :without_validations }
   let(:slug) { coronavirus_page.slug }
   let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
   let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
@@ -14,6 +13,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
       config.second[:raw_content_url]
     end
   end
+  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:raw_content) { File.read(fixture_path) }
   let(:stub_all_content_urls) do
     all_content_urls.each do |url|
@@ -21,7 +21,6 @@ RSpec.describe CoronavirusPagesController, type: :controller do
         .to_return(status: 200, body: raw_content)
     end
   end
-  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
 
   describe "GET /coronavirus" do
     it "renders page successfully" do
@@ -82,50 +81,6 @@ RSpec.describe CoronavirusPagesController, type: :controller do
     it "redirects to index with an unknown slug" do
       get :show, params: { slug: "unknown" }
       expect(response).to redirect_to(coronavirus_pages_path)
-    end
-  end
-
-  describe "GET /coronavirus/:coronavirus_page_slug/reorder" do
-    before do
-      stub_user.permissions << "Unreleased feature"
-    end
-
-    it "renders page successfuly" do
-      get :reorder, params: { slug: coronavirus_page.slug }
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "POST /coronavirus/:coronavirus_page_slug/reorder" do
-    before do
-      stub_user.permissions << "Unreleased feature"
-      stub_request(:get, coronavirus_page.raw_content_url)
-        .to_return(status: 200, body: raw_content)
-      stub_coronavirus_publishing_api
-      live_stream
-    end
-    let!(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }
-    let!(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page }
-
-    let(:section_params) { "[{\"id\":#{sub_section_0.id}, \"position\":1},{\"id\":#{sub_section_1.id},\"position\":0}]" }
-    let(:subject) { post :reorder, params: { slug: coronavirus_page.slug, section_order_save: section_params } }
-
-    it "redirects to coronavirus page on success" do
-      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
-    end
-
-    it "reorders the sections" do
-      subject
-      expect(sub_section_0.reload.position).to eq 1
-      expect(sub_section_1.reload.position).to eq 0
-    end
-
-    it "reinstates the previous order if draft updater fails" do
-      stub_any_publishing_api_put_content
-        .to_return(status: 500)
-      subject
-      expect(sub_section_0.reload.position).to eq 0
-      expect(sub_section_1.reload.position).to eq 1
     end
   end
 end

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
+  let!(:live_stream) { create :live_stream, :without_validations }
   let(:slug) { coronavirus_page.slug }
   let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
   let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
@@ -81,6 +82,17 @@ RSpec.describe CoronavirusPagesController, type: :controller do
     it "redirects to index with an unknown slug" do
       get :show, params: { slug: "unknown" }
       expect(response).to redirect_to(coronavirus_pages_path)
+    end
+  end
+
+  describe "GET /coronavirus/:coronavirus_page_slug/reorder" do
+    before do
+      stub_user.permissions << "Unreleased feature"
+    end
+
+    it "renders page successfuly" do
+      get :reorder, params: { slug: coronavirus_page.slug }
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -246,7 +246,7 @@ FactoryBot.define do
   factory :sub_section do
     title { Faker::Lorem.sentence }
     content { "[#{Faker::Lorem.sentence}](/#{File.join(Faker::Lorem.words)})" }
-    position { rand(4) }
+    position { (SubSection.maximum(:position) || 0) + 1 }
     coronavirus_page
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -246,6 +246,7 @@ FactoryBot.define do
   factory :sub_section do
     title { Faker::Lorem.sentence }
     content { "[#{Faker::Lorem.sentence}](/#{File.join(Faker::Lorem.words)})" }
+    position { rand(4) }
     coronavirus_page
   end
 

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_coronavirus_publishing_api
       stub_all_github_requests
       stub_any_publishing_api_put_intent
+      given_a_livestream_exists
     end
 
     scenario "Publishing landing page" do
@@ -36,6 +37,15 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       then_the_page_publishes_a_minor_update
       and_i_remain_on_the_coronavirus_page
       and_i_see_a_page_published_message
+    end
+
+    scenario "Reordering sections", js: true do
+      set_up_basic_sub_sections
+      when_i_visit_the_reorder_page
+      i_see_subsection_one_in_position_one
+      and_i_move_section_one_down
+      then_the_reordered_subsections_are_sent_to_publishing_api
+      then_i_see_section_updated_message
     end
   end
 

--- a/spec/fixtures/simple_coronavirus_page.yml
+++ b/spec/fixtures/simple_coronavirus_page.yml
@@ -8,5 +8,5 @@ content:
   sections_heading: "sections_heading"
   sections: "sections"
   topic_section: "topic_section"
-  live_stream: ""
+  live_stream: null
   notifications: "notifications"

--- a/spec/fixtures/simple_coronavirus_page.yml
+++ b/spec/fixtures/simple_coronavirus_page.yml
@@ -1,0 +1,12 @@
+content:
+  title: "Coronavirus (COVID-19): what you need to do"
+  meta_description: "Find out about the government response to coronavirus (COVID-19) and what you need to do."
+  header_section: "header_section"
+  announcements_label: "announcements_label"
+  announcements: "announcements"
+  nhs_banner: "nhs_banner"
+  sections_heading: "sections_heading"
+  sections: "sections"
+  topic_section: "topic_section"
+  live_stream: ""
+  notifications: "notifications"

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -47,11 +47,13 @@ RSpec.describe CoronavirusPages::ContentBuilder do
     end
 
     context "with subsections" do
-      let(:sub_section) { create :sub_section }
-      let(:coronavirus_page) { sub_section.coronavirus_page }
-      let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section).output }
-      it "returns the sub_section JSON" do
-        expect(subject.sub_sections_data).to eq [sub_section_json]
+      let!(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }
+      let!(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page}
+      let(:sub_section_0_json) { SubSectionJsonPresenter.new(sub_section_0).output }
+      let(:sub_section_1_json) { SubSectionJsonPresenter.new(sub_section_1).output }
+
+      it "returns the sub_section JSON ordered by position" do
+        expect(subject.sub_sections_data).to eq [sub_section_0_json, sub_section_1_json ]
       end
     end
   end

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe CoronavirusPages::ContentBuilder do
 
     context "with subsections" do
       let!(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }
-      let!(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page}
+      let!(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page }
       let(:sub_section_0_json) { SubSectionJsonPresenter.new(sub_section_0).output }
       let(:sub_section_1_json) { SubSectionJsonPresenter.new(sub_section_1).output }
 
       it "returns the sub_section JSON ordered by position" do
-        expect(subject.sub_sections_data).to eq [sub_section_0_json, sub_section_1_json ]
+        expect(subject.sub_sections_data).to eq [sub_section_0_json, sub_section_1_json]
       end
     end
   end

--- a/spec/services/coronavirus_pages/model_builder_spec.rb
+++ b/spec/services/coronavirus_pages/model_builder_spec.rb
@@ -49,22 +49,11 @@ RSpec.describe CoronavirusPages::ModelBuilder do
       end
 
       it "creates sub_sections with a position that reflects their order in the content item" do
-        input_order =
-          source_sections.pluck("title").each_with_index.to_h.invert
-
-        # {0=>"How to protect yourself and others",
-        #  1=>"Employment and financial support",
-        #  2=>"School closures, education, and childcare",
-        #  3=>"Businesses and other organisations",
-        #  4=>"Healthcare workers and carers",
-        #  5=>"Travel",
-        #  6=>"How coronavirus is affecting public services",
-        #  7=>"How you can help",
-        #  8=>"Coronavirus (COVID-19) cases in the UK"}
+        input_order = source_sections.pluck("title").each_with_index.to_h.invert
 
         model_builder.page.sub_sections.each do |sub_section|
-          i = sub_section.position
-          expect(input_order[i]).to eq(sub_section.title)
+          position = sub_section.position
+          expect(input_order[position]).to eq(sub_section.title)
         end
       end
     end

--- a/spec/services/coronavirus_pages/model_builder_spec.rb
+++ b/spec/services/coronavirus_pages/model_builder_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe CoronavirusPages::ModelBuilder do
         model_builder.page
         expect(sub_section.content).to include(section["sub_sections"].first["list"].first["label"])
       end
+
+      it "creates sub_sections with a position that reflects their order in the content item" do
+        input_order =
+          source_sections.pluck("title").each_with_index.to_h.invert
+
+        # {0=>"How to protect yourself and others",
+        #  1=>"Employment and financial support",
+        #  2=>"School closures, education, and childcare",
+        #  3=>"Businesses and other organisations",
+        #  4=>"Healthcare workers and carers",
+        #  5=>"Travel",
+        #  6=>"How coronavirus is affecting public services",
+        #  7=>"How you can help",
+        #  8=>"Coronavirus (COVID-19) cases in the UK"}
+
+        model_builder.page.sub_sections.each do |sub_section|
+          i = sub_section.position
+          expect(input_order[i]).to eq(sub_section.title)
+        end
+      end
     end
 
     context "a coronavirus page with matching slug is present in database" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -194,7 +194,7 @@ def set_up_basic_sub_sections
                     content: "###title\n[label](/url)")
   path = Rails.root.join "spec/fixtures/simple_coronavirus_page.yml"
   github_yaml_content = File.read(path)
-  stub_request(:get, coronavirus_page.raw_content_url)
+  stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
     .to_return(status: 200, body: github_yaml_content)
 end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -174,6 +174,79 @@ def when_i_visit_a_coronavirus_page
   visit "/coronavirus/landing"
 end
 
+### Reordering sections spec ##
+
+def when_i_visit_the_reorder_page
+  visit "/coronavirus/landing/reorder"
+end
+
+def set_up_basic_sub_sections
+  c = FactoryBot.create(:coronavirus_page, :landing)
+  FactoryBot.create(:sub_section,
+                    coronavirus_page_id: c.id,
+                    position: 0,
+                    title: "I am first",
+                    content: "###title\n[label](/url)")
+  FactoryBot.create(:sub_section,
+                    coronavirus_page_id: c.id,
+                    position: 1,
+                    title: "I am second",
+                    content: "###title\n[label](/url)")
+  path = Rails.root.join + "spec/fixtures/simple_coronavirus_page.yml"
+  github_yaml_content = File.read(path)
+  stub_request(:get, c.raw_content_url)
+    .to_return(status: 200, body: github_yaml_content)
+end
+
+def i_see_subsection_one_in_position_one
+  e = find("#step-0").find(".step-by-step-reorder__step-title")
+  expect(e).to have_content "I am first"
+end
+
+def and_i_move_section_one_down
+  find("#step-0").find(".js-order-controls").find(".js-down").click
+  click_button "Save"
+  expect(page).to have_content "Sections were successfully reordered."
+end
+
+def then_the_reordered_subsections_are_sent_to_publishing_api
+  section = { "title" => "title", "list" => [{ "label" => "label", "url" => "/url" }] }
+  reordered_sections = [
+    {
+      "title" => "I am second",
+      "sub_sections" => [section],
+    },
+    {
+      "title" => "I am first",
+      "sub_sections" => [section],
+    },
+  ]
+  assert_publishing_api_put_content(
+    CoronavirusPage.topic_page.first.content_id,
+    request_json_includes(
+      "details" => {
+        "header_section" => "header_section",
+        "announcements_label" => "announcements_label",
+        "announcements" => "announcements",
+        "nhs_banner" => "nhs_banner",
+        "sections_heading" => "sections_heading",
+        "sections" => "sections",
+        "topic_section" => "topic_section",
+        "live_stream" => {
+          "video_url" => LiveStream.first.url,
+          "date" => LiveStream.first.formatted_stream_date,
+        },
+        "notifications" => "notifications",
+        "content_sections" => reordered_sections,
+      },
+    ),
+  )
+end
+
+def then_i_see_section_updated_message
+  expect(page).to have_text("Sections were successfully reordered.")
+end
+
 def then_i_am_redirected_to_the_index_page
   expect(current_path).to eq("/coronavirus")
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -177,30 +177,30 @@ end
 ### Reordering sections spec ##
 
 def when_i_visit_the_reorder_page
-  visit "/coronavirus/landing/reorder"
+  visit "/coronavirus/landing/sub_sections/reorder"
 end
 
 def set_up_basic_sub_sections
-  c = FactoryBot.create(:coronavirus_page, :landing)
+  coronavirus_page = FactoryBot.create(:coronavirus_page, :landing)
   FactoryBot.create(:sub_section,
-                    coronavirus_page_id: c.id,
+                    coronavirus_page_id: coronavirus_page.id,
                     position: 0,
                     title: "I am first",
                     content: "###title\n[label](/url)")
   FactoryBot.create(:sub_section,
-                    coronavirus_page_id: c.id,
+                    coronavirus_page_id: coronavirus_page.id,
                     position: 1,
                     title: "I am second",
                     content: "###title\n[label](/url)")
-  path = Rails.root.join + "spec/fixtures/simple_coronavirus_page.yml"
+  path = Rails.root.join "spec/fixtures/simple_coronavirus_page.yml"
   github_yaml_content = File.read(path)
-  stub_request(:get, c.raw_content_url)
+  stub_request(:get, coronavirus_page.raw_content_url)
     .to_return(status: 200, body: github_yaml_content)
 end
 
 def i_see_subsection_one_in_position_one
-  e = find("#step-0").find(".step-by-step-reorder__step-title")
-  expect(e).to have_content "I am first"
+  element = find("#step-0").find(".step-by-step-reorder__step-title")
+  expect(element).to have_content "I am first"
 end
 
 def and_i_move_section_one_down


### PR DESCRIPTION
Pair programming effort @danacotoran and @hannako 

## What 
Implements reordering of subsections (aka accordions)

## How
**Frontend** 
- Implements accordion reordering following the existing [pattern established in step-by-step pages]( https://collections-publisher.integration.publishing.service.gov.uk/step-by-step-pages/87/reorder) 

- On the accordion reordering page [there is a form](https://github.com/alphagov/collections-publisher/pull/1063/files#diff-c9b3ce154ac76d4a02cb44e9c925ca34) with a `<input type="hidden" name="section_order_save" id="js_order_save" />` On page load (and whenever the items under `<ul id="js-reorder-group">` are moved up/down), the value of this hidden input is dynamically updated to reflect the positions of the items. 

- The value will look something like this `value="[{"id":652,"position":1},{"id":653,"position":2},{"id":654,"position":3}]"`

- When the user hits the Save button, this form data is `POST`ed to the form endpoint.

**Backend**
- Adds a position attribute to the SubSection model
- When we fetch the subsection data from github and create the model, we set the position based on its position in the source file.
- When we display and send the subsections back to publishing api, we do so in order of the subsection position.
- I've implemented rolling back of the new positions if the call to publishing api fails. I don't know if this is necessarily a good thing, it might be annoying to lose your work. It is easy to remove. 

Trello: https://trello.com/c/RfnRjvr2/362-story-5-accordions-can-be-reordered-from-accordion-publishing-tool