### PR TITLE
Add announcements table

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,5 @@
+class Announcement < ApplicationRecord
+  belongs_to :coronavirus_page
+  validates :text, :href, :published_at, presence: true
+  validates :coronavirus_page, presence: true
+end

--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -1,6 +1,7 @@
 class CoronavirusPage < ApplicationRecord
   STATUSES = %w[draft published].freeze
   has_many :sub_sections, dependent: :destroy
+  has_many :announcements, dependent: :destroy
   scope :topic_page, -> { where(slug: "landing") }
   scope :subtopic_pages, -> { where.not(slug: "landing") }
   validates :state, inclusion: { in: STATUSES }, presence: true

--- a/db/migrate/20200911084908_create_announcements.rb
+++ b/db/migrate/20200911084908_create_announcements.rb
@@ -1,0 +1,12 @@
+class CreateAnnouncements < ActiveRecord::Migration[6.0]
+  def change
+    create_table :announcements do |t|
+      t.bigint :coronavirus_page_id
+      t.string :text
+      t.string :href
+      t.datetime :published_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_13_094514) do
+ActiveRecord::Schema.define(version: 2020_09_11_084908) do
+
+  create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "coronavirus_page_id"
+    t.string "text"
+    t.string "href"
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "sections_title"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -253,4 +253,11 @@ FactoryBot.define do
       to_create { |instance| instance.save validate: false }
     end
   end
+
+  factory :announcement do
+    text { Faker::Lorem.words }
+    href { Faker::Internet.url(host: "example.com") }
+    published_at { Time.zone.local(2020, 9, 11) }
+    coronavirus_page
+  end
 end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Announcement, type: :model do
+  let(:announcement) { create :announcement }
+
+  describe "validations" do
+    it "should belong to a coronavirus_page" do
+      should validate_presence_of(:coronavirus_page)
+    end
+
+    it "fails if coronavirus_page does not exist" do
+      announcement.coronavirus_page = nil
+
+      expect(announcement).not_to be_valid
+    end
+
+    it "is created with valid attributes" do
+      expect(announcement).to be_valid
+      expect(announcement.save).to eql true
+      expect(announcement).to be_persisted
+    end
+
+    it "requires text" do
+      announcement.text = ""
+
+      expect(announcement).not_to be_valid
+      expect(announcement.errors).to have_key(:text)
+    end
+
+    it "requires an href" do
+      announcement.href = ""
+
+      expect(announcement).not_to be_valid
+      expect(announcement.errors).to have_key(:href)
+    end
+
+    it "requires a published at time" do
+      announcement.published_at = ""
+
+      expect(announcement).not_to be_valid
+      expect(announcement.errors).to have_key(:published_at)
+    end
+  end
+end


### PR DESCRIPTION
Adds announcements model and migration.
This is part of the work to make the /coronavirus announcements section
publishable solely via this application as opposed to editing the YAML
in Github.

Has basic validation to check presence of fields, will add further
validation in future PR when adding the form.

Co-authored-by: @Rosa-Fox

[Trello](https://trello.com/c/7sOyvOmE/797-create-announcements-table)