### PR TITLE
Sync announcements from govuk-coronavirus-content to collections-publisher

### DIFF
--- a/app/services/coronavirus_pages/announcements_builder.rb
+++ b/app/services/coronavirus_pages/announcements_builder.rb
@@ -1,0 +1,24 @@
+class CoronavirusPages::AnnouncementsBuilder
+  def create_announcements
+    Announcement.transaction do
+      announcements_from_yaml.each do |announcement|
+        coronavirus_page.announcements.create!(
+          text: announcement["text"],
+          href: announcement["href"],
+          published_at: Date.parse(announcement["published_text"]),
+        )
+      end
+    end
+  end
+
+private
+
+  def announcements_from_yaml
+    github_data = YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
+    github_data["content"]["announcements"]
+  end
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPage.find_by(slug: "landing")
+  end
+end

--- a/app/services/coronavirus_pages/announcements_builder.rb
+++ b/app/services/coronavirus_pages/announcements_builder.rb
@@ -1,14 +1,16 @@
 class CoronavirusPages::AnnouncementsBuilder
   def create_announcements
-    Announcement.transaction do
-      coronavirus_page.announcements.delete_all
+    if announcements_from_yaml.any?
+      Announcement.transaction do
+        coronavirus_page.announcements.delete_all
 
-      announcements_from_yaml.each do |announcement|
-        coronavirus_page.announcements.create!(
-          text: announcement["text"],
-          href: announcement["href"],
-          published_at: Date.parse(announcement["published_text"]),
-        )
+        announcements_from_yaml.each do |announcement|
+          coronavirus_page.announcements.create!(
+            text: announcement["text"],
+            href: announcement["href"],
+            published_at: Date.parse(announcement["published_text"]),
+          )
+        end
       end
     end
   end
@@ -16,8 +18,8 @@ class CoronavirusPages::AnnouncementsBuilder
 private
 
   def announcements_from_yaml
-    github_data = YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
-    github_data["content"]["announcements"]
+    @github_data ||= YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
+    @github_data["content"]["announcements"]
   end
 
   def coronavirus_page

--- a/app/services/coronavirus_pages/announcements_builder.rb
+++ b/app/services/coronavirus_pages/announcements_builder.rb
@@ -1,6 +1,8 @@
 class CoronavirusPages::AnnouncementsBuilder
   def create_announcements
     Announcement.transaction do
+      coronavirus_page.announcements.delete_all
+
       announcements_from_yaml.each do |announcement|
         coronavirus_page.announcements.create!(
           text: announcement["text"],

--- a/lib/tasks/coronavirus.rake
+++ b/lib/tasks/coronavirus.rake
@@ -23,4 +23,11 @@ namespace :coronavirus do
     puts "title: #{page.title}"
     puts "sections_title: #{page.sections_title}"
   end
+
+  desc "Sync announcements with entries in the yaml file"
+  task sync_announcements: :environment do
+    CoronavirusPages::AnnouncementsBuilder.new.create_announcements
+
+    puts "Announcements synced for coronavirus landing page..."
+  end
 end

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -15,10 +15,13 @@ content:
   announcements:
     - text: You must stay at home apart from essential travel or you may be fined
       href: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
+      published_text: Published 5 November 2020
     - text: If you live in the UK and are currently abroad you are strongly advised to return now
       href: /guidance/travel-advice-novel-coronavirus
+      published_text: Published 4 November 2020
     - text: All non-essential shops and community spaces are closed
       href: /government/publications/further-businesses-and-premises-to-close
+      published_text: Published 3 November 2020
   nhs_banner:
     heading: "Do not leave home if you or someone you live with has either:"
     list:

--- a/spec/services/coronavirus_pages/announcements_builder_spec.rb
+++ b/spec/services/coronavirus_pages/announcements_builder_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe CoronavirusPages::AnnouncementsBuilder do
     expect(first_announcement.published_at).to eq(Date.parse(github_announcement["published_text"]))
   end
 
+  it "removes existing announcements before creating new ones" do
+    create(:announcement, coronavirus_page: coronavirus_page)
+    create(:announcement, coronavirus_page: coronavirus_page)
+
+    described_class.new.create_announcements
+
+    expect(coronavirus_page.announcements.count).to eq(3)
+  end
+
   def github_announcement
     github_content["content"]["announcements"].first
   end

--- a/spec/services/coronavirus_pages/announcements_builder_spec.rb
+++ b/spec/services/coronavirus_pages/announcements_builder_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe CoronavirusPages::AnnouncementsBuilder do
+  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+  let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
+
+  let(:coronavirus_page) { create(:coronavirus_page, :landing) }
+
+  before do
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
+      .to_return(status: 200, body: github_content.to_json)
+  end
+
+  it "creates new announcements from the yaml file" do
+    described_class.new.create_announcements
+
+    expect(coronavirus_page.announcements.count).to eq(3)
+
+    first_announcement = coronavirus_page.announcements.first
+
+    expect(first_announcement.text).to eq(github_announcement["text"])
+    expect(first_announcement.href).to eq(github_announcement["href"])
+    expect(first_announcement.published_at).to eq(Date.parse(github_announcement["published_text"]))
+  end
+
+  def github_announcement
+    github_content["content"]["announcements"].first
+  end
+end

--- a/spec/services/coronavirus_pages/announcements_builder_spec.rb
+++ b/spec/services/coronavirus_pages/announcements_builder_spec.rb
@@ -32,6 +32,25 @@ RSpec.describe CoronavirusPages::AnnouncementsBuilder do
     expect(coronavirus_page.announcements.count).to eq(3)
   end
 
+  it "doesn't remove existing announcements if the YAML file is empty" do
+    github_content = YAML.safe_load(File.read(fixture_path))
+    github_content["content"]["announcements"].clear
+
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
+      .to_return(status: 200, body: github_content.to_json)
+
+    announcement = create(:announcement, coronavirus_page: coronavirus_page)
+
+    described_class.new.create_announcements
+
+    first_announcement = coronavirus_page.announcements.first
+
+    expect(coronavirus_page.announcements.count).to eq(1)
+    expect(first_announcement.text).to eq(announcement.text)
+    expect(first_announcement.href).to eq(announcement.href)
+    expect(first_announcement.published_at).to eq(announcement.published_at)
+  end
+
   def github_announcement
     github_content["content"]["announcements"].first
   end


### PR DESCRIPTION
Trello: https://trello.com/c/ODT9KYZB

# What's changed?

Adds a task to get the existing announcements from the [YAML file](https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml) and store them in the database.

# How to test locally

1. Run the task:

```
$ govuk-docker-run bundle exec rake coronavirus:sync_announcements
```

2. Open console:

```
$ govuk-docker-run bundle exec rails c
```

3. You should see three announcements in the DB:

```
> coronavirus_page = CoronavirusPage.find_by(slug: "landing")
> coronavirus_page.announcements.count
```



