### PR TITLE
Create announcement using the UI

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,0 +1,4 @@
+class AnnouncementsController < ApplicationController
+  before_action :require_unreleased_feature_permissions!
+  before_action :require_coronavirus_editor_permissions!
+end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,4 +1,39 @@
 class AnnouncementsController < ApplicationController
+  include DateFormatHelper
   before_action :require_unreleased_feature_permissions!
   before_action :require_coronavirus_editor_permissions!
+  layout "admin_layout"
+
+  def new
+    @announcement = coronavirus_page.announcements.new
+  end
+
+  def create
+    @announcement = coronavirus_page.announcements.new(announcement_params)
+    if @announcement.save && draft_updater.send
+      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Announcement was successfully created."
+    else
+      render :new
+    end
+  end
+
+private
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
+  end
+
+  def announcement_params
+    params.require(:announcement)
+    .permit(:title, :path, :published_at)
+    .merge(format_published_at(
+             params["announcement"]["published_at"]["day"],
+             params["announcement"]["published_at"]["month"],
+             params["announcement"]["published_at"]["year"],
+           ))
+  end
+
+  def draft_updater
+    @draft_updater ||= CoronavirusPages::DraftUpdater.new(@coronavirus_page)
+  end
 end

--- a/app/helpers/date_format_helper.rb
+++ b/app/helpers/date_format_helper.rb
@@ -1,0 +1,26 @@
+module DateFormatHelper
+  def format_published_at(day, month, year)
+    if date_fields_present?(day, month, year)
+      begin
+        format_date(day, month, year)
+      rescue ArgumentError, RangeError => e
+        Rails.logger.info "Rescued: #{e.inspect}"
+        nil
+      end
+    end
+  end
+
+private
+
+  def date_fields_present?(day, month, year)
+    day.present? && month.present? && year.present?
+  end
+
+  def format_date(day, month, year)
+    { published_at: Time.zone.local(
+      year,
+      month,
+      day,
+    ) }
+  end
+end

--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -1,0 +1,7 @@
+module ErrorItemsHelper
+  def error_items(error_messages, field)
+    if error_messages.key?(field)
+      error_messages[field].map { |message| "#{field.to_s.titleize} #{message}".capitalize }.join("\n")
+    end
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,7 +1,9 @@
 class Announcement < ApplicationRecord
   belongs_to :coronavirus_page
-  validates :text, :href, :published_at, presence: true
+  validates :title, :path, presence: true
   validates :coronavirus_page, presence: true
+  validate :published_at_format
+  validate :path_format
   after_create :set_position
   after_destroy :set_parent_positions
 
@@ -13,5 +15,23 @@ private
 
   def set_parent_positions
     coronavirus_page.make_announcement_positions_sequential
+  end
+
+  def published_at_format
+    unless published_at.is_a?(Time) && valid_year?
+      errors.add(:published_at, "must be a valid date")
+    end
+  end
+
+  def valid_year?
+    published_at.past? && published_at.year > 1950
+  end
+
+  def path_format
+    return if path.blank?
+
+    if path.nil? || !path.start_with?("/")
+      errors.add(:path, "must be a valid path starting with a /")
+    end
   end
 end

--- a/app/presenters/announcement_json_presenter.rb
+++ b/app/presenters/announcement_json_presenter.rb
@@ -1,0 +1,19 @@
+class AnnouncementJsonPresenter
+  attr_reader :announcement
+  def initialize(announcement)
+    @announcement = announcement
+  end
+
+  def output
+    @output ||=
+      {
+        "text" => announcement.title.to_s,
+        "href" => announcement.path.to_s,
+        "published_text" => format_published_text,
+      }
+  end
+
+  def format_published_text
+    announcement.published_at.strftime("Published %-d %B %Y")
+  end
+end

