### PR TITLE
Coronavirus publishing tool: Copy changes following review.

### DIFF
--- a/app/controllers/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus_pages_controller.rb
@@ -82,7 +82,7 @@ private
     change_state("published")
     flash["notice"] = "Page published!"
   rescue GdsApi::HTTPConflict
-    flash["alert"] = "Page already published - update the draft first"
+    flash["alert"] = "You have already published this page."
   end
 
   def with_longer_timeout

--- a/app/helpers/coronavirus_page_helper.rb
+++ b/app/helpers/coronavirus_page_helper.rb
@@ -1,6 +1,6 @@
 module CoronavirusPageHelper
   def page_type(coronavirus_page)
-    coronavirus_page.topic_page? ? "Topic page" : "Sub-topic page"
+    coronavirus_page.topic_page? ? "Coronavirus landing page" : "Coronavirus hub page"
   end
 
   def formatted_title(coronavirus_page)

--- a/app/services/coronavirus_pages/configuration.rb
+++ b/app/services/coronavirus_pages/configuration.rb
@@ -33,7 +33,7 @@ module CoronavirusPages
             github_url: "https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_education_page.yml",
             state: "published",
           },
-        employees:
+        workers:
           {
             name: "Worker page",
             content_id: "5ebf285a-9165-476c-be90-66b9729f50da".freeze,

--- a/app/services/coronavirus_pages/configuration.rb
+++ b/app/services/coronavirus_pages/configuration.rb
@@ -17,7 +17,7 @@ module CoronavirusPages
           },
         business:
           {
-            name: "Business support page",
+            name: "Business hub",
             content_id: "09944b84-02ba-4742-a696-9e562fc9b29d".freeze,
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml".freeze,
             base_path: "/coronavirus/business-support",
@@ -26,7 +26,7 @@ module CoronavirusPages
           },
         education:
           {
-            name: "Education page",
+            name: "Education hub",
             content_id: "b350e61d-1db9-4cc2-bb44-fab02882ac25".freeze,
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_education_page.yml".freeze,
             base_path: "/coronavirus/education-and-childcare",
@@ -35,7 +35,7 @@ module CoronavirusPages
           },
         workers:
           {
-            name: "Worker page",
+            name: "Worker hub",
             content_id: "5ebf285a-9165-476c-be90-66b9729f50da".freeze,
             raw_content_url: "https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_worker_page.yml".freeze,
             base_path: "/coronavirus/worker-support",

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -38,7 +38,7 @@ module CoronavirusPages
     def discard
       Services.publishing_api.discard_draft(content_id)
     rescue GdsApi::HTTPUnprocessableEntity => e
-      error_handler(e, "There is not a draft edition of this document to discard")
+      error_handler(e, "You do not have a draft to discard")
     rescue GdsApi::HTTPErrorResponse => e
       error_handler(e, "There has been an error discarding your changes. Try again.")
     end

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -1,19 +1,20 @@
-<% content_for :title, "Coronavirus topic pages" %>
+<% content_for :title, "Coronavirus pages" %>
 
-<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Topic landing page</h2>
+<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Coronavirus landing page</h2>
 <ul class="govuk-list">
   <% if unreleased_feature_user? %>
-    <li><%= link_to "Edit #{@topic_page.name.downcase} '#{@topic_page.sections_title.downcase}' accordion", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+    <li><%= link_to "Edit landing page accordions", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
   <% end %>
-  <li><%= link_to "Publish #{@topic_page.name.downcase}", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
-  <li><%= link_to "Update live stream", live_stream_index_path, class:"govuk-link" %></li>
+  <li><%= link_to "Edit live stream URL", live_stream_index_path, class:"govuk-link" %></li>
+  <li><%= link_to "Edit something else on the landing page", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
 </ul>
-<h2 class="govuk-heading-s govuk-!-margin-bottom-2">Sub-topic pages</h2>
-<ul class="govuk-list <%= unreleased_feature_user? ? 'covid__spaced-list' : '' %>">
-  <% @subtopic_pages.each do |page| %>
+
+<% @subtopic_pages.each do |page| %>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%=page.name%></h2>
+  <ul class="govuk-list">
   <% if unreleased_feature_user? %>
-    <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name.downcase} '#{page.sections_title.downcase}' accordion", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name.downcase} accordions", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
   <% end %>
