### PR TITLE
Tidy up specialist publisher tests

### DIFF
--- a/spec/lib/special_route_publisher_spec.rb
+++ b/spec/lib/special_route_publisher_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require_relative "../../lib/special_route_publisher"
 
 RSpec.describe SpecialRoutePublisher do
-  describe "publish" do
+  describe "#publish" do
     it "calls 'publish' on SpecialRoutePublisher with a route" do
       route = {
         document_type: "answer",
@@ -22,14 +22,14 @@ RSpec.describe SpecialRoutePublisher do
             type: "exact",
             update_type: "major",
           }.merge(route),
-        ).at_least(:once)
+        )
 
-      SpecialRoutePublisher.new
+      described_class.new
         .publish(route)
     end
   end
 
-  describe "unpublish" do
+  describe "#unpublish" do
     it "calls Publishing API's unpublish method directly" do
       content_id = SecureRandom.uuid
       options = { type: "exact" }
@@ -39,14 +39,22 @@ RSpec.describe SpecialRoutePublisher do
         options,
       )
 
-      SpecialRoutePublisher.new
+      described_class.new
         .unpublish(content_id, options)
     end
   end
 
-  describe "routes" do
+  describe ".routes" do
     it "should return an array of routes" do
-      expect(SpecialRoutePublisher.routes.first).to include(:content_id)
+      expect(described_class.routes.first).to include(:content_id)
+    end
+  end
+
+  describe ".find_route" do
+    it "returns a route by its base_path" do
+      path = "/eubusiness"
+      response = described_class.find_route(path)
+      expect(response).to include(base_path: path)
     end
   end
 end

--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -5,29 +5,20 @@ RSpec.describe "rake publishing_api:publish_special_route", type: :task do
   before do
     Rails.application.load_tasks
     Rake::Task["publishing_api:publish_special_route"].reenable
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
   end
 
   it "finds a configured route by base path and publishes it" do
-    expected_payload = {
-      base_path: "/eubusiness.de",
-      content_id: "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",
-      description: "Das Vereinigte Königreich ist aus der EU ausgetreten. Am 31. Dezember 2020 wird das Vereinigte Königreich den EU-Binnenmarkt und die Zollunion verlassen. Ab 1. Januar 2021 ändern sich die Regeln für den Handel mit dem Vereinigten Königreich.",
-      locale: "de",
-      publishing_app: "collections-publisher",
-      rendering_app: "collections",
-      title: "Handel mit dem Vereinigten Königreich ab 1. Januar 2021 als Unternehmen mit Sitz in der EU",
-      type: "exact",
-      update_type: "major",
-    }
+    Rake::Task["publishing_api:publish_special_route"].invoke("/eubusiness.it")
 
-    allow(Services.publishing_api).to receive(:put_content)
-    allow(Services.publishing_api).to receive(:publish)
+    assert_publishing_api_put_content(
+      "bb986a97-3b8c-4b1a-89bf-2a9f46be9747",
+      request_json_includes(
+        "base_path" => "/eubusiness.it",
+      ),
+    )
 
-    expect_any_instance_of(GdsApi::PublishingApi::SpecialRoutePublisher)
-      .to receive(:publish)
-      .with(expected_payload)
-      .at_least(:once)
-
-    Rake::Task["publishing_api:publish_special_route"].invoke("/eubusiness.de")
+    assert_publishing_api_publish("bb986a97-3b8c-4b1a-89bf-2a9f46be9747")
   end
 end


### PR DESCRIPTION
## What
The `#publish` test in special_route_publisher_spec.rb is very similar to the spec for the publishing_api rake tasks in lib/tasks/publishing_api_spec.rb. As both tests stub the same call, the [CI](https://ci.integration.publishing.service.gov.uk/job/collections-publisher/job/master/1061/console) is intermittently failing. 

- Refactor the rake task spec to check if publishing api receives the call to put and publish, rather than assert that the specialist publisher receives it.
- Add a test for find_route to the special_route_publisher_spec.rb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
