### PR TITLE
Superbreadcrumbs query parameters

### DIFF
--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -14,10 +14,11 @@ class SubSectionJsonPresenter
   )
   # Url pattern from https://stackoverflow.com/a/163684/1014251
 
-  attr_reader :sub_section
+  attr_reader :sub_section, :priority_taxon
 
-  def initialize(sub_section)
+  def initialize(sub_section, priority_taxon = nil)
     @sub_section = sub_section
+    @priority_taxon = priority_taxon
   end
 
   delegate :title, to: :sub_section
@@ -120,7 +121,7 @@ class SubSectionJsonPresenter
       link[:description] = description_for_featured_link(link[:url])
       link[:featured_link] = true
     end
-    link
+    append_priority_taxon_query_param(link)
   end
 
   def description_from_raw_content(url)
@@ -140,5 +141,16 @@ class SubSectionJsonPresenter
 
   def subtopic_paths
     @subtopic_paths ||= CoronavirusPage.subtopic_pages.pluck(:base_path, :raw_content_url).to_h
+  end
+
+  def append_priority_taxon_query_param(link)
+    return link if priority_taxon.blank?
+
+    uri = Addressable::URI.parse(link[:url])
+    query_params = { "priority-taxon" => priority_taxon }
+
+    uri.query_values = (uri.query_values || {}).merge(query_params)
+    link[:url] = uri.to_s
+    link
   end
 end

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -79,7 +79,7 @@ class CoronavirusPages::ContentBuilder
 
   def sub_sections_data
     coronavirus_page.sub_sections.order(:position).map do |sub_section|
-      presenter = SubSectionJsonPresenter.new(sub_section)
+      presenter = SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id)
       add_error(presenter.errors) unless presenter.success?
       presenter.output
     end

--- a/app/services/coronavirus_pages/sub_section_processor.rb
+++ b/app/services/coronavirus_pages/sub_section_processor.rb
@@ -35,10 +35,16 @@ module CoronavirusPages
       sub_sections.each do |sub_section|
         add_string("####{sub_section['title']}") if sub_section["title"].present?
         sub_section["list"].each do |item|
-          add_string "[#{item['label']}](#{item['url']})"
+          add_string "[#{item['label']}](#{remove_priority_taxon_param(item['url'])})"
           add_featured_link(item["url"]) if item["featured_link"]
         end
       end
+    end
+
+    def remove_priority_taxon_param(url)
+      uri = Addressable::URI.parse(url)
+      uri.query_values = uri.query_values&.except("priority-taxon")
+      uri.normalize.to_s
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -241,7 +241,7 @@ FactoryBot.define do
 
   factory :sub_section do
     title { Faker::Lorem.sentence }
-    content { "[#{Faker::Lorem.sentence}](/#{File.join(Faker::Lorem.words)})" }
+    content { "[#{Faker::Lorem.sentence}](/#{File.join(Faker::Lorem.words)}?priority-taxon=#{coronavirus_page.content_id})" }
     position { (SubSection.maximum(:position) || 0) + 1 }
     coronavirus_page
   end

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -9,7 +9,7 @@
           {
             "list": [
               {
-                "url": "/government/publications/covid-19-stay-at-home-guidance",
+                "url": "/government/publications/covid-19-stay-at-home-guidance?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae",
                 "label": "Stay at home if you think you have coronavirus (self-isolating)"
               }
             ]
@@ -22,7 +22,7 @@
           {
             "list": [
               {
-                "url": "/get-coronavirus-test",
+                "url": "/get-coronavirus-test?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae",
                 "label": "Get a test to check if you have coronavirus"
               }
             ]
@@ -35,7 +35,7 @@
           {
             "list": [
               {
-                "url": "/guidance/blackburn-with-darwen-local-restrictions",
+                "url": "/guidance/blackburn-with-darwen-local-restrictions?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae",
                 "label": "Blackburn with Darwen: local restrictions"
               }
             ]

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
   let(:coronavirus_page) { create :coronavirus_page, :landing }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
-  let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section).output }
+  let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id).output }
   let!(:live_stream) { create :live_stream, :without_validations }
 
   subject { described_class.new(coronavirus_page) }

