### PR TITLE
Remove incorrect issuer usage in JWT token

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,10 +11,9 @@ module ApplicationHelper
     Plek.find("draft-origin", external: true) + path
   end
 
-  def step_by_step_preview_url(step_by_step_page, user)
+  def step_by_step_preview_url(step_by_step_page)
     payload = {
       "sub" => step_by_step_page.auth_bypass_id,
-      "iss" => user.uid,
       "iat" => Time.zone.now.to_i,
       "exp" => 1.month.from_now.to_i,
       "draft_asset_manager_access" => true,

--- a/app/views/step_by_step_pages/index/_results.erb
+++ b/app/views/step_by_step_pages/index/_results.erb
@@ -11,7 +11,7 @@
 
       <% preview_link = capture do %>
         <% if step_by_step_page.has_draft? %>
-          <%= link_to "/#{step_by_step_page.slug}", step_by_step_preview_url(step_by_step_page, current_user), target: "_blank", class: "govuk-link" %>
+          <%= link_to "/#{step_by_step_page.slug}", step_by_step_preview_url(step_by_step_page), target: "_blank", class: "govuk-link" %>
         <% elsif step_by_step_page.status.published? %>
           <%= link_to "/#{step_by_step_page.slug}", published_url(step_by_step_page.slug), target: "_blank", class: "govuk-link" %>
         <% else %>

--- a/app/views/step_by_step_pages/show/_actions.erb
+++ b/app/views/step_by_step_pages/show/_actions.erb
@@ -1,6 +1,6 @@
 <% preview_link = render "govuk_publishing_components/components/button", {
   text: "Preview",
-  href: step_by_step_preview_url(@step_by_step_page, current_user),
+  href: step_by_step_preview_url(@step_by_step_page),
   target: "_blank",
   secondary: true
 } %>


### PR DESCRIPTION
Trello: https://trello.com/c/IQ26eiaW/240-make-content-publisher-use-changing-auth-bypass-tokens

This token was defining the issuer (using the iss grant) with the uid of
the user who created this token, which was a rather general applying of
the issuer name.

The use of issuer should relate more to the organisation that is
issuing the token rather than the user that created it, such that this
issuer could be validated online [1].

The use of the user_id is also a little dubious as this could be
construed as personally identifiable information in some contexts and
JWTs are not encrypted (which is a common misconception). The simplest
thing is to just remove them from tokens.

I'm of the mindset that one day in some scenario it would have been very
useful to know the user_id of who issued a token but it does not seem to
be worth living with risks before hand. I'm also hoping that the
combination of content id and timestamp make it relatively easy to
determine the request made that generated the token.

As part of this change I refactored how we test the token as it's quite
hard to work with a long signed string for making amends.

[1]: https://auth0.com/docs/tokens/guides/validate-jwts#check-standard-claims