### PR TITLE
Keep existing user input on error

### DIFF
--- a/app/views/announcements/_form.html.erb
+++ b/app/views/announcements/_form.html.erb
@@ -4,15 +4,18 @@
     bold: true,
   },
   name: "announcement[title]",
+  value: @announcement.title,
   id: "title",
   error_message: error_items(@announcement.errors.messages, :title),
 } %>
+
 <%= render "govuk_publishing_components/components/input", {
   label: {
     text: "Enter the path to the announcement",
     bold: true,
   },
   name: "announcement[path]",
+  value: @announcement.path,
   id: "path",
   error_message: error_items(@announcement.errors.messages, :path),
   hint: "Example format: /government/news/coronavirus-covid-19",

--- a/app/views/announcements/_form.html.erb
+++ b/app/views/announcements/_form.html.erb
@@ -20,16 +20,36 @@
   error_message: error_items(@announcement.errors.messages, :path),
   hint: "Example format: /government/news/coronavirus-covid-19",
 } %>
+
 <% legend = capture do %>
   <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= "Enter the date of publication" %></span>
 <% end %>
+
 <%= render "govuk_publishing_components/components/date_input", {
   name: "announcement[published_at]",
   id: "published_at",
   legend_text: legend,
   hint: "For example, 31 3 2020",
   error_message: error_items(@announcement.errors.messages, :published_at),
+  items: [
+    {
+      name: "day",
+      width: 2,
+      value: @announcement.published_at&.day
+    },
+    {
+      name: "month",
+      width: 2,
+      value: @announcement.published_at&.month
+    },
+    {
+      name: "year",
+      width: 4,
+      value: @announcement.published_at&.year
+    }
+  ]
 } %>
+
 <%= render "govuk_publishing_components/components/button", {
   text: "Save",
   margin_bottom: true


### PR DESCRIPTION
Trello: https://trello.com/c/dYuQSgk7

## What?

Form fields are pre-populated with user's input when the create announcement form is submitted and fails validation. Previously if the user filled any of the fields out incorrectly, the submitted data disappeared for all of the other fields, even though those fields did not fail validation.

## Why?

Better user experience! It is annoying to have to fill the whole form out again if only one field was incorrect.

# Expected changes
## Error on title field
### Before
<img width="1552" alt="Screenshot 2020-12-08 at 18 04 36" src="https://user-images.githubusercontent.com/5793815/101523059-ff318f80-397f-11eb-97b0-297627fabeaf.png">

### After
<img width="1552" alt="Screenshot 2020-12-08 at 18 03 23" src="https://user-images.githubusercontent.com/5793815/101523066-00fb5300-3980-11eb-90d0-d66725c00966.png">

## Error on path field
### Before
<img width="1552" alt="Screenshot 2020-12-08 at 18 04 15" src="https://user-images.githubusercontent.com/5793815/101523061-ffca2600-397f-11eb-8656-e1ef3d7438b2.png">

### After
<img width="1552" alt="Screenshot 2020-12-08 at 18 03 03" src="https://user-images.githubusercontent.com/5793815/101523050-fc369f00-397f-11eb-955c-8e3db6688122.png">

## Error on published_at field
### Before
<img width="1552" alt="Screenshot 2020-12-08 at 18 04 48" src="https://user-images.githubusercontent.com/5793815/101523054-fe006280-397f-11eb-8923-09c8b5b029ae.png">

### After
<img width="1552" alt="Screenshot 2020-12-08 at 18 03 39" src="https://user-images.githubusercontent.com/5793815/101523063-0062bc80-3980-11eb-8a4b-2989dfa00394.png">

