### PR TITLE
Bug Fix: Sub-sections are deleted and not replaced when the draft is discarded

### DIFF
--- a/app/services/coronavirus_pages/model_builder.rb
+++ b/app/services/coronavirus_pages/model_builder.rb
@@ -20,8 +20,10 @@ module CoronavirusPages
 
     def discard_changes
       if live_content.any?
-        store_live_subsections
-        page.update!(state: "published")
+        CoronavirusPage.transaction do
+          store_live_subsections
+          page.update!(state: "published")
+        end
       end
     end
 

--- a/app/services/coronavirus_pages/model_builder.rb
+++ b/app/services/coronavirus_pages/model_builder.rb
@@ -58,10 +58,15 @@ module CoronavirusPages
     end
 
     def sub_sections
-      sub_section_attributes.each_with_index.map do |attributes, i|
-        attributes["position"] = i
-        SubSection.new(attributes)
+      new_sub_sections = sub_section_attributes.each_with_index.map do |attributes, i|
+        SubSection.new(
+          title: attributes[:title],
+          content: attributes[:content],
+          position: i,
+        )
       end
+
+      new_sub_sections
     end
 
     def sub_section_attributes


### PR DESCRIPTION
Trello: https://trello.com/c/4i8Qmhpn

# What?

The "discard draft" action was failing. All of the subsections were being removed, but they were not being replaced by the entries in publishing-api. This change fixes that.

Error:

```
{"exception_class":"ActiveRecord::RecordNotSaved","exception_message":"Failed to replace sub_sections because one or more of the new records could not be saved.","stacktrace":["app/services/coronavirus_pages/model_builder.rb:40:in `store_live_subsections'","app/services/coronavirus_pages/model_builder.rb:23:in `discard_changes'","app/controllers/coronavirus_pages_controller.rb:64:in `discard_model_changes'","app/controllers/coronavirus_pages_controller.rb:39:in `discard'"]}
```

I'm don't know why storing the new sub_sections in variable before saving in the database works, but it does. I've tried adding tests to replicate the bug but was unable to do so.