### PR TITLE
Remove need for at least one live stream in db

### DIFF
--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -94,6 +94,8 @@ class CoronavirusPages::ContentBuilder
   end
 
   def persisted_live_stream_data
+    return {} unless LiveStream.any?
+
     live_stream = LiveStream.last
     {
       "video_url" => live_stream.url,

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe AnnouncementsController, type: :controller do
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :landing }
   let(:announcement) { create :announcement, coronavirus_page: coronavirus_page }
-  let!(:live_stream) { create :live_stream, :without_validations }
   let(:title) { Faker::Lorem.sentence }
   let(:path) { "/government/foo/vader/baby/yoda" }
   let(:published_at) { { "day" => "12", "month" => "12", "year" => "1980" } }

--- a/spec/controllers/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/reorder_sub_sections_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
   render_views
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
-  let(:live_stream) { create :live_stream, :without_validations }
   let(:slug) { coronavirus_page.slug }
   let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
@@ -22,7 +21,6 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
       stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
         .to_return(status: 200, body: raw_content)
       stub_coronavirus_publishing_api
-      live_stream
     end
     let(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }
     let(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page }

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe SubSectionsController, type: :controller do
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
   let(:sub_section) { create :sub_section, coronavirus_page: coronavirus_page }
-  let!(:live_stream) { create :live_stream, :without_validations }
   let(:title) { Faker::Lorem.sentence }
   let(:content) { "###{Faker::Lorem.sentence}" }
   let(:sub_section_params) do
@@ -33,7 +32,6 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
-      live_stream
     end
     subject do
       post :create, params: { coronavirus_page_slug: slug, sub_section: sub_section_params }
@@ -120,7 +118,6 @@ RSpec.describe SubSectionsController, type: :controller do
       stub_request(:get, raw_content_url_regex)
         .to_return(body: raw_content)
       stub_coronavirus_publishing_api
-      live_stream
     end
     let(:params) do
       {

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CoronavirusPagePresenter do
   let(:meta_description) { github_content["content"]["meta_description"] }
   let(:data) { CoronavirusPages::ContentBuilder.new(coronavirus_page).data }
   let(:details) { data.except(title, meta_description) }
-  let!(:live_stream) { create :live_stream, :without_validations }
 
   let(:payload) do
     {
@@ -33,7 +32,6 @@ RSpec.describe CoronavirusPagePresenter do
   subject { described_class.new(data, base_path) }
 
   before do
-    live_stream
     stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
     stub_coronavirus_publishing_api

--- a/spec/services/coronavirus_pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus_pages/draft_updater_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPages::DraftUpdater do
-  let(:live_stream) { create :live_stream, :without_validations }
   let(:coronavirus_page) { create :coronavirus_page }
   let(:content_builder) { CoronavirusPages::ContentBuilder.new(coronavirus_page) }
   let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
@@ -11,7 +10,6 @@ RSpec.describe CoronavirusPages::DraftUpdater do
   subject { described_class.new(coronavirus_page) }
 
   before do
-    live_stream
     stub_coronavirus_publishing_api
     stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)


### PR DESCRIPTION
Trello: https://trello.com/c/1YohbtSc

# What's changed and why?
Adds a guard so that the merging of live stream data doesn't fail if the
database doesn't contain a live stream.

The live stream is an optional component on the coronavirus landing
page, and there hasn't been a live stream in months.

However the code expected there to be at least one live stream in the
database.

Adding the guard means that we no longer have to create an unnecessary
live stream object to test things like announcements and sub_sections.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
