### PR TITLE
Allow users to set a link as a "featured link" in an accordion

### DIFF
--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -50,7 +50,7 @@ class SubSectionsController < ApplicationController
 private
 
   def sub_section_params
-    params.require(:sub_section).permit(:title, :content)
+    params.require(:sub_section).permit(:title, :content, :featured_link)
   end
 
   def draft_updater

--- a/app/models/sub_section.rb
+++ b/app/models/sub_section.rb
@@ -2,4 +2,12 @@ class SubSection < ApplicationRecord
   belongs_to :coronavirus_page
   validates :title, :content, presence: true
   validates :coronavirus_page, presence: true
+
+  validate :featured_link_must_be_in_content
+
+  def featured_link_must_be_in_content
+    if featured_link.present? && !content.include?(featured_link)
+      errors.add(:featured_link, "does not exist in accordion content")
+    end
+  end
 end

--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -102,6 +102,9 @@ class SubSectionJsonPresenter
     if subtopic_paths.keys.include?(link[:url])
       link[:description] = description_from_raw_content(link[:url])
       link[:featured_link] = true
+    elsif @sub_section.featured_link == link[:url]
+      link[:description] = description_for_featured_link(link[:url])
+      link[:featured_link] = true
     end
     link
   end
@@ -110,6 +113,15 @@ class SubSectionJsonPresenter
     raw_content_url = subtopic_paths[url]
     raw_content = YamlFetcher.new(raw_content_url).body_as_hash
     raw_content.dig("content", "meta_description")
+  end
+
+  def description_for_featured_link(base_path)
+    content_item(base_path)["description"]
+  end
+
+  def content_item(base_path)
+    content_id = GdsApi.publishing_api.lookup_content_id(base_path: base_path)
+    GdsApi.publishing_api.get_content(content_id)
   end
 
   def subtopic_paths

--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -28,6 +28,12 @@ class SubSectionJsonPresenter
         title: title,
         sub_sections: sub_sections,
       }
+
+    if @sub_section.featured_link.present? && !link_set_as_featured?
+      errors << "Featured link does not exist in accordion content"
+    end
+
+    @output
   end
 
   def errors
@@ -41,6 +47,14 @@ class SubSectionJsonPresenter
 
   def sub_sections
     content_groups.map { |content_group| sub_section_hash_from_content_group(content_group) }
+  end
+
+  def link_set_as_featured?
+    featured_links = @output[:sub_sections].flat_map do |section|
+      section[:list].map { |item| item[:featured_link] }
+    end
+
+    featured_links.any?
   end
 
   # Groups the sub section content into an array of arrays, such that:

--- a/app/services/coronavirus_pages/sections_presenter.rb
+++ b/app/services/coronavirus_pages/sections_presenter.rb
@@ -12,9 +12,12 @@ module CoronavirusPages
     end
 
     def converter(hash)
+      sub_section_data = SubSectionProcessor.call(hash["sub_sections"])
+
       {
         "title": hash["title"],
-        "content": SubSectionProcessor.call(hash["sub_sections"]),
+        "content": sub_section_data[:content],
+        "featured_link": sub_section_data[:featured_link],
       }
     end
   end

--- a/app/services/coronavirus_pages/sub_section_processor.rb
+++ b/app/services/coronavirus_pages/sub_section_processor.rb
@@ -4,15 +4,19 @@ module CoronavirusPages
       new(*args).output
     end
 
-    attr_reader :sub_sections
+    attr_reader :sub_sections, :featured_link
 
     def initialize(sub_sections)
       @sub_sections = [sub_sections].flatten
+      @featured_link = nil
     end
 
     def output
       process
-      output_array.join("\n")
+      {
+        content: output_array.join("\n"),
+        featured_link: featured_link,
+      }
     end
 
     def output_array
@@ -23,11 +27,16 @@ module CoronavirusPages
       output_array << text
     end
 
+    def add_featured_link(url)
+      @featured_link = url
+    end
+
     def process
       sub_sections.each do |sub_section|
         add_string("####{sub_section['title']}") if sub_section["title"].present?
         sub_section["list"].each do |item|
           add_string "[#{item['label']}](#{item['url']})"