--- a/app/services/coronavirus_pages/announcements_builder.rb
+++ b/app/services/coronavirus_pages/announcements_builder.rb
@@ -6,8 +6,8 @@ class CoronavirusPages::AnnouncementsBuilder
 
         announcements_from_yaml.each do |announcement|
           coronavirus_page.announcements.create!(
-            text: announcement["text"],
-            href: announcement["href"],
+            title: announcement["text"],
+            path: announcement["href"],
             published_at: Date.parse(announcement["published_text"]),
           )
         end

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -11,6 +11,7 @@ class CoronavirusPages::ContentBuilder
       validate_content
       data = github_data
       data["sections"] = sub_sections_data
+      data["announcements"] = announcements_data
       add_live_stream(data)
       data["hidden_search_terms"] = hidden_search_terms
       data
@@ -81,6 +82,13 @@ class CoronavirusPages::ContentBuilder
     coronavirus_page.sub_sections.order(:position).map do |sub_section|
       presenter = SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id)
       add_error(presenter.errors) unless presenter.success?
+      presenter.output
+    end
+  end
+
+  def announcements_data
+    coronavirus_page.announcements.order(:position).map do |announcement|
+      presenter = AnnouncementJsonPresenter.new(announcement)
       presenter.output
     end
   end

--- a/app/services/coronavirus_pages/draft_discarder.rb
+++ b/app/services/coronavirus_pages/draft_discarder.rb
@@ -26,8 +26,8 @@ module CoronavirusPages
     def announcements
       announcements_from_payload.map.with_index do |announcement, index|
         Announcement.new(
-          text: announcement[:text],
-          href: announcement[:href],
+          title: announcement[:title],
+          path: announcement[:path],
           published_at: Date.parse(announcement[:published_text]),
           position: index + 1,
         )

--- a/app/views/announcements/_form.html.erb
+++ b/app/views/announcements/_form.html.erb
@@ -5,6 +5,7 @@
   },
   name: "announcement[title]",
   id: "title",
+  error_message: error_items(@announcement.errors.messages, :title),
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -13,6 +14,7 @@
   },
   name: "announcement[path]",
   id: "path",
+  error_message: error_items(@announcement.errors.messages, :path),
   hint: "Example format: /government/news/coronavirus-covid-19",
 } %>
 <% legend = capture do %>
@@ -23,6 +25,7 @@
   id: "published_at",
   legend_text: legend,
   hint: "For example, 31 3 2020",
+  error_message: error_items(@announcement.errors.messages, :published_at),
 } %>
 <%= render "govuk_publishing_components/components/button", {
   text: "Save",

--- a/app/views/announcements/_form.html.erb
+++ b/app/views/announcements/_form.html.erb
@@ -1,0 +1,31 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Enter the title of the announcement",
+    bold: true,
+  },
+  name: "announcement[title]",
+  id: "title",
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Enter the path to the announcement",
+    bold: true,
+  },
+  name: "announcement[path]",
+  id: "path",
+  hint: "Example format: /government/news/coronavirus-covid-19",
+} %>
+<% legend = capture do %>
+  <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= "Enter the date of publication" %></span>
+<% end %>
+<%= render "govuk_publishing_components/components/date_input", {
+  name: "announcement[published_at]",
+  id: "published_at",
+  legend_text: legend,
+  hint: "For example, 31 3 2020",
+} %>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Save",
+  margin_bottom: true
+} %>
+<%= tag.p (link_to 'Cancel', coronavirus_page_path(@coronavirus_page.slug), class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>

--- a/app/views/announcements/new.html.erb
+++ b/app/views/announcements/new.html.erb
@@ -22,6 +22,10 @@
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@coronavirus_page) %>
 <% content_for :context, "Add announcement" %>
+<% if @announcement.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @announcement %>
+<% end %>
+
 <div class="covid-edit-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @announcement, announcement: @announcement, url: coronavirus_page_announcements_path do  %>