-    <li class="covid__spaced-list-item"><%= link_to "Publish #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
-  <% end %>
-</ul>
+    <li class="covid__spaced-list-item"><%= link_to "Edit something else on the #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
+  </ul>
+<% end %>

--- a/app/views/coronavirus_pages/prepare.html.erb
+++ b/app/views/coronavirus_pages/prepare.html.erb
@@ -1,5 +1,8 @@
-<% content_for :title, "Publish #{@coronavirus_page.name.downcase}" %>
-<% content_for :context, "https://www.gov.uk#{@coronavirus_page.base_path}" %>
+<% content_for :title, "Edit the #{@coronavirus_page.name}" %>
+<% content_for :context, "www.gov.uk#{@coronavirus_page.base_path}" %>
+<%= render "govuk_publishing_components/components/lead_paragraph", {
+  text: "Follow the steps below to make changes to any part of the #{@coronavirus_page.name}, except the accordions."
+} %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <%= render "coronavirus_pages/shared/github", github_url: @coronavirus_page.github_url %>

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -5,7 +5,7 @@
       href: coronavirus_pages_path
     },
     {
-      text: formatted_title(@coronavirus_page)
+      text: "#{@coronavirus_page.name} accordions"
     }
   ]
 
@@ -23,7 +23,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "sub_sections_summary_list" %>
     <%= render "govuk_publishing_components/components/button", {
-      text: "Add section",
+      text: "Add accordion",
       href: new_coronavirus_page_sub_section_path(@coronavirus_page.slug)
     } %>
   </div>

--- a/app/views/reorder_sub_sections/index.html.erb
+++ b/app/views/reorder_sub_sections/index.html.erb
@@ -1,4 +1,20 @@
-<% content_for :title, "Coronavirus (COVID-19)" %>
+<%
+  links = [
+    {
+      text: 'Coronavirus pages',
+      href: coronavirus_pages_path
+    },
+    {
+      text: "#{@coronavirus_page.name} accordions",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Reorder"
+    },
+  ]
+%>
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page)%>
 <% content_for :context, "Reorder #{@coronavirus_page.sections_title.downcase} accordion" %>
 
 <div class="covid-manage-page govuk-grid-row">

--- a/app/views/sub_sections/_form.html.erb
+++ b/app/views/sub_sections/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Section title",
+    text: "Accordion name",
     bold: true
   },
   name: "sub_section[title]",
