### PR TITLE
Make Dockerfile more production focused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,26 +4,28 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs yarn && apt-get clean
 RUN gem install foreman
 
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV production
+
 ENV DATABASE_URL mysql2://root:root@mysql/collections_publisher_development
 ENV GOVUK_APP_NAME collections-publisher
 ENV PORT 3071
-ENV RAILS_ENV development
-ENV REDIS_HOST redis
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* .ruby-version $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
+
+ADD package.json yarn.lock $APP_HOME/
+RUN yarn install --frozen-lockfile
+
 ADD . $APP_HOME
 
-COPY package.json ./
-COPY yarn.lock ./
-RUN yarn install
-RUN cp yarn.lock /tmp
-
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
+RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bundle exec rails assets:precompile
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 


### PR DESCRIPTION
This removes REDIS_HOST as GOV.UK no longer use that env var to
configure Redis. The rest of the Dockerfile is then updated in a
consistent manner to static [1], where it's tailored towards production
running - reflecting that no-one can use this for test environments (and
potentially development ones).

[1]: https://github.com/alphagov/static/pull/2327

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
