### PR TITLE
Coronavirus publishing tool: Add column state to CoronavirusPages

### DIFF
--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -1,5 +1,7 @@
 class CoronavirusPage < ApplicationRecord
+  STATUSES = %w[draft published].freeze
   has_many :sub_sections
   scope :topic_page, -> { where(slug: "landing") }
   scope :subtopic_pages, -> { where.not(slug: "landing") }
+  validates :state, inclusion: { in: STATUSES }, presence: true
 end

--- a/app/services/coronavirus_pages/configuration.rb
+++ b/app/services/coronavirus_pages/configuration.rb
@@ -13,6 +13,7 @@ module CoronavirusPages
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml".freeze,
             base_path: "/coronavirus",
             github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml",
+            state: "published",
           },
         business:
           {
@@ -21,6 +22,7 @@ module CoronavirusPages
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml".freeze,
             base_path: "/coronavirus/business-support",
             github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_business_page.yml",
+            state: "published",
           },
         education:
           {
@@ -29,6 +31,7 @@ module CoronavirusPages
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_education_page.yml".freeze,
             base_path: "/coronavirus/education-and-childcare",
             github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_education_page.yml",
+            state: "published",
           },
         employees:
           {
@@ -37,6 +40,7 @@ module CoronavirusPages
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_worker_page.yml".freeze,
             base_path: "/coronavirus/worker-support",
             github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_worker_page.yml",
+            state: "published",
           },
       }
     end

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -11,8 +11,8 @@
   ]
 
   metadata = {
-    "Status" => "Draft",
-    "Last saved" => format_full_date_and_time(DateTime.now),
+    "Status" => @coronavirus_page.state.capitalize,
+    "Last saved" => format_full_date_and_time(@coronavirus_page.updated_at),
   }
 %>
 

--- a/db/migrate/20200623165045_add_state_to_coronavirus_pages.rb
+++ b/db/migrate/20200623165045_add_state_to_coronavirus_pages.rb
@@ -1,0 +1,6 @@
+class AddStateToCoronavirusPages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :coronavirus_pages, :state, :string, default: "draft"
+    change_column_null :coronavirus_pages, :state, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_141142) do
+ActiveRecord::Schema.define(version: 2020_06_23_165045) do
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sections_title"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2020_06_18_141142) do
     t.string "content_id"
     t.string "github_url"
     t.string "raw_content_url"
+    t.string "state", default: "draft", null: false
   end
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/models/coronavirus_page_spec.rb
+++ b/spec/models/coronavirus_page_spec.rb
@@ -15,4 +15,22 @@ RSpec.describe CoronavirusPage do
       expect(CoronavirusPage.subtopic_pages).to eq [business, education, employees]
     end
   end
+
+  describe "validations" do
+    let(:coronavirus_page) { create :coronavirus_page }
+
+    it "has a default state when created" do
+      expect(coronavirus_page.state).to eq "draft"
+    end
+
+    it "state cannot be nil" do
+      coronavirus_page.state = ""
+      expect(coronavirus_page).not_to be_valid
+    end
+
+    it "state must be draft or published" do
+      coronavirus_page.state = "lovely"
+      expect(coronavirus_page).not_to be_valid
+    end
+  end
 end

--- a/spec/services/coronavirus_pages/updater_spec.rb
+++ b/spec/services/coronavirus_pages/updater_spec.rb
@@ -8,15 +8,9 @@ RSpec.describe CoronavirusPages::Updater do
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:source_yaml) { YAML.load_file(fixture_path) }
   let(:source_sections) { source_yaml.dig("content", "sections") }
+  let(:sections_title) { source_yaml.dig("content", "sections_heading") }
   let(:coronavirus_page_attributes) do
-    {
-      sections_title: source_yaml.dig("content", "sections_heading"),
-      base_path: page_config[:base_path],
-      name: page_config[:name],
-      slug: slug,
-      github_url: page_config[:github_url],
-      raw_content_url: raw_content_url,
-    }
+    page_config.merge(sections_title: sections_title, slug: slug)
   end
 
   before do


### PR DESCRIPTION
## What
Once we implement updating and publishing, we will need to store the state of the CoronavirusPage object. 

## How
- Adding a column to the coronavirus_pages table
- Default state is draft
- Setting state to published for the existing landing and hub pages

Trello: https://trello.com/c/zNcOOclL/377-coronavirus-publishing-tool-update-draft-content-item