### PR TITLE
Coronavirus page publishing tool: Send updates to publishing api

### DIFF
--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -10,9 +10,10 @@ class SubSectionsController < ApplicationController
   def create
     @coronavirus_page = CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
     @sub_section = @coronavirus_page.sub_sections.new(sub_section_params)
-    if @sub_section.save
+    if @sub_section.save && draft_updater.send
       redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Sub-section was successfully created."
     else
+      @sub_section.errors.add :base, draft_updater.errors.to_sentence
       render :new
     end
   end
@@ -25,14 +26,21 @@ class SubSectionsController < ApplicationController
   def update
     @sub_section = SubSection.find(params[:id])
     @coronavirus_page = @sub_section.coronavirus_page
-    if @sub_section.update(sub_section_params)
+    if @sub_section.update(sub_section_params) && draft_updater.send
       redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Sub-section was successfully updated."
     else
+      @sub_section.errors.add :base, draft_updater.errors.to_sentence
       render :edit
     end
   end
 
   def sub_section_params
     params.require(:sub_section).permit(:title, :content)
+  end
+
+private
+
+  def draft_updater
+    @draft_updater ||= CoronavirusPages::DraftUpdater.new(@coronavirus_page)
   end
 end

--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -8,7 +8,7 @@ class SubSectionJsonPresenter
   )
 
   LINK_PATTERN = PatternMaker.call(
-    "starts_with perhaps_spaces within(brackets,capture(label)) then perhaps_spaces and within(sq_brackets,capture(url))",
+    "starts_with perhaps_spaces within(sq_brackets,capture(label)) then perhaps_spaces and within(brackets,capture(url))",
     label: '\s*\w.+',
     url: '\s*(\b(https?)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]\s*',
   )

--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -23,14 +23,20 @@ class SubSectionJsonPresenter
   delegate :title, to: :sub_section
 
   def output
-    {
-      title: title,
-      sub_sections: sub_sections,
-    }
+    @output ||=
+      {
+        title: title,
+        sub_sections: sub_sections,
+      }
   end
 
   def errors
     @errors ||= []
+  end
+
+  def success?
+    output
+    errors.empty?
   end
 
   def sub_sections
@@ -69,15 +75,15 @@ class SubSectionJsonPresenter
   #        }
   #    {
   def sub_section_hash_from_content_group(content_group)
-    content_group.each_with_object({ title: nil }) do |element, hash|
-      if is_header?(element)
-        title = HEADER_PATTERN.match(element).named_captures["title"]
+    content_group.each_with_object({ title: nil }) do |line, hash|
+      if is_header?(line)
+        title = HEADER_PATTERN.match(line).named_captures["title"]
         hash[:title] = title
-      elsif is_link?(element)
+      elsif is_link?(line)
         hash[:list] ||= []
-        hash[:list] << build_link(element)
+        hash[:list] << build_link(line)
       else
-        errors << "Unable to parse markdown: '#{element}'"
+        errors << "Unable to parse markdown: '#{line}'"
       end
     end
   end

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -24,18 +24,20 @@ module CoronavirusPages
 
     def send
       @send ||= Services.publishing_api.put_content(content_id, payload)
-    rescue GdsApi::HTTPServerError
-      # TODO: Send to sentry
-      errors << "Failed to update the draft content item - please try saving again"
-      false
+    rescue GdsApi::HTTPServerError => e
+      error_handler(e, "Failed to update the draft content item - please try saving again")
     rescue GdsApi::HTTPUnprocessableEntity, DraftUpdaterError => e
-      # TODO: Send to sentry
-      errors << e.message
-      false
+      error_handler(e)
     end
 
     def errors
       @errors ||= []
+    end
+
+    def error_handler(error, message = nil)
+      GovukError.notify(error, extra: { content_id: content_id, coronavirus_page_slug: coronavirus_page.slug })
+      errors << (message || error.message)
+      false
     end
   end
 end

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -28,7 +28,8 @@ module CoronavirusPages
       # TODO: Send to sentry
       errors << "Updating the draft timed out - please try again"
       false
-    rescue DraftUpdaterError => e
+    rescue GdsApi::HTTPUnprocessableEntity, GdsApi::HTTPServerError, DraftUpdaterError => e
+      # TODO: Send to sentry
       errors << e.message
       false
     end

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -24,11 +24,11 @@ module CoronavirusPages
 
     def send
       @send ||= Services.publishing_api.put_content(content_id, payload)
-    rescue GdsApi::HTTPGatewayTimeout
+    rescue GdsApi::HTTPServerError
       # TODO: Send to sentry
-      errors << "Updating the draft timed out - please try again"
+      errors << "Failed to update the draft content item - please try saving again"
       false