--- a/app/views/announcements/new.html.erb
+++ b/app/views/announcements/new.html.erb
@@ -1,0 +1,31 @@
+<%
+  links = [
+    {
+      text: 'Coronavirus pages',
+      href: coronavirus_pages_path
+    },
+    {
+      text: "#{@coronavirus_page.name} announcements",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Add announcement"
+    },
+  ]
+
+  metadata = {
+    "Status" => "Draft",
+    "Last saved" => format_full_date_and_time(DateTime.now),
+  }
+%>
+
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page) %>
+<% content_for :context, "Add announcement" %>
+<div class="covid-edit-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @announcement, announcement: @announcement, url: coronavirus_page_announcements_path do  %>
+      <%= render "form" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -2,7 +2,7 @@
  @coronavirus_page.announcements.order(:position).map do |announcement|
    {
      id: announcement.id,
-     field: announcement.text,
+     field: announcement.title,
      edit: { href: coronavirus_page_path(@coronavirus_page.slug) },
      delete: {
        href: coronavirus_page_path(@coronavirus_page.slug),

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -23,9 +23,8 @@
       href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug)
     }
   } %>
-
   <%= render "govuk_publishing_components/components/button", {
     text: "Add announcement",
-    href: coronavirus_page_path(@coronavirus_page.slug)
+    href: new_coronavirus_page_announcement_path(@coronavirus_page.slug)
   } %>
 </div>

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -2,7 +2,11 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Coronavirus landing page</h2>
 <ul class="govuk-list">
-  <li><%= link_to "Edit landing page accordions", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <% if unreleased_feature_user? %>
+    <li><%= link_to "Edit landing page accordions and announcements", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <% else %>
+    <li><%= link_to "Edit landing page accordions", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <% end %>
   <li><%= link_to "Edit live stream URL", live_stream_index_path, class:"govuk-link" %></li>
   <li><%= link_to "Edit something else on the landing page", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
 </ul>

--- a/app/views/reorder_announcements/_reorder_list.html.erb
+++ b/app/views/reorder_announcements/_reorder_list.html.erb
@@ -6,7 +6,7 @@
       <li class="js-reorder" data-id="<%= announcement.id %>">
         <div class="govuk-grid-row" id="step-<%= index %>">
           <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
-            <%= announcement.text %>
+            <%= announcement.title %>
           </div>
           <div class="govuk-grid-column-one-quarter js-order-controls">
           </div>

--- a/app/views/shared/sub_sections/_form_errors.html.erb
+++ b/app/views/shared/sub_sections/_form_errors.html.erb
@@ -1,10 +1,6 @@
 <% if resource.errors.any? %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: "There is a problem",
-    items: resource.errors.full_messages.map do |message|
-      {
-        text: message
-      }
-    end
+    items: resource.errors.full_messages.map { |message| { text: message } }
   } %>
 <% end %>

--- a/db/migrate/20201124144059_change_column_names.rb
+++ b/db/migrate/20201124144059_change_column_names.rb
@@ -1,0 +1,8 @@
+class ChangeColumnNames < ActiveRecord::Migration[6.0]
+  def change
+    change_table :announcements, bulk: true do |t|
+      t.rename :text, :title
+      t.rename :href, :path
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_25_123542) do
+ActiveRecord::Schema.define(version: 2020_11_24_144059) do
 
   create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
-    t.string "text"
-    t.string "href"
+    t.string "title"
+    t.string "path"
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe AnnouncementsController, type: :controller do
+  render_views
+
+  let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
+  let(:coronavirus_page) { create :coronavirus_page, :landing }
+  let!(:live_stream) { create :live_stream, :without_validations }
+  let(:title) { Faker::Lorem.sentence }
+  let(:path) { "/government/foo/vader/baby/yoda" }
+  let(:published_at) { { "day" => "12", "month" => "12", "year" => "1980" } }
+
+  describe "GET /coronavirus/:coronavirus_page_slug/announcements/new" do
+    it "renders successfully if the user has unreleased feature permission" do
+      stub_user.permissions << "Unreleased feature"
+      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not render successfully if the user does not have Coronavirus editor permissions" do
+      create :user, name: "Name Surname"
+      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  let(:announcement_params) do
+    {
+      title: title,
+      path: path,
+      published_at: published_at,
+    }
+  end
+
+  describe "POST /coronavirus/:coronavirus_page_slug/announcements" do
+    before do
+      stub_user.permissions << "Unreleased feature"
+      setup_github_data
+      stub_coronavirus_publishing_api
+    end
+
+    it "redirects to coronavirus page on success" do
+      post :create, params: { coronavirus_page_slug: coronavirus_page.slug, announcement: announcement_params }
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+      expect(flash.now[:errors]).to be_nil
+    end
+
+    it "adds attributes to new announcement" do
+      post :create, params: { coronavirus_page_slug: coronavirus_page.slug, announcement: announcement_params }
+      published_at_time = Time.zone.local(published_at["year"], published_at["month"], published_at["day"])
+      announcement = coronavirus_page.announcements.last
+      expect(announcement.title).to eq(title)
+      expect(announcement.path).to eq(path)
+      expect(announcement.published_at).to eq(published_at_time)
+    end
+  end
+
+  def setup_github_data
+    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+      .to_return(status: 200, body: raw_content)
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -255,8 +255,8 @@ FactoryBot.define do
   end
 
   factory :announcement do
