### PR TITLE
Add confirmation banner when publishing without 2i

### DIFF
--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -59,7 +59,8 @@
         <%= render "govuk_publishing_components/components/button", {
           text: "Publish without 2i review",
           href: step_by_step_page_publish_without_2i_review_path(@step_by_step_page),
-          destructive: true
+          destructive: true,
+          data_attributes: { confirm: "You should only publish step by steps without 2i review in exceptional circumstances, for example if you're the only person responding to an emergency out of hours call." },
         } %>
       <% end %>
     <% end %>


### PR DESCRIPTION
This adds some guidance around when a publisher should publish without
2i when they hit the "Publish without 2i review" button. The
confirmation pop up follows the same pattern as some of the other
actions like 'delete' and 'revert to draft'.

The bulk of the text was copied from whitehall's 'Force publish' partial
here -> https://github.com/alphagov/whitehall/blob/master/app/views/admin/edition_workflow/_force_publish_modal.html.erb,
with a few words changed as there isn't a 'Force publish' concept in
collections-publisher.

### Screenshot (before content review)
<img width="1051" alt="Screenshot 2020-06-22 at 11 53 20" src="https://user-images.githubusercontent.com/24479188/85279835-fd7e1900-b47e-11ea-9389-6f8b73d90c94.png">

Trello:
https://trello.com/c/NrZVDIlG/2018-3-alert-users-when-a-step-by-step-is-force-published-in-collections-publisher