### PR TITLE
Add create timeline page

### DIFF
--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -7,9 +7,27 @@ class TimelineEntriesController < ApplicationController
     @timeline_entry = coronavirus_page.timeline_entries.new
   end
 
+  def create
+    @timeline_entry = coronavirus_page.timeline_entries.new(timeline_entry_params)
+
+    if @timeline_entry.save && draft_updater.send
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Timeline entry was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
 private
+
+  def timeline_entry_params
+    params.require(:timeline_entry).permit(:heading, :content)
+  end
 
   def coronavirus_page
     @coronavirus_page ||= CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
+  end
+
+  def draft_updater
+    @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
   end
 end

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -1,6 +1,15 @@
 class TimelineEntriesController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
   before_action :require_unreleased_feature_permissions!
+  layout "admin_layout"
 
-  def new; end
+  def new
+    @timeline_entry = coronavirus_page.timeline_entries.new
+  end
+
+private
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
+  end
 end

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -1,0 +1,6 @@
+class TimelineEntriesController < ApplicationController
+  before_action :require_coronavirus_editor_permissions!
+  before_action :require_unreleased_feature_permissions!
+
+  def new; end
+end

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -24,6 +24,11 @@
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
+          <% if controls.include?(:blockquote) %>
+            <md-quote class="app-c-markdown-editor__toolbar-button" title="Blockquote" aria-label="Blockquote" data-gtm="markdown-toolbar-blockquote" data-gtm-click-tracking="true">
+              <%= render "components/markdown_editor/blockquote.svg" %>
+            </md-quote>
+          <% end %>
           <% if controls.include?(:bullets) %>
             <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
               <%= render "components/markdown_editor/bullets.svg" %>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -29,6 +29,11 @@
               <%= render "components/markdown_editor/blockquote.svg" %>
             </md-quote>
           <% end %>
+          <% if controls.include?(:numbered_list) %>
+            <md-ordered-list class="app-c-markdown-editor__toolbar-button" title="Numbered list" aria-label="Numbered list" data-gtm="markdown-toolbar-list" data-gtm-click-tracking="true">
+              <%= render "components/markdown_editor/numbered_list.svg" %>
+            </md-ordered-list>
+          <% end %>
           <% if controls.include?(:bullets) %>
             <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
               <%= render "components/markdown_editor/bullets.svg" %>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -1,7 +1,7 @@
 <%
   textarea ||= {}
   component_classes = %w[app-c-markdown-editor govuk-form-group]
-  bullets_button ||= false
+  controls ||= []
 %>
 <%= tag.div class: component_classes do %>
 
@@ -16,7 +16,7 @@
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
-          <% if bullets_button %>
+          <% if controls.include?(:bullets) %>
             <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
               <%= render "components/markdown_editor/bullets.svg" %>
             </md-unordered-list>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -2,12 +2,21 @@
   textarea ||= {}
   component_classes = %w[app-c-markdown-editor govuk-form-group]
   controls ||= []
+  error_message ||= ""
+
+  component_classes << "govuk-form-group--error" if error_message.present?
 %>
 <%= tag.div class: component_classes do %>
 
   <%= render "govuk_publishing_components/components/label", {
     html_for: textarea[:id],
   }.merge(label.symbolize_keys) %>
+
+  <% if error_message.present? %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      text: error_message,
+    } %>
+  <% end %>
 
    <div class="app-c-markdown-editor__container">
     <div class="app-c-markdown-editor__head">

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -13,6 +13,14 @@
     <div class="app-c-markdown-editor__head">
       <div class="app-c-markdown-editor__toolbar">
         <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="<%= textarea[:id] %>">
+          <% if controls.include?(:headings) %>
+            <md-header-2 class="app-c-markdown-editor__toolbar-button" title="Heading level 2" aria-label="Heading level 2" data-gtm="markdown-toolbar-h2" data-gtm-click-tracking="true">
+              <%= render "components/markdown_editor/heading_two.svg" %>
+            </md-header-2>
+            <md-header-3 class="app-c-markdown-editor__toolbar-button" title="Heading level 3" aria-label="Heading level 3" data-gtm="markdown-toolbar-h3" data-gtm-click-tracking="true">
+              <%= render "components/markdown_editor/heading_three.svg" %>
+            </md-header-3>
+          <% end %>
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -1,7 +1,7 @@
 <%
   textarea ||= {}
   component_classes = %w[app-c-markdown-editor govuk-form-group]
-  hide_bullets_button ||= false
+  bullets_button ||= false
 %>
 <%= tag.div class: component_classes do %>
 
@@ -16,7 +16,7 @@
           <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
