### PR TITLE
Remove redundant GDS SSO initialiser

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,6 +1,0 @@
-GDS::SSO.config do |config|
-  config.user_model = "User"
-  config.oauth_id = ENV["OAUTH_ID"] || "abcdefg"
-  config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.new.external_url_for("signon")
-end


### PR DESCRIPTION
This file is no longer required as the latest release of the gds-sso gem sets these defaults itself ref: alphagov/gds-sso#241