### PR TITLE
Skip authentication on healthcheck endpoint

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,4 +1,6 @@
 class HealthcheckController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def index
     healthcheck = GovukHealthcheck.healthcheck([
       GovukHealthcheck::SidekiqRedis,


### PR DESCRIPTION
Follow on from #1199. Smokey needs to be able to access the healthcheck endpoint without authenticating.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
