### PR TITLE
Change /eubusiness to an exact route

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -24,7 +24,7 @@ class SpecialRoutePublisher
 
   def self.routes
     {
-      prefix: [
+      exact: [
         {
           document_type: "answer",
           content_id: "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",


### PR DESCRIPTION
[We're getting errors](https://sentry.io/organizations/govuk/issues/1884114207/?environment=production&project=202213&referrer=slack) because router is sending sub paths of /eubusiness to collections. We only have the /eubusiness page right now, so an exact route is the way to go.

I'll check about removing the prefix route once this is republished.

https://trello.com/c/aRd8ha9V/437-fix-app-error-in-collections