### PR TITLE
Prepare for Continuous Deployment

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,9 @@
+class HealthcheckController < ApplicationController
+  def index
+    healthcheck = GovukHealthcheck.healthcheck([
+      GovukHealthcheck::SidekiqRedis,
+      GovukHealthcheck::ActiveRecord,
+    ])
+    render json: healthcheck
+  end
+end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -23,7 +23,7 @@ class ListItemsController < ApplicationController
         if saved
           render json: { errors: [], updateURL: tag_list_list_item_path(@tag, @list, list_item) }
         else
-          render json: { errors: list_item.errors.to_json }, status: :unprocessable_entity
+          render json: { errors: list_item.errors }, status: :unprocessable_entity
         end
       end
     end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -51,7 +51,7 @@ class ListItemsController < ApplicationController
         if destroyed
           render json: { errors: [] }
         else
-          render json: { errors: list_item.errors.to_json }, status: :unprocessable_entity
+          render json: { errors: list_item.errors }, status: :unprocessable_entity
         end
       end
     end

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -69,7 +69,7 @@ class ListItemsController < ApplicationController
 
           render json: { errors: [] }
         else
-          render json: { errors: list_item.errors.to_json }, status: :unprocessable_entity
+          render json: { errors: list_item.errors }, status: :unprocessable_entity
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Rails.application.routes.draw do
 
   post "/link_report", to: "link_report#update"
 
+  get "/healthcheck", to: "healthcheck#index"
+
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -1,9 +1,9 @@
 require "gds_api/publishing_api/special_route_publisher"
 
 class SpecialRoutePublisher
-  def initialize(publisher_options)
+  def initialize(publisher_options, publisher = nil)
     @publishing_api = publisher_options[:publishing_api]
-    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
+    @publisher = publisher || GdsApi::PublishingApi::SpecialRoutePublisher.new(publisher_options)
   end
 
   def publish(route_type, route)

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe HealthcheckController, type: :controller do
+  describe "GET /healthcheck" do
+    before do
+      get :index
+    end
+
+    it "returns a 200 HTTP status" do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "includes a status in the response body" do
+      expect(JSON.parse(response.body)).to have_key("status")
+    end
+
+    it "checks for database connectivity" do
+      json = JSON.parse(response.body)
+      expect(json["checks"]).to include("database_connectivity")
+    end
+
+    it "checks for redis connectivity" do
+      json = JSON.parse(response.body)
+      expect(json["checks"]).to include("redis_connectivity")
+    end
+  end
+end

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -97,4 +97,55 @@ RSpec.describe ListItemsController, type: :controller do
       end
     end
   end
