### PR TITLE
Add a reorder page for announcements

### DIFF
--- a/app/controllers/reorder_announcements_controller.rb
+++ b/app/controllers/reorder_announcements_controller.rb
@@ -1,0 +1,20 @@
+class ReorderAnnouncementsController < ApplicationController
+  before_action :require_coronavirus_editor_permissions!
+  layout "admin_layout"
+
+  def index
+    coronavirus_page
+  end
+
+  def update; end
+
+private
+
+  def slug
+    params[:slug] || params[:coronavirus_page_slug]
+  end
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPages::ModelBuilder.call(slug)
+  end
+end

--- a/app/controllers/reorder_announcements_controller.rb
+++ b/app/controllers/reorder_announcements_controller.rb
@@ -6,7 +6,20 @@ class ReorderAnnouncementsController < ApplicationController
     coronavirus_page
   end
 
-  def update; end
+  def update
+    reordered_announcements = JSON.parse(params[:announcement_order_save])
+    reordered_announcements.each do |announcement_data|
+      announcement = coronavirus_page.announcements.find(announcement_data["id"])
+      announcement.update!(position: announcement_data["position"])
+    end
+
+    if draft_updater.send
+      redirect_to coronavirus_page_path(slug), notice: "Announcements were successfully reordered."
+    else
+      message = "Sorry! Announcements have not been reordered: #{draft_updater.errors.to_sentence}."
+      redirect_to reorder_coronavirus_page_announcements_path(slug), alert: message
+    end
+  end
 
 private
 
@@ -16,5 +29,9 @@ private
 
   def coronavirus_page
     @coronavirus_page ||= CoronavirusPages::ModelBuilder.call(slug)
+  end
+
+  def draft_updater
+    @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
   end
 end

--- a/app/controllers/reorder_announcements_controller.rb
+++ b/app/controllers/reorder_announcements_controller.rb
@@ -1,4 +1,5 @@
 class ReorderAnnouncementsController < ApplicationController
+  before_action :require_unreleased_feature_permissions!
   before_action :require_coronavirus_editor_permissions!
   layout "admin_layout"
 

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -2,4 +2,11 @@ class Announcement < ApplicationRecord
   belongs_to :coronavirus_page
   validates :text, :href, :published_at, presence: true
   validates :coronavirus_page, presence: true
+  after_create :set_position
+
+private
+
+  def set_position
+    update!(position: coronavirus_page.announcements.count)
+  end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -3,10 +3,15 @@ class Announcement < ApplicationRecord
   validates :text, :href, :published_at, presence: true
   validates :coronavirus_page, presence: true
   after_create :set_position
+  after_destroy :set_parent_positions
 
 private
 
   def set_position
     update!(position: coronavirus_page.announcements.count)
+  end
+
+  def set_parent_positions
+    coronavirus_page.make_announcement_positions_sequential
   end
 end

--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -9,4 +9,10 @@ class CoronavirusPage < ApplicationRecord
   def topic_page?
     slug == "landing"
   end
+
+  def make_announcement_positions_sequential
+    announcements.sort_by(&:position).each.with_index(1) do |announcement, index|
+      announcement.update!(position: index)
+    end
+  end
 end

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -20,7 +20,7 @@
     items: announcements,
     edit: {
       link_text: "Reorder",
-      href: coronavirus_page_path(@coronavirus_page.slug)
+      href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug)
     }
   } %>
 

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -1,5 +1,5 @@
 <% announcements =
