### PR TITLE
Hide markdown editor bullets button from covid accordion editor

### DIFF
--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -1,6 +1,7 @@
 <%
   textarea ||= {}
   component_classes = %w[app-c-markdown-editor govuk-form-group]
+  hide_bullets_button ||= false
 %>
 <%= tag.div class: component_classes do %>
 
@@ -15,9 +16,11 @@
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
-          <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
-            <%= render "components/markdown_editor/bullets.svg" %>
-          </md-unordered-list>
+          <% if !hide_bullets_button %>
+            <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
+              <%= render "components/markdown_editor/bullets.svg" %>
+            </md-unordered-list>
+          <% end %>
         </markdown-toolbar>
       </div>
     </div>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -16,7 +16,7 @@
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
-          <% if !hide_bullets_button %>
+          <% unless hide_bullets_button %>
             <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
               <%= render "components/markdown_editor/bullets.svg" %>
             </md-unordered-list>

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -26,3 +26,11 @@ examples:
       textarea:
         name: markdown-editor
         id: markdown-editor
+  without_bullet_list_button:
+    data:
+      hide_bullets_button: true
+      label:
+        text: Body
+      textarea:
+        name: markdown-editor
+        id: markdown-editor

--- a/app/views/sub_sections/_form.html.erb
+++ b/app/views/sub_sections/_form.html.erb
@@ -17,7 +17,8 @@
     id: "content",
     rows: 20,
     value: @sub_section.content
-  }
+  },
+  hide_bullets_button: true
 } %>
 <%= render "govuk_publishing_components/components/button", {
   text: "Save",

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -21,4 +21,18 @@ RSpec.describe "Markdown editor", type: :view do
     assert_select ".app-c-markdown-editor__toolbar-group[for='markdown-editor']"
     assert_select ".govuk-textarea[id='markdown-editor']"
   end
+
+  it "does not render bullet list toolbar button if hide_bullets_button is true" do
+    render "components/markdown_editor",
+           hide_bullets_button: true,
+           label: {
+             text: "Body",
+           },
+           textarea: {
+             name: "markdown-editor",
+             id: "markdown-editor",
+           }
+
+    assert_select ".app-c-markdown-editor__toolbar-button[title='Bullets']", count: 0
+  end
 end


### PR DESCRIPTION
## What

- Extend markdown editor component with an option to hide the bullets button on the toolbar.
- Remove the bullets button from the markdown editor toolbar on the coronavirus accordion section editor form.

Markdown editor component with the bullets button vs without bullets button:

<img width="1292" alt="Screenshot 2020-07-01 at 11 56 30" src="https://user-images.githubusercontent.com/7116819/86236461-03b47980-bb92-11ea-8e89-71bece93aea6.png">



## Why

Users should not need to use this control in this particular instance, we are removing the button from the toolbar as an additional measure.  

https://trello.com/c/thetabg3