### PR TITLE
Use default logger in Special Route publishing

### DIFF
--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -3,8 +3,7 @@ require "gds_api/publishing_api/special_route_publisher"
 class SpecialRoutePublisher
   def initialize
     @publishing_api = Services.publishing_api
-    logger = Rails.logger
-    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(logger: logger, publishing_api: @publishing_api)
+    @publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(publishing_api: @publishing_api)
   end
 
   def publish(route)


### PR DESCRIPTION
The the logger wasn't being stubbed in the tests that call Special Router Publisher
GdsApi adapter method.

That mean't the first test that ran passed, but the second test fails with:

```
1) rake publishing_api:publish_special_route finds a configured route by base path and publishes it
     Failure/Error: @publisher.publish(default_options.merge(route))
       The message 'publish' was received by #<GdsApi::PublishingApi::SpecialRoutePublisher:227700 @logger=#<ActiveSupport::Logger:0x0000559f9afaea08>, @publishing_api=#<GdsApi::PublishingApi:0x0000559f9e5b92d8>> but has already been received by #<GdsApi::PublishingApi::SpecialRoutePublisher:0x0000559f9f870cf0>
     # ./lib/special_route_publisher.rb:18:in `publish'
     # ./lib/tasks/publishing_api.rake:47:in `block (2 levels) in <top (required)>'
     # ./spec/lib/tasks/publishing_api_spec.rb:31:in `block (2 levels) in <top (required)>'

Finished in 1 minute 49.86 seconds (files took 17.42 seconds to load)
920 examples, 1 failure
```

If a logger isn't passed in, GdsApi adapters will use its [Base Logger] which I think is fine.

[Base Logger]: https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/publishing_api/special_route_publisher.rb#L8

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
