### PR TITLE
Add new timeline entries front of list

### DIFF
--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -16,4 +16,10 @@ class CoronavirusPage < ApplicationRecord
       announcement.update!(position: index)
     end
   end
+
+  def make_timeline_entry_positions_sequential
+    timeline_entries.sort_by(&:position).each.with_index(1) do |timeline_entry, index|
+      timeline_entry.update!(position: index)
+    end
+  end
 end

--- a/app/models/coronavirus_page.rb
+++ b/app/models/coronavirus_page.rb
@@ -12,14 +12,18 @@ class CoronavirusPage < ApplicationRecord
   end
 
   def make_announcement_positions_sequential
-    announcements.sort_by(&:position).each.with_index(1) do |announcement, index|
-      announcement.update!(position: index)
-    end
+    make_positions_sequential(announcements)
   end
 
   def make_timeline_entry_positions_sequential
-    timeline_entries.sort_by(&:position).each.with_index(1) do |timeline_entry, index|
-      timeline_entry.update!(position: index)
+    make_positions_sequential(timeline_entries)
+  end
+
+private
+
+  def make_positions_sequential(collection)
+    collection.sort_by(&:position).each.with_index(1) do |object, index|
+      object.update_column(:position, index)
     end
   end
 end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -2,4 +2,10 @@ class TimelineEntry < ApplicationRecord
   belongs_to :coronavirus_page
   validates :heading, presence: true, length: { maximum: 255 }
   validates :content, presence: true
+  before_create :set_position
+
+  def set_position
+    coronavirus_page.timeline_entries.update_all("position = position + 1")
+    self.position = 1
+  end
 end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -3,9 +3,14 @@ class TimelineEntry < ApplicationRecord
   validates :heading, presence: true, length: { maximum: 255 }
   validates :content, presence: true
   before_create :set_position
+  after_destroy :set_parent_positions
 
   def set_position
     coronavirus_page.timeline_entries.update_all("position = position + 1")
     self.position = 1
+  end
+
+  def set_parent_positions
+    coronavirus_page.make_timeline_entry_positions_sequential
   end
 end

--- a/app/services/coronavirus_pages/draft_discarder.rb
+++ b/app/services/coronavirus_pages/draft_discarder.rb
@@ -63,7 +63,7 @@ module CoronavirusPages
     end
 
     def update_timeline_entries
-      coronavirus_page.timeline_entries.destroy_all
+      coronavirus_page.timeline_entries.delete_all
       coronavirus_page.timeline_entries = timeline_entries
     end
 

--- a/app/services/coronavirus_pages/draft_discarder.rb
+++ b/app/services/coronavirus_pages/draft_discarder.rb
@@ -68,11 +68,10 @@ module CoronavirusPages
     end
 
     def timeline_entries
-      timeline_entries_from_payload.each_with_index.map do |attributes, index|
+      timeline_entries_from_payload.reverse.map do |attributes|
         TimelineEntry.new(
           heading: attributes[:heading],
           content: attributes[:paragraph],
-          position: index + 1,
         )
       end
     end

--- a/db/migrate/20210126122043_change_position_to_not_null.rb
+++ b/db/migrate/20210126122043_change_position_to_not_null.rb
@@ -1,0 +1,5 @@
+class ChangePositionToNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:timeline_entries, :position, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_11_110154) do
+ActiveRecord::Schema.define(version: 2021_01_26_122043) do
 
   create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
@@ -203,7 +203,7 @@ ActiveRecord::Schema.define(version: 2021_01_11_110154) do
     t.bigint "coronavirus_page_id", null: false
     t.text "content", null: false
     t.string "heading", null: false
-    t.integer "position"
+    t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["coronavirus_page_id"], name: "index_timeline_entries_on_coronavirus_page_id"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -264,7 +264,6 @@ FactoryBot.define do
   factory :timeline_entry do
     content { "Amazing fantastic content" }
     heading { "Unbelievable heading" }
-    position { 1 }
     coronavirus_page
   end
 end

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -55,6 +55,10 @@
         {
           "heading": "5 January",
           "paragraph": "[National lockdown rules apply in England](/guidance/national-lockdown-stay-at-home). Stay at home."
+        },
+        {
+          "heading": "4 January",
+          "paragraph": "[Changes expected](/guidance/tiering-changes-expected). Watch this space."
         }
       ],
       "heading": "Recent and upcoming changes"

