### PR TITLE
Continue to get announcements from YAML

### DIFF
--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -11,7 +11,7 @@ class CoronavirusPages::ContentBuilder
       validate_content
       data = github_data
       data["sections"] = sub_sections_data
-      data["announcements"] = announcements_data
+      data["announcements"] = announcements_data if coronavirus_page.announcements.any?
       add_live_stream(data)
       data["hidden_search_terms"] = hidden_search_terms
       data

--- a/spec/fixtures/simple_coronavirus_page.yml
+++ b/spec/fixtures/simple_coronavirus_page.yml
@@ -3,7 +3,7 @@ content:
   meta_description: "Find out about the government response to coronavirus (COVID-19) and what you need to do."
   header_section: "header_section"
   announcements_label: "announcements_label"
-  announcements: "announcements"
+  announcements: []
   nhs_banner: "nhs_banner"
   sections_heading: "sections_heading"
   sections: "sections"


### PR DESCRIPTION
# What?

Until we are ready to go live with the announcements section and import the existing
announcements from the Github to the database, we need to make sure that we are still
sending announcements to publishing-api correctly.

When we [updated the DraftUpdater](https://github.com/alphagov/collections-publisher/commit/52e8fc1e31ca5b2a3140be54ad10baf7f80f9c19#) to get the announcements from the
database we inadvertently removed the announcements from the publishing-api.
This is because the assignment `data["announcements"] = announcements_data` overwrites
the announcements pulled in from the github data, but at the moment there is nothing to replace it
with.

To get the tests to work, we need to update the fixture to not return any announcements. This is so that
it matches the assertion in step `then_the_reordered_subsections_are_sent_to_publishing_api`

# Expected changes
## Before
![screenshot-www gov uk-2020 12 08-15_33_06](https://user-images.githubusercontent.com/5793815/101504118-c4712c80-396a-11eb-8444-5fe90fbf8ced.png)

## After
![screenshot-draft-origin integration publishing service gov uk-2020 12 08-15_32_38](https://user-images.githubusercontent.com/5793815/101504145-ca670d80-396a-11eb-8e99-e1b5110efcc4.png)
