### PR TITLE
Delete announcements

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -17,6 +17,19 @@ class AnnouncementsController < ApplicationController
     end
   end
 
+  def destroy
+    @announcement = coronavirus_page.announcements.find(params[:id])
+    @coronavirus_page = @announcement.coronavirus_page
+    attrs = @announcement.attributes.except("id", "created_at", "updated_at")
+    if @announcement.destroy && draft_updater.send
+      message = { notice: "Announcement was successfully deleted." }
+    else
+      draft_updater.rebuild_announcement(attrs)
+      message = { alert: "Announcement couldn't be deleted" }
+    end
+    redirect_to coronavirus_page_path(@coronavirus_page.slug), message
+  end
+
 private
 
   def coronavirus_page

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -18,6 +18,10 @@ module CoronavirusPages
       coronavirus_page.sub_sections.create(attrs)
     end
 
+    def rebuild_announcement(attrs)
+      coronavirus_page.announcements.create(attrs)
+    end
+
     def payload
       if content_builder.success?
         CoronavirusPagePresenter.new(content_builder.data, base_path).payload

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -5,7 +5,7 @@
      field: announcement.title,
      edit: { href: coronavirus_page_path(@coronavirus_page.slug) },
      delete: {
-       href: coronavirus_page_path(@coronavirus_page.slug),
+       href: coronavirus_page_announcement_path(@coronavirus_page.slug, announcement),
        data_attributes: {
          confirm: "Are you sure?",
          method: "delete"

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -81,7 +81,18 @@ RSpec.describe AnnouncementsController, type: :controller do
       announcement
       expect { subject }.to change { Announcement.count }.by(-1)
     end
+
+    it "recreates the announcement if draft_updater fails" do
+      announcement
+      stub_any_publishing_api_put_content
+        .to_return(status: 500)
+      expect { subject }.not_to(change { Announcement.count })
+      expect(announcement.title).to eq Announcement.last.title
+      expect(announcement.path).to eq Announcement.last.path
+      expect(announcement.id).not_to eq Announcement.last.id
+    end
   end
+
   def setup_github_data
     raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
     stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -24,19 +24,19 @@ RSpec.describe AnnouncementsController, type: :controller do
     end
   end
 
-  let(:announcement_params) do
-    {
-      title: title,
-      path: path,
-      published_at: published_at,
-    }
-  end
-
   describe "POST /coronavirus/:coronavirus_page_slug/announcements" do
     before do
       stub_user.permissions << "Unreleased feature"
       setup_github_data
       stub_coronavirus_publishing_api
+    end
+
+    let(:announcement_params) do
+      {
+        title: title,
+        path: path,
+        published_at: published_at,
+      }
     end
 
     it "redirects to coronavirus page on success" do
@@ -55,6 +55,33 @@ RSpec.describe AnnouncementsController, type: :controller do
     end
   end
 
+  describe "DELETE /coronavirus/:coronavirus_page_slug/announcements/:id" do
+    before do
+      stub_user.permissions << "Unreleased feature"
+      setup_github_data
+      stub_coronavirus_publishing_api
+    end
+
+    let(:announcement) { create(:announcement, coronavirus_page: coronavirus_page) }
+
+    let(:announcement_params) do
+      {
+        id: announcement,
+        coronavirus_page_slug: coronavirus_page.slug,
+      }
+    end
+
+    subject { delete :destroy, params: announcement_params }
+
+    it "redirects to the coronavirus page" do
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+
+    it "deletes the announcement" do
+      announcement
+      expect { subject }.to change { Announcement.count }.by(-1)
+    end
+  end
   def setup_github_data
     raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
     stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -115,7 +115,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Adding announcements" do
-        set_up_github_data
         given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements
         when_i_visit_a_coronavirus_page
@@ -124,6 +123,15 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         then_i_see_the_create_announcement_form
         when_i_fill_in_the_announcement_form_with_valid_data
         then_i_can_see_a_new_announcement_has_been_created
+      end
+
+      scenario "Deleting announcements", js: true do
+        given_i_can_access_unreleased_features
+        given_there_is_coronavirus_page_with_announcements
+        when_i_visit_a_coronavirus_page
+        then_i_can_see_an_announcements_section
+        when_i_delete_an_announcement
+        then_i_can_see_an_announcement_has_been_deleted
       end
 
       scenario "Reordering announcements", js: true do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -232,8 +232,7 @@ end
 
 # Adding an announcement
 
-def set_up_github_data
-  coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
+def set_up_github_data(coronavirus_page)
   raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
   stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
     .to_return(status: 200, body: raw_content)
@@ -250,6 +249,7 @@ def then_i_see_the_create_announcement_form
 end
 
 def when_i_fill_in_the_announcement_form_with_valid_data
+  set_up_github_data(@coronavirus_page)
   fill_in("title", with: "fancy title")
   fill_in("path", with: "/government")
   fill_in("announcement[published_at][day]", with: "12")
@@ -261,6 +261,21 @@ end
 def then_i_can_see_a_new_announcement_has_been_created
   expect(current_path).to eq("/coronavirus/landing")
   expect(expect(page).to(have_text("fancy title")))
+end
+
+# Deleting an announcement
+
+def when_i_delete_an_announcement
+  set_up_github_data(@coronavirus_page)
+
+  page.accept_alert "Are you sure?" do
+    page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}\"]", text: "Delete").click
+  end
+end
+
+def then_i_can_see_an_announcement_has_been_deleted
+  expect(page).to have_text("Announcement was successfully deleted.")
+  expect(page).not_to(have_text(@announcement_one.title))
 end
 
 def set_up_basic_sub_sections


### PR DESCRIPTION
[Trello](https://trello.com/c/hDirwfFk/801-delete-an-announcement-using-the-ui)

- Allows deletion of an `announcement` via the UI.
- This will also update publishing api. If the draft content item isn't updated, then it rolls back deletion in order to maintain consistency.  
- Tests have been added. If anyone has a better approach on setting up the feature spec then let me know (see commit message for more info). 


![delete-announcement](https://user-images.githubusercontent.com/5963488/101648223-825eee00-3a31-11eb-9fe9-cb83041c95e6.png)
