### PR TITLE
Internationalise announcements and subsections

### DIFF
--- a/app/views/coronavirus_pages/_actions.html.erb
+++ b/app/views/coronavirus_pages/_actions.html.erb
@@ -1,18 +1,18 @@
 <div class="app-side">
   <div class="app-side__actions">
     <%= form_with(url: coronavirus_page_publish_path(coronavirus_page_slug: @coronavirus_page.slug), local: true) do %>
-      <%= render "govuk_publishing_components/components/button", { text: "Publish" } %>
+      <%= render "govuk_publishing_components/components/button", { text: t("coronavirus_pages.actions.publish") } %>
     <% end %>
     <%= render "govuk_publishing_components/components/button", {
-      text: "Preview",
+      text: t("coronavirus_pages.actions.preview"),
       href: draft_govuk_url(@coronavirus_page.base_path),
       target: "_blank",
       secondary: true
     } %>
 
-    <%= link_to 'Discard changes', discard_coronavirus_page_path,class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
+    <%= link_to t("coronavirus_pages.actions.discard_changes"), discard_coronavirus_page_path,class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-    <%= link_to "View on GOV.UK", published_url(@coronavirus_page.base_path.delete_prefix("/")), target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
+    <%= link_to t("coronavirus_pages.actions.view_on_govuk"), published_url(@coronavirus_page.base_path.delete_prefix("/")), target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -7,7 +7,7 @@
      delete: {
        href: coronavirus_page_announcement_path(@coronavirus_page.slug, announcement),
        data_attributes: {
-         confirm: "Are you sure?",
+         confirm: t("coronavirus_pages.announcements.confirm"),
          method: "delete"
        }
      }
@@ -19,12 +19,12 @@
     title: "Announcements",
     items: announcements,
     edit: {
-      link_text: "Reorder",
+      link_text: t("coronavirus_pages.announcements.reorder"),
       href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug)
     }
   } %>
   <%= render "govuk_publishing_components/components/button", {
-    text: "Add announcement",
+    text: t("coronavirus_pages.announcements.add"),
     href: new_coronavirus_page_announcement_path(@coronavirus_page.slug)
   } %>
 </div>

--- a/app/views/coronavirus_pages/_sub_sections.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections.html.erb
@@ -7,7 +7,7 @@
      delete: {
        href: coronavirus_page_sub_section_path(@coronavirus_page.slug, sub_section),
        data_attributes: {
-         confirm: "Are you sure?",
+         confirm: t("coronavirus_pages.sub_sections.confirm"),
          method: "delete"
        }
      }
@@ -19,13 +19,13 @@
     title: @coronavirus_page.sections_title,
     items: sub_sections,
     edit: {
-      link_text: "Reorder",
+      link_text: t("coronavirus_pages.sub_sections.reorder"),
       href: reorder_coronavirus_page_sub_sections_path(@coronavirus_page.slug)
     }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Add accordion",
+    text: t("coronavirus_pages.sub_sections.add"),
     href: new_coronavirus_page_sub_section_path(@coronavirus_page.slug)
   } %>
 </div>

--- a/app/views/coronavirus_pages/index.html.erb
+++ b/app/views/coronavirus_pages/index.html.erb
@@ -2,15 +2,15 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Coronavirus landing page</h2>
 <ul class="govuk-list">
-  <li><%= link_to "Edit landing page accordions and announcements", coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
-  <li><%= link_to "Edit live stream URL", live_stream_index_path, class:"govuk-link" %></li>
-  <li><%= link_to "Edit something else on the landing page", prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
+  <li><%= link_to t("coronavirus_pages.index.landing_page_edit.accordions"), coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <li><%= link_to t("coronavirus_pages.index.landing_page_edit.live_stream_url"), live_stream_index_path, class:"govuk-link" %></li>
+  <li><%= link_to t("coronavirus_pages.index.landing_page_edit.something_else"), prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
 </ul>
 
 <% @subtopic_pages.each do |page| %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%=page.name%></h2>
   <ul class="govuk-list">
-    <li class="covid__spaced-list-item"><%= link_to "Edit #{page.name.downcase} accordions", coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
-    <li class="covid__spaced-list-item"><%= link_to "Edit something else on the #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to t("coronavirus_pages.index.subtopic_edit.accordions", page_name: page.name.downcase), coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to "#{t("coronavirus_pages.index.subtopic_edit.something")} #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   </ul>
 <% end %>

--- a/app/views/coronavirus_pages/prepare.html.erb
+++ b/app/views/coronavirus_pages/prepare.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Edit the #{@coronavirus_page.name}" %>
 <% content_for :context, "www.gov.uk#{@coronavirus_page.base_path}" %>
 <%= render "govuk_publishing_components/components/lead_paragraph", {
-  text: "Follow the steps below to make changes to any part of the #{@coronavirus_page.name}, except the accordions."
+  text: t("coronavirus_pages.prepare.lead_paragraph", coronavirus_page_name: @coronavirus_page.name)
 } %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/coronavirus_pages/shared/_draft.html.erb
+++ b/app/views/coronavirus_pages/shared/_draft.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-!-padding-bottom-6">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "3. Update draft",
+    text: t("coronavirus_pages.draft.heading"),
     padding: true
   } %>
   <%= form_with(url: coronavirus_page_path, method: "put", local: true) do %>
     <%= render "govuk_publishing_components/components/button", {
-        text: "Update draft",
+        text: t("coronavirus_pages.draft.button_text"),
         margin_bottom: false
     } %>
   <% end %>

