### PR TITLE
Send DB timeline entries to Publishing API

### DIFF
--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -12,6 +12,12 @@ class CoronavirusPages::ContentBuilder
       data = github_data
       data["sections"] = sub_sections_data
       data["announcements"] = announcements_data
+
+      if Rails.configuration.unreleased_features
+        data["timeline"] ||= {}
+        data["timeline"]["list"] = timeline_data
+      end
+
       add_live_stream(data)
       data["hidden_search_terms"] = hidden_search_terms
       data
@@ -91,6 +97,14 @@ class CoronavirusPages::ContentBuilder
       presenter = AnnouncementJsonPresenter.new(announcement)
       presenter.output
     end
+  end
+
+  def timeline_data
+    coronavirus_page
+      .timeline_entries
+      .order(:position)
+      .pluck(:heading, :content)
+      .map { |(heading, content)| { "heading" => heading, "paragraph" => content } }
   end
 
   def persisted_live_stream_data

--- a/app/services/coronavirus_pages/draft_discarder.rb
+++ b/app/services/coronavirus_pages/draft_discarder.rb
@@ -13,6 +13,7 @@ module CoronavirusPages
         coronavirus_page.update!(state: "published")
         update_announcements
         update_sub_sections
+        update_timeline_entries
       end
     end
 
@@ -59,6 +60,25 @@ module CoronavirusPages
 
     def sections_from_payload
       payload_from_publishing_api[:details][:sections] || []
+    end
+
+    def update_timeline_entries
+      coronavirus_page.timeline_entries.destroy_all
+      coronavirus_page.timeline_entries = timeline_entries
+    end
+
+    def timeline_entries
+      timeline_entries_from_payload.each_with_index.map do |attributes, index|
+        TimelineEntry.new(
+          heading: attributes[:heading],
+          content: attributes[:paragraph],
+          position: index + 1,
+        )
+      end
+    end
+
+    def timeline_entries_from_payload
+      payload_from_publishing_api.dig(:details, :timeline, :list) || []
     end
 
     def payload_from_publishing_api

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -49,7 +49,16 @@
           }
         ]
       }
-    ]
+    ],
+    "timeline": {
+      "list": [
+        {
+          "heading": "5 January",
+          "paragraph": "[National lockdown rules apply in England](/guidance/national-lockdown-stay-at-home). Stay at home."
+        }
+      ],
+      "heading": "Recent and upcoming changes"
+    }
   },
   "state_history": { "1": "published" }
 }

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe CoronavirusPages::ContentBuilder do
 
   describe "#success?" do
     it "is true if call successful" do
-      expect(subject.success?).to be(true), subject.errors
+      expect(subject.success?).to be(true)
     end
 
     context "on failure" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -371,23 +371,13 @@ def then_the_reordered_subsections_are_sent_to_publishing_api
 
   assert_publishing_api_put_content(
     CoronavirusPage.topic_page.first.content_id,
-    request_json_includes(
-      "details" => {
-        "header_section" => "header_section",
-        "announcements_label" => "announcements_label",
-        "announcements" => [],
-        "nhs_banner" => "nhs_banner",
-        "sections_heading" => "sections_heading",
-        "topic_section" => "topic_section",
-        "live_stream" => {
-          "video_url" => LiveStream.first.url,
-          "date" => LiveStream.first.formatted_stream_date,
-        },
-        "notifications" => "notifications",
+    lambda do |request|
+      details = JSON.parse(request.body)["details"]
+      expect(details).to match hash_including({
         "sections" => reordered_sections,
         "hidden_search_terms" => hidden_search_terms.flatten.select(&:present?).uniq,
-      },
-    ),
+      })
+    end,
   )
 end
 


### PR DESCRIPTION
Trello: https://trello.com/c/0sxftxEF/1007-push-timeline-changes-to-publishing-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This adds in the ability for timeline entries from the DB to be sent to the Publishing API. This is currently behind the `unreleased_features` flag so will not impact production where the YAML file will still be used. This also updates the draft discarder which I assumed was part of this task.

Screenshot of this working from integration:

![Screenshot 2021-01-08 at 16 31 20](https://user-images.githubusercontent.com/282717/104040175-3db0a900-51cf-11eb-912a-f0ad36ed5d75.png)

A couple of pain points were: TimelineEntry and Publishing API use different naming for the content of an entry. Timeline entry uses "contents" and Publishing API already has "paragraph" which adds verbosity. Then we also have that timeline is nested inside an object which also increases verbosity. It feels like we could fix these things with some surgery of the page as a follow up story.

More info in the commits...
