### PR TITLE
Update feature tests for add / edit timeline entry

### DIFF
--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -153,20 +153,22 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       scenario "Adding timeline entries" do
         given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page
-        when_i_visit_the_new_timeline_entry_page
+        when_i_visit_a_coronavirus_page
+        and_i_add_a_new_timeline_entry
         then_i_see_the_timeline_entry_form
         when_i_fill_in_the_timeline_entry_form_with_valid_data
-        then_a_new_timeline_entry_is_created
+        then_i_see_a_new_timeline_entry_has_been_created
       end
 
       scenario "Editing timeline entries" do
         given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
-        when_i_visit_the_edit_timeline_entry_page
+        when_i_visit_a_coronavirus_page
+        and_i_change_a_timeline_entry
         then_i_see_the_timeline_entry_form
         and_i_see_the_existing_timeline_entry_data
         when_i_fill_in_the_timeline_entry_form_with_valid_data
-        then_the_timeline_entry_is_updated
+        then_i_see_the_timeline_entry_has_been_updated
       end
 
       scenario "Viewing timeline entries" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -320,8 +320,8 @@ end
 
 # Adding a timeline entry
 
-def when_i_visit_the_new_timeline_entry_page
-  visit "/coronavirus/landing/timeline_entries/new"
+def and_i_add_a_new_timeline_entry
+  click_on("Add timeline entry")
 end
 
 def then_i_see_the_timeline_entry_form
@@ -336,15 +336,15 @@ def when_i_fill_in_the_timeline_entry_form_with_valid_data
   click_on("Save")
 end
 
-def then_a_new_timeline_entry_is_created
-  timeline_entry = @coronavirus_page.timeline_entries.last
-  expect(timeline_entry.content).to eq("##Form content")
+def then_i_see_a_new_timeline_entry_has_been_created
+  expect(current_path).to eq("/coronavirus/landing")
+  expect(expect(page).to(have_text("Fancy title")))
 end
 
 # Editing timeline entries
 
-def when_i_visit_the_edit_timeline_entry_page
-  visit "/coronavirus/landing/timeline_entries/#{@timeline_entry.id}/edit"
+def and_i_change_a_timeline_entry
+  page.find("a[href=\"/coronavirus/landing/timeline_entries/#{@timeline_entry.id}/edit\"]", text: "Change").click
 end
 
 def and_i_see_the_existing_timeline_entry_data
@@ -352,7 +352,7 @@ def and_i_see_the_existing_timeline_entry_data
   expect(page).to have_content(@timeline_entry.content)
 end
 
-def then_the_timeline_entry_is_updated
+def then_i_see_the_timeline_entry_has_been_updated
   expect(@timeline_entry.reload.content).to eq("##Form content")
 end
 


### PR DESCRIPTION
Trello: https://trello.com/c/W4nJDLBi

# What's changed and why?
When the add and edit timeline pages where created, the timeline section
hadn't been added to the summary page. Now that the timeline section
exists, the feature tests can be updated to properly represent the user
journey / experience.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
