### PR TITLE
Coronavirus publishing tool: Correctly form payload

### DIFF
--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -16,7 +16,7 @@ module CoronavirusPages
 
     def payload
       if content_builder.success?
-        CoronavirusPagePresenter.new(content_builder.data, base_path)
+        CoronavirusPagePresenter.new(content_builder.data, base_path).payload
       else
         raise DraftUpdaterError, content_builder.errors.to_sentence
       end

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
+      stub_youtube
     end
     subject do
       post :create, params: { coronavirus_page_slug: slug, sub_section: sub_section_params }
@@ -105,6 +106,7 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
+      stub_youtube
     end
     let(:params) do
       {

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_coronavirus_publishing_api
       stub_all_github_requests
       stub_any_publishing_api_put_intent
+      stub_youtube
     end
 
     context "Landing page" do

--- a/spec/services/coronavirus_pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus_pages/draft_updater_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe CoronavirusPages::DraftUpdater do
+  let(:coronavirus_page) { create :coronavirus_page }
+  let(:content_builder) { CoronavirusPages::ContentBuilder.new(coronavirus_page) }
+  let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
+  let(:github_fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+  let(:github_content) { YAML.safe_load(File.read(github_fixture_path)) }
+
+  subject { described_class.new(coronavirus_page) }
+
+  before do
+    stub_youtube
+    stub_coronavirus_publishing_api
+    stub_request(:get, coronavirus_page.raw_content_url)
+      .to_return(status: 200, body: github_content.to_json)
+  end
+
+  it "#payload" do
+    expect(subject.payload).to eq payload
+  end
+end


### PR DESCRIPTION
- The CoronavirusPages::DraftUpdater should have been calling the
payload method on the presenter.
- Adds a spec so we don't mess up again.

https://sentry.io/organizations/govuk/issues/448130709/?project=202214&query=is%3Aunresolved