--- a/spec/models/timeline_entry_spec.rb
+++ b/spec/models/timeline_entry_spec.rb
@@ -4,4 +4,27 @@ RSpec.describe TimelineEntry do
   it { should validate_presence_of(:heading) }
   it { should validate_length_of(:heading).is_at_most(255) }
   it { should validate_presence_of(:content) }
+
+  describe "position" do
+    let(:coronavirus_page) { create(:coronavirus_page) }
+
+    it "should default to position 1 if it is the first timeline entry to have been added" do
+      expect(coronavirus_page.timeline_entries.count).to eq 0
+
+      timeline_entry = create(:timeline_entry, coronavirus_page: coronavirus_page)
+      expect(timeline_entry.reload.position).to eq 1
+    end
+
+    it "if more timeline entries are added, the previous entries will increment position by 1" do
+      expect(coronavirus_page.timeline_entries.count).to eq 0
+
+      first_timeline_entry = create(:timeline_entry, coronavirus_page: coronavirus_page, heading: "one")
+      expect(first_timeline_entry.reload.position).to eq 1
+
+      second_timeline_entry = create(:timeline_entry, coronavirus_page: coronavirus_page, heading: "two")
+
+      expect(first_timeline_entry.reload.position).to eq 2
+      expect(second_timeline_entry.reload.position).to eq 1
+    end
+  end
 end

--- a/spec/models/timeline_entry_spec.rb
+++ b/spec/models/timeline_entry_spec.rb
@@ -26,5 +26,21 @@ RSpec.describe TimelineEntry do
       expect(first_timeline_entry.reload.position).to eq 2
       expect(second_timeline_entry.reload.position).to eq 1
     end
+
+    it "should update timeline entry positions when a timeline entry is deleted" do
+      original_timeline_entry_one = create(:timeline_entry, coronavirus_page: coronavirus_page)
+      original_timeline_entry_two = create(:timeline_entry, coronavirus_page: coronavirus_page)
+      expect(coronavirus_page.timeline_entries.count).to eq 2
+
+      expect(original_timeline_entry_one.reload.position).to eq 2
+      expect(original_timeline_entry_two.reload.position).to eq 1
+
+      original_timeline_entry_two.destroy!
+      coronavirus_page.reload
+      original_timeline_entry_one.reload
+
+      expect(original_timeline_entry_one.position).to eq 1
+      expect(coronavirus_page.timeline_entries.count).to eq 1
+    end
   end
 end

--- a/spec/services/coronavirus_pages/draft_discarder_spec.rb
+++ b/spec/services/coronavirus_pages/draft_discarder_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe CoronavirusPages::DraftDiscarder do
   end
 
   describe "timeline entries" do
-    it "replaces the existing timeline entries" do
+    it "replaces the existing timeline entries in the correct position order" do
       create(
         :timeline_entry,
         coronavirus_page: coronavirus_page,
@@ -119,11 +119,13 @@ RSpec.describe CoronavirusPages::DraftDiscarder do
       stub_publishing_api_has_item(payload_from_publishing_api)
 
       described_class.new(coronavirus_page).call
-      coronavirus_page.reload
+      coronavirus_page.timeline_entries.reload
 
-      expect(coronavirus_page.timeline_entries.count).to eq(1)
-      expect(coronavirus_page.timeline_entries.first.heading).to eq("5 January")
-      expect(coronavirus_page.timeline_entries.first.position).to eq(1)
+      expect(coronavirus_page.timeline_entries.count).to eq(2)
+      expect(coronavirus_page.timeline_entries.second.heading).to eq("5 January")
+      expect(coronavirus_page.timeline_entries.second.position).to eq(1)
+      expect(coronavirus_page.timeline_entries.first.heading).to eq("4 January")
+      expect(coronavirus_page.timeline_entries.first.position).to eq(2)
     end
 
     it "removes the timeline entries if there isn't a timeline list in Publishing API" do


### PR DESCRIPTION
Trello: https://trello.com/c/0oeC49ub

# What's changed and why?

Add new timeline entries to the front of the list (i.e. position 1) so that content designers can be sure that the order of the entries they see in the publishing tool matches the order of the timeline entries shown to the user.

For example, a content designer might add an entry for  "2 January", and later add an entry for "24 - 26 January". By default we need to display these entries in this order:

"24 -26 January"
"2 January"

A page to allow users to reorder timeline entries will be added in a later PR.

Paired with @Rosa-Fox 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
