### PR TITLE
Move livestream logic

### DIFF
--- a/app/presenters/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus_page_presenter.rb
@@ -15,7 +15,7 @@ class CoronavirusPagePresenter
       "description" => description,
       "document_type" => "coronavirus_landing_page",
       "schema_name" => "coronavirus_landing_page",
-      "details" => details.deep_merge(live_stream_url),
+      "details" => details,
       "links" => {},
       "locale" => "en",
       "rendering_app" => "collections",
@@ -23,18 +23,5 @@ class CoronavirusPagePresenter
       "routes" => [{ "path" => path, "type" => "exact" }],
       "update_type" => "minor",
     }
-  end
-
-  def live_stream_url
-    {
-      "live_stream" => {
-        "video_url" => live_stream.url,
-        "date" => live_stream.formatted_stream_date,
-      },
-    }
-  end
-
-  def live_stream
-    LiveStreamUpdater.new.object
   end
 end

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -10,7 +10,8 @@ class CoronavirusPages::ContentBuilder
     @data ||= begin
       validate_content
       data = github_data
-      data["content_sections"] = model_data # Rename to sections when ready to go live
+      data["content_sections"] = sub_sections_data # Rename to sections when ready to go live
+      data["live_stream"] = live_stream_data
       data
     end
   rescue RestClient::Exception => e
@@ -70,15 +71,19 @@ class CoronavirusPages::ContentBuilder
     @github_data ||= github_raw_data["content"]
   end
 
-  def model_data
-    sub_sections_data
-  end
-
   def sub_sections_data
     coronavirus_page.sub_sections.map do |sub_section|
       presenter = SubSectionJsonPresenter.new(sub_section)
       add_error(presenter.errors) unless presenter.success?
       presenter.output
     end
+  end
+
+  def live_stream_data
+    live_stream = LiveStream.last
+    {
+      "video_url" => live_stream.url,
+      "date" => live_stream.formatted_stream_date,
+    }
   end
 end

--- a/app/services/live_stream_updater.rb
+++ b/app/services/live_stream_updater.rb
@@ -39,7 +39,7 @@ private
 
   def update_content_item
     with_longer_timeout do
-      Services.publishing_api.put_content(landing_page_id, live_stream_payload)
+      Services.publishing_api.put_content(landing_page_id, payload)
     rescue GdsApi::HTTPErrorResponse
       object.update(url: live_url, formatted_stream_date: live_date)
     end
@@ -67,13 +67,23 @@ private
     CoronavirusPagePresenter.new(live_content_item["details"], "/coronavirus")
   end
 
-  def live_stream_payload
+  def payload
     presenter.payload.merge(
       {
         "title" => "Coronavirus (COVID-19): what you need to do",
         "description" => live_content_item["description"],
+        "details" => live_content_item["details"].deep_merge(live_stream_payload),
       },
     )
+  end
+
+  def live_stream_payload
+    {
+      "live_stream" => {
+        "video_url" => object.url,
+        "date" => object.formatted_stream_date,
+      },
+    }
   end
 
   def landing_page_id

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SubSectionsController, type: :controller do
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
   let(:sub_section) { create :sub_section, coronavirus_page: coronavirus_page }
+  let!(:live_stream) { create :live_stream, :without_validations }
   let(:title) { Faker::Lorem.sentence }
   let(:content) { "###{Faker::Lorem.sentence}" }
   let(:sub_section_params) do
@@ -31,7 +32,7 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
-      stub_youtube
+      live_stream
     end
     subject do
       post :create, params: { coronavirus_page_slug: slug, sub_section: sub_section_params }
@@ -106,7 +107,7 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
-      stub_youtube
+      live_stream
     end
     let(:params) do
       {

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -248,4 +248,12 @@ FactoryBot.define do
     content { "(#{Faker::Lorem.sentence})[/#{File.join(Faker::Lorem.words)}]" }
     coronavirus_page
   end
+
+  factory :live_stream do
+    url { "https://www.youtube.com/watch?v=NiplUCnwc5A" }
+    formatted_stream_date { "1 April 2020" }
+    trait :without_validations do
+      to_create { |instance| instance.save validate: false }
+    end
+  end
 end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_coronavirus_publishing_api
       stub_all_github_requests
       stub_any_publishing_api_put_intent
-      stub_youtube
+      given_a_livestream_exists
     end
 
     context "Landing page" do

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
   let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section).output }
+  let!(:live_stream) { create :live_stream, :without_validations }
 
   subject { described_class.new(coronavirus_page) }
   before do
@@ -20,9 +21,16 @@ RSpec.describe CoronavirusPages::ContentBuilder do
   describe "#data" do
     let(:sub_section) { create :sub_section }
     let(:coronavirus_page) { sub_section.coronavirus_page }
+    let(:live_stream_data) do
+      {
+        "video_url" => live_stream.url,
+        "date" => live_stream.formatted_stream_date,
+      }
+    end
     let(:data) do
       data = github_content["content"]
       data["content_sections"] = [sub_section_json]
+      data["live_stream"] = live_stream_data
       data
     end
     it "returns github and model data" do
@@ -30,9 +38,9 @@ RSpec.describe CoronavirusPages::ContentBuilder do
     end
   end
 
-  describe "#model_data" do
+  describe "#sub_sections_data" do
     it "returns the sub_sections" do
-      expect(subject.model_data).to eq []
+      expect(subject.sub_sections_data).to eq []
     end
 
     context "with subsections" do
@@ -40,7 +48,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
       let(:coronavirus_page) { sub_section.coronavirus_page }
       let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section).output }
       it "returns the sub_section JSON" do
-        expect(subject.model_data).to eq [sub_section_json]
+        expect(subject.sub_sections_data).to eq [sub_section_json]
       end
     end
   end

--- a/spec/services/coronavirus_pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus_pages/draft_updater_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPages::DraftUpdater do
+  let(:live_stream) { create :live_stream, :without_validations }
   let(:coronavirus_page) { create :coronavirus_page }
   let(:content_builder) { CoronavirusPages::ContentBuilder.new(coronavirus_page) }
   let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
@@ -10,7 +11,7 @@ RSpec.describe CoronavirusPages::DraftUpdater do
   subject { described_class.new(coronavirus_page) }
 
   before do
-    stub_youtube
+    live_stream
     stub_coronavirus_publishing_api
     stub_request(:get, coronavirus_page.raw_content_url)
       .to_return(status: 200, body: github_content.to_json)

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -8,6 +8,10 @@ def given_i_am_an_unreleased_feature_editor
   stub_user.name = "Test author"
 end
 
+def given_a_livestream_exists
+  FactoryBot.create(:live_stream, :without_validations)
+end
+
 def the_payload_contains_the_valid_url
   live_stream_payload = coronavirus_live_stream_hash.merge(
     {
@@ -15,7 +19,6 @@ def the_payload_contains_the_valid_url
       "date" => todays_date,
     },
   )
-
   assert_publishing_api_put_content(
     coronavirus_content_id,
     request_json_includes(


### PR DESCRIPTION
## What
Move the logic that combines the livestream data into the payload for publishing api, out of the CoronavirusPagePresenter and into the ContentBuilder and LivestreamUpdater.

## Why
When we make content changes, we fetch the github yaml file, turn it into a hash and combine it with the coronaviruspage data persisted in the database. We should add the livestream data persisted in the database to the content hash as well, rather than doing that elsewhere in the code base. As that is the pattern that can be continued as we persist more and more parts of the github content into the collections publisher database. 