@@ -9,7 +9,7 @@
 } %>
 <%= render "components/markdown_editor", {
   label: {
-    text: "Content and links",
+    text: "Links and link text",
     bold: true
   },
   textarea: {

--- a/app/views/sub_sections/edit.html.erb
+++ b/app/views/sub_sections/edit.html.erb
@@ -1,13 +1,17 @@
 <%
-  links = [
-    {
-      text: 'Coronavirus topic pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: "Coronavirus (COVID-19)"
-    }
-  ]
+links = [
+  {
+    text: 'Coronavirus pages',
+    href: coronavirus_pages_path
+  },
+  {
+    text: "#{@coronavirus_page.name} accordions",
+    href: coronavirus_page_path(slug: @coronavirus_page.slug)
+  },
+  {
+    text: "Edit"
+  },
+]
 
   metadata = {
     "Status" => "Draft",
@@ -16,7 +20,7 @@
 %>
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
-<% content_for :title, "Coronavirus (COVID-19)" %>
+<% content_for :title, @coronavirus_page.title %>
 <% content_for :context, 'Edit guidance and support accordion' %>
 <% if @sub_section.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @sub_section %>

--- a/app/views/sub_sections/new.html.erb
+++ b/app/views/sub_sections/new.html.erb
@@ -1,12 +1,16 @@
 <%
   links = [
     {
-      text: 'Coronavirus topic pages',
+      text: 'Coronavirus pages',
       href: coronavirus_pages_path
     },
     {
-      text: "Coronavirus (COVID-19)"
-    }
+      text: "#{@coronavirus_page.name} accordions",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Add accordion"
+    },
   ]
 
   metadata = {
@@ -16,8 +20,8 @@
 %>
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
-<% content_for :title, "Coronavirus (COVID-19)" %>
-<% content_for :context, 'Add guidance and support accordion' %>
+<% content_for :title, formatted_title(@coronavirus_page) %>
+<% content_for :context, "Add accordion" %>
 <% if @sub_section.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @sub_section %>
 <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -230,7 +230,7 @@ FactoryBot.define do
     raw_content_url { Faker::Internet.url(host: "example.com") }
     base_path { "/#{File.join(Faker::Lorem.words)}" }
 
-    slugs = %w[landing business education employees]
+    slugs = %w[landing business education workers]
 
     trait :of_known_type do
       slug { slugs.sample }

--- a/spec/models/coronavirus_page_spec.rb
+++ b/spec/models/coronavirus_page_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe CoronavirusPage do
     let!(:business) { create :coronavirus_page, :business }
     let!(:landing) { create :coronavirus_page, :landing }
     let!(:education) { create :coronavirus_page, :education }
-    let!(:employees) { create :coronavirus_page, :employees }
+    let!(:workers) { create :coronavirus_page, :workers }
 
     it "topic_page" do
       expect(CoronavirusPage.topic_page.first).to eq landing
     end
 
     it "sub_topics" do
-      expect(CoronavirusPage.subtopic_pages).to eq [business, education, employees]
+      expect(CoronavirusPage.subtopic_pages).to eq [business, education, workers]
     end
   end
 
@@ -35,11 +35,11 @@ RSpec.describe CoronavirusPage do
   end
 
   describe "dependencies" do
-    let!(:employees) { create :coronavirus_page, :employees }
-    let!(:sub_section) { create :sub_section, coronavirus_page: employees }
+    let!(:workers) { create :coronavirus_page, :workers }
+    let!(:sub_section) { create :sub_section, coronavirus_page: workers }
 
     it "deletion destroys all child subsections" do
-      expect { employees.destroy }.to change { SubSection.count }.by(-1)
+      expect { workers.destroy }.to change { SubSection.count }.by(-1)
     end
   end
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -118,27 +118,29 @@ def then_the_business_content_is_sent_to_publishing_api
 end
 
 def i_see_a_publish_landing_page_link
-  expect(page).to have_link("Publish coronavirus landing page")
+  expect(page).to have_link("Edit something else on the landing page")
 end
 
 def i_see_a_publish_business_page_link
-  expect(page).to have_link("Publish business support page")
+  expect(page).to have_link("Edit something else on the business hub")
 end
 
 def i_see_livestream_button
-  expect(page).to have_link("Update live stream")
+  expect(page).to have_link("Edit live stream URL")
 end
 
 def and_i_select_landing_page
-  click_link("Publish coronavirus landing page")
+  click_link("Edit something else on the landing page")
 end
 
 def and_i_select_business_page
-  click_link("Publish business support page")
+  within ".business" do
+    click_link("Edit something else on the business hub")
+  end
 end
 
 def and_i_select_live_stream
-  click_link("Update live stream")
+  click_link("Edit live stream URL")
   expect(page).to have_text("Update live stream URL")
 end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -134,9 +134,7 @@ def and_i_select_landing_page
 end
 
 def and_i_select_business_page
-  within ".business" do
-    click_link("Edit something else on the business hub")
-  end
+  click_link("Edit something else on the business hub")
 end
 
 def and_i_select_live_stream
@@ -222,7 +220,7 @@ end
 
 def stub_discard_coronavirus_page_no_draft
   stub_any_publishing_api_discard_draft
-    .to_return(status: 422, body: "There is not a draft edition of this document to discard")
+    .to_return(status: 422, body: "You do not have a draft to discard")
 end
 
 def i_see_subsection_one_in_position_one
@@ -289,7 +287,7 @@ def and_i_discard_my_changes
 end
 
 def i_see_error_message_no_changes_to_discard
-  expect(page).to have_text("There is not a draft edition of this document to discard")
+  expect(page).to have_text("You do not have a draft to discard")
 end
 
 def then_i_am_redirected_to_the_index_page


### PR DESCRIPTION
## What

Content designers on Coronavirus Content reviewed the tool and asked for changes to labelling and error message. Here is the [doc](https://docs.google.com/document/d/1aa-C5EEJwmI5bcJ50C26wu4rbW9Z4t8GJbzT7pmOAxI/edit) with requested changes.