-    text { Faker::Lorem.words }
-    href { Faker::Internet.url(host: "example.com") }
+    title { Faker::Lorem.words }
+    path { "/government/foo/vader/baby/yoda" }
     published_at { Time.zone.local(2020, 9, 11) }
     coronavirus_page
   end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -114,6 +114,18 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         and_i_can_see_existing_announcements
       end
 
+      scenario "Adding announcements" do
+        set_up_github_data
+        given_i_can_access_unreleased_features
+        given_there_is_coronavirus_page_with_announcements
+        when_i_visit_a_coronavirus_page
+        then_i_can_see_an_announcements_section
+        and_i_add_a_new_announcement
+        then_i_see_the_create_announcement_form
+        when_i_fill_in_the_announcement_form_with_valid_data
+        then_i_can_see_a_new_announcement_has_been_created
+      end
+
       scenario "Reordering announcements", js: true do
         given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements

--- a/spec/fixtures/coronavirus_landing_page_with_announcements.yml
+++ b/spec/fixtures/coronavirus_landing_page_with_announcements.yml
@@ -13,6 +13,15 @@ content:
       text: Full guidance on staying at home and away from others
   announcements_label: Announcements
   announcements:
+    - text: You must stay at home apart from essential travel or you may be fined
+      href: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
+      published_text: Published 5 November 2020
+    - text: If you live in the UK and are currently abroad you are strongly advised to return now
+      href: /guidance/travel-advice-novel-coronavirus
+      published_text: Published 4 November 2020
+    - text: All non-essential shops and community spaces are closed
+      href: /government/publications/further-businesses-and-premises-to-close
+      published_text: Published 3 November 2020
   nhs_banner:
     heading: "Do not leave home if you or someone you live with has either:"
     list:

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -4,8 +4,8 @@
     "announcements_label": "Announcements",
     "announcements": [
       {
-        "href": "/government/news/more-rapid-covid-19-tests-to-be-rolled-out-across-england",
-        "text": "More rapid COVID-19 tests to be rolled out across England",
+        "path": "/government/news/more-rapid-covid-19-tests-to-be-rolled-out-across-england",
+        "title": "More rapid COVID-19 tests to be rolled out across England",
         "published_text": "Published 10 November 2020"
       }
     ],

--- a/spec/helpers/date_format_helper_spec.rb
+++ b/spec/helpers/date_format_helper_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+RSpec.describe DateFormatHelper do
+  let(:day) { "01" }
+  let(:month) { "10" }
+  let(:year) { "2020" }
+
+  describe "#format_published_at" do
+    it "formats time with valid parameters" do
+      expect(format_published_at(day, month, year)).to eq({ published_at: expected_published_at_time })
+    end
+
+    it "returns nil if any of the date params are empty" do
+      year = ""
+      expect(format_published_at(day, month, year)).to eq(nil)
+    end
+
+    it "throws an ArgumentError and returns nil if param is outside of the calendar" do
+      day = "2020"
+      expect(format_published_at(day, month, year)).to eq(nil)
+    end
+
+    it "throws a RangeError and returns nil if param is too big" do
+      day = "99999999999999999999999999999999999999999999999"
+      expect(format_published_at(day, month, year)).to eq(nil)
+    end
+
+    def expected_published_at_time
+      Time.zone.local(
+        year,
+        month,
+        day,
+      )
+    end
+  end
+end

