### PR TITLE
Include step content in the body field

### DIFF
--- a/app/presenters/step_nav_presenter.rb
+++ b/app/presenters/step_nav_presenter.rb
@@ -70,6 +70,7 @@ private
         ],
         steps: steps,
       },
+      body: body,
     }
   end
 
@@ -130,5 +131,12 @@ private
     step_nav.secondary_content_links.map do |secondary_content_link|
       done_page_base_path(secondary_content_link)
     end
+  end
+
+  def body
+    step_nav.steps.map { |step|
+      "<h2>#{step.title}</h2>\n\n" +
+        Kramdown::Document.new(step.contents).to_html
+    }.join("\n\n")
   end
 end

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -25,6 +25,32 @@ RSpec.describe StepNavPresenter do
       expect(presented[:routes]).to eq([{ path: "/how-to-be-the-amazing-1", type: "exact" }])
     end
 
+    it "includes an html representation of the page so that it may be indexed in search" do
+      presented = subject.render_for_publishing_api
+      expected = <<~BODY
+        <h2>Check how awesome you are</h2>
+
+        <p>This is a great step</p>
+
+        <ul>
+          <li><a href="/good/stuff">Good stuff</a></li>
+          <li>
+            <p><a href="/also/good/stuff">Also good stuff</a></p>
+          </li>
+          <li><a href="/not/as/great">Not as great</a>£25</li>
+          <li><a href="http://example.com/good">But good nonetheless</a></li>
+        </ul>
+
+
+        <h2>Dress like the Fonz</h2>
+
+        <p>This is another great step</p>
+      BODY
+
+      expect(presented).to be_valid_against_schema("step_by_step_nav")
+      expect(presented[:details][:body]).to eq(expected)
+    end
+
     it "presents edition links correctly" do
       presented = subject.render_for_publishing_api
       expect(presented[:links][:pages_part_of_step_nav].count).to eq(2)


### PR DESCRIPTION
We want step content to be indexed by search so we can find these pages more easily. Search-api can understand html, and steps are written in markdown.

We therefore want render all the step content and titles as html, not for public consumption, but so that search can index the page content.

I've tried to present the output fairly verbosely with plenty of space between sections. Fully fledged step by step pages are quite chunky, and should we experience problems it'd be nice to be able to view this bit in a debugger without it just being a mass of html.

https://trello.com/c/rsiS0jZ6/516-improve-visibility-of-import-export-step-by-steps-in-site-search
