### PR TITLE
Add ul spacing class conditionally

### DIFF
--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -1,4 +1,3 @@
-
 <% content_for :title, "Coronavirus topic pages" %>
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
@@ -9,9 +8,8 @@
   <li><%= link_to "Publish #{@topic_page.name}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
   <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
 </ul>
-
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
-<ul class="govuk-list covid__spaced-list">
+<ul class="govuk-list <%= unreleased_feature_user? ? 'covid__spaced-list' : '' %>">
   <% @subtopic_pages.each do |page| %>
   <% if unreleased_feature_user? %>
     <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>


### PR DESCRIPTION
This change affects the corona virus index page subtopic links.
When the Edit accordion links are not there, the 2 by 2 spacing looks strange.

<img width="1071" alt="Screenshot 2020-06-24 at 09 29 15" src="https://user-images.githubusercontent.com/7116819/85530041-88891b80-b605-11ea-9448-faade71c00aa.png">

This ensures that the spaced list class is only applied when the Edit Accordions links are present



https://trello.com/c/u16kFlyh