- @coronavirus_page.announcements.map do |announcement|
+ @coronavirus_page.announcements.order(:position).map do |announcement|
    {
      id: announcement.id,
      field: announcement.text,

--- a/app/views/reorder_announcements/_reorder_list.html.erb
+++ b/app/views/reorder_announcements/_reorder_list.html.erb
@@ -1,0 +1,17 @@
+<% announcements = @coronavirus_page.announcements.order(:position) %>
+
+<div class="covid-manage-page__accordion-summary-list">
+  <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
+    <% announcements.each_with_index do |announcement, index| %>
+      <li class="js-reorder" data-id="<%= announcement.id %>">
+        <div class="govuk-grid-row" id="step-<%= index %>">
+          <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
+            <%= announcement.text %>
+          </div>
+          <div class="govuk-grid-column-one-quarter js-order-controls">
+          </div>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/reorder_announcements/index.html.erb
+++ b/app/views/reorder_announcements/index.html.erb
@@ -1,0 +1,36 @@
+<%
+  links = [
+    {
+      text: 'Coronavirus pages',
+      href: coronavirus_pages_path
+    },
+    {
+      text: "#{@coronavirus_page.name}",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Reorder announcements"
+    },
+  ]
+%>
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page)%>
+<% content_for :context, "Reorder announcements" %>
+
+<div class="covid-manage-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_markdown "Use the up/down buttons on the right to reorder the announcements, or click and hold on a section to reorder using drag and drop." %>
+
+    <%= form_for(@coronavirus_page, url: reorder_coronavirus_page_announcements_path, method: :put) do |form| %>
+      <input type="hidden" name="announcement_order_save" id="js_order_save" value="" />
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save"
+          } %>
+          <%= link_to 'Cancel', coronavirus_page_path(@coronavirus_page.slug), class: "govuk-link govuk-button" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reorder_announcements/index.html.erb
+++ b/app/views/reorder_announcements/index.html.erb
@@ -20,6 +20,7 @@
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown "Use the up/down buttons on the right to reorder the announcements, or click and hold on a section to reorder using drag and drop." %>
+    <%= render "reorder_list" %>
 
     <%= form_for(@coronavirus_page, url: reorder_coronavirus_page_announcements_path, method: :put) do |form| %>
       <input type="hidden" name="announcement_order_save" id="js_order_save" value="" />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,13 @@ Rails.application.routes.draw do
         put "reorder", to: "reorder_sub_sections#update"
       end
     end
+
+    resources :announcements do
+      collection do
+        get "reorder", to: "reorder_announcements#index"
+        put "reorder", to: "reorder_announcements#update"
+      end
+    end
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/db/migrate/20200925123542_add_position_to_announcements.rb
+++ b/db/migrate/20200925123542_add_position_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddPositionToAnnouncements < ActiveRecord::Migration[6.0]
+  def change
+    add_column :announcements, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_11_084908) do
+ActiveRecord::Schema.define(version: 2020_09_25_123542) do
 
   create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_09_11_084908) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position"
   end
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/controllers/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/reorder_announcements_controller_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe ReorderAnnouncementsController, type: :controller do
+  let(:coronavirus_page) { create(:coronavirus_page) }
+  let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
+
+  describe "Coronavirus reorder announcements page" do
+    it "can only be accessed by users with Coronavirus editor permissions" do
+      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "cannot be accessed by users without Coronavirus editor permissions" do
+      stub_user.permissions = %w[signin]
+      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/controllers/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/reorder_announcements_controller_spec.rb
@@ -5,12 +5,20 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
 
   describe "GET Coronavirus reorder announcements page" do
-    it "can only be accessed by users with Coronavirus editor permissions" do
+    it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
+      stub_user.permissions << "Unreleased feature"
+
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
       expect(response).to have_http_status(:success)
     end
 
-    it "cannot be accessed by users without Coronavirus editor permissions" do
+    it "cannot be accessed by users with only Coronavirus editor permissions" do
+      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response.status).to eq(403)
+    end
+
+    it "cannot be accessed by users without Coronavirus editor and Unreleased feature permissions" do
       stub_user.permissions = %w[signin]
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
 
@@ -25,6 +33,7 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
     before do
       setup_github_data
       stub_coronavirus_publishing_api
+      stub_user.permissions << "Unreleased feature"
     end
 
     it "reorders the announcements" do

--- a/spec/controllers/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/reorder_announcements_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
   let(:coronavirus_page) { create(:coronavirus_page) }
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
 
