### PR TITLE
Coronavirus publishing tool: Add some validations to SubSections 

### DIFF
--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -9,12 +9,11 @@ class SubSectionsController < ApplicationController
 
   def create
     @coronavirus_page = CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
-    sub_section = @coronavirus_page.sub_sections.new(sub_section_params)
-    if sub_section.save
-      redirect_to coronavirus_page_path(@coronavirus_page.slug)
+    @sub_section = @coronavirus_page.sub_sections.new(sub_section_params)
+    if @sub_section.save
+      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Sub-section was successfully created."
     else
-      flash[:alert] = "Not saved!"
-      redirect_to new_coronavirus_page_sub_section_path
+      render :new
     end
   end
 
@@ -24,12 +23,12 @@ class SubSectionsController < ApplicationController
   end
 
   def update
-    sub_section = SubSection.find(params[:id])
-    if sub_section.update(sub_section_params)
-      redirect_to coronavirus_page_path(sub_section.coronavirus_page.slug)
+    @sub_section = SubSection.find(params[:id])
+    @coronavirus_page = @sub_section.coronavirus_page
+    if @sub_section.update(sub_section_params)
+      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Step was successfully updated."
     else
-      flash[:alert] = "Not saved!"
-      redirect_to edit_coronavirus_page_sub_section_path(sub_section.coronavirus_page.slug, sub_section)
+      render :edit
     end
   end
 

--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -26,7 +26,7 @@ class SubSectionsController < ApplicationController
     @sub_section = SubSection.find(params[:id])
     @coronavirus_page = @sub_section.coronavirus_page
     if @sub_section.update(sub_section_params)
-      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Step was successfully updated."
+      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Sub-section was successfully updated."
     else
       render :edit
     end

--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -1,6 +1,6 @@
 class CoronavirusPage < ApplicationRecord
   STATUSES = %w[draft published].freeze
-  has_many :sub_sections
+  has_many :sub_sections, dependent: :destroy
   scope :topic_page, -> { where(slug: "landing") }
   scope :subtopic_pages, -> { where.not(slug: "landing") }
   validates :state, inclusion: { in: STATUSES }, presence: true

--- a/app/models/sub_section.rb
+++ b/app/models/sub_section.rb
@@ -1,4 +1,5 @@
 class SubSection < ApplicationRecord
   belongs_to :coronavirus_page
   validates :title, :content, presence: true
+  validates :coronavirus_page, presence: true
 end

--- a/app/models/sub_section.rb
+++ b/app/models/sub_section.rb
@@ -1,3 +1,4 @@
 class SubSection < ApplicationRecord
   belongs_to :coronavirus_page
+  validates :title, :content, presence: true
 end

--- a/app/views/shared/sub_sections/_form_errors.html.erb
+++ b/app/views/shared/sub_sections/_form_errors.html.erb
@@ -1,0 +1,10 @@
+<% if resource.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: resource.errors.full_messages.map do |message|
+      {
+        text: message
+      }
+    end
+  } %>
+<% end %>

--- a/app/views/sub_sections/_form.html.erb
+++ b/app/views/sub_sections/_form.html.erb
@@ -23,4 +23,4 @@
   text: "Save",
   margin_bottom: true
 } %>
-<%= tag.p (link_to 'Cancel', @coronavirus_page, class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>
+<%= tag.p (link_to 'Cancel', coronavirus_page_path(@coronavirus_page.slug), class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>

--- a/app/views/sub_sections/edit.html.erb
+++ b/app/views/sub_sections/edit.html.erb
@@ -18,6 +18,9 @@
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, "Coronavirus (COVID-19)" %>
 <% content_for :context, 'Edit guidance and support accordion' %>
+<% if @sub_section.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @sub_section %>
+<% end %>
 
 <div class="covid-edit-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/sub_sections/new.html.erb
+++ b/app/views/sub_sections/new.html.erb
@@ -18,6 +18,9 @@
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, "Coronavirus (COVID-19)" %>
 <% content_for :context, 'Add guidance and support accordion' %>
+<% if @sub_section.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @sub_section %>
+<% end %>
 
 <div class="covid-edit-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/models/coronavirus_page_spec.rb
+++ b/spec/models/coronavirus_page_spec.rb
@@ -33,4 +33,13 @@ RSpec.describe CoronavirusPage do
       expect(coronavirus_page).not_to be_valid
     end
   end
+
+  describe "dependencies" do
+    let!(:employees) { create :coronavirus_page, :employees }
+    let!(:sub_section) { create :sub_section, coronavirus_page: employees }
+
+    it "deletion destroys all child subsections" do
+      expect { employees.destroy }.to change { SubSection.count }.by(-1)
+    end
+  end
 end

--- a/spec/models/sub_section_spec.rb
+++ b/spec/models/sub_section_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe SubSection do
   let(:sub_section) { create :sub_section }
 
   describe "validations" do
+    it "should belong to a coronavirus_page" do
+      should validate_presence_of(:coronavirus_page)
+    end
+
+    it "fails if coronavirus_page does not exist" do
+      sub_section.coronavirus_page = nil
+
+      expect(sub_section).not_to be_valid
+    end
     it "is created with valid attributes" do
       expect(sub_section).to be_valid
       expect(sub_section.save).to eql true

--- a/spec/models/sub_section_spec.rb
+++ b/spec/models/sub_section_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe SubSection do
+  let(:sub_section) { create :sub_section }
+
+  describe "validations" do
+    it "is created with valid attributes" do
+      expect(sub_section).to be_valid
+      expect(sub_section.save).to eql true
+      expect(sub_section).to be_persisted
+    end
+
+    it "requires a title" do
+      sub_section.title = ""
+
+      expect(sub_section).not_to be_valid
+      expect(sub_section.errors).to have_key(:title)
+    end
+
+    it "requires content" do
+      sub_section.content = ""
+
+      expect(sub_section).not_to be_valid
+      expect(sub_section.errors).to have_key(:content)
+    end
+  end
+end


### PR DESCRIPTION
### What
Currently we allow invalid subsections to be saved to the database. Adding validations so that all subsections must have title, content, and a parent CoronavirusPage.

### Before
```
s = SubSection.create!
s.valid?
true
```
### After
```
s = SubSection.create!
ActiveRecord::RecordInvalid (Validation failed: Title can't be blank, Content can't be blank, Coronavirus page can't be blank)
```

trello: https://trello.com/c/zNcOOclL/377-coronavirus-publishing-tool-update-draft-content-item