### PR TITLE
Cache bust yaml fetch from Github

### DIFF
--- a/app/services/yaml_fetcher.rb
+++ b/app/services/yaml_fetcher.rb
@@ -6,7 +6,7 @@ class YamlFetcher
   end
 
   def response
-    @response ||= RestClient.get(url)
+    @response ||= RestClient.get(cache_busted_url)
   end
 
   def success?
@@ -19,5 +19,15 @@ class YamlFetcher
 
   def body_as_hash
     @body_as_hash ||= YAML.safe_load(body)
+  end
+
+private
+
+  def cache_busted_url
+    uri = Addressable::URI.parse(url)
+
+    cache_bust = { "cache-bust" => Time.zone.now.to_i }
+    uri.query_values = (uri.query_values || {}).merge(cache_bust)
+    uri.to_s
   end
 end

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
   let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
+  let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
   let(:all_content_urls) do
     CoronavirusPages::Configuration.all_pages.map do |config|
       config.second[:raw_content_url]
@@ -15,7 +16,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
   let(:raw_content) { File.read(fixture_path) }
   let(:stub_all_content_urls) do
     all_content_urls.each do |url|
-      stub_request(:get, url)
+      stub_request(:get, Regexp.new(url))
         .to_return(status: 200, body: raw_content)
     end
   end
@@ -32,7 +33,7 @@ RSpec.describe CoronavirusPagesController, type: :controller do
   describe "GET /coronavirus/:slug/prepare" do
     subject { get :prepare, params: { slug: slug } }
     it "renders page successfuly" do
-      stub_request(:get, raw_content_url)
+      stub_request(:get, raw_content_url_regex)
         .to_return(status: 200)
       expect(subject).to have_http_status(:success)
     end
@@ -53,13 +54,13 @@ RSpec.describe CoronavirusPagesController, type: :controller do
       let(:coronavirus_page) { build :coronavirus_page, :of_known_type }
 
       it "renders page successfuly" do
-        stub_request(:get, raw_content_url)
+        stub_request(:get, raw_content_url_regex)
           .to_return(status: 200, body: raw_content)
         expect(subject).to have_http_status(:success)
       end
 
       it "creates a new coronavirus page" do
-        stub_request(:get, raw_content_url)
+        stub_request(:get, raw_content_url_regex)
           .to_return(status: 200, body: raw_content)
         coronavirus_page # ensure any creation during initialization doesn't get counted
         expect { subject }.to (change { CoronavirusPage.count }).by(1)

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe SubSectionsController, type: :controller do
     }
   end
   let(:raw_content_url) { coronavirus_page.raw_content_url }
+  let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:raw_content) { File.read(fixture_path) }
 
@@ -29,7 +30,7 @@ RSpec.describe SubSectionsController, type: :controller do
 
   describe "POST /coronavirus/:coronavirus_page_slug/sub_sections" do
     before do
-      stub_request(:get, raw_content_url)
+      stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
       live_stream
@@ -104,7 +105,7 @@ RSpec.describe SubSectionsController, type: :controller do
 
   describe "PATCH /coronavirus/:coronavirus_page_slug/sub_sections" do
     before do
-      stub_request(:get, raw_content_url)
+      stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
       live_stream
@@ -138,7 +139,7 @@ RSpec.describe SubSectionsController, type: :controller do
 
   describe "DELETE /coronavirus/:coronavirus_page_slug/sub_sections/:id" do
     before do
-      stub_request(:get, raw_content_url)
+      stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
     end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CoronavirusPagePresenter do
 
   before do
     live_stream
-    stub_request(:get, coronavirus_page.raw_content_url)
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
     stub_coronavirus_publishing_api
   end

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe SubSectionJsonPresenter do
       let(:path) { business.base_path }
 
       before do
-        stub_request(:get, business.raw_content_url)
+        stub_request(:get, Regexp.new(business.raw_content_url))
           .to_return(body: File.read(fixture_path))
       end
 

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
 
   subject { described_class.new(coronavirus_page) }
   before do
-    stub_request(:get, coronavirus_page.raw_content_url)
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
   end
   describe "#github_data" do
@@ -60,7 +60,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
 
     context "on failure" do
       before do
-        stub_request(:get, coronavirus_page.raw_content_url)
+        stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
           .to_return(status: 400)
       end
 

--- a/spec/services/coronavirus_pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus_pages/draft_updater_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CoronavirusPages::DraftUpdater do
   before do
     live_stream
     stub_coronavirus_publishing_api
-    stub_request(:get, coronavirus_page.raw_content_url)
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
   end
 

--- a/spec/services/coronavirus_pages/model_builder_spec.rb
+++ b/spec/services/coronavirus_pages/model_builder_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CoronavirusPages::ModelBuilder do
   let(:model_builder) { CoronavirusPages::ModelBuilder.new(slug) }
   let(:page_config) { CoronavirusPages::Configuration.page(slug) }
   let(:raw_content_url) { page_config[:raw_content_url] }
+  let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:source_yaml) { YAML.load_file(fixture_path) }
   let(:source_sections) { source_yaml.dig("content", "sections") }
@@ -14,7 +15,7 @@ RSpec.describe CoronavirusPages::ModelBuilder do
   end
 
   before do
-    stub_request(:get, raw_content_url)
+    stub_request(:get, raw_content_url_regex)
       .to_return(body: File.read(fixture_path))
   end
 

--- a/spec/services/yaml_fetcher_spec.rb
+++ b/spec/services/yaml_fetcher_spec.rb
@@ -1,14 +1,22 @@
 require "rails_helper"
 
 RSpec.describe YamlFetcher do
-  let(:url) { Faker::Internet.url(host: "example.com") }
+  let(:random_epoch) { rand(10**10) }
+  let(:url) { Faker::Internet.url(host: "example.com") + "?cache-bust=#{random_epoch}" }
   let(:yaml) { File.read(Rails.root.join("spec/fixtures/simple.yml")) }
   let(:body) { "something" }
   let(:stub_response) { { body: body } }
 
   subject { described_class.new(url) }
 
-  before { stub_request(:get, url).to_return(stub_response) }
+  before do
+    Timecop.freeze(Time.zone.at(random_epoch))
+    stub_request(:get, url).to_return(stub_response)
+  end
+
+  after do
+    Timecop.return
+  end
 
   describe "#response" do
     it "does something" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -81,13 +81,13 @@ end
 
 def stub_all_github_requests
   raw_content_urls.each do |url|
-    stub_request(:get, url)
+    stub_request(:get, Regexp.new(url))
       .to_return(status: 200, body: github_response)
   end
 end
 
 def stub_github_business_request
-  stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml")
+  stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml"))
     .to_return(status: 200, body: github_business_response)
 end
 
@@ -204,14 +204,14 @@ def and_i_push_a_new_draft_version
 end
 
 def and_i_push_a_new_draft_version_with_invalid_content
-  stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml")
+  stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml"))
   .to_return(status: 200, body: invalid_github_response)
 
   and_i_push_a_new_draft_version
 end
 
 def and_i_push_a_new_draft_business_version_with_invalid_content
-  stub_request(:get, "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml")
+  stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml"))
   .to_return(status: 200, body: invalid_github_response)
 
   and_i_push_a_new_draft_version


### PR DESCRIPTION
Github caches requests to the raw endpoint for 5 minutes (and it feels longer sometimes).  Adding a cache bust query parameter seems to defeat this, and will hopefully make repeated updates more reliable in the short term.

In the long term, the yaml is going to be less important as we're pulling this into the publishing tool.