### PR TITLE
Add rescue condition for featured link description

### DIFF
--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -131,9 +131,15 @@ class SubSectionJsonPresenter
   end
 
   def description_for_featured_link(base_path)
+    return nil if external_link?(base_path)
+
     content_item(base_path)["description"]
   rescue GdsApi::HTTPNotFound
     nil
+  end
+
+  def external_link?(base_path)
+    URI.parse(base_path).absolute?
   end
 
   def content_item(base_path)

--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -132,6 +132,8 @@ class SubSectionJsonPresenter
 
   def description_for_featured_link(base_path)
     content_item(base_path)["description"]
+  rescue GdsApi::HTTPNotFound
+    nil
   end
 
   def content_item(base_path)

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -100,6 +100,40 @@ RSpec.describe SubSectionJsonPresenter do
 
         expect { subject.output }.to change { subject.errors.length }.by(1)
       end
+
+      it "allows external featured links" do
+        stub_any_publishing_api_call_to_return_not_found
+
+        url = "https://www.nhs.uk/"
+        title = "Foo"
+        label = "NHS"
+        link = "[#{label}](#{url})"
+
+        sub_section = build(
+          :sub_section,
+          content: ["###{title}", link].join("\n"),
+          featured_link: url,
+        )
+
+        expected = {
+          title: sub_section.title,
+          sub_sections: [
+            {
+              list: [
+                {
+                  url: url,
+                  label: label,
+                  featured_link: true,
+                  description: nil,
+                },
+              ],
+              title: title,
+            },
+          ],
+        }
+
+        expect(described_class.new(sub_section).output).to eq(expected)
+      end
     end
   end
 

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -101,10 +101,41 @@ RSpec.describe SubSectionJsonPresenter do
         expect { subject.output }.to change { subject.errors.length }.by(1)
       end
 
-      it "allows external featured links" do
+      it "sets a nil featured link description for an external link" do
+        url = "https://www.nhs.uk/"
+        title = "Foo"
+        label = "NHS"
+        link = "[#{label}](#{url})"
+
+        sub_section = build(
+          :sub_section,
+          content: ["###{title}", link].join("\n"),
+          featured_link: url,
+        )
+        expected = {
+          title: sub_section.title,
+          sub_sections: [
+            {
+              list: [
+                {
+                  url: url,
+                  label: label,
+                  featured_link: true,
+                  description: nil,
+                },
+              ],
+              title: title,
+            },
+          ],
+        }
+
+        expect(described_class.new(sub_section).output).to eq(expected)
+      end
+
+      it "sets a nil featured link description if internal link is not found" do
         stub_any_publishing_api_call_to_return_not_found
 
-        url = "https://www.nhs.uk/"
+        url = "/not-here"
         title = "Foo"
         label = "NHS"
         link = "[#{label}](#{url})"


### PR DESCRIPTION
At the moment we're pulling out the featured link descriptions from the content item to display in the action link. For now we are content for external links to be featured without this description so we can just add a rescue condition to circumvent any 404s we receive from the publishing-api. Adding/editing meta descriptions for non-govuk featured links can be added later if we determine there is a need for them. 

With this condition the test shows that we can build a new subsection with the description being nil

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/a8aT8ExJ/1051-allow-featured-links-in-accordions-to-link-to-external-links)