+          add_featured_link(item["url"]) if item["featured_link"]
         end
       end
     end

--- a/app/views/sub_sections/_form.html.erb
+++ b/app/views/sub_sections/_form.html.erb
@@ -20,6 +20,15 @@
   },
   hide_bullets_button: true
 } %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Featured link",
+    bold: true
+  },
+  name: "sub_section[featured_link]",
+  id: "title",
+  value: @sub_section.featured_link
+} %>
 <%= render "govuk_publishing_components/components/button", {
   text: "Save",
   margin_bottom: true

--- a/db/migrate/20200813094514_add_featured_link_to_sub_sections.rb
+++ b/db/migrate/20200813094514_add_featured_link_to_sub_sections.rb
@@ -1,0 +1,5 @@
+class AddFeaturedLinkToSubSections < ActiveRecord::Migration[6.0]
+  def change
+    add_column :sub_sections, :featured_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_201559) do
+ActiveRecord::Schema.define(version: 2020_08_13_094514) do
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sections_title"
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 2020_07_07_201559) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.string "featured_link"
     t.index ["coronavirus_page_id"], name: "index_sub_sections_on_coronavirus_page_id"
   end
 

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe SubSectionsController, type: :controller do
       let(:featured_link) { "/#{SecureRandom.urlsafe_base64}" }
 
       it "stores the featured link" do
+        content_id = SecureRandom.uuid
+        stub_publishing_api_has_item(base_path: featured_link, content_id: content_id)
+        stub_publishing_api_has_lookups(featured_link.to_s => content_id)
+
         content = "###{Faker::Lorem.sentence}\n[Link text](#{featured_link})"
         sub_section_params.merge!(content: content, featured_link: featured_link)
 

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -91,6 +91,16 @@ RSpec.describe SubSectionsController, type: :controller do
         sub_section = SubSection.last
         expect(sub_section.featured_link).to eq(featured_link)
       end
+
+      it "successfully renders error on edit page if featured link not in content" do
+        sub_section_params.merge!(featured_link: featured_link)
+        expect(subject).to have_http_status(:success)
+      end
+
+      it "displays the expected error if featured link not in content" do
+        sub_section_params.merge!(featured_link: featured_link)
+        expect(subject.body).to include("Featured link does not exist in accordion content")
+      end
     end
   end
 

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe SubSectionsController, type: :controller do
         expect(subject.body).to include("Unable to parse markdown:")
       end
     end
+
+    context "featured_links" do
+      let(:featured_link) { "/#{SecureRandom.urlsafe_base64}" }
+
+      it "stores the featured link" do
+        content = "###{Faker::Lorem.sentence}\n[Link text](#{featured_link})"
+        sub_section_params.merge!(content: content, featured_link: featured_link)
+
+        subject
+        sub_section = SubSection.last
+        expect(sub_section.featured_link).to eq(featured_link)
+      end
+    end
   end
 
   describe "GET /coronavirus/:coronavirus_page_slug/sub_sections/:id/edit" do

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -60,6 +60,40 @@ RSpec.describe SubSectionJsonPresenter do
         expect { subject.output }.to change { subject.errors.length }.by(1)
       end
     end
+
+    context "with featured links" do
+      it "sets a link as a featured link" do
+        sub_section.featured_link = path
+        description = Faker::Lorem.sentence
+
+        content_id = SecureRandom.uuid
+        stub_publishing_api_has_item(
+          base_path: path,
+          content_id: content_id,
+          description: description,
+        )
+        stub_publishing_api_has_lookups(path.to_s => content_id)
+
+        expected = {
+          title: subject.title,
+          sub_sections: [
+            {
+              list: [
+                {
+                  url: path,
+                  label: label,
+                  featured_link: true,
+                  description: description,
+                },
+              ],
+              title: title,
+            },
+          ],
+        }
+
+        expect(subject.output).to eq(expected)
+      end
+    end
   end
 
   describe "#sub_section_hash_from_content_group" do

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe SubSectionJsonPresenter do
 
         expect(subject.output).to eq(expected)
       end
+
+      it "has an error when content does not contain the featured link" do
+        featured_link = "/#{SecureRandom.urlsafe_base64}"
+        sub_section.featured_link = featured_link
+
+        expect { subject.output }.to change { subject.errors.length }.by(1)
+      end
     end
   end
 

