### PR TITLE
Add Notify to collections publisher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "govuk_admin_template", "~> 6.7"
 gem "govuk_app_config", "~> 2.2"
 gem "govuk_publishing_components", "~> 21.43"
 gem "govuk_sidekiq", "~> 3.0"
+gem "mail-notify"
 gem "plek", "~> 3.0"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,9 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mail-notify (1.0.2)
+      actionmailer (>= 5.2.4.2, < 6.1)
+      notifications-ruby-client (~> 5.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
@@ -216,6 +219,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.1.2)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -448,6 +453,7 @@ DEPENDENCIES
   govuk_test
   jasmine (~> 3.5)
   jasmine_selenium_runner (~> 3)
+  mail-notify
   mysql2
   nokogiri
   parser (= 2.7.1.3)

--- a/app/controllers/step_by_step_pages_controller.rb
+++ b/app/controllers/step_by_step_pages_controller.rb
@@ -85,6 +85,7 @@ class StepByStepPagesController < ApplicationController
         publish_page(@publish_intent)
         generate_internal_change_note("Published without 2i review", publish_note_description)
         set_change_note_version
+        send_publish_without_2i_email
         redirect_to @step_by_step_page, notice: "'#{@step_by_step_page.title}' has been published."
       end
     else
@@ -270,5 +271,9 @@ private
     unless @step_by_step_page.status.approved_2i?
       redirect_to @step_by_step_page, notice: "Step by step must be 2i approved before you can #{action_name} this step by step."
     end
+  end
+
+  def send_publish_without_2i_email
+    PublisherNotifications.publish_without_2i(@step_by_step_page, current_user).deliver_now
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,5 @@
+class ApplicationMailer < Mail::Notify::Mailer
+  def template_id
+    @template_id ||= ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id")
+  end
+end

--- a/app/mailers/publisher_notifications.rb
+++ b/app/mailers/publisher_notifications.rb
@@ -1,0 +1,15 @@
+class PublisherNotifications < ApplicationMailer
+  include ApplicationHelper
+
+  PUBLISH_WITHOUT_2I_EMAIL = ENV.fetch("PUBLISH_WITHOUT_2I_EMAIL", "test-email-address@gmail.com").freeze
+
+  def publish_without_2i(step_by_step_page, current_user)
+    @current_user = current_user
+    @step_by_step_page = step_by_step_page
+    @live_url = published_url(step_by_step_page.slug)
+
+    view_mail(template_id,
+              to: PUBLISH_WITHOUT_2I_EMAIL,
+              subject: "[PUBLISHER] Step by step published without 2i review for '#{step_by_step_page.title}'")
+  end
+end

--- a/app/views/publisher_notifications/publish_without_2i.text.erb
+++ b/app/views/publisher_notifications/publish_without_2i.text.erb
@@ -1,0 +1,8 @@
+Hello,
+
+<%= @current_user.name %> has published a step by step without 2i review: '<%= @step_by_step_page.title %>'.
+
+You can view it here:
+<%= @live_url %>
+
+Sent by the GOV.UK Collections Publisher application

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
-# require "action_mailer/railtie"
+require "action_mailer/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
@@ -26,6 +26,10 @@ module CollectionsPublisher
     config.time_zone = "London"
     config.action_view.raise_on_missing_translations = true
     config.active_record.belongs_to_required_by_default = false
+
+    config.action_mailer.notify_settings = {
+      api_key: Rails.application.secrets.notify_api_key || "test-api-key",
+    }
 
     unless Rails.env.production?
       ENV["JWT_AUTH_SECRET"] = "123"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,6 +31,8 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  config.action_mailer.delivery_method = :notify
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,6 +29,13 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # We need to set this 'from' address as SMTP requires it when attempting to
+  # deliver the email when running the tests. The error we were seeing was
+  # 'SMTP From address may not be blank: nil' when running 'deliver' on the
+  # generated email. This doesn't apply to production as we use notify as the
+  # delivery method.
+  config.action_mailer.default_options = { from: "test-sender@test.com" }
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,6 +24,11 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,3 +20,4 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/spec/controllers/step_by_step_pages_controller_spec.rb
+++ b/spec/controllers/step_by_step_pages_controller_spec.rb
@@ -195,6 +195,15 @@ RSpec.describe StepByStepPagesController do
 
         expect(step_by_step_page.internal_change_notes.first.edition_number).to eq(3)
       end
+
+      it "sends an email" do
+        expect(PublisherNotifications).to receive(:publish_without_2i).with(step_by_step_page, stub_user).and_call_original
+
+        stub_publishing_api
+        post :publish_without_2i_review, params: { step_by_step_page_id: step_by_step_page.id, update_type: "minor", headline: "" }
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
     end
   end
 

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -68,6 +68,18 @@ RSpec.feature "Managing step by step pages" do
     then_there_should_be_a_change_note "Published"
   end
 
+  scenario "User publishes a page without 2i review" do
+    given_i_can_skip_review
+    given_there_is_a_step_by_step_page_with_a_link_report
+    when_i_visit_the_step_by_step_page
+    when_i_click_button "Publish without 2i review"
+    and_when_i_click_button "Publish"
+    then_i_am_told_that_it_is_published
+    and_i_see_the_step_by_step_page
+    when_i_visit_the_history_page
+    then_there_should_be_a_change_note "Published without 2i review"
+  end
+
   scenario "User reverts an approved page to draft" do
     given_there_is_an_approved_2i_step_by_step_page_with_a_link_report
     when_i_view_the_step_by_step_page
@@ -450,6 +462,7 @@ RSpec.feature "Managing step by step pages" do
   def then_i_see_the_step_by_step_page
     expect(page).to have_content("How to be amazing")
   end
+  alias_method :and_i_see_the_step_by_step_page, :then_i_see_the_step_by_step_page
 
   def then_i_can_see_a_summary_section
     within_summary_section do

--- a/spec/mailers/publisher_notifications_spec.rb
+++ b/spec/mailers/publisher_notifications_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe PublisherNotifications do
+  before do
+    allow(Services.publishing_api).to receive(:lookup_content_id)
+  end
+
+  describe "#publish_without_2i" do
+    it "generates an email" do
+      step_by_step_page = create(:step_by_step_page)
+      user = create(:user, name: "Peter")
+      mail_subject = "[PUBLISHER] Step by step published without 2i review for '#{step_by_step_page.title}'"
+
+      mail = described_class.publish_without_2i(step_by_step_page, user)
+
+      expect(mail.to).to eq([PublisherNotifications::PUBLISH_WITHOUT_2I_EMAIL])
+      expect(mail.subject).to eq(mail_subject)
+      expect(mail.body.to_s).to include("Peter")
+      expect(mail.body.to_s).to include(step_by_step_page.title)
+      expect(mail.body.to_s).to include("https://www.test.gov.uk/#{step_by_step_page.slug}")
+    end
+  end
+end


### PR DESCRIPTION
Adds Notify to Collections Publisher and adds an action to send an email when content has been published without 2i review so content teams can keep track of who is publishing without review as this should only happen in exceptional circumstances.

Depends on the below being merged:
- [x] [govuk-secrets](alphagov/govuk-secrets#1000)
- [x] [govuk-puppet](alphagov/govuk-puppet#10457)

### Email sent in integration (before content review)
<img width="1066" alt="Screenshot 2020-06-25 at 13 21 36" src="https://user-images.githubusercontent.com/24479188/85718926-e3df0a80-b6e6-11ea-83cd-0b17597a05eb.png">


Trello:
https://trello.com/c/NrZVDIlG/2018-3-alert-users-when-a-step-by-step-is-force-published-in-collections-publisher