+
+  describe "update" do
+    let(:list_item) { create(:list_item, index: 7) }
+
+    def patch_list_item
+      patch :update, params: {
+        tag_id: tag.content_id,
+        list_id: list.id,
+        format: :js,
+        id: list_item.id,
+        new_list_id: list.id,
+        index: index,
+      }
+    end
+
+    context "with valid parameters" do
+      let(:index) { 3 }
+
+      it "updates the list item" do
+        patch_list_item
+        expect(list_item.reload.index).to eq(index)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "marks the tag as dirty" do
+        expect(tag.reload.dirty).to be(false)
+        patch_list_item
+        expect(tag.reload.dirty).to be(true)
+      end
+    end
+
+    context "with invalid parameters" do
+      let(:index) { -1 }
+
+      it "does not update the list item" do
+        patch_list_item
+        expect(list_item.reload.index).to eq(7)
+      end
+
+      it "returns an error status code" do
+        patch_list_item
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns JSON describing the errors" do
+        patch_list_item
+        json = JSON.parse(response.body)
+        expect(json["errors"]).to eq({ "index" => ["must be greater than or equal to 0"] })
+      end
+    end
+  end
 end

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+RSpec.describe ListItemsController, type: :controller do
+  let(:tag) { create(:tag) }
+  let(:list) { create(:list, tag: tag) }
+  let(:title) { "List item title" }
+  let(:path) { "/government/foo/vader/baby/yoda" }
+
+  describe "create" do
+    subject! do
+      post :create, params: {
+        tag_id: tag.content_id,
+        list_id: list.id,
+        list_item: { title: title, base_path: path, index: index },
+        format: format,
+      }
+    end
+
+    context "HTML format" do
+      let(:format) { :html }
+
+      context "with valid parameters" do
+        let(:index) { 3 }
+
+        it "creates the list item" do
+          list_item = list.list_items.last
+          expect(list_item.title).to eq(title)
+          expect(list_item.base_path).to eq(path)
+          expect(list_item.index).to eq(index)
+        end
+
+        it "redirects to the tag lists path" do
+          expect(subject).to redirect_to(tag_lists_path(tag))
+        end
+
+        it "indicates a success state to the user" do
+          expect(flash.key?(:success)).to be(true)
+        end
+      end
+
+      context "with invalid parameters" do
+        let(:index) { -1 }
+
+        it "does not create the list item" do
+          expect(list.list_items.count).to eq(0)
+        end
+
+        it "redirects to the tag lists path" do
+          expect(subject).to redirect_to(tag_lists_path(tag))
+        end
+
+        it "indicates a fail state to the user" do
+          expect(flash.key?(:danger)).to be(true)
+        end
+      end
+    end
+
+    context "JS format" do
+      let(:format) { :js }
+
+      context "with valid parameters" do
+        let(:index) { 3 }
+
+        it "creates the list item" do
+          list_item = list.list_items.last
+          expect(list_item.title).to eq(title)
+          expect(list_item.base_path).to eq(path)
+          expect(list_item.index).to eq(index)
+        end
+
+        it "returns a success status code" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "returns JSON containing the update URL" do
+          json = JSON.parse(response.body)
+          expect(json["errors"]).to eq([])
+          expect(json["updateURL"]).to eq(tag_list_list_item_path(tag, list, list.list_items.last))
+        end
+      end
+
+      context "with invalid parameters" do
+        let(:index) { -1 }
+
+        it "does not create the list item" do
+          expect(list.list_items.count).to eq(0)
+        end
+
+        it "returns an error status code" do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "returns JSON describing the errors" do
+          json = JSON.parse(response.body)
+          expect(json["errors"]).to eq({ "index" => ["must be greater than or equal to 0"] })
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+require_relative "../../lib/special_route_publisher"
+
+RSpec.describe SpecialRoutePublisher do
+  describe "publish" do
+    it "calls 'publish' on the passed 'publisher' argument" do
+      publisher = double("GdsApi::PublishingApi::SpecialRoutePublisher")
+      expect(publisher).to receive(:publish).with(hash_including({
+        publishing_app: "collections-publisher",
+        rendering_app: "collections",
+        type: "route_type",
+        public_updated_at: Time.zone.now.iso8601,
+        update_type: "major",
+        foo: "bar",
+      }))
+
+      SpecialRoutePublisher.new({}, publisher)
+        .publish("route_type", { foo: "bar" })
+    end
+  end
+
+  describe "unpublish" do
+    it "calls Publishing API's unpublish method directly" do
+      publishing_api = double("Publishing API")
+      content_id = SecureRandom.uuid
+      options = { foo: "bar" }
+      expect(publishing_api).to receive(:unpublish).with(
+        content_id,
+        options,
+      )
+
+      SpecialRoutePublisher.new({ publishing_api: publishing_api })
+        .unpublish(content_id, options)
+    end
+  end
+
+  describe "routes" do
+    it "should return a hash" do
+      expect(SpecialRoutePublisher.routes).to include(:exact)
+    end
+  end
+end


### PR DESCRIPTION
This PR brings Collections Publisher in line with the safety criteria defined in [RFC 128](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md) and enables Continuous Deployment.

Specifically, it adds:

- a 'healthcheck' endpoint
- a bunch of missing tests, bringing the code coverage above 95%
- a PR template warning about Continuous Deployment. 