### PR TITLE
Coronavirus publishing tool: remove feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?, :unreleased_feature_user?
+  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
@@ -23,10 +23,6 @@ private
 
   def livestream_editor?
     current_user.has_permission? "Livestream editor"
-  end
-
-  def unreleased_feature_user?
-    current_user.has_permission? "Unreleased feature"
   end
 
   # Can be overridden to allow controllers to choose the active menu item.
@@ -56,10 +52,6 @@ private
 
   def require_gds_editor_permissions_to_edit_browse_pages!
     require_gds_editor_permissions! if @tag.is_a?(MainstreamBrowsePage)
-  end
-
-  def require_unreleased_feature_permissions!
-    authorise_user!("Unreleased feature")
   end
 
   def find_tag

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,10 +11,14 @@ class ApplicationController < ActionController::Base
 
 private
 
-  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?
+  helper_method :gds_editor?, :active_navigation_item, :coronavirus_editor?, :livestream_editor?, :unreleased_feature_user?
 
   def gds_editor?
     current_user.has_permission? "GDS Editor"
+  end
+
+  def unreleased_feature_user?
+    current_user.has_permission? "Unreleased feature"
   end
 
   def coronavirus_editor?
@@ -52,6 +56,10 @@ private
 
   def require_gds_editor_permissions_to_edit_browse_pages!
     require_gds_editor_permissions! if @tag.is_a?(MainstreamBrowsePage)
+  end
+
+  def require_unreleased_feature_permissions!
+    authorise_user!("Unreleased feature")
   end
 
   def find_tag

--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -1,6 +1,5 @@
 class CoronavirusPagesController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
-  before_action :require_unreleased_feature_permissions!, only: %w[show]
   before_action :redirect_to_index_if_slug_unknown, only: %w[prepare show]
   before_action :initialise_coronavirus_pages, only: %w[index]
   layout "admin_layout"

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -1,6 +1,5 @@
 class ReorderSubSectionsController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
-  before_action :require_unreleased_feature_permissions!
   before_action :redirect_to_index_if_slug_unknown
   layout "admin_layout"
 

--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -1,5 +1,5 @@
 class SubSectionsController < ApplicationController
-  before_action :require_unreleased_feature_permissions!
+  before_action :require_coronavirus_editor_permissions!
   layout "admin_layout"
 
   def new

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -2,9 +2,7 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Coronavirus landing page</h2>
 <ul class="govuk-list">
-  <% if unreleased_feature_user? %>
-    <li><%= link_to "Edit landing page accordions", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
-  <% end %>
+  <li><%= link_to "Edit landing page accordions", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
   <li><%= link_to "Edit live stream URL", live_stream_index_path, class:"govuk-link" %></li>
   <li><%= link_to "Edit something else on the landing page", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
 </ul>
@@ -12,9 +10,7 @@
 <% @subtopic_pages.each do |page| %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%=page.name%></h2>
   <ul class="govuk-list">
-  <% if unreleased_feature_user? %>
     <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name.downcase} accordions", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
-  <% end %>
     <li class="covid__spaced-list-item"><%= link_to "Edit something else on the #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   </ul>
 <% end %>

--- a/spec/controllers/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus_pages_controller_spec.rb
@@ -69,10 +69,6 @@ RSpec.describe CoronavirusPagesController, type: :controller do
   end
 
   describe "GET /coronavirus/:slug" do
-    before do
-      stub_user.permissions << "Unreleased feature"
-    end
-
     it "renders page successfuly" do
       get :show, params: { slug: coronavirus_page.slug }
       expect(response).to have_http_status(:success)
@@ -100,7 +96,6 @@ RSpec.describe CoronavirusPagesController, type: :controller do
     subject { get :discard, params: { slug: slug } }
 
     before do
-      stub_user.permissions << "Unreleased feature"
       stub_publishing_api_has_item(live_content_item)
       stub_any_publishing_api_discard_draft
     end

--- a/spec/controllers/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/reorder_sub_sections_controller_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
   let(:raw_content) { File.read(fixture_path) }
 
   describe "GET /coronavirus/:coronavirus_page_slug/sub_sections/reorder" do
-    before do
-      stub_user.permissions << "Unreleased feature"
-    end
-
     it "renders page successfuly" do
       get :index, params: { coronavirus_page_slug: slug }
       expect(response).to have_http_status(:success)
@@ -23,7 +19,6 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
 
   describe "PUT /coronavirus/:coronavirus_page_slug/sub_sections/reorder" do
     before do
-      stub_user.permissions << "Unreleased feature"
       stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
         .to_return(status: 200, body: raw_content)
       stub_coronavirus_publishing_api

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SubSectionsController, type: :controller do
   render_views
 
-  let(:stub_user) { create :user, :unreleased_feature, name: "Name Surname" }
+  let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
   let(:sub_section) { create :sub_section, coronavirus_page: coronavirus_page }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -175,10 +175,6 @@ FactoryBot.define do
     trait :coronovirus_editor do
       permissions { ["signin", "Coronavirus editor"] }
     end
-
-    trait :unreleased_feature do
-      permissions { ["Unreleased feature"] }
-    end
   end
 
   factory :list do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
 
   describe "Changes made in collections publisher" do
     before do
-      given_i_am_an_unreleased_feature_editor
       given_i_am_a_coronavirus_editor
       stub_coronavirus_publishing_api
       stub_all_github_requests

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -3,11 +3,6 @@ def given_i_am_a_coronavirus_editor
   stub_user.name = "Test author"
 end
 
-def given_i_am_an_unreleased_feature_editor
-  stub_user.permissions << "Unreleased feature"
-  stub_user.name = "Test author"
-end
-
 def given_a_livestream_exists
   FactoryBot.create(:live_stream, :without_validations)
 end


### PR DESCRIPTION
Remove checks for Unreleased feature signon permission that currently hide the new tools features.

https://trello.com/c/DU5dRL03/415-remove-feature-flag-hiding-the-coronavirus-publishing-tool