### PR TITLE
Fix flaky test

### DIFF
--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -3,7 +3,6 @@ require "gds_api/publishing_api/special_route_publisher"
 
 RSpec.describe "rake publishing_api:publish_special_route", type: :task do
   before do
-    Rails.application.load_tasks
     Rake::Task["publishing_api:publish_special_route"].reenable
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish

--- a/spec/lib/tasks/set_step_by_step_status_spec.rb
+++ b/spec/lib/tasks/set_step_by_step_status_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.describe "rake step_by_step:set_status", type: :task do
   before do
     allow(Services.publishing_api).to receive(:lookup_content_id)
-
-    Rails.application.load_tasks
     Rake::Task["step_by_step:set_status"].reenable
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+Rails.application.load_tasks
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Each time `load_tasks` is run it’ll multiply the task so, as the line was in
two test files, whichever run first would pass, and the other would fail with:

```
The request PUT https://publishing-api.test.gov.uk/v2/content/bb986a97-3b8c-4b1a-89bf-2a9f46be9747 with given block was expected to execute 1 time but it executed 6 times
```

Hopefully this fixes it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
