### PR TITLE
Coronavirus publishing tool: Delete sub_sections

### DIFF
--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -37,12 +37,13 @@ class SubSectionsController < ApplicationController
   def destroy
     @sub_section = SubSection.find(params[:id])
     @coronavirus_page = @sub_section.coronavirus_page
-    message =
-      if @sub_section.delete && draft_updater.send
-        { notice: "Sub-section was successfully deleted." }
-      else
-        { alert: "Sub-section couldn't be deleted" }
-      end
+    attrs = @sub_section.attributes.except("id", "created_at", "updated_at")
+    if @sub_section.delete && draft_updater.send
+      message = { notice: "Sub-section was successfully deleted." }
+    else
+      draft_updater.rebuild_sub_section(attrs)
+      message = { alert: "Sub-section couldn't be deleted" }
+    end
     redirect_to coronavirus_page_path(@coronavirus_page.slug), message
   end
 

--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -34,11 +34,23 @@ class SubSectionsController < ApplicationController
     end
   end
 
-  def sub_section_params
-    params.require(:sub_section).permit(:title, :content)
+  def destroy
+    @sub_section = SubSection.find(params[:id])
+    @coronavirus_page = @sub_section.coronavirus_page
+    message =
+      if @sub_section.delete && draft_updater.send
+        { notice: "Sub-section was successfully deleted." }
+      else
+        { alert: "Sub-section couldn't be deleted" }
+      end
+    redirect_to coronavirus_page_path(@coronavirus_page.slug), message
   end
 
 private
+
+  def sub_section_params
+    params.require(:sub_section).permit(:title, :content)
+  end
 
   def draft_updater
     @draft_updater ||= CoronavirusPages::DraftUpdater.new(@coronavirus_page)

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -14,6 +14,10 @@ module CoronavirusPages
       @content_builder ||= CoronavirusPages::ContentBuilder.new(coronavirus_page)
     end
 
+    def rebuild_sub_section(attrs)
+      coronavirus_page.sub_sections.create(attrs)
+    end
+
     def payload
       if content_builder.success?
         CoronavirusPagePresenter.new(content_builder.data, base_path)

--- a/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
@@ -1,5 +1,5 @@
 
-<% accordions =
+<% sub_sections =
  @coronavirus_page.sub_sections.map do |sub_section|
    {
      field: sub_section.title ,
@@ -10,6 +10,6 @@
 <div class="covid-manage-page__accordion-summary-list">
   <%= render "govuk_publishing_components/components/summary_list", {
     title: @coronavirus_page.sections_title,
-    items: accordions
+    items: sub_sections
   } %>
 </div>

--- a/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections_summary_list.html.erb
@@ -4,7 +4,13 @@
    {
      field: sub_section.title ,
      edit: { href: edit_coronavirus_page_sub_section_path(@coronavirus_page.slug, sub_section) },
-     delete: { href: "delete-summary" }
+     delete: {
+       href: coronavirus_page_sub_section_path(@coronavirus_page.slug, sub_section),
+       data_attributes: {
+         confirm: "Are you sure?",
+         method: "delete"
+       }
+     }
    }
  end %>
 <div class="covid-manage-page__accordion-summary-list">

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -1,4 +1,3 @@
-
 <%
   links = [
     {
@@ -22,7 +21,7 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "accordion_summary_list" %>
+    <%= render "sub_sections_summary_list" %>
     <%= render "govuk_publishing_components/components/button", {
       text: "Add section",
       href: new_coronavirus_page_sub_section_path(@coronavirus_page.slug)

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe SubSectionsController, type: :controller do
       expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
     end
 
-    it "create a new sub_section" do
+    it "updates the sub_section" do
       sub_section
       expect { subject }.not_to(change { SubSection.count })
     end
@@ -130,6 +130,40 @@ RSpec.describe SubSectionsController, type: :controller do
       sub_section.reload
       expect(sub_section.title).to eq(title)
       expect(sub_section.content).to eq(content)
+    end
+  end
+
+  describe "DELETE /coronavirus/:coronavirus_page_slug/sub_sections/:id" do
+    before do
+      stub_request(:get, raw_content_url)
+        .to_return(body: raw_content)
+      stub_coronavirus_publishing_api
+    end
+    let(:params) do
+      {
+        id: sub_section,
+        coronavirus_page_slug: slug,
+      }
+    end
+    subject { delete :destroy, params: params }
+
+    it "redirects to the coronavirus page on success" do
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+
+    it "deletes the subsection" do
+      sub_section
+      expect { subject }.to change { SubSection.count }.by(-1)
+    end
+
+    it "recreates the subsection if draft_updater fails" do
+      sub_section
+      stub_any_publishing_api_put_content
+        .to_return(status: 500)
+      expect { subject }.not_to(change { SubSection.count })
+      expect(sub_section.title).to eq SubSection.last.title
+      expect(sub_section.content).to eq SubSection.last.content
+      expect(sub_section.id).not_to eq SubSection.last.id
     end
   end
 end


### PR DESCRIPTION
## What

- Wire up the delete subsection button on the coronavirus show page
- If after deleting the subsection, publishing api fails to update the draft content item, we recreate the subsection in the database.

[trello](https://trello.com/c/3JOJVLT8/360-story-4-delete-sections-from-collections-publisher)