-          <% unless hide_bullets_button %>
+          <% if bullets_button %>
             <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets">
               <%= render "components/markdown_editor/bullets.svg" %>
             </md-unordered-list>

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -42,3 +42,11 @@ examples:
       textarea:
         name: markdown-editor
         id: markdown-editor
+  with_blockquote_button:
+    data:
+      controls: [:blockquote]
+      label:
+        text: Body
+      textarea:
+        name: markdown-editor
+        id: markdown-editor

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -28,7 +28,7 @@ examples:
         id: markdown-editor
   with_bullet_list_button:
     data:
-      bullets_button: true
+      controls: [:bullets]
       label:
         text: Body
       textarea:

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -50,3 +50,11 @@ examples:
       textarea:
         name: markdown-editor
         id: markdown-editor
+  with_numbered_list_button:
+    data:
+      controls: [:numbered_list]
+      label:
+        text: Body
+      textarea:
+        name: markdown-editor
+        id: markdown-editor

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -34,3 +34,11 @@ examples:
       textarea:
         name: markdown-editor
         id: markdown-editor
+  with_headings_buttons:
+    data:
+      controls: [:headings]
+      label:
+        text: Body
+      textarea:
+        name: markdown-editor
+        id: markdown-editor

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -26,9 +26,9 @@ examples:
       textarea:
         name: markdown-editor
         id: markdown-editor
-  without_bullet_list_button:
+  with_bullet_list_button:
     data:
-      hide_bullets_button: true
+      bullets_button: true
       label:
         text: Body
       textarea:

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -118,7 +118,8 @@
       id: "step-content",
       rows: 20,
       value: step.contents
-    }
+    },
+    bullets_button: true
   } %>
 <% end %>
 

--- a/app/views/steps/_form.html.erb
+++ b/app/views/steps/_form.html.erb
@@ -119,7 +119,7 @@
       rows: 20,
       value: step.contents
     },
-    bullets_button: true
+    controls: [:bullets]
   } %>
 <% end %>
 

--- a/app/views/sub_sections/_form.html.erb
+++ b/app/views/sub_sections/_form.html.erb
@@ -17,8 +17,7 @@
     id: "content",
     rows: 20,
     value: @sub_section.content
-  },
-  hide_bullets_button: true
+  }
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {

--- a/app/views/timeline_entries/_form.html.erb
+++ b/app/views/timeline_entries/_form.html.erb
@@ -1,0 +1,31 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Enter the heading of the timeline entry",
+    bold: true,
+  },
+  name: "timeline_entry[heading]",
+  value: @timeline_entry.heading,
+  id: "heading",
+  error_message: error_items(@timeline_entry.errors.messages, :heading),
+} %>
+
+<%= render "components/markdown_editor", {
+  label: {
+    text: "Content",
+    bold: true
+  },
+  textarea: {
+    name: "timeline_entry[content]",
+    id: "content",
+    rows: 20,
+    value: @timeline_entry.content
+  },
+  error_message: error_items(@timeline_entry.errors.messages, :content),
+  controls: [:headings, :blockquote, :numbered_list, :bullets]
+} %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Save",
+  margin_bottom: true
+} %>
+<%= tag.p (link_to 'Cancel', coronavirus_page_path(@coronavirus_page.slug), class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>

--- a/app/views/timeline_entries/new.html.erb
+++ b/app/views/timeline_entries/new.html.erb
@@ -1,0 +1,1 @@
+<p>Placeholder</p>

--- a/app/views/timeline_entries/new.html.erb
+++ b/app/views/timeline_entries/new.html.erb
@@ -1,1 +1,30 @@
-<p>Placeholder</p>
+<%
+  links = [
+    {
+      text: 'Coronavirus pages',
+      href: coronavirus_pages_path
+    },
+    {
+      text: "#{@coronavirus_page.name} timeline entries",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Add timeline entry"
+    },
+  ]
+%>
+
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page) %>
+<% content_for :context, "Add timeline entry" %>
+<% if @timeline_entry.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @timeline_entry %>
+<% end %>
+
+<div class="covid-edit-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: coronavirus_page_timeline_entries_path do %>
+      <%= render "form" %>
+    <% end %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,9 @@ module CollectionsPublisher
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    # Sets local to "true" in all forms that use form_with. This is only needed
+    # until the application is upgraded to Rails 6.1.
+    config.action_view.form_with_generates_remote_forms = false
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
         put "reorder", to: "reorder_announcements#update"
       end
     end
+
+    resources :timeline_entries, only: [:new]
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :timeline_entries, only: [:new]
+    resources :timeline_entries, only: %i[new create]
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/db/migrate/20210111110154_change_position_to_null.rb
+++ b/db/migrate/20210111110154_change_position_to_null.rb
@@ -1,0 +1,5 @@
+class ChangePositionToNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:timeline_entries, :position, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_140318) do
+ActiveRecord::Schema.define(version: 2021_01_11_110154) do
 
   create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_140318) do
     t.bigint "coronavirus_page_id", null: false
     t.text "content", null: false
     t.string "heading", null: false
