### PR TITLE
Fix failing Special Route Publisher rake test

### DIFF
--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe "rake publishing_api:publish_special_route", type: :task do
     allow(Services.publishing_api).to receive(:put_content)
     allow(Services.publishing_api).to receive(:publish)
 
-    expect_any_instance_of(GdsApi::PublishingApi::SpecialRoutePublisher).to receive(:publish).with(expected_payload)
+    expect_any_instance_of(GdsApi::PublishingApi::SpecialRoutePublisher)
+      .to receive(:publish)
+      .with(expected_payload)
+      .at_least(:once)
 
     Rake::Task["publishing_api:publish_special_route"].invoke("/eubusiness.de")
   end


### PR DESCRIPTION
Fixes error:

```
  1) rake publishing_api:publish_special_route finds a configured route by base path and publishes it
     Failure/Error: @publisher.publish(default_options.merge(route))
       The message 'publish' was received by #<GdsApi::PublishingApi::SpecialRoutePublisher:183300 @logger=#<ActiveSupport::Logger:0x0000562df0dbd908>, @publishing_api=#<GdsApi::PublishingApi:0x0000562df08b0e10>> but has already been received by #<GdsApi::PublishingApi::SpecialRoutePublisher:0x0000562df70125e0>
     # ./lib/special_route_publisher.rb:18:in `publish'
     # ./lib/tasks/publishing_api.rake:47:in `block (2 levels) in <top (required)>'
     # ./spec/lib/tasks/publishing_api_spec.rb:28:in `block (2 levels) in <top (required)>'

Finished in 1 minute 39.33 seconds (files took 16.95 seconds to load)
920 examples, 1 failure

Failed examples:

rspec ./spec/lib/tasks/publishing_api_spec.rb:10 # rake publishing_api:publish_special_route finds a configured route by base path and publishes it
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