--- a/spec/helpers/error_items_helper_spec.rb
+++ b/spec/helpers/error_items_helper_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+RSpec.describe ErrorItemsHelper do
+  describe "#error_items" do
+    let(:empty_error_messages) { {} }
+    let(:error_messages) { { title: ["can't be blank"], path: ["must be a valid path starting with a /"] } }
+    let(:multiple_error_messages) { { title: ["can't be blank", "invalid"] } }
+
+    it "does not format error messages when there are no errors" do
+      expect(error_items(empty_error_messages, :title)).to eq(nil)
+    end
+
+    it "formats the error message for a blank title field" do
+      expect(error_items(error_messages, :title)).to eq("Title can't be blank")
+    end
+
+    it "formats the error message for an invalid path field" do
+      expect(error_items(error_messages, :path)).to eq("Path must be a valid path starting with a /")
+    end
+
+    it "formats the error message when there are multiple errors on a field" do
+      expect(error_items(multiple_error_messages, :title)).to eq("Title can't be blank\nTitle invalid")
+    end
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -20,18 +20,18 @@ RSpec.describe Announcement, type: :model do
       expect(announcement).to be_persisted
     end
 
-    it "requires text" do
-      announcement.text = ""
+    it "requires title" do
+      announcement.title = ""
 
       expect(announcement).not_to be_valid
-      expect(announcement.errors).to have_key(:text)
+      expect(announcement.errors).to have_key(:title)
     end
 
-    it "requires an href" do
-      announcement.href = ""
+    it "requires a path" do
+      announcement.path = ""
 
       expect(announcement).not_to be_valid
-      expect(announcement.errors).to have_key(:href)
+      expect(announcement.errors).to have_key(:path)
     end
 
     it "requires a published at time" do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -34,8 +34,22 @@ RSpec.describe Announcement, type: :model do
       expect(announcement.errors).to have_key(:path)
     end
 
+    it "requires a path to begin with /" do
+      announcement.path = "government/coronavirus"
+
+      expect(announcement).not_to be_valid
+      expect(announcement.errors).to have_key(:path)
+    end
+
     it "requires a published at time" do
       announcement.published_at = ""
+
+      expect(announcement).not_to be_valid
+      expect(announcement.errors).to have_key(:published_at)
+    end
+
+    it "should only have four digits for the year" do
+      announcement.published_at = "12345-09-10 23:00:00"
 
       expect(announcement).not_to be_valid
       expect(announcement.errors).to have_key(:published_at)

--- a/spec/presenters/announcement_json_presenter_spec.rb
+++ b/spec/presenters/announcement_json_presenter_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe AnnouncementJsonPresenter do
+  let!(:announcement) { create :announcement }
+
+  before do
+    setup_github_data
+  end
+
+  describe "#output" do
+    it "returns presented announcement" do
+      expected = {
+        "text" => announcement.title.to_s,
+        "href" => announcement.path.to_s,
+        "published_text" => announcement.published_at.strftime("Published %-d %B %Y"),
+      }
+
+      expect(described_class.new(announcement).output).to eq(expected)
+    end
+  end
+
+  def setup_github_data
+    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+    stub_request(:get, /#{announcement.coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+      .to_return(status: 200, body: raw_content)
+  end
+end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -44,5 +44,15 @@ RSpec.describe CoronavirusPagePresenter do
       expect(subject.payload).to be_valid_against_schema("coronavirus_landing_page")
       expect(subject.payload).to eq payload
     end
+
+    it "includes announcements" do
+      announcement = create(:announcement, coronavirus_page: coronavirus_page)
+      expect(subject.payload["details"]["announcements"].count).to eq 1
+      expect(subject.payload["details"]["announcements"].first).to eq({
+        "href" => announcement.path,
+        "text" => announcement.title,
+        "published_text" => announcement.published_at.strftime("Published %-d %B %Y"),
+      })
+    end
   end
 end

--- a/spec/services/coronavirus_pages/announcements_builder_spec.rb
+++ b/spec/services/coronavirus_pages/announcements_builder_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPages::AnnouncementsBuilder do
-  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page_with_announcements.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
 
   let(:coronavirus_page) { create(:coronavirus_page, :landing) }

--- a/spec/services/coronavirus_pages/announcements_builder_spec.rb
+++ b/spec/services/coronavirus_pages/announcements_builder_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe CoronavirusPages::AnnouncementsBuilder do
 
     first_announcement = coronavirus_page.announcements.first
 
-    expect(first_announcement.text).to eq(github_announcement["text"])
-    expect(first_announcement.href).to eq(github_announcement["href"])
+    expect(first_announcement.title).to eq(github_announcement["text"])
+    expect(first_announcement.path).to eq(github_announcement["href"])
     expect(first_announcement.published_at).to eq(Date.parse(github_announcement["published_text"]))
   end
 
@@ -46,8 +46,8 @@ RSpec.describe CoronavirusPages::AnnouncementsBuilder do
     first_announcement = coronavirus_page.announcements.first
 
     expect(coronavirus_page.announcements.count).to eq(1)
-    expect(first_announcement.text).to eq(announcement.text)
-    expect(first_announcement.href).to eq(announcement.href)
+    expect(first_announcement.title).to eq(announcement.title)
+    expect(first_announcement.path).to eq(announcement.path)
     expect(first_announcement.published_at).to eq(announcement.published_at)
   end
 

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
   let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id).output }
