### PR TITLE
Add page to edit timeline entries

### DIFF
--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -17,7 +17,9 @@ class TimelineEntriesController < ApplicationController
     end
   end
 
-  def edit; end
+  def edit
+    @timeline_entry = coronavirus_page.timeline_entries.find(params[:id])
+  end
 
 private
 

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -17,6 +17,8 @@ class TimelineEntriesController < ApplicationController
     end
   end
 
+  def edit; end
+
 private
 
   def timeline_entry_params

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -21,6 +21,16 @@ class TimelineEntriesController < ApplicationController
     @timeline_entry = coronavirus_page.timeline_entries.find(params[:id])
   end
 
+  def update
+    @timeline_entry = coronavirus_page.timeline_entries.find(params[:id])
+
+    if @timeline_entry.update(timeline_entry_params) && draft_updater.send
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Timeline entry was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
 private
 
   def timeline_entry_params

--- a/app/views/timeline_entries/edit.html.erb
+++ b/app/views/timeline_entries/edit.html.erb
@@ -1,0 +1,1 @@
+<p>Placeholder</p>

--- a/app/views/timeline_entries/edit.html.erb
+++ b/app/views/timeline_entries/edit.html.erb
@@ -1,1 +1,30 @@
-<p>Placeholder</p>
+<%
+  links = [
+    {
+      text: 'Coronavirus pages',
+      href: coronavirus_pages_path
+    },
+    {
+      text: "#{@coronavirus_page.name} timeline entries",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Edit timeline entry"
+    },
+  ]
+%>
+
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page) %>
+<% content_for :context, "Edit timeline entry" %>
+<% if @timeline_entry.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @timeline_entry %>
+<% end %>
+
+<div class="covid-edit-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with method: :patch, url: coronavirus_page_timeline_entry_path do %>
+      <%= render "form" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :timeline_entries, only: %i[new create]
+    resources :timeline_entries, only: %i[new create edit]
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :timeline_entries, only: %i[new create edit]
+    resources :timeline_entries, only: %i[new create edit update]
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -67,6 +67,43 @@ RSpec.describe TimelineEntriesController do
     end
   end
 
+  describe "GET /coronavirus/:coronavirus_page_slug/timeline_entries/:id/edit" do
+    let(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
+
+    it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
+      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+      get :edit,
+          params: {
+            id: timeline_entry.id,
+            coronavirus_page_slug: coronavirus_page.slug,
+          }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "cannot be accessed by users without Unreleased feature permissions" do
+      stub_user.permissions << "Coronavirus editor"
+      get :edit,
+          params: {
+            id: timeline_entry.id,
+            coronavirus_page_slug: coronavirus_page.slug,
+          }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "cannot be accessed by users without Coronavirus editor permissions" do
+      stub_user.permissions << "Unreleased feature"
+      get :edit,
+          params: {
+            id: timeline_entry.id,
+            coronavirus_page_slug: coronavirus_page.slug,
+          }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   def setup_github_data
     raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
     stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -104,6 +104,47 @@ RSpec.describe TimelineEntriesController do
     end
   end
 
+  describe "PATCH /coronavirus/:coronavirus_page_slug/timeline_entries/:id" do
+    let(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
+
+    let(:updated_timeline_entry_params) do
+      {
+        heading: "Updated heading",
+        content: "##Updated content",
+      }
+    end
+
+    before do
+      setup_github_data
+      stub_coronavirus_publishing_api
+      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+    end
+
+    it "updates the timeline entry" do
+      patch :update,
+            params: {
+              id: timeline_entry.id,
+              coronavirus_page_slug: coronavirus_page.slug,
+              timeline_entry: updated_timeline_entry_params,
+            }
+
+      timeline_entry.reload
+      expect(timeline_entry.heading).to eq(updated_timeline_entry_params[:heading])
+      expect(timeline_entry.content).to eq(updated_timeline_entry_params[:content])
+    end
+
+    it "redirects to coronavirus page on success" do
+      patch :update,
+            params: {
+              id: timeline_entry.id,
+              coronavirus_page_slug: coronavirus_page.slug,
+              timeline_entry: updated_timeline_entry_params,
+            }
+
+      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+  end
+
   def setup_github_data
     raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
     stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -154,9 +154,19 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page
         when_i_visit_the_new_timeline_entry_page
-        then_i_see_the_create_timeline_entry_form
+        then_i_see_the_timeline_entry_form
         when_i_fill_in_the_timeline_entry_form_with_valid_data
         then_a_new_timeline_entry_is_created
+      end
+
+      scenario "Editing timeline entries" do
+        given_i_can_access_unreleased_features
+        given_there_is_a_coronavirus_page_with_timeline_entries
+        when_i_visit_the_edit_timeline_entry_page
+        then_i_see_the_timeline_entry_form
+        and_i_see_the_existing_timeline_entry_data
+        when_i_fill_in_the_timeline_entry_form_with_valid_data
+        then_the_timeline_entry_is_updated
       end
     end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -21,6 +21,11 @@ def given_there_is_coronavirus_page_with_announcements
   @announcement_two = FactoryBot.create(:announcement, position: 1, coronavirus_page: @coronavirus_page)
 end
 
+def given_there_is_a_coronavirus_page_with_timeline_entries
+  @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
+  @timeline_entry = FactoryBot.create(:timeline_entry, coronavirus_page: @coronavirus_page)
+end
+
 def the_payload_contains_the_valid_url
   live_stream_payload = coronavirus_live_stream_hash.merge(
     {
@@ -305,7 +310,7 @@ def when_i_visit_the_new_timeline_entry_page
   visit "/coronavirus/landing/timeline_entries/new"
 end
 
-def then_i_see_the_create_timeline_entry_form
+def then_i_see_the_timeline_entry_form
   expect(page).to have_text("Enter the heading of the timeline entry")
   expect(page).to have_text("Content")
 end
@@ -320,6 +325,21 @@ end
 def then_a_new_timeline_entry_is_created
   timeline_entry = @coronavirus_page.timeline_entries.last
   expect(timeline_entry.content).to eq("##Form content")
+end
+
+# Editing timeline entries
+
+def when_i_visit_the_edit_timeline_entry_page
+  visit "/coronavirus/landing/timeline_entries/#{@timeline_entry.id}/edit"
+end
+
+def and_i_see_the_existing_timeline_entry_data
+  expect(page).to have_selector("input[value='#{@timeline_entry.heading}']")
+  expect(page).to have_content(@timeline_entry.content)
+end
+
+def then_the_timeline_entry_is_updated
+  expect(@timeline_entry.reload.content).to eq("##Form content")
 end
 
 def set_up_basic_sub_sections


### PR DESCRIPTION
Trello: https://trello.com/c/8Kn2hKnd

# What?

Create a page to allow existing timeline entries to be edited.

Only users with "Unreleased feature" permissions should be able to access the page whilst the timeline feature is being built.

The changes to the timeline entry is only persisted to the database. Whilst we are calling DraftUpdater, to send changes to the publishing-api, the actual creation of the payload for publishing-api will happen in another story.


# Expected changes

URL of page: `http://collections-publisher.dev.gov.uk/coronavirus/landing/timeline_entries/<timeline-entry-id>/edit`

![screenshot-collections-publisher dev gov uk-2021 01 18-11_13_36](https://user-images.githubusercontent.com/5793815/104909276-87dc1c00-597f-11eb-9d5f-dba5799a0a6c.png)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
