### PR TITLE
Add temp rake task to redirect legacy signups

### DIFF
--- a/lib/tasks/redirect_legacy_email_signups.rake
+++ b/lib/tasks/redirect_legacy_email_signups.rake
@@ -1,0 +1,27 @@
+desc "Redirect legacy email signups"
+task redirect_legacy_email_signups: :environment do
+  # Exclude parent specialist sectors as they never included an email signup option
+  specialist_sector_slugs = Topic.where(state: "published").where.not(parent_id: nil).map(&:full_slug)
+
+  specialist_sector_slugs.each do |slug|
+    base_path = "/topic/#{slug}/email-signup"
+    destination = "/topic/#{slug}"
+
+    redirect = {
+      base_path: base_path,
+      document_type: "redirect",
+      schema_name: "redirect",
+      publishing_app: "collections-publisher",
+      update_type: "major",
+      redirects: [
+        { path: base_path, type: "exact", destination: destination },
+      ],
+    }
+
+    content_id = SecureRandom.uuid
+    Services.publishing_api.put_content(content_id, redirect)
+    Services.publishing_api.publish(content_id)
+
+    puts "Redirected #{base_path} to #{destination}"
+  end
+end


### PR DESCRIPTION
Adds a temporary rake task to create redirects for specialist sector
email signup URL's.

The current behaviour is for these specialist sector email-signup URL's
to be sent to collections which then redirects to email-alert-frontend.

This commit creates a redirect for each specialist sector email signup
URL which points to the relevant parent page rendered by collections.

Depends on:
https://github.com/alphagov/collections-publisher/pull/1102

---

Trello:
https://trello.com/c/Fi2Z2zDy/399-redirect-and-remove-legacy-email-signup-routes-for-collections