-    t.integer "position", null: false
+    t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["coronavirus_page_id"], name: "index_timeline_entries_on_coronavirus_page_id"

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe "Markdown editor", type: :view do
     assert_select ".govuk-textarea[id='markdown-editor']"
   end
 
-  it "renders bullet list toolbar button if bullets_button is true" do
+  it "renders bullet list toolbar button if bullets is configured" do
     render "components/markdown_editor",
-           bullets_button: true,
+           controls: [:bullets],
            label: {
              text: "Body",
            },

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -50,4 +50,18 @@ RSpec.describe "Markdown editor", type: :view do
     assert_select ".app-c-markdown-editor__toolbar-button[title='Heading level 2']", count: 1
     assert_select ".app-c-markdown-editor__toolbar-button[title='Heading level 3']", count: 1
   end
+
+  it "renders blockquote toolbar button if blockquote is configured" do
+    render "components/markdown_editor",
+           controls: [:blockquote],
+           label: {
+             text: "Body",
+           },
+           textarea: {
+             name: "markdown-editor",
+             id: "markdown-editor",
+           }
+
+    assert_select ".app-c-markdown-editor__toolbar-button[title='Blockquote']", count: 1
+  end
 end

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -35,4 +35,19 @@ RSpec.describe "Markdown editor", type: :view do
 
     assert_select ".app-c-markdown-editor__toolbar-button[title='Bullets']", count: 1
   end
+
+  it "renders heading toolbar buttons if headings is configured" do
+    render "components/markdown_editor",
+           controls: [:headings],
+           label: {
+             text: "Body",
+           },
+           textarea: {
+             name: "markdown-editor",
+             id: "markdown-editor",
+           }
+
+    assert_select ".app-c-markdown-editor__toolbar-button[title='Heading level 2']", count: 1
+    assert_select ".app-c-markdown-editor__toolbar-button[title='Heading level 3']", count: 1
+  end
 end

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -78,4 +78,18 @@ RSpec.describe "Markdown editor", type: :view do
 
     assert_select ".app-c-markdown-editor__toolbar-button[title='Numbered list']", count: 1
   end
+
+  it "renders error messages if passed to the component" do
+    render "components/markdown_editor",
+           error_message: "Something is wrong",
+           label: {
+             text: "Body",
+           },
+           textarea: {
+             name: "markdown-editor",
+             id: "markdown-editor",
+           }
+
+    assert_select ".govuk-error-message", text: "Error: Something is wrong"
+  end
 end

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe "Markdown editor", type: :view do
     assert_select ".govuk-textarea[id='markdown-editor']"
   end
 
-  it "does not render bullet list toolbar button if hide_bullets_button is true" do
+  it "renders bullet list toolbar button if bullets_button is true" do
     render "components/markdown_editor",
-           hide_bullets_button: true,
+           bullets_button: true,
            label: {
              text: "Body",
            },
@@ -33,6 +33,6 @@ RSpec.describe "Markdown editor", type: :view do
              id: "markdown-editor",
            }
 
-    assert_select ".app-c-markdown-editor__toolbar-button[title='Bullets']", count: 0
+    assert_select ".app-c-markdown-editor__toolbar-button[title='Bullets']", count: 1
   end
 end

--- a/spec/components/markdown_editor_spec.rb
+++ b/spec/components/markdown_editor_spec.rb
@@ -64,4 +64,18 @@ RSpec.describe "Markdown editor", type: :view do
 
     assert_select ".app-c-markdown-editor__toolbar-button[title='Blockquote']", count: 1
   end
+
+  it "renders numbered list toolbar button if numbered_list is configured" do
+    render "components/markdown_editor",
+           controls: [:numbered_list],
+           label: {
+             text: "Body",
+           },
+           textarea: {
+             name: "markdown-editor",
+             id: "markdown-editor",
+           }
+
+    assert_select ".app-c-markdown-editor__toolbar-button[title='Numbered list']", count: 1
+  end
 end

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe TimelineEntriesController do
-  describe "GET /coronavirus/:coronavirus_page_slug/timeline_entries/new" do
-    let(:stub_user) { create :user, name: "Name Surname" }
-    let(:coronavirus_page) { create :coronavirus_page, :landing }
+  let(:stub_user) { create :user, name: "Name Surname" }
+  let(:coronavirus_page) { create :coronavirus_page, :landing }
 
+  describe "GET /coronavirus/:coronavirus_page_slug/timeline_entries/new" do
     it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
       stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
       get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
@@ -25,5 +25,51 @@ RSpec.describe TimelineEntriesController do
 
       expect(response).to have_http_status(:forbidden)
     end