+  let(:announcement_json) { AnnouncementJsonPresenter.new(announcement).output }
   let!(:live_stream) { create :live_stream, :without_validations }
 
   subject { described_class.new(coronavirus_page) }
@@ -20,6 +21,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
 
   describe "#data" do
     let!(:sub_section) { create :sub_section, coronavirus_page_id: coronavirus_page.id }
+    let!(:announcement) { create :announcement, coronavirus_page: coronavirus_page }
     let(:github_livestream_data) { github_content.dig("content", "live_stream") }
 
     let(:live_stream_data) do
@@ -45,6 +47,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
     before do
       data["sections"] = [sub_section_json]
       data["live_stream"] = live_stream_data
+      data["announcements"] = [announcement_json]
       data["hidden_search_terms"] = hidden_search_terms
     end
 
@@ -66,6 +69,21 @@ RSpec.describe CoronavirusPages::ContentBuilder do
 
       it "returns the sub_section JSON ordered by position" do
         expect(subject.sub_sections_data).to eq [sub_section_0_json, sub_section_1_json]
+      end
+    end
+  end
+
+  describe "#announcements_data" do
+    context "with announcements" do
+      let!(:announcement_0) { create :announcement, published_at: Time.zone.local(2020, 9, 10), coronavirus_page: coronavirus_page  }
+      let!(:announcement_1) { create :announcement, published_at: Time.zone.local(2020, 9, 11), coronavirus_page: coronavirus_page  }
+      let!(:announcement_0_json) { AnnouncementJsonPresenter.new(announcement_0).output }
+      let!(:announcement_1_json) { AnnouncementJsonPresenter.new(announcement_1).output }
+
+      it "returns the announcements JSON ordered by position" do
+        announcement_0.position = 3
+        announcement_0.save!
+        expect(subject.announcements_data).to eq [announcement_1_json, announcement_0_json]
       end
     end
   end

--- a/spec/services/coronavirus_pages/draft_discarder_spec.rb
+++ b/spec/services/coronavirus_pages/draft_discarder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CoronavirusPages::DraftDiscarder do
       create(
         :announcement,
         coronavirus_page: coronavirus_page,
-        text: "Foo",
+        title: "Foo",
       )
 
       stub_publishing_api_has_item(payload_from_publishing_api)
@@ -28,7 +28,7 @@ RSpec.describe CoronavirusPages::DraftDiscarder do
       coronavirus_page.reload
 
       expect(coronavirus_page.announcements.count).to eq(1)
