### PR TITLE
Index timeline content in search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "6.0.3.3"
 
 gem "aasm"
 gem "generic_form_builder"
+gem "kramdown"
 gem "mysql2"
 gem "sass-rails"
 gem "select2-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,6 +442,7 @@ DEPENDENCIES
   govuk_test
   jasmine
   jasmine_selenium_runner
+  kramdown
   mail-notify
   mysql2
   nokogiri

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -100,7 +100,7 @@ class CoronavirusPages::ContentBuilder
   end
 
   def hidden_search_terms
-    search_terms_in_sections
+    search_terms_in_sections + search_terms_in_timeline
   end
 
   def search_terms_in_sections
@@ -119,5 +119,18 @@ class CoronavirusPages::ContentBuilder
 
       [subsection[:title], labels]
     end
+  end
+
+  def search_terms_in_timeline
+    return [] if github_data["timeline"].blank?
+
+    timeline = github_data["timeline"]["list"].map do |item|
+      [
+        item["heading"],
+        MarkdownService.new.strip_markdown(item["paragraph"]),
+      ]
+    end
+
+    timeline.flatten.select(&:present?).uniq
   end
 end

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -100,6 +100,10 @@ class CoronavirusPages::ContentBuilder
   end
 
   def hidden_search_terms
+    search_terms_in_sections
+  end
+
+  def search_terms_in_sections
     sections = sub_sections_data.map do |section|
       [section[:title], search_terms_in_sub_sections(section[:sub_sections])]
     end

--- a/app/services/markdown_service.rb
+++ b/app/services/markdown_service.rb
@@ -1,0 +1,10 @@
+require "action_view"
+
+class MarkdownService
+  include ActionView::Helpers::SanitizeHelper
+
+  def strip_markdown(content)
+    document = Kramdown::Document.new(content)
+    strip_tags(document.to_html).squish
+  end
+end

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -68,3 +68,12 @@ content:
   notifications:
     intro: "Stay up to date with GOV.UK"
     email_link: "Sign up to get emails when we change any coronavirus information on the GOV.UK website"
+  timeline:
+    heading: Recent and upcoming changes
+    list:
+      - heading: 18 September
+        paragraph: |
+          If you live, work or travel in the North East, you need to [follow different covid rules](/guidance/north-east-of-england-local-restrictions)
+      - heading: 15 September
+        paragraph: |
+          If you live, work or visit Bolton, you need to [follow different covid rules](/guidance/bolton-local-restrictions)

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -29,19 +29,23 @@ RSpec.describe CoronavirusPages::ContentBuilder do
       )
     end
 
+    let(:data) { github_content["content"] }
+
     let(:hidden_search_terms) do
       [
         sub_section_json[:title],
         sub_section_json[:sub_sections].first[:list].first[:label],
+        data["timeline"]["list"].first["heading"],
+        MarkdownService.new.strip_markdown(data["timeline"]["list"].first["paragraph"]),
+        data["timeline"]["list"].last["heading"],
+        MarkdownService.new.strip_markdown(data["timeline"]["list"].last["paragraph"]),
       ]
     end
 
-    let(:data) do
-      data = github_content["content"]
+    before do
       data["sections"] = [sub_section_json]
       data["live_stream"] = live_stream_data
       data["hidden_search_terms"] = hidden_search_terms
-      data
     end
 
     it "returns github and model data" do

--- a/spec/services/markdown_service_spec.rb
+++ b/spec/services/markdown_service_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe MarkdownService do
+  describe "#strip_markdown" do
+    it "removes markdown from link" do
+      content = "Here is a [link to something](/foo) and here is a [link to something else](/bar)"
+      expected = "Here is a link to something and here is a link to something else"
+
+      expect(described_class.new.strip_markdown(content)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/jdBmdPef
Follows on from: PR #1128 

# What?

Allow users to find the landing page by searching for timeline content in the GOV.UK site search.

# Why?

At the moment only the content in the accordions on the landing and hub pages are being indexed in search.

It's likely that the content that appears in the timeline might not be repeated anywhere else on GOV.UK, so we need to give users a way to find it.

# Expected changes
## Content item
<img width="1532" alt="Screenshot 2020-09-24 at 08 55 23" src="https://user-images.githubusercontent.com/5793815/94119471-dd2b7500-fe46-11ea-925d-7a7bc512e04d.png">

## Search data
<img width="1532" alt="Screenshot 2020-09-24 at 08 59 26" src="https://user-images.githubusercontent.com/5793815/94119424-d0a71c80-fe46-11ea-8400-5b43e0189b13.png">

The landing and page will need to be republished for these changes to  take effect.