--- a/spec/services/coronavirus_pages/model_builder_spec.rb
+++ b/spec/services/coronavirus_pages/model_builder_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe CoronavirusPages::ModelBuilder do
       expect(coronavirus_page.sub_sections.first.title).to eq live_title
     end
 
+    it "removes any priority-taxons query parameters from the live content" do
+      expect(live_content_item["details"]["sections"].first["sub_sections"].first["list"].first["url"]).to eq "/government/publications/covid-19-stay-at-home-guidance?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae"
+      discard_changes
+      expect(coronavirus_page.sub_sections.first.content).to include "(/government/publications/covid-19-stay-at-home-guidance)"
+      expect(coronavirus_page.sub_sections.first.content).not_to include "priority-taxon"
+    end
+
     it "creates sub_sections with a position that reflects their order in the content item" do
       discard_changes
       input_order = live_sections.pluck("title").each_with_index.to_h.invert

--- a/spec/services/coronavirus_pages/sub_section_processor_spec.rb
+++ b/spec/services/coronavirus_pages/sub_section_processor_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CoronavirusPages::SubSectionProcessor do
   let(:label) { Faker::Lorem.sentence }
   let(:url) { "/#{File.join(Faker::Lorem.words)}" }
   let(:label_1) { Faker::Lorem.sentence }
-  let(:url_1) { "/#{File.join(Faker::Lorem.words)}" }
+  let(:url_1) { "/#{File.join(Faker::Lorem.words)}?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae" }
   let(:data) do
     [
       {
@@ -43,8 +43,8 @@ RSpec.describe CoronavirusPages::SubSectionProcessor do
       expect(lines.second).to eq "[#{label}](#{url})"
     end
 
-    it "has the second link as the third line" do
-      expect(lines.third).to eq "[#{label_1}](#{url_1})"
+    it "removes any priority-taxons query parameters from the url" do
+      expect(lines.third).to eq "[#{label_1}](#{url_1.gsub('?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae', '')})"
     end
 
     it "returns the featured link" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -204,12 +204,12 @@ def set_up_basic_sub_sections
                     coronavirus_page_id: coronavirus_page.id,
                     position: 0,
                     title: "I am first",
-                    content: "###title\n[label](/url)")
+                    content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
   FactoryBot.create(:sub_section,
                     coronavirus_page_id: coronavirus_page.id,
                     position: 1,
                     title: "I am second",
-                    content: "###title\n[label](/url)")
+                    content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
   path = Rails.root.join "spec/fixtures/simple_coronavirus_page.yml"
   github_yaml_content = File.read(path)
   stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
@@ -217,14 +217,13 @@ def set_up_basic_sub_sections
   stub_live_sub_sections_content_request(coronavirus_page.content_id)
 end
 
-def coronavirus_content_json_with_sections
+def coronavirus_content_json_with_sections(content_id)
   path = Rails.root.join("spec/fixtures/coronavirus_page_sections.json")
-  JSON.parse(File.read(path))
+  JSON.parse(File.read(path).gsub("774cee22-d896-44c1-a611-e3109cce8eae", content_id))
 end
 
 def stub_live_sub_sections_content_request(content_id)
-  content = coronavirus_content_json_with_sections
-  content["content_id"] = content_id
+  content = coronavirus_content_json_with_sections(content_id)
   stub_publishing_api_has_item(content)
 end
 
@@ -253,7 +252,7 @@ def and_i_move_section_one_down
 end
 
 def then_the_reordered_subsections_are_sent_to_publishing_api
-  section = { "title" => "title", "list" => [{ "label" => "label", "url" => "/url" }] }
+  section = { "title" => "title", "list" => [{ "label" => "label", "url" => "/url?priority-taxon=#{CoronavirusPage.topic_page.first.content_id}" }] }
   reordered_sections = [
     {
       "title" => "I am second",


### PR DESCRIPTION
Update the payload for publishing-api by adding the preferred content-id as a query parameter "priority-taxon"

This is needed as there are cases where the content can be referenced from multiple places, so we want to be able to trace back to the content they linked from. Using the query parameter we can tell the superbreadcrumb which content it should link back to.

https://trello.com/c/Kdnp9TPC/761-spike-conditional-super-breadcrumb-based-on-which-hub-a-user-has-come-from