### PR TITLE
Coronavirus publishing tool: Form landing page content payload correctly

### DIFF
--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -11,7 +11,7 @@ class CoronavirusPages::ContentBuilder
       validate_content
       data = github_data
       data["content_sections"] = sub_sections_data # Rename to sections when ready to go live
-      data["live_stream"] = live_stream_data
+      add_live_stream(data)
       data
     end
   rescue RestClient::Exception => e
@@ -50,6 +50,7 @@ class CoronavirusPages::ContentBuilder
       sections
       topic_section
       notifications
+      live_stream
     ]
   end
 
@@ -71,6 +72,10 @@ class CoronavirusPages::ContentBuilder
     @github_data ||= github_raw_data["content"]
   end
 
+  def github_live_stream_data
+    github_data["live_stream"] || {}
+  end
+
   def sub_sections_data
     coronavirus_page.sub_sections.map do |sub_section|
       presenter = SubSectionJsonPresenter.new(sub_section)
@@ -79,11 +84,17 @@ class CoronavirusPages::ContentBuilder
     end
   end
 
-  def live_stream_data
+  def persisted_live_stream_data
     live_stream = LiveStream.last
     {
       "video_url" => live_stream.url,
       "date" => live_stream.formatted_stream_date,
     }
+  end
+
+  def add_live_stream(data)
+    if coronavirus_page.slug == "landing"
+      data["live_stream"] = github_live_stream_data.merge(persisted_live_stream_data)
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -245,7 +245,7 @@ FactoryBot.define do
 
   factory :sub_section do
     title { Faker::Lorem.sentence }
-    content { "(#{Faker::Lorem.sentence})[/#{File.join(Faker::Lorem.words)}]" }
+    content { "[#{Faker::Lorem.sentence}](/#{File.join(Faker::Lorem.words)})" }
     coronavirus_page
   end
 

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -162,6 +162,33 @@ content:
       - label: "Guidance"
         url: /search/all?topical_events%5B%5D=coronavirus-covid-19-uk-government-response&order=updated-newest
   live_stream:
+    show_live_stream: true
+    title: Press conferences and speeches
+    date_text: Broadcast
+    no_cookies:
+      change_settings: "Change your cookie settings"
+      change_settings_link: "/help/cookies"
+      to_watch: "to watch the video"
+      or: "or"
+      watch_link_text: "Watch on YouTube"
+      icon_text: "Video"
+    previous_videos:
+      url: https://www.youtube.com/user/Number10gov/videos
+      previous_videos_text: Watch all press conferences on YouTube
+      next_conference_text: The next live press conference will be shown here
+    # set spaced_links to true to insert breaks in the list of links, for increased legibility
+    spaced_links: true
+    ask_a_question_visible: false
+    ask_a_question_text: Ask a question at a press conference
+    ask_a_question_link: /ask
+    popular_questions_link_visible: false
+    see_popular_questions_text: See answers to the most common topics asked about by the public
+    see_popular_questions_link: /guidance/answers-to-the-most-common-topics-asked-about-by-the-public-for-the-coronavirus-press-conference
+    transcript_text: Read all press conference statements
+    transcript_link: /government/collections/slides-and-datasets-to-accompany-coronavirus-press-conferences#transcripts
+    # video_url and date are set by https://collections-publisher.publishing.service.gov.uk/coronavirus/live_stream.
+    video_url:
+    date:
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPages::ContentBuilder do
-  let(:coronavirus_page) { create :coronavirus_page }
+  let(:coronavirus_page) { create :coronavirus_page, :landing }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
   let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section).output }
@@ -19,20 +19,23 @@ RSpec.describe CoronavirusPages::ContentBuilder do
   end
 
   describe "#data" do
-    let(:sub_section) { create :sub_section }
-    let(:coronavirus_page) { sub_section.coronavirus_page }
+    let!(:sub_section) { create :sub_section, coronavirus_page_id: coronavirus_page.id }
+    let(:github_livestream_data) { github_content.dig("content", "live_stream") }
+
     let(:live_stream_data) do
-      {
+      github_livestream_data.merge(
         "video_url" => live_stream.url,
         "date" => live_stream.formatted_stream_date,
-      }
+      )
     end
+
     let(:data) do
       data = github_content["content"]
       data["content_sections"] = [sub_section_json]
       data["live_stream"] = live_stream_data
       data
     end
+
     it "returns github and model data" do
       expect(subject.data).to eq data
     end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -222,7 +222,7 @@ def invalid_github_response
 end
 
 def and_i_see_an_alert
-  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, announcements_label, announcements, nhs_banner, sections, topic_section, notifications.")
+  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, announcements_label, announcements, nhs_banner, sections, topic_section, notifications, live_stream.")
 end
 
 def and_i_see_an_alert_for_missing_hub_page_keys


### PR DESCRIPTION
## What
When #1084 was merged, a bug was introduced. 
- Updating the livestream url was behaving as normal.
- Updating the page via the prepare action was removing the livestream content still stored in github from the content item

## How
Combine livestream content currently stored in github, with the persisted livestream data, when we publish the landing page.
