### PR TITLE
Add feature flag for backend code

### DIFF
--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -94,6 +94,8 @@ class CoronavirusPages::ContentBuilder
   end
 
   def persisted_live_stream_data
+    return {} unless LiveStream.any?
+
     live_stream = LiveStream.last
     {
       "video_url" => live_stream.url,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.hosts << "collections-publisher.dev.gov.uk"
+
+  config.unreleased_features = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,4 +103,6 @@ Rails.application.configure do
   # Rather than use a CSS compressor, use the SASS style to perform compression.
   config.sass.style = :compressed
   config.sass.line_comments = false
+
+  config.unreleased_features = ENV["UNRELEASED_FEATURES"].present?
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.unreleased_features = true
 end

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe AnnouncementsController, type: :controller do
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :landing }
   let(:announcement) { create :announcement, coronavirus_page: coronavirus_page }
-  let!(:live_stream) { create :live_stream, :without_validations }
   let(:title) { Faker::Lorem.sentence }
   let(:path) { "/government/foo/vader/baby/yoda" }
   let(:published_at) { { "day" => "12", "month" => "12", "year" => "1980" } }

--- a/spec/controllers/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/reorder_sub_sections_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
   render_views
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
-  let(:live_stream) { create :live_stream, :without_validations }
   let(:slug) { coronavirus_page.slug }
   let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
@@ -22,7 +21,6 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
       stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
         .to_return(status: 200, body: raw_content)
       stub_coronavirus_publishing_api
-      live_stream
     end
     let(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }
     let(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page }

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe SubSectionsController, type: :controller do
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
   let(:sub_section) { create :sub_section, coronavirus_page: coronavirus_page }
-  let!(:live_stream) { create :live_stream, :without_validations }
   let(:title) { Faker::Lorem.sentence }
   let(:content) { "###{Faker::Lorem.sentence}" }
   let(:sub_section_params) do
@@ -33,7 +32,6 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
-      live_stream
     end
     subject do
       post :create, params: { coronavirus_page_slug: slug, sub_section: sub_section_params }
@@ -120,7 +118,6 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
-      live_stream
     end
     let(:params) do
       {

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CoronavirusPagePresenter do
   let(:meta_description) { github_content["content"]["meta_description"] }
   let(:data) { CoronavirusPages::ContentBuilder.new(coronavirus_page).data }
   let(:details) { data.except(title, meta_description) }
-  let!(:live_stream) { create :live_stream, :without_validations }
 
   let(:payload) do
     {
@@ -33,7 +32,6 @@ RSpec.describe CoronavirusPagePresenter do
   subject { described_class.new(data, base_path) }
 
   before do
-    live_stream
     stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
     stub_coronavirus_publishing_api

--- a/spec/services/coronavirus_pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus_pages/draft_updater_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPages::DraftUpdater do
-  let(:live_stream) { create :live_stream, :without_validations }
   let(:coronavirus_page) { create :coronavirus_page }
   let(:content_builder) { CoronavirusPages::ContentBuilder.new(coronavirus_page) }
   let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
@@ -11,7 +10,6 @@ RSpec.describe CoronavirusPages::DraftUpdater do
   subject { described_class.new(coronavirus_page) }
 
   before do
-    live_stream
     stub_coronavirus_publishing_api
     stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)


### PR DESCRIPTION
Trello: https://trello.com/c/gzWPC4LU

# What's changed and why?

The announcements UI was being hidden behind a user permission
"Unreleased feature" to stop them seeing and interacting with
announcements, however there was nothing to stop the backend code from
running.

This caused problems recently where the announcements section was
removed [1] in live because the code to populate publishing-api was
looking for the announcements in the wrong place. We added a flag to
check if there are any existing announcements to get around the problem
but since found that this had a knock-on effect when drafts are
discarded.

When the draft is discarded, announcements are retrieved from
publishing-api and populated in the database. As the local database had
announcements, any changes made to the announcements section via Github
weren't picked up because the flag we added evaluated to true.

To stop problems like occurring in the upcoming timeline feature, config
has been added that sets the conditions for when the backend code
associated with an unreleased feature should be run.

The config class relies on the presence of an environment variable. The
bonus of this is that we can enable unreleased_features differently in
different environments.

For example, if we set ENV["UNRELEASED_FEATURES"] in integration only,
that means we'll be able to test the feature in Integration, but it
would be turned off by default in staging and production.

So rather than doing something like:

```
data["announcements"] = announcements_data if coronavirus_page.announcements.any?
```

We can instead do:

```
data["announcements"] = announcements_data if Rails.application.config.unreleased_features?
```

[1]: #1191