### PR TITLE
Change TimelineEntry#contents type and validate heading length

### DIFF
--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -1,4 +1,5 @@
 class TimelineEntry < ApplicationRecord
   belongs_to :coronavirus_page
-  validates :content, :heading, presence: true
+  validates :heading, presence: true, length: { maximum: 255 }
+  validates :content, presence: true
 end

--- a/db/migrate/20210108140318_change_timeline_entries_content_type.rb
+++ b/db/migrate/20210108140318_change_timeline_entries_content_type.rb
@@ -1,0 +1,5 @@
+class ChangeTimelineEntriesContentType < ActiveRecord::Migration[6.0]
+  def change
+    change_column :timeline_entries, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_04_141058) do
+ActiveRecord::Schema.define(version: 2021_01_08_140318) do
 
   create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
@@ -201,7 +201,7 @@ ActiveRecord::Schema.define(version: 2021_01_04_141058) do
 
   create_table "timeline_entries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id", null: false
-    t.string "content", null: false
+    t.text "content", null: false
     t.string "heading", null: false
     t.integer "position", null: false
     t.datetime "created_at", null: false

--- a/spec/models/timeline_entry_spec.rb
+++ b/spec/models/timeline_entry_spec.rb
@@ -2,5 +2,6 @@ require "rails_helper"
 
 RSpec.describe TimelineEntry do
   it { should validate_presence_of(:heading) }
+  it { should validate_length_of(:heading).is_at_most(255) }
   it { should validate_presence_of(:content) }
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

We created this model with a DB column type of string, which in MySQL equates to a VARCHAR of max length 255. This causes us a problem as the current value we have in the timeline content is 679 characters. To resolve this I've switched the type to be text which has a max length of 64 KB.

I felt that there wasn't a real need for the heading field to be greater than 255 characters, so I haven't changed that. However it did seem a sufficiently small length that it could catch a user out, so I've added a validation. I didn't think there was much chance of a user being caught out with the 64KB content field so I didn't add a validation there.