+  end
+
+  describe "POST /coronavirus/:coronavirus_page_slug/timeline_entries" do
+    let(:heading) { Faker::Lorem.sentence }
+    let(:content) { Faker::Lorem.sentence }
+    let(:timeline_entry_params) do
+      {
+        heading: heading,
+        content: content,
+      }
+    end
+
+    before do
+      setup_github_data
+      stub_any_publishing_api_call
+      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+    end
+
+    it "saves a new timeline entry" do
+      post :create,
+           params: {
+             coronavirus_page_slug: coronavirus_page.slug,
+             timeline_entry: timeline_entry_params,
+           }
+
+      timeline_entry = coronavirus_page.timeline_entries.last
+
+      expect(timeline_entry.heading).to eq(heading)
+      expect(timeline_entry.content).to eq(content)
+    end
+
+    it "redirects to coronavirus page on success" do
+      post :create,
+           params: {
+             coronavirus_page_slug: coronavirus_page.slug,
+             timeline_entry: timeline_entry_params,
+           }
+
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+  end
+
+  def setup_github_data
+    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe TimelineEntriesController do
+  describe "GET /coronavirus/:coronavirus_page_slug/timeline_entries/new" do
+    let(:stub_user) { create :user, name: "Name Surname" }
+    let(:coronavirus_page) { create :coronavirus_page, :landing }
+
+    it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
+      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "cannot be accessed by users without Unreleased feature permissions" do
+      stub_user.permissions << "Coronavirus editor"
+      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "cannot be accessed by users without Coronavirus editor permissions" do
+      stub_user.permissions << "Unreleased feature"
+      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -149,6 +149,15 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         then_i_see_announcement_updated_message
         and_i_see_the_announcements_have_changed_order
       end
+
+      scenario "Adding timeline entries" do
+        given_i_can_access_unreleased_features
+        given_there_is_a_coronavirus_page
+        when_i_visit_the_new_timeline_entry_page
+        then_i_see_the_create_timeline_entry_form
+        when_i_fill_in_the_timeline_entry_form_with_valid_data
+        then_a_new_timeline_entry_is_created
+      end
     end
 
     context "Business page" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -11,6 +11,10 @@ def given_a_livestream_exists
   FactoryBot.create(:live_stream, :without_validations)
 end
 
+def given_there_is_a_coronavirus_page
+  @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
+end
+
 def given_there_is_coronavirus_page_with_announcements
   @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
   @announcement_one = FactoryBot.create(:announcement, position: 0, coronavirus_page: @coronavirus_page)
@@ -293,6 +297,29 @@ end
 def then_i_can_see_that_the_announcement_has_been_updated
   expect(page).to have_content("Announcement was successfully updated.")
   expect(page).to have_content("Updated title")
+end
+
+# Adding a timeline entry
+
+def when_i_visit_the_new_timeline_entry_page
+  visit "/coronavirus/landing/timeline_entries/new"
+end
+
+def then_i_see_the_create_timeline_entry_form
+  expect(page).to have_text("Enter the heading of the timeline entry")
+  expect(page).to have_text("Content")
+end
+
+def when_i_fill_in_the_timeline_entry_form_with_valid_data
+  set_up_github_data(@coronavirus_page)
+  fill_in("heading", with: "Fancy title")
+  fill_in("content", with: "##Form content")
+  click_on("Save")
+end
+
+def then_a_new_timeline_entry_is_created
+  timeline_entry = @coronavirus_page.timeline_entries.last
+  expect(timeline_entry.content).to eq("##Form content")
 end
 
 def set_up_basic_sub_sections


### PR DESCRIPTION
Trello: https://trello.com/c/Gqe4lgaI

# What?

Create a page to allow new timeline entries to be stored in the database. 

Changes the markdown editor component to allow users to see the full range of menu options, whilst keeping the existing menu restrictions on the "step" and "sub-section" edit pages.

Only users with "Unreleased feature" permissions should be able to access the page whilst the timeline feature is being built.

The timeline entry is only persisted to the database. Whilst we are calling `DraftUpdater`, to send changes to the publishing-api, the actual creation of the payload for publishing-api will happen in another story.

# Expected changes

URL of page: http://collections-publisher.dev.gov.uk/coronavirus/landing/timeline_entries/new

![screenshot-collections-publisher dev gov uk-2021 01 12-10_15_33](https://user-images.githubusercontent.com/5793815/104301441-8c0bc380-54bf-11eb-9944-953fbc1d3fb6.png)

Error messages:

<img width="1532" alt="Screenshot 2021-01-13 at 17 15 59" src="https://user-images.githubusercontent.com/5793815/104489265-56ea9880-55c7-11eb-86d0-b63dea6bbe14.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