-      expect(coronavirus_page.announcements.first.text).to eq("More rapid COVID-19 tests to be rolled out across England")
+      expect(coronavirus_page.announcements.first.title).to eq("More rapid COVID-19 tests to be rolled out across England")
       expect(coronavirus_page.announcements.first.position).to eq(1)
     end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -200,16 +200,16 @@ def then_i_cannot_see_an_announcements_section
 end
 
 def and_i_can_see_existing_announcements
-  expect(page).to have_content(@announcement_one.text)
-  expect(page).to have_content(@announcement_two.text)
+  expect(page).to have_content(@announcement_one.title)
+  expect(page).to have_content(@announcement_two.title)
 end
 
 def then_i_see_the_announcements_in_order
   element = find("#step-0").find(".step-by-step-reorder__step-title")
-  expect(element).to have_content @announcement_one.text
+  expect(element).to have_content @announcement_one.title
 
   element = find("#step-1").find(".step-by-step-reorder__step-title")
-  expect(element).to have_content @announcement_two.text
+  expect(element).to have_content @announcement_two.title
 end
 
 def when_i_move_announcement_one_down
@@ -226,8 +226,8 @@ def then_i_see_announcement_updated_message
 end
 
 def and_i_see_the_announcements_have_changed_order
-  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(1)", text: @announcement_two.text)
-  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.text)
+  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(1)", text: @announcement_two.title)
+  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.title)
 end
 
 def set_up_basic_sub_sections

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -310,7 +310,7 @@ def then_the_reordered_subsections_are_sent_to_publishing_api
       "details" => {
         "header_section" => "header_section",
         "announcements_label" => "announcements_label",
-        "announcements" => "announcements",
+        "announcements" => [],
         "nhs_banner" => "nhs_banner",
         "sections_heading" => "sections_heading",
         "topic_section" => "topic_section",

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -230,6 +230,39 @@ def and_i_see_the_announcements_have_changed_order
   expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.title)
 end
 
+# Adding an announcement
+
+def set_up_github_data
+  coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
+  raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+  stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+    .to_return(status: 200, body: raw_content)
+end
+
+def and_i_add_a_new_announcement
+  click_on("Add announcement")
+end
+
+def then_i_see_the_create_announcement_form
+  expect(page).to have_text("Enter the title of the announcement")
+  expect(page).to have_text("Enter the path to the announcement")
+  expect(page).to have_text("Enter the date of publication")
+end
+
+def when_i_fill_in_the_announcement_form_with_valid_data
+  fill_in("title", with: "fancy title")
+  fill_in("path", with: "/government")
+  fill_in("announcement[published_at][day]", with: "12")
+  fill_in("announcement[published_at][month]", with: "1")
+  fill_in("announcement[published_at][year]", with: "2020")
+  click_on("Save")
+end
+
+def then_i_can_see_a_new_announcement_has_been_created
+  expect(current_path).to eq("/coronavirus/landing")
+  expect(expect(page).to(have_text("fancy title")))
+end
+
 def set_up_basic_sub_sections
   coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
   FactoryBot.create(:sub_section,


### PR DESCRIPTION
## What?

**We want to be able to add an announcement via the UI.**

<img width="694" alt="Screenshot 2020-11-19 at 13 16 47" src="https://user-images.githubusercontent.com/41922771/99671202-9d10f900-2a69-11eb-93c3-bbcedfca4754.png">


**This PR adds a button to the /coronavirus/landing page that enables a user to add an announcement via a form.** 

<img width="737" alt="Screenshot 2020-11-19 at 13 17 02" src="https://user-images.githubusercontent.com/41922771/99671243-aef29c00-2a69-11eb-831d-2f01357268ff.png">


There was no formal design for this form, instead we adopted a style similar to the 'Edit guidance section` example on the [figma design](https://www.figma.com/file/92QVsy9eJOXdiULVrjQbEk/Coronavirus-topic-publisher?node-id=0%3A1).

There is still work to do on this including the edit and delete announcement actions, which will follow in subsequent PRs. Until then we have hidden the announcements view behind an unreleased feature flag requirement so it should only be accessible to those with the appropriate permissions 

We have tested that new announcements persist to the database,  and that the draft content is sent to the publishing api using the `CoronavirusPages::DraftUpdater` in Integration