--- a/app/views/coronavirus_pages/shared/_github.html.erb
+++ b/app/views/coronavirus_pages/shared/_github.html.erb
@@ -1,18 +1,18 @@
 <div class="govuk-!-padding-bottom-1">
   <%= render "govuk_publishing_components/components/heading", {
-  text: "1. Update GitHub",
+  text: t("coronavirus_pages.github.update_heading"),
   padding: true
   } %>
   <p class="govuk-body">
-     Update the<%= link_to " coronavirus content on GitHub", github_url %>
+    <%= t("coronavirus_pages.github.update_sub_heading_html", github_url: github_url) %>
   </p>
 </div>
 <div class="govuk-!-padding-bottom-1">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "2. Get changes reviewed and merged",
+    text: t("coronavirus_pages.github.review_heading"),
     padding: true
   } %>
   <p class="govuk-body">
-    Get the changes approved and merged into master.
+    <%= t("coronavirus_pages.github.approve_sub_heading") %>
   </p>
 </div>

--- a/app/views/coronavirus_pages/shared/_live.html.erb
+++ b/app/views/coronavirus_pages/shared/_live.html.erb
@@ -1,9 +1,9 @@
 <%= render "govuk_publishing_components/components/heading", {
-  text: "6. Check live",
+  text: t("coronavirus_pages.live.heading"),
   padding: true
 } %>
 <%= render "govuk_publishing_components/components/button", {
-    text: "View live version",
+    text: t("coronavirus_pages.live.button_text"),
     href: published_url(path.delete_prefix("/")),
     target: "_blank",
     secondary: true

--- a/app/views/coronavirus_pages/shared/_preview.html.erb
+++ b/app/views/coronavirus_pages/shared/_preview.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-!-padding-bottom-2">
   <%= render "govuk_publishing_components/components/heading", {
-    text: "4. Preview changes",
+    text: t("coronavirus_pages.preview.heading"),
     padding: true
   } %>
   <div class="govuk-!-padding-bottom-3">
     <%= render "govuk_publishing_components/components/button", {
-      text: "Preview",
+      text: t("coronavirus_pages.preview.button_text"),
       href: draft_govuk_url(path),
       target: "_blank",
       secondary: true

--- a/app/views/coronavirus_pages/shared/_publish.html.erb
+++ b/app/views/coronavirus_pages/shared/_publish.html.erb
@@ -1,28 +1,28 @@
 <div class="govuk-!-padding-bottom-4">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "5. Publish changes",
+      text: t("coronavirus_pages.publish.heading"),
       padding: true
     } %>
     <%= form_with(url: coronavirus_page_publish_path(coronavirus_page_slug: params[:slug]), local: true) do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "update-type",
-        heading: "Update type",
+        heading: t("coronavirus_pages.publish.radio_heading"),
         heading_size: "s",
         small: true,
         items: [
           {
             value: "minor",
-            text: "Minor",
+            text: t("coronavirus_pages.publish.minor_type"),
             checked: true
           },
           {
             value: "major",
-            text: "Major"
+            text: t("coronavirus_pages.publish.major_type")
           }
         ]
       } %>
       <%= render "govuk_publishing_components/components/button", {
-          text: "Publish",
+          text: t("coronavirus_pages.publish.button_text"),
       } %>
     <% end %>
 </div>

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -1,11 +1,11 @@
 <%
   links = [
     {
-      text: 'Coronavirus pages',
+      text: t("coronavirus_pages.show.link_text"),
       href: coronavirus_pages_path
     },
     {
-      text: "#{@coronavirus_page.name} accordions"
+      text: t("coronavirus_pages.show.accordion_text", coronavirus_page_name: @coronavirus_page.name)
     }
   ]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,51 @@
 en:
+  coronavirus_pages:
+    actions:
+      discard_changes: Discard changes
+      view_on_govuk: View on GOV.UK
+      preview: Preview
+      publish: Publish
+    announcements:
+      confirm: Are you sure?
+      reorder: Reorder
+      add: Add announcement
+    draft:
+      heading: 3. Update draft
+      button_text: Update draft
+    github:
+      update_heading: 1. Update GitHub
+      review_heading: 2. Get changes reviewed and merged
+      update_sub_heading_html: "Update the <a href=\"%{github_url}\">coronavirus content on Github</a>"
+      approve_sub_heading: Get the changes approved and merged into master.
+    index:
+      landing_page_edit:
+        accordions: Edit landing page accordions and announcements
+        live_stream_url: Edit live stream URL
+        something_else: Edit something else on the landing page
+      subtopic_edit:
+        accordions: "Edit %{page_name} accordions"
+        something: Edit something else on the
+    live:
+      heading: 6. Check live
+      button_text: View live version
+    prepare:
+      lead_paragraph: "Follow the steps below to make changes to any part of the %{coronavirus_page_name}, except the accordions."
+    preview:
+      heading: 4. Preview changes
+      button_text: Preview
+    publish:
+      heading: 5. Publish changes
+      radio_heading: Update type
+      major_type: Major
+      minor_type: Minor
+      button_text: Publish
+    show:
+      link_text: Coronavirus pages
+      accordion_text: "%{coronavirus_page_name} accordions"
+    sub_sections:
+      confirm: Are you sure?
+      reorder: Reorder
+      add: Add accordion
   step_by_step_page:
     statuses:
       draft: Draft


### PR DESCRIPTION
This moves the copy for announcements and sub sections into the en locale file. This will make it easier to keep track of.

There won't be any frontend changes with this, users won't notice a difference.

Trello - https://trello.com/c/0Nm1iIcz/973-put-content-for-coronavirus-publishing-tool-subsections-and-announcements-into-an-en-locale-file

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
