### PR TITLE
Coronavirus publishing tool: Persist titles

### DIFF
--- a/app/helpers/coronavirus_page_helper.rb
+++ b/app/helpers/coronavirus_page_helper.rb
@@ -2,4 +2,8 @@ module CoronavirusPageHelper
   def page_type(coronavirus_page)
     coronavirus_page.topic_page? ? "Topic page" : "Sub-topic page"
   end
+
+  def formatted_title(coronavirus_page)
+    coronavirus_page.topic_page? ? "Coronavirus (COVID-19)" : coronavirus_page.title
+  end
 end

--- a/app/helpers/coronavirus_page_helper.rb
+++ b/app/helpers/coronavirus_page_helper.rb
@@ -1,0 +1,5 @@
+module CoronavirusPageHelper
+  def page_type(coronavirus_page)
+    coronavirus_page.topic_page? ? "Topic page" : "Sub-topic page"
+  end
+end

--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -4,4 +4,8 @@ class CoronavirusPage < ApplicationRecord
   scope :topic_page, -> { where(slug: "landing") }
   scope :subtopic_pages, -> { where.not(slug: "landing") }
   validates :state, inclusion: { in: STATUSES }, presence: true
+
+  def topic_page?
+    slug == "landing"
+  end
 end

--- a/app/services/coronavirus_pages/model_builder.rb
+++ b/app/services/coronavirus_pages/model_builder.rb
@@ -27,11 +27,16 @@ module CoronavirusPages
     def coronavirus_page_attributes
       page_config.merge(
         sections_title: sections_heading,
+        title: title,
       )
     end
 
     def sections_heading
       yaml_data.dig("content", "sections_heading")
+    end
+
+    def title
+      yaml_data.dig("content", "title")
     end
 
     def raw_content_url

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -3,17 +3,17 @@
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
 <ul class="govuk-list">
   <% if unreleased_feature_user? %>
-    <li><%= link_to "Edit #{@topic_page.name} '#{@topic_page.sections_title.downcase}' accordion", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+    <li><%= link_to "Edit #{@topic_page.name.downcase} '#{@topic_page.sections_title.downcase}' accordion", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
   <% end %>
-  <li><%= link_to "Publish #{@topic_page.name}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
+  <li><%= link_to "Publish #{@topic_page.name.downcase}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
   <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
 </ul>
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
 <ul class="govuk-list <%= unreleased_feature_user? ? 'covid__spaced-list' : '' %>">
   <% @subtopic_pages.each do |page| %>
   <% if unreleased_feature_user? %>
-    <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name.downcase} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
   <% end %>
-    <li class="covid__spaced-list-item"><%= link_to "Publish #{page.name}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to "Publish #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   <% end %>
 </ul>

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -5,7 +5,7 @@
       href: coronavirus_pages_path
     },
     {
-      text: "Coronavirus (COVID-19)"
+      text: formatted_title(@coronavirus_page)
     }
   ]
 
@@ -16,7 +16,7 @@
 %>
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
-<% content_for :title, "Coronavirus (COVID-19)" %>
+<% content_for :title, formatted_title(@coronavirus_page)%>
 <% content_for :context, page_type(@coronavirus_page) %>
 
 <div class="covid-manage-page govuk-grid-row">

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -17,7 +17,7 @@
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, "Coronavirus (COVID-19)" %>
-<% content_for :context, 'Topic page' %>
+<% content_for :context, page_type(@coronavirus_page) %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/db/migrate/20200707201559_add_title_to_coronavirus_page.rb
+++ b/db/migrate/20200707201559_add_title_to_coronavirus_page.rb
@@ -1,0 +1,5 @@
+class AddTitleToCoronavirusPage < ActiveRecord::Migration[6.0]
+  def change
+    add_column :coronavirus_pages, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_141142) do
+ActiveRecord::Schema.define(version: 2020_07_07_201559) do
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sections_title"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_141142) do
     t.string "github_url"
     t.string "raw_content_url"
     t.string "state", default: "draft", null: false
+    t.string "title"
   end
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -118,11 +118,11 @@ def then_the_business_content_is_sent_to_publishing_api
 end
 
 def i_see_a_publish_landing_page_link
-  expect(page).to have_link("Publish Coronavirus landing page")
+  expect(page).to have_link("Publish coronavirus landing page")
 end
 
 def i_see_a_publish_business_page_link
-  expect(page).to have_link("Publish Business support page")
+  expect(page).to have_link("Publish business support page")
 end
 
 def i_see_livestream_button
@@ -130,11 +130,11 @@ def i_see_livestream_button
 end
 
 def and_i_select_landing_page
-  click_link("Publish Coronavirus landing page")
+  click_link("Publish coronavirus landing page")
 end
 
 def and_i_select_business_page
-  click_link("Publish Business support page")
+  click_link("Publish business support page")
 end
 
 def and_i_select_live_stream


### PR DESCRIPTION
## What
Replace hard coded strings with attributes stored on the coronavirus page model. 
 - Store title field on the model
 - Create helper to format the title to match the output on the [design](https://www.figma.com/file/92QVsy9eJOXdiULVrjQbEk/Coronavirus-topic-publisher?node-id=0%3A1)

trello: https://trello.com/c/6DHW4Wxx/413-persist-coronavirus-page-title