-    rescue GdsApi::HTTPUnprocessableEntity, GdsApi::HTTPServerError, DraftUpdaterError => e
+    rescue GdsApi::HTTPUnprocessableEntity, DraftUpdaterError => e
       # TODO: Send to sentry
       errors << e.message
       false

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
       config.second[:raw_content_url]
     end
   end
+  let(:raw_content) { File.read(fixture_path) }
   let(:stub_all_content_urls) do
     all_content_urls.each do |url|
       stub_request(:get, url)
@@ -19,7 +20,6 @@ RSpec.describe CoronavirusPagesController, type: :controller do
     end
   end
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
-  let(:raw_content) { File.read(fixture_path) }
 
   describe "GET /coronavirus" do
     it "renders page successfully" do

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe SubSectionsController, type: :controller do
       content: content,
     }
   end
+  let(:raw_content_url) { coronavirus_page.raw_content_url }
+  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+  let(:raw_content) { File.read(fixture_path) }
 
   describe "GET /coronavirus/:coronavirus_page_slug/sub_sections/new" do
     it "renders successfully" do
@@ -24,6 +27,11 @@ RSpec.describe SubSectionsController, type: :controller do
   end
 
   describe "POST /coronavirus/:coronavirus_page_slug/sub_sections" do
+    before do
+      stub_request(:get, raw_content_url)
+        .to_return(body: raw_content)
+      stub_coronavirus_publishing_api
+    end
     subject do
       post :create, params: { coronavirus_page_slug: slug, sub_section: sub_section_params }
     end
@@ -52,6 +60,11 @@ RSpec.describe SubSectionsController, type: :controller do
   end
 
   describe "PATCH /coronavirus/:coronavirus_page_slug/sub_sections" do
+    before do
+      stub_request(:get, raw_content_url)
+        .to_return(body: raw_content)
+      stub_coronavirus_publishing_api
+    end
     let(:params) do
       {
         id: sub_section,

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SubSectionJsonPresenter do
     let(:title_markup) { "###{title}" }
     let(:label) { Faker::Lorem.sentence }
     let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
-    let(:link) { "(#{label})[#{path}]" }
+    let(:link) { "[#{label}](#{path})" }
     let(:content) { [title_markup, link].join("\n") }
 
     let(:expected) do
@@ -65,7 +65,7 @@ RSpec.describe SubSectionJsonPresenter do
   describe "#sub_section_hash_from_content_group" do
     let(:label) { Faker::Lorem.sentence }
     let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
-    let(:link) { "(#{label})[#{path}]" }
+    let(:link) { "[#{label}](#{path})" }
 
     let(:group) { [link] }
     let(:sub_section_hash) { subject.sub_section_hash_from_content_group(group) }
@@ -112,7 +112,7 @@ RSpec.describe SubSectionJsonPresenter do
 
     context "with a full url in link" do
       let(:url) { Faker::Internet.url }
-      let(:link) { "(#{label})[#{url}]" }
+      let(:link) { "[#{label}](#{url})" }
 
       it "puts the link path and label into list" do
         expect(sub_section_hash[:list].first[:label]).to eq(label)
@@ -122,7 +122,7 @@ RSpec.describe SubSectionJsonPresenter do
 
     context "with a full secure url in link" do
       let(:url) { Faker::Internet.url }
-      let(:link) { "(#{label})[#{url}]" }
+      let(:link) { "[#{label}](#{url})" }
 
       it "puts the link path and label into list" do
         expect(sub_section_hash[:list].first[:label]).to eq(label)
@@ -131,7 +131,7 @@ RSpec.describe SubSectionJsonPresenter do
     end
 
     context "with spaces" do
-      let(:link) { " ( #{label} ) [ #{path} ] " }
+      let(:link) { " [ #{label} ] ( #{path} ) " }
 
       it "puts the link path and label into list" do
         expect(sub_section_hash[:list].first[:label]).to eq(label)
@@ -142,7 +142,7 @@ RSpec.describe SubSectionJsonPresenter do
     context "with two links" do
       let(:label_two) { Faker::Lorem.sentence }
       let(:path_two)  { "/#{File.join(Faker::Lorem.words)}" }
-      let(:link_two) { "(#{label_two})[#{path_two}]" }
+      let(:link_two) { "[#{label_two}](#{path_two})" }
       let(:group) { [link, link_two] }
 
       it "puts the link path and label into list" do
@@ -225,7 +225,7 @@ RSpec.describe SubSectionJsonPresenter do
   def random_link_markdown
     label = Faker::Lorem.sentence
     path = "/#{File.join(Faker::Lorem.words)}"
-    "(#{label})[#{path}]"
+    "[#{label}](#{path})"
   end
 
   def random_title


### PR DESCRIPTION
- pair programming effort with @reggieb 

## What

- Wire up the app to send changes to the coronavirus page database model to publishing api.
- Better reporting of errors to user
- Send errors to sentry.

[trello](https://trello.com/c/zNcOOclL/377-coronavirus-publishing-tool-update-draft-content-item)