### PR TITLE
Coronavirus Publishing tool rake task

### DIFF
--- a/lib/tasks/coronavirus.rake
+++ b/lib/tasks/coronavirus.rake
@@ -1,0 +1,23 @@
+## This rake task deletes all CoronavirusPage from the collections publisher database
+## Once it's been run, visiting https://collections-publisher.publishing.service.gov.uk/coronavirus will
+## trigger the latest data to be pulled from github, and then this task should be deleted.
+
+namespace :coronavirus do
+  desc "
+  Delete all coronavirus records.
+  Usage
+  rake coronavirus:resync_database[dry_run_false]
+  "
+  task :resync_database, [:dry_run] => [:environment] do |_task, args|
+    count = CoronavirusPage.count
+    slugs = CoronavirusPage.all.pluck(:slug)
+
+    if args.dry_run == "dry_run_false"
+      puts "Deleting #{count} coronavirus pages from the database: #{slugs}"
+      CoronavirusPage.destroy_all
+      CoronavirusPage.any? ? "Something went wrong, #{slugs} were not deleted." : "Done"
+    else
+      puts "This task is in dry run mode. It would have removed #{count} coronavirus pages from the database: #{slugs}"
+    end
+  end
+end


### PR DESCRIPTION
- Rake task to destroy all Coronavirus pages.
- If there are no coronavirus pages in the database, the first time https://collections-publisher.publishing.service.gov.uk/coronavirus is requested, we fetch all the content from github and create the coronavirus page models.
- Should be run once we are ready to make the tool live, before we remove the sections content from github, and then can be removed from the code base.

https://trello.com/c/NTcgcNwn/379-coronavirus-publishing-tool-resync-database-rake-task