### PR TITLE
Edit announcement

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -30,6 +30,20 @@ class AnnouncementsController < ApplicationController
     redirect_to coronavirus_page_path(@coronavirus_page.slug), message
   end
 
+  def edit
+    @announcement = coronavirus_page.announcements.find(params[:id])
+  end
+
+  def update
+    @announcement = coronavirus_page.announcements.find(params[:id])
+
+    if @announcement.update(announcement_params) && draft_updater.send
+      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Announcement was successfully updated."
+    else
+      render :edit
+    end
+  end
+
 private
 
   def coronavirus_page

--- a/app/views/announcements/edit.html.erb
+++ b/app/views/announcements/edit.html.erb
@@ -1,0 +1,35 @@
+<%
+links = [
+  {
+    text: 'Coronavirus pages',
+    href: coronavirus_pages_path
+  },
+  {
+    text: "#{@coronavirus_page.name} announcements",
+    href: coronavirus_page_path(slug: @coronavirus_page.slug)
+  },
+  {
+    text: "Edit"
+  },
+]
+
+  metadata = {
+    "Status" => "Draft",
+    "Last saved" => format_full_date_and_time(DateTime.now),
+  }
+%>
+
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page) %>
+<% content_for :context, 'Edit announcement' %>
+<% if @announcement.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @announcement %>
+<% end %>
+
+<div class="covid-edit-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @announcement, url: coronavirus_page_announcement_path(@coronavirus_page.slug, @announcement) do %>
+      <%= render "form" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -3,7 +3,7 @@
    {
      id: announcement.id,
      field: announcement.title,
-     edit: { href: coronavirus_page_path(@coronavirus_page.slug) },
+     edit: { href: edit_coronavirus_page_announcement_path(@coronavirus_page.slug, announcement) },
      delete: {
        href: coronavirus_page_announcement_path(@coronavirus_page.slug, announcement),
        data_attributes: {

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :landing }
+  let(:announcement) { create :announcement, coronavirus_page: coronavirus_page }
   let!(:live_stream) { create :live_stream, :without_validations }
   let(:title) { Faker::Lorem.sentence }
   let(:path) { "/government/foo/vader/baby/yoda" }
@@ -90,6 +91,62 @@ RSpec.describe AnnouncementsController, type: :controller do
       expect(announcement.title).to eq Announcement.last.title
       expect(announcement.path).to eq Announcement.last.path
       expect(announcement.id).not_to eq Announcement.last.id
+    end
+  end
+
+  describe "GET /coronavirus/:coronavirus_page_slug/announcements/:id/edit" do
+    it "renders successfully" do
+      stub_user.permissions << "Unreleased feature"
+      get :edit, params: { id: announcement, coronavirus_page_slug: coronavirus_page.slug }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not render successfully if the user does not have Coronavirus editor permissions" do
+      create :user
+      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe "PATCH /coronavirus/:coronavirus_page_slug/announcement" do
+    before do
+      stub_user.permissions << "Unreleased feature"
+    end
+
+    let(:updated_announcement_params) do
+      {
+        title: "Updated title",
+        path: "/updated/path",
+        published_at: published_at,
+      }
+    end
+
+    let(:params) do
+      {
+        id: announcement,
+        coronavirus_page_slug: coronavirus_page.slug,
+        announcement: updated_announcement_params,
+      }
+    end
+
+    subject { patch :update, params: params }
+
+    it "redirects to coronavirus page on success" do
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+
+    it "updates the announcements" do
+      announcement
+      expect { subject }.not_to(change { Announcement.count })
+    end
+
+    it "changes the attributes of the announcement" do
+      subject
+      published_at_time = Time.zone.local(updated_announcement_params[:published_at]["year"], updated_announcement_params[:published_at]["month"], updated_announcement_params[:published_at]["day"])
+      announcement.reload
+      expect(announcement.title).to eq(updated_announcement_params[:title])
+      expect(announcement.path).to eq(updated_announcement_params[:path])
+      expect(announcement.published_at).to eq(published_at_time)
     end
   end
 

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -111,6 +111,8 @@ RSpec.describe AnnouncementsController, type: :controller do
   describe "PATCH /coronavirus/:coronavirus_page_slug/announcement" do
     before do
       stub_user.permissions << "Unreleased feature"
+      setup_github_data
+      stub_coronavirus_publishing_api
     end
 
     let(:updated_announcement_params) do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -125,6 +125,17 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         then_i_can_see_a_new_announcement_has_been_created
       end
 
+      scenario "Editing announcements" do
+        given_i_can_access_unreleased_features
+        given_there_is_coronavirus_page_with_announcements
+        when_i_visit_a_coronavirus_page
+        then_i_can_see_an_announcements_section
+        when_i_can_click_change_for_an_announcement
+        then_i_see_the_edit_announcement_form
+        when_i_can_edit_the_announcement_form_with_valid_data
+        then_i_can_see_that_the_announcement_has_been_updated
+      end
+
       scenario "Deleting announcements", js: true do
         given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -263,8 +263,6 @@ def then_i_can_see_a_new_announcement_has_been_created
   expect(expect(page).to(have_text("fancy title")))
 end
 
-# Deleting an announcement
-
 def when_i_delete_an_announcement
   set_up_github_data(@coronavirus_page)
 
@@ -276,6 +274,25 @@ end
 def then_i_can_see_an_announcement_has_been_deleted
   expect(page).to have_text("Announcement was successfully deleted.")
   expect(page).not_to(have_text(@announcement_one.title))
+end
+
+def when_i_can_click_change_for_an_announcement
+  page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}/edit\"]", text: "Change").click
+end
+
+def then_i_see_the_edit_announcement_form
+  expect(page).to have_text("Edit announcement")
+end
+
+def when_i_can_edit_the_announcement_form_with_valid_data
+  set_up_github_data(@coronavirus_page)
+  fill_in("title", with: "Updated title")
+  click_on("Save")
+end
+
+def then_i_can_see_that_the_announcement_has_been_updated
+  expect(page).to have_content("Announcement was successfully updated.")
+  expect(page).to have_content("Updated title")
 end
 
 def set_up_basic_sub_sections


### PR DESCRIPTION
[Trello](https://trello.com/c/MLHLiI8L/800-edit-an-announcement-using-the-ui)

- Announcements are editable via the user interface.
- Draft content is sent to the publishing api.

<img width="1057" alt="edit-announcement" src="https://user-images.githubusercontent.com/5963488/101794190-8573e000-3afe-11eb-9f65-2285e61a9fc3.png">

