### PR TITLE
Fix error when discarding draft announcements

### DIFF
--- a/app/services/coronavirus_pages/draft_discarder.rb
+++ b/app/services/coronavirus_pages/draft_discarder.rb
@@ -26,8 +26,8 @@ module CoronavirusPages
     def announcements
       announcements_from_payload.map.with_index do |announcement, index|
         Announcement.new(
-          title: announcement[:title],
-          path: announcement[:path],
+          title: announcement[:text],
+          path: announcement[:href],
           published_at: Date.parse(announcement[:published_text]),
           position: index + 1,
         )

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -4,8 +4,8 @@
     "announcements_label": "Announcements",
     "announcements": [
       {
-        "path": "/government/news/more-rapid-covid-19-tests-to-be-rolled-out-across-england",
-        "title": "More rapid COVID-19 tests to be rolled out across England",
+        "href": "/government/news/more-rapid-covid-19-tests-to-be-rolled-out-across-england",
+        "text": "More rapid COVID-19 tests to be rolled out across England",
         "published_text": "Published 10 November 2020"
       }
     ],


### PR DESCRIPTION
Trello: https://trello.com/c/xN4yagBW

# What's changed and why?

Discarding announcements was failing with this error:

[975bd1ce-869d-4e73-b234-d399b0ab70e2] {"exception_class":"ActiveRecord::RecordNotSaved","exception_message":"Failed to replace announcements because one or more of the new records could not be saved.","stacktrace":["app/services/coronavirus_pages/draft_discarder.rb:23:in `update_announcements'","app/services/coronavirus_pages/draft_discarder.rb:14:in `block in call'","app/services/coronavirus_pages/draft_discarder.rb:12:in `call'","app/controllers/coronavirus_pages_controller.rb:39:in `discard'"]}


When the name of the columns in the Announcements table changed to no longer match the
field names from publishing-api, it looks like fields from publishing-api where also accidentally
replaced.

# Expected changes
## Before
<img width="1532" alt="Screenshot 2020-12-16 at 15 45 29" src="https://user-images.githubusercontent.com/5793815/102391762-0f73eb00-3fce-11eb-89d8-dd8203924347.png">

## After
<img width="1532" alt="Screenshot 2020-12-16 at 18 25 18" src="https://user-images.githubusercontent.com/5793815/102391775-13a00880-3fce-11eb-877b-e9507f4a1974.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
