### PR TITLE
Add Timeline entry model and migration.

### DIFF
--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -2,6 +2,7 @@ class CoronavirusPage < ApplicationRecord
   STATUSES = %w[draft published].freeze
   has_many :sub_sections, dependent: :destroy
   has_many :announcements, dependent: :destroy
+  has_many :timeline_entries, dependent: :destroy
   scope :topic_page, -> { where(slug: "landing") }
   scope :subtopic_pages, -> { where.not(slug: "landing") }
   validates :state, inclusion: { in: STATUSES }, presence: true

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -1,0 +1,4 @@
+class TimelineEntry < ApplicationRecord
+  belongs_to :coronavirus_page
+  validates :content, :heading, presence: true
+end

--- a/db/migrate/20210104141058_create_timeline_entries.rb
+++ b/db/migrate/20210104141058_create_timeline_entries.rb
@@ -1,0 +1,12 @@
+class CreateTimelineEntries < ActiveRecord::Migration[6.0]
+  def change
+    create_table :timeline_entries do |t|
+      t.references :coronavirus_page, foreign_key: true, null: false
+      t.string :content, null: false
+      t.string :heading, null: false
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_144059) do
+ActiveRecord::Schema.define(version: 2021_01_04_141058) do
 
   create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
@@ -199,6 +199,16 @@ ActiveRecord::Schema.define(version: 2020_11_24_144059) do
     t.index ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true
   end
 
+  create_table "timeline_entries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "coronavirus_page_id", null: false
+    t.string "content", null: false
+    t.string "heading", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coronavirus_page_id"], name: "index_timeline_entries_on_coronavirus_page_id"
+  end
+
   create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -225,4 +235,5 @@ ActiveRecord::Schema.define(version: 2020_11_24_144059) do
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade
   add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"
+  add_foreign_key "timeline_entries", "coronavirus_pages"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -260,4 +260,11 @@ FactoryBot.define do
     published_at { Time.zone.local(2020, 9, 11) }
     coronavirus_page
   end
+
+  factory :timeline_entry do
+    content { "Amazing fantastic content" }
+    heading { "Unbelievable heading" }
+    position { 1 }
+    coronavirus_page
+  end
 end

--- a/spec/models/timeline_entry_spec.rb
+++ b/spec/models/timeline_entry_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe TimelineEntry do
+  it { should validate_presence_of(:heading) }
+  it { should validate_presence_of(:content) }
+end


### PR DESCRIPTION
We need somewhere to store the timeline entries from the coronavirus_landing_page.yml within the publishing application.

It turns out that rails can handle pluralizing ‘entry’ to ‘entries’ so we shouldn’t have to specify the association between the model and the table

Has basic validation to check presence of the heading and content fields. These fields don't currently match the fields in publishing-api, but that doesn't matter right now. We can do the mapping later when it's time to update the payload to publishing-api.

Currently there is no check for the presence of a 'position' value, nor is there a way of assigning a 'position' value. This will need to be addressed in subsequent work as the table will not accept a null value for 'position'. I have not set a default value for position as the intention is that this value will be incremented for each new value.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/9iIzSaME/1005-create-table-to-store-timeline-entries)