--- a/spec/services/coronavirus_pages/sections_presenter_spec.rb
+++ b/spec/services/coronavirus_pages/sections_presenter_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe CoronavirusPages::SectionsPresenter do
               {
                 "label" => "Stay at home if you think you have coronavirus (self-isolating)",
                 "url" => " /government/publications/covid-19-stay-at-home-guidance",
+                "featured_link" => true,
+                "description" => Faker::Lorem.sentence,
               },
               {
                 "label" => "Stay alert and safe: social distancing guidance for everyone",
@@ -31,7 +33,7 @@ RSpec.describe CoronavirusPages::SectionsPresenter do
     it "produces an array of hashes" do
       expect(subject).to be_an(Array)
       expect(subject.first).to be_a(Hash)
-      expect(subject.first.keys).to contain_exactly(:title, :content)
+      expect(subject.first.keys).to contain_exactly(:title, :content, :featured_link)
     end
 
     it "parses the title" do
@@ -41,6 +43,10 @@ RSpec.describe CoronavirusPages::SectionsPresenter do
     it "parses the content" do
       expect(subject.first[:content]).to be_a(String)
       expect(subject.first[:content].lines.count).to eq 3
+    end
+
+    it "gets the featured link" do
+      expect(subject.first[:featured_link]).to be_a(String)
     end
   end
 end

--- a/spec/services/coronavirus_pages/sub_section_processor_spec.rb
+++ b/spec/services/coronavirus_pages/sub_section_processor_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe CoronavirusPages::SubSectionProcessor do
           {
             "label" => label,
             "url" => url,
+            "featured_link" => true,
+            "description" => Faker::Lorem.sentence,
           },
           {
             "label" => label_1,
@@ -26,7 +28,7 @@ RSpec.describe CoronavirusPages::SubSectionProcessor do
 
   describe ".call" do
     subject { described_class.call(data) }
-    let(:lines) { subject.split("\n") }
+    let(:lines) { subject[:content].split("\n") }
 
     it "creates the correct number of lines" do
       # 3 = 1 title plus 2 links
@@ -43,6 +45,10 @@ RSpec.describe CoronavirusPages::SubSectionProcessor do
 
     it "has the second link as the third line" do
       expect(lines.third).to eq "[#{label_1}](#{url_1})"
+    end
+
+    it "returns the featured link" do
+      expect(subject[:featured_link]).to eq(url)
     end
 
     context "with blank title" do


### PR DESCRIPTION
Trello: https://trello.com/c/7Li6NbQr

# What's changed?
Add an input field to the accordion page to allow users to mark one of the links featured in the content as a "featured" link. In the frontend application, links that have "featured_link" set to true automatically have special styling applied to them (the arrow head).
 
Add a "featured_link" attribute for a sub_section. This "featured_link" should contain the path to a page on GOV.UK. 
Also adds validations to make sure that the "featured_link" appears in the body content of the accordion.
Finally, the discard draft action has been updated to allow any changes to the featured link to be reverted with the rest of the draft changes.

# Why?
At the moment the featured link is generate automatically if a topic link is included in the accordion.

We need the ability to add "featured links" (ie with an arrow and meta description) to content links as well as hub page links. 

This is specifically important for the coronavirus testing page which is a quick answer guide format, and is currently only linked to in a standard link style. 

We want to emphasise this content in the accordion as the main starting point for users who want to find out more about testing and get routed to the right testing service for their situation.

# Expected changes
<img width="1552" alt="Screenshot 2020-08-17 at 14 24 47" src="https://user-images.githubusercontent.com/5793815/90401135-7079c980-e095-11ea-8155-1999d98b1fbb.png">
<img width="1532" alt="Screenshot 2020-08-14 at 12 43 38" src="https://user-images.githubusercontent.com/5793815/90399974-addd5780-e093-11ea-9b54-c396ce9155c5.png">
<img width="1532" alt="Screenshot 2020-08-14 at 12 44 13" src="https://user-images.githubusercontent.com/5793815/90399982-af0e8480-e093-11ea-897a-56c65ba74e58.png">