-  describe "Coronavirus reorder announcements page" do
+  describe "GET Coronavirus reorder announcements page" do
     it "can only be accessed by users with Coronavirus editor permissions" do
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
       expect(response).to have_http_status(:success)
@@ -16,5 +16,89 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
 
       expect(response.status).to eq(403)
     end
+  end
+
+  describe "PUT Coronavirus reorder announcements page" do
+    let(:announcement) { create(:announcement, position: 0, coronavirus_page: coronavirus_page) }
+    let(:another_announcement) { create(:announcement, position: 1, coronavirus_page: coronavirus_page) }
+
+    before do
+      setup_github_data
+      stub_coronavirus_publishing_api
+    end
+
+    it "reorders the announcements" do
+      announcement_params = [
+        {
+          id: announcement.id,
+          position: 1,
+        },
+        {
+          id: another_announcement.id,
+          position: 0,
+        },
+      ]
+
+      put :update, params: {
+        coronavirus_page_slug: coronavirus_page.slug,
+        announcement_order_save: announcement_params.to_json,
+      }
+
+      expect(announcement.reload.position).to eq 1
+      expect(another_announcement.reload.position).to eq 0
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+
+    it "keeps the existing order if submitted without changes" do
+      announcement_params = [
+        {
+          id: announcement.id,
+          position: 0,
+        },
+        {
+          id: another_announcement.id,
+          position: 1,
+        },
+      ]
+
+      put :update, params: {
+        coronavirus_page_slug: coronavirus_page.slug,
+        announcement_order_save: announcement_params.to_json,
+      }
+
+      expect(announcement.reload.position).to eq 0
+      expect(another_announcement.reload.position).to eq 1
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+
+    it "keeps the new ordering if updating the draft fails" do
+      stub_publishing_api_isnt_available
+
+      announcement_params = [
+        {
+          id: announcement.id,
+          position: 1,
+        },
+        {
+          id: another_announcement.id,
+          position: 0,
+        },
+      ]
+
+      put :update, params: {
+        coronavirus_page_slug: coronavirus_page.slug,
+        announcement_order_save: announcement_params.to_json,
+      }
+
+      expect(announcement.reload.position).to eq 1
+      expect(another_announcement.reload.position).to eq 0
+      expect(subject).to redirect_to(reorder_coronavirus_page_announcements_path(coronavirus_page.slug))
+    end
+  end
+
+  def setup_github_data
+    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -113,6 +113,16 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         then_i_can_see_an_announcements_section
         and_i_can_see_existing_announcements
       end
+
+      scenario "Reordering announcements", js: true do
+        given_i_can_access_unreleased_features
+        given_there_is_coronavirus_page_with_announcements
+        when_i_visit_the_reorder_announcements_page
+        then_i_see_the_announcements_in_order
+        when_i_move_announcement_one_down
+        then_i_see_announcement_updated_message
+        and_i_see_the_announcements_have_changed_order
+      end
     end
 
     context "Business page" do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -59,5 +59,25 @@ RSpec.describe Announcement, type: :model do
       announcement = create(:announcement, coronavirus_page: coronavirus_page)
       expect(announcement.position).to eq 2
     end
+
+    it "should update announcement positions when an announcement is deleted" do
+      coronavirus_page = create(:coronavirus_page)
+      create(:announcement, coronavirus_page: coronavirus_page)
+      create(:announcement, coronavirus_page: coronavirus_page)
+      expect(coronavirus_page.announcements.count).to eq 2
+
+      original_announcement_one = coronavirus_page.announcements.first
+      original_announcement_two = coronavirus_page.announcements.last
+      expect(original_announcement_one.position).to eq 1
+      expect(original_announcement_two.position).to eq 2
+
+      original_announcement_one.destroy!
+      coronavirus_page.reload
+      original_announcement_two.reload
+
+      expect(original_announcement_two.position).to eq 1
+      expect(coronavirus_page.announcements.first).to eq original_announcement_two
+      expect(coronavirus_page.announcements.count).to eq 1
+    end
   end
 end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -41,4 +41,23 @@ RSpec.describe Announcement, type: :model do
       expect(announcement.errors).to have_key(:published_at)
     end
   end
