### PR TITLE
Display timeline entries

### DIFF
--- a/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
+++ b/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
@@ -1,5 +1,5 @@
-.covid-manage-page__accordion-summary-list,
-.covid-manage-page__announcements-summary-list {
+.covid-manage-page__summary-list,
+.covid-manage-page__summary-list--divider {
   .govuk-summary-list__key {
     width: 70%;
   }
@@ -13,7 +13,7 @@
   }
 }
 
-.covid-manage-page__announcements-summary-list {
+.covid-manage-page__summary-list--divider:not(:first-child) {
   margin-top: govuk-spacing(8);
   margin-bottom: govuk-spacing(6);
   padding-top: govuk-spacing(6);

--- a/app/views/coronavirus_pages/_announcements.html.erb
+++ b/app/views/coronavirus_pages/_announcements.html.erb
@@ -14,7 +14,7 @@
    }
  end %>
 
-<div class="covid-manage-page__announcements-summary-list">
+<div class="covid-manage-page__summary-list--divider">
   <%= render "govuk_publishing_components/components/summary_list", {
     title: "Announcements",
     items: announcements,

--- a/app/views/coronavirus_pages/_sub_sections.html.erb
+++ b/app/views/coronavirus_pages/_sub_sections.html.erb
@@ -14,7 +14,7 @@
    }
  end %>
 
-<div class="covid-manage-page__accordion-summary-list">
+<div class="covid-manage-page__summary-list--divider">
   <%= render "govuk_publishing_components/components/summary_list", {
     title: @coronavirus_page.sections_title,
     items: sub_sections,

--- a/app/views/coronavirus_pages/_timeline_entries.html.erb
+++ b/app/views/coronavirus_pages/_timeline_entries.html.erb
@@ -1,0 +1,30 @@
+<% timeline_entries =
+ @coronavirus_page.timeline_entries.order(:position).map do |timeline_entry|
+   {
+     id: timeline_entry.id,
+     field: timeline_entry.heading,
+     edit: { href: edit_coronavirus_page_timeline_entry_path(@coronavirus_page.slug, timeline_entry) },
+     delete: {
+       href: coronavirus_page_path(@coronavirus_page.slug),
+       data_attributes: {
+         confirm: "Are you sure?",
+         method: "delete"
+       }
+     }
+   }
+ end %>
+
+<div class="covid-manage-page__summary-list--divider">
+  <%= render "govuk_publishing_components/components/summary_list", {
+    title: "Timeline entries",
+    items: timeline_entries,
+    edit: {
+      link_text: "Reorder",
+      href: coronavirus_page_path(@coronavirus_page.slug)
+    }
+  } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Add timeline entry",
+    href: new_coronavirus_page_timeline_entry_path(@coronavirus_page.slug)
+  } %>
+</div>

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -21,6 +21,7 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "timeline_entries" %>
     <%= render "sub_sections" %>
     <% if @coronavirus_page.topic_page? %>
       <%= render "announcements" %>

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -21,7 +21,9 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if unreleased_feature_user? && @coronavirus_page.topic_page? %>
     <%= render "timeline_entries" %>
+    <% end %>
     <%= render "sub_sections" %>
     <% if @coronavirus_page.topic_page? %>
       <%= render "announcements" %>

--- a/app/views/reorder_announcements/_reorder_list.html.erb
+++ b/app/views/reorder_announcements/_reorder_list.html.erb
@@ -1,6 +1,6 @@
 <% announcements = @coronavirus_page.announcements.order(:position) %>
 
-<div class="covid-manage-page__accordion-summary-list">
+<div class="covid-manage-page__summary-list">
   <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
     <% announcements.each_with_index do |announcement, index| %>
       <li class="js-reorder" data-id="<%= announcement.id %>">

--- a/app/views/reorder_sub_sections/_reorder_list.html.erb
+++ b/app/views/reorder_sub_sections/_reorder_list.html.erb
@@ -1,6 +1,6 @@
 <% sub_sections = @coronavirus_page.sub_sections.order(:position) %>
 
-<div class="covid-manage-page__accordion-summary-list">
+<div class="covid-manage-page__summary-list">
   <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
     <% sub_sections.each_with_index do |sub_section, index| %>
       <li class="js-reorder" data-id="<%= sub_section.id %>">

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -170,10 +170,17 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Viewing timeline entries" do
+        given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
         when_i_visit_a_coronavirus_page
         then_i_can_see_a_timeline_entries_section
         and_i_can_see_an_existing_timeline_entry
+      end
+
+      scenario "Timeline entries should only be visable on the landing page" do
+        when_i_visit_the_coronavirus_index_page
+        and_i_select_business_page
+        then_i_cannot_see_a_timeline_entries_section
       end
     end
 

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -168,6 +168,13 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         when_i_fill_in_the_timeline_entry_form_with_valid_data
         then_the_timeline_entry_is_updated
       end
+
+      scenario "Viewing timeline entries" do
+        given_there_is_a_coronavirus_page_with_timeline_entries
+        when_i_visit_a_coronavirus_page
+        then_i_can_see_a_timeline_entries_section
+        and_i_can_see_an_existing_timeline_entry
+      end
     end
 
     context "Business page" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -249,8 +249,8 @@ def then_i_see_announcement_updated_message
 end
 
 def and_i_see_the_announcements_have_changed_order
-  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(1)", text: @announcement_two.title)
-  expect(page).to have_css(".covid-manage-page__announcements-summary-list .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.title)
+  expect(page).to have_css(".covid-manage-page__summary-list--divider .gem-c-summary-list .govuk-summary-list__row:nth-child(1)", text: @announcement_two.title)
+  expect(page).to have_css(".covid-manage-page__summary-list--divider .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.title)
 end
 
 # Adding an announcement

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -214,6 +214,10 @@ def then_i_cannot_see_an_announcements_section
   expect(page).to_not have_content("Announcements")
 end
 
+def then_i_cannot_see_a_timeline_entries_section
+  expect(page).to_not have_content("Timeline entries")
+end
+
 def and_i_can_see_existing_announcements
   expect(page).to have_content(@announcement_one.title)
   expect(page).to have_content(@announcement_two.title)

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -204,6 +204,12 @@ def then_i_can_see_an_announcements_section
   expect(page).to have_link("Add announcement")
 end
 
+def then_i_can_see_a_timeline_entries_section
+  expect(page).to have_content("Timeline entries")
+  expect(page).to have_link("Reorder", href: coronavirus_page_path(@coronavirus_page.slug))
+  expect(page).to have_link("Add timeline entry")
+end
+
 def then_i_cannot_see_an_announcements_section
   expect(page).to_not have_content("Announcements")
 end
@@ -211,6 +217,10 @@ end
 def and_i_can_see_existing_announcements
   expect(page).to have_content(@announcement_one.title)
   expect(page).to have_content(@announcement_two.title)
+end
+
+def and_i_can_see_an_existing_timeline_entry
+  expect(page).to have_content(@timeline_entry.heading)
 end
 
 def then_i_see_the_announcements_in_order


### PR DESCRIPTION
### **What?**

Display the new timeline entries section on /coronavirus/landing page in Collections Publisher.

The `Add timeline entry`, `change`, `delete`, `reorder` links don't go to anywhere yet. That functionality will be added in follow up PRs.

This section has been hidden behind the unreleased feature flag until the whole timeline entry feature is ready.

### **Expected Change**

<img width="512" alt="Screenshot 2021-01-15 at 04 34 01" src="https://user-images.githubusercontent.com/41922771/104681717-ec327d80-56ea-11eb-8131-98138aa4d546.png">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/5BFwTEHk/1008-display-timeline-entries-on-the-summary-page-for-the-coronavirus-landing-page)