### PR TITLE
Make announcements section live

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -1,6 +1,5 @@
 class AnnouncementsController < ApplicationController
   include DateFormatHelper
-  before_action :require_unreleased_feature_permissions!
   before_action :require_coronavirus_editor_permissions!
   layout "admin_layout"
 

--- a/app/controllers/reorder_announcements_controller.rb
+++ b/app/controllers/reorder_announcements_controller.rb
@@ -1,5 +1,4 @@
 class ReorderAnnouncementsController < ApplicationController
-  before_action :require_unreleased_feature_permissions!
   before_action :require_coronavirus_editor_permissions!
   layout "admin_layout"
 

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -11,7 +11,7 @@ class CoronavirusPages::ContentBuilder
       validate_content
       data = github_data
       data["sections"] = sub_sections_data
-      data["announcements"] = announcements_data if coronavirus_page.announcements.any?
+      data["announcements"] = announcements_data
       add_live_stream(data)
       data["hidden_search_terms"] = hidden_search_terms
       data

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -2,11 +2,7 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Coronavirus landing page</h2>
 <ul class="govuk-list">
-  <% if unreleased_feature_user? %>
-    <li><%= link_to "Edit landing page accordions and announcements", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
-  <% else %>
-    <li><%= link_to "Edit landing page accordions", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
-  <% end %>
+  <li><%= link_to "Edit landing page accordions and announcements", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
   <li><%= link_to "Edit live stream URL", live_stream_index_path, class:"govuk-link" %></li>
   <li><%= link_to "Edit something else on the landing page", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
 </ul>

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -22,7 +22,7 @@
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "sub_sections" %>
-    <% if unreleased_feature_user? && @coronavirus_page.topic_page? %>
+    <% if @coronavirus_page.topic_page? %>
       <%= render "announcements" %>
     <% end %>
   </div>

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -12,14 +12,8 @@ RSpec.describe AnnouncementsController, type: :controller do
   let(:published_at) { { "day" => "12", "month" => "12", "year" => "1980" } }
 
   describe "GET /coronavirus/:coronavirus_page_slug/announcements/new" do
-    it "renders successfully if the user has unreleased feature permission" do
-      stub_user.permissions << "Unreleased feature"
-      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
-      expect(response).to have_http_status(:success)
-    end
-
     it "does not render successfully if the user does not have Coronavirus editor permissions" do
-      create :user, name: "Name Surname"
+      stub_user.permissions = %w[signin]
       get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
       expect(response).to have_http_status(:forbidden)
     end
@@ -27,7 +21,6 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "POST /coronavirus/:coronavirus_page_slug/announcements" do
     before do
-      stub_user.permissions << "Unreleased feature"
       setup_github_data
       stub_coronavirus_publishing_api
     end
@@ -58,7 +51,6 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "DELETE /coronavirus/:coronavirus_page_slug/announcements/:id" do
     before do
-      stub_user.permissions << "Unreleased feature"
       setup_github_data
       stub_coronavirus_publishing_api
     end
@@ -96,13 +88,12 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "GET /coronavirus/:coronavirus_page_slug/announcements/:id/edit" do
     it "renders successfully" do
-      stub_user.permissions << "Unreleased feature"
       get :edit, params: { id: announcement, coronavirus_page_slug: coronavirus_page.slug }
       expect(response).to have_http_status(:success)
     end
 
     it "does not render successfully if the user does not have Coronavirus editor permissions" do
-      create :user
+      stub_user.permissions = %w[signin]
       get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
       expect(response).to have_http_status(:forbidden)
     end
@@ -110,7 +101,6 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "PATCH /coronavirus/:coronavirus_page_slug/announcement" do
     before do
-      stub_user.permissions << "Unreleased feature"
       setup_github_data
       stub_coronavirus_publishing_api
     end

--- a/spec/controllers/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/reorder_announcements_controller_spec.rb
@@ -5,20 +5,12 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
 
   describe "GET Coronavirus reorder announcements page" do
-    it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
-      stub_user.permissions << "Unreleased feature"
-
+    it "can only be accessed by users with Coronavirus editor permissions" do
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
       expect(response).to have_http_status(:success)
     end
 
-    it "cannot be accessed by users with only Coronavirus editor permissions" do
-      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
-
-      expect(response.status).to eq(403)
-    end
-
-    it "cannot be accessed by users without Coronavirus editor and Unreleased feature permissions" do
+    it "cannot be accessed by users without Coronavirus editor permissions" do
       stub_user.permissions = %w[signin]
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
 
@@ -33,7 +25,6 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
     before do
       setup_github_data
       stub_coronavirus_publishing_api
-      stub_user.permissions << "Unreleased feature"
     end
 
     it "reorders the announcements" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -107,7 +107,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Viewing announcements" do
-        given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements
         when_i_visit_a_coronavirus_page
         then_i_can_see_an_announcements_section
@@ -115,7 +114,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Adding announcements" do
-        given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements
         when_i_visit_a_coronavirus_page
         then_i_can_see_an_announcements_section
@@ -126,7 +124,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Editing announcements" do
-        given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements
         when_i_visit_a_coronavirus_page
         then_i_can_see_an_announcements_section
@@ -137,7 +134,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Deleting announcements", js: true do
-        given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements
         when_i_visit_a_coronavirus_page
         then_i_can_see_an_announcements_section
@@ -206,7 +202,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Viewing announcements" do
-        given_i_can_access_unreleased_features
         when_i_visit_the_coronavirus_index_page
         and_i_select_business_page
         then_i_cannot_see_an_announcements_section

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -142,7 +142,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Reordering announcements", js: true do
-        given_i_can_access_unreleased_features
         given_there_is_coronavirus_page_with_announcements
         when_i_visit_the_reorder_announcements_page
         then_i_see_the_announcements_in_order


### PR DESCRIPTION
Trello: https://trello.com/c/ekjW492n

# What's changed and why?

We're ready to make the announcements section, so we need to remove the "Unreleased feature" feature flag.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