+
+  describe "position" do
+    it "should default to position 1 if it is the first announcement to have been added" do
+      coronavirus_page = create(:coronavirus_page)
+      expect(coronavirus_page.announcements.count).to eq 0
+
+      announcement = create(:announcement, coronavirus_page: coronavirus_page)
+      expect(announcement.position).to eq 1
+    end
+
+    it "should increment if there are existing announcements" do
+      coronavirus_page = create(:coronavirus_page)
+      create(:announcement, coronavirus_page: coronavirus_page)
+      expect(coronavirus_page.announcements.count).to eq 1
+
+      announcement = create(:announcement, coronavirus_page: coronavirus_page)
+      expect(announcement.position).to eq 2
+    end
+  end
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -186,7 +186,7 @@ end
 
 def then_i_can_see_an_announcements_section
   expect(page).to have_content("Announcements")
-  expect(page).to have_link("Reorder", href: coronavirus_page_path(@coronavirus_page.slug))
+  expect(page).to have_link("Reorder", href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug))
   expect(page).to have_link("Add announcement")
 end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -13,7 +13,8 @@ end
 
 def given_there_is_coronavirus_page_with_announcements
   @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
-  @announcement = FactoryBot.create(:announcement, coronavirus_page: @coronavirus_page)
+  @announcement_one = FactoryBot.create(:announcement, position: 0, coronavirus_page: @coronavirus_page)
+  @announcement_two = FactoryBot.create(:announcement, position: 1, coronavirus_page: @coronavirus_page)
 end
 
 def the_payload_contains_the_valid_url
@@ -184,6 +185,10 @@ def when_i_visit_the_reorder_page
   visit "/coronavirus/landing/sub_sections/reorder"
 end
 
+def when_i_visit_the_reorder_announcements_page
+  visit "/coronavirus/landing/announcements/reorder"
+end
+
 def then_i_can_see_an_announcements_section
   expect(page).to have_content("Announcements")
   expect(page).to have_link("Reorder", href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug))
@@ -195,7 +200,34 @@ def then_i_cannot_see_an_announcements_section
 end
 
 def and_i_can_see_existing_announcements
-  expect(page).to have_content(@announcement.text)
+  expect(page).to have_content(@announcement_one.text)
+  expect(page).to have_content(@announcement_two.text)
+end
+
+def then_i_see_the_announcements_in_order
+  element = find("#step-0").find(".step-by-step-reorder__step-title")
+  expect(element).to have_content @announcement_one.text
+
+  element = find("#step-1").find(".step-by-step-reorder__step-title")
+  expect(element).to have_content @announcement_two.text
+end
+
+def when_i_move_announcement_one_down
+  raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+  stub_request(:get, /#{@coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+    .to_return(status: 200, body: raw_content)
+
+  find("#step-0").find(".js-order-controls").find(".js-down").click
+  click_button "Save"
+end
+
+def then_i_see_announcement_updated_message
+  expect(page).to have_content "Announcements were successfully reordered."
+end
+
+def and_i_see_the_announcements_have_changed_order
+  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(1)", text: @announcement_two.text)
+  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.text)
 end
 
 def set_up_basic_sub_sections


### PR DESCRIPTION
Trello: https://trello.com/c/LgmLXbqZ

# What?

Allow users to reorder announcements in the Announcements section of the Coronavirus landing page.

# Expected changes
<img width="1532" alt="Screenshot 2020-11-05 at 16 24 44" src="https://user-images.githubusercontent.com/5793815/98267772-a7b89200-1f83-11eb-9d0b-f8da1bf487fa.png">
<img width="1532" alt="Screenshot 2020-11-05 at 16 25 08" src="https://user-images.githubusercontent.com/5793815/98267765-a6876500-1f83-11eb-9272-f4e2f28af80b.png">

# Note to Reviewer

The work to update publishing-api with the new order will be done in a separate commit.

