### PR TITLE
Store the accordion heading (aka section heading) 

### DIFF
--- a/app/services/coronavirus_pages/updater.rb
+++ b/app/services/coronavirus_pages/updater.rb
@@ -17,15 +17,21 @@ module CoronavirusPages
   private
 
     def page_config
-      CoronavirusPages::Configuration
+      CoronavirusPages::Configuration.page(slug)
     end
 
     def coronavirus_page_attributes
-      page_config.page(slug)
+      page_config.merge(
+        sections_title: sections_heading,
+      )
+    end
+
+    def sections_heading
+      yaml_data.dig(:content, :sections_heading)
     end
 
     def raw_content_url
-      coronavirus_page_attributes[:raw_content_url]
+      page_config[:raw_content_url]
     end
 
     def sub_sections

--- a/app/views/coronavirus_pages/_accordion_summary_list.html.erb
+++ b/app/views/coronavirus_pages/_accordion_summary_list.html.erb
@@ -9,7 +9,7 @@
  end %>
 <div class="covid-manage-page__accordion-summary-list">
   <%= render "govuk_publishing_components/components/summary_list", {
-    title: "Guidance and support accordion",
+    title: @coronavirus_page.sections_title,
     items: accordions
   } %>
 </div>

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -27,6 +27,7 @@ content:
     call_to_action:
       title: Check the NHS website if you have symptoms
       href: https://www.nhs.uk/conditions/coronavirus-covid-19/
+  sections_heading: Guidance and support
   sections:
     - title: How to protect yourself and others
       sub_sections:

--- a/spec/services/coronavirus_pages/updater_spec.rb
+++ b/spec/services/coronavirus_pages/updater_spec.rb
@@ -3,10 +3,21 @@ require "rails_helper"
 RSpec.describe CoronavirusPages::Updater do
   let(:slug) { "landing" }
   let(:updater) { CoronavirusPages::Updater.new(slug) }
-  let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
+  let(:page_config) { CoronavirusPages::Configuration.page(slug) }
+  let(:raw_content_url) { page_config[:raw_content_url] }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:source_yaml) { YAML.load_file(fixture_path) }
   let(:source_sections) { source_yaml.dig("content", "sections") }
+  let(:coronavirus_page_attributes) do
+    {
+      sections_title: source_yaml.dig("content", "sections_heading"),
+      base_path: page_config[:base_path],
+      name: page_config[:name],
+      slug: slug,
+      github_url: page_config[:github_url],
+      raw_content_url: raw_content_url,
+    }
+  end
 
   before do
     stub_request(:get, raw_content_url)
@@ -17,6 +28,7 @@ RSpec.describe CoronavirusPages::Updater do
     context "coronavirus page with matching slug is absent from database" do
       it "creates a coronavirus page" do
         expect { updater.page }.to change { CoronavirusPage.count }.by(1)
+        expect(CoronavirusPage.last).to have_attributes(coronavirus_page_attributes)
       end
 
       it "creates associated sub_sections" do


### PR DESCRIPTION
## What
This work relates to the WIP coronavirus publishing tool.
- When we find or create our coronavirus page model, we should store the sections title as well.
- In the view, read the sections title from the database rather than hard coding it.
