### PR TITLE
Stop publishing email-signup routes for Topic's

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -10,7 +10,7 @@ class Topic < Tag
   def subroutes
     return [] unless subtopic?
 
-    %w[/latest /email-signup]
+    %w[/latest]
   end
 
   def dependent_tags

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ArchivedTagPresenter do
 
   describe "#render_for_publishing_api" do
     before(:each) do
-      %w[child-1 child-1/latest child-1/email-signup].each do |route|
+      %w[child-1 child-1/latest].each do |route|
         child.redirect_routes.create!(from_base_path: "/topic/parent/#{route}", to_base_path: parent.base_path, tag_id: child.id)
       end
     end
@@ -25,11 +25,6 @@ RSpec.describe ArchivedTagPresenter do
           },
           {
             path: "/topic/parent/child-1/latest",
-            destination: "/topic/parent",
-            type: "exact",
-          },
-          {
-            path: "/topic/parent/child-1/email-signup",
             destination: "/topic/parent",
             type: "exact",
           },

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -104,11 +104,10 @@ RSpec.describe TopicPresenter do
         expect(presented_data[:public_updated_at]).to eq(the_past.iso8601)
       end
 
-      it "includes routes for latest, and email_signups in addition to base route" do
+      it "includes a /latest route in addition to the base route" do
         expect(presented_data[:routes]).to eq([
           { path: "/topic/oil-and-gas/offshore", type: "exact" },
           { path: "/topic/oil-and-gas/offshore/latest", type: "exact" },
-          { path: "/topic/oil-and-gas/offshore/email-signup", type: "exact" },
         ])
       end
 

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe TagArchiver do
       expect(tag.redirect_routes.map(&:from_base_path)).to eql([
         "/topic/foo/bar",
         "/topic/foo/bar/latest",
-        "/topic/foo/bar/email-signup",
       ])
     end
 
@@ -65,7 +64,6 @@ RSpec.describe TagArchiver do
       TagArchiver.new(tag, successor).archive
 
       expect(tag.redirect_routes.map(&:to_base_path)).to eql([
-        "/topic/foo",
         "/topic/foo",
         "/topic/foo",
       ])
@@ -80,7 +78,6 @@ RSpec.describe TagArchiver do
       expect(tag.redirect_routes.map(&:to_base_path)).to eql([
         "/topic/foo/bar",
         "/topic/foo/bar/latest",
-        "/topic/foo/bar/email-signup",
       ])
     end
 


### PR DESCRIPTION
These email subroutes get published when a Topic (specialist sector) is
published / republished. As part of the work to move these redirected
routes out of collections-publisher we need to stop publishing them in
the first place.

After this gets merged we should republish all the Topic's via https://github.com/alphagov/collections-publisher/blob/master/lib/tasks/publishing_api.rake#L12.
This will keep the publishing-api in sync.

---

Trello:
https://trello.com/c/Fi2Z2zDy/399-redirect-and-remove-legacy-email-signup-routes-for-collections