### PR TITLE
Add rake task to sync timeline entries

### DIFF
--- a/app/services/coronavirus_pages/timeline_entry_builder.rb
+++ b/app/services/coronavirus_pages/timeline_entry_builder.rb
@@ -1,0 +1,27 @@
+class CoronavirusPages::TimelineEntryBuilder
+  def create_timeline_entries
+    return if timeline_entries_from_yaml.empty?
+
+    TimelineEntry.transaction do
+      coronavirus_page.timeline_entries.delete_all
+
+      timeline_entries_from_yaml.reverse.each do |entry|
+        coronavirus_page.timeline_entries.create!(
+          heading: entry["heading"],
+          content: entry["paragraph"],
+        )
+      end
+    end
+  end
+
+private
+
+  def timeline_entries_from_yaml
+    @github_data ||= YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
+    @github_data.dig("content", "timeline", "list")
+  end
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPage.find_by(slug: "landing")
+  end
+end

--- a/lib/tasks/coronavirus.rake
+++ b/lib/tasks/coronavirus.rake
@@ -23,4 +23,11 @@ namespace :coronavirus do
     puts "title: #{page.title}"
     puts "sections_title: #{page.sections_title}"
   end
+
+  desc "Sync timeline entries with entries in the yaml file"
+  task sync_timeline_entries: :environment do
+    CoronavirusPages::TimelineEntryBuilder.new.create_timeline_entries
+
+    puts "Timeline Entries synced for coronavirus landing page..."
+  end
 end

--- a/spec/services/coronavirus_pages/timeline_entry_builder_spec.rb
+++ b/spec/services/coronavirus_pages/timeline_entry_builder_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe CoronavirusPages::TimelineEntryBuilder do
+  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+  let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
+
+  let(:coronavirus_page) { create(:coronavirus_page, :landing) }
+
+  before do
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
+      .to_return(status: 200, body: github_content.to_json)
+  end
+
+  it "creates new timeline entries from the yaml file in reverse order" do
+    described_class.new.create_timeline_entries
+
+    expect(coronavirus_page.timeline_entries.count).to eq(2)
+
+    first_entry = coronavirus_page.timeline_entries.first
+
+    expect(first_entry.heading).to eq(github_entry_list.second["heading"])
+    expect(first_entry.content).to eq(github_entry_list.second["paragraph"])
+  end
+
+  it "removes existing timeline entries before creating new ones" do
+    create(:timeline_entry, coronavirus_page: coronavirus_page)
+    create(:timeline_entry, coronavirus_page: coronavirus_page)
+    create(:timeline_entry, coronavirus_page: coronavirus_page)
+
+    described_class.new.create_timeline_entries
+
+    expect(coronavirus_page.timeline_entries.count).to eq(2)
+  end
+
+  it "doesn't remove existing timeline entries if the YAML file is empty" do
+    described_class.new.create_timeline_entries
+
+    github_content = YAML.safe_load(File.read(fixture_path))
+    github_content.dig("content", "timeline", "list").clear
+
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
+      .to_return(status: 200, body: github_content.to_json)
+
+    described_class.new.create_timeline_entries
+
+    expect(coronavirus_page.timeline_entries.count).to be(2)
+  end
+
+  it "keeps the timeline entries in the right order" do
+    new_data = { "heading" => "heading", "paragraph" => "paragraph" }
+
+    github_content = YAML.safe_load(File.read(fixture_path))
+    github_content.dig("content", "timeline", "list").unshift(new_data)
+
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
+      .to_return(status: 200, body: github_content.to_json)
+
+    described_class.new.create_timeline_entries
+
+    expect(coronavirus_page.timeline_entries.last.heading).to eq("heading")
+    expect(coronavirus_page.timeline_entries.last.position).to eq(1)
+  end
+
+  def github_entry_list
+    github_content.dig("content", "timeline", "list")
+  end
+end


### PR DESCRIPTION
This adds a rake task to sync timeline entries with the database. Borrows heavily from [previous work](https://github.com/alphagov/collections-publisher/commit/116f59fcdd61e8bbd3a4a301e8ed366fee03b7ab) to do similar work for announcements.

Trello - https://trello.com/c/Hlr7PxjA/1050-migrate-timeline-entries-from-govuk-coronavirus-content-to-collections-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
