### PR TITLE
Add a reorder page for timeline entries

### DIFF
--- a/app/controllers/reorder_announcements_controller.rb
+++ b/app/controllers/reorder_announcements_controller.rb
@@ -10,7 +10,7 @@ class ReorderAnnouncementsController < ApplicationController
     reordered_announcements = JSON.parse(params[:announcement_order_save])
     reordered_announcements.each do |announcement_data|
       announcement = coronavirus_page.announcements.find(announcement_data["id"])
-      announcement.update!(position: announcement_data["position"])
+      announcement.update_column(:position, announcement_data["position"])
     end
 
     if draft_updater.send

--- a/app/controllers/reorder_announcements_controller.rb
+++ b/app/controllers/reorder_announcements_controller.rb
@@ -14,21 +14,17 @@ class ReorderAnnouncementsController < ApplicationController
     end
 
     if draft_updater.send
-      redirect_to coronavirus_page_path(slug), notice: "Announcements were successfully reordered."
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Announcements were successfully reordered."
     else
       message = "Sorry! Announcements have not been reordered: #{draft_updater.errors.to_sentence}."
-      redirect_to reorder_coronavirus_page_announcements_path(slug), alert: message
+      redirect_to reorder_coronavirus_page_announcements_path(coronavirus_page.slug), alert: message
     end
   end
 
 private
 
-  def slug
-    params[:slug] || params[:coronavirus_page_slug]
-  end
-
   def coronavirus_page
-    @coronavirus_page ||= CoronavirusPages::ModelBuilder.call(slug)
+    @coronavirus_page ||= CoronavirusPage.find_by!(slug: params[:coronavirus_page_slug])
   end
 
   def draft_updater

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -7,8 +7,7 @@ class ReorderSubSectionsController < ApplicationController
   end
 
   def update
-    current_positions
-    set_positions(submitted_positions)
+    set_positions
     if draft_updater.send
       redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Sections were successfully reordered."
     else
@@ -23,19 +22,11 @@ private
     @coronavirus_page ||= CoronavirusPage.find_by!(slug: params[:coronavirus_page_slug])
   end
 
-  def current_positions
-    @current_positions ||= coronavirus_page.sub_sections.map do |sub_section|
-      { "id" => sub_section.id, "position" => sub_section.position }
-    end
-  end
-
-  def submitted_positions
-    JSON.parse(params[:section_order_save])
-  end
-
-  def set_positions(positions)
-    positions.each do |sub_section|
-      SubSection.find(sub_section["id"]).update_column(:position, sub_section["position"])
+  def set_positions
+    reordered_subsections = JSON.parse(params[:section_order_save])
+    reordered_subsections.each do |sub_section_data|
+      sub_section = coronavirus_page.sub_sections.find(sub_section_data["id"])
+      sub_section.update_column(:position, sub_section_data["position"])
     end
   end
 

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -7,9 +7,20 @@ class ReorderSubSectionsController < ApplicationController
   end
 
   def update
-    set_positions
-    if draft_updater.send
-      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Sections were successfully reordered."
+    success = true
+
+    SubSection.transaction do
+      set_positions
+
+      unless draft_updater.send
+        success = false
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    if success
+      message = "Sections were successfully reordered."
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: message
     else
       message = "Sorry! Sections have not been reordered: #{draft_updater.errors.to_sentence}."
       redirect_to reorder_coronavirus_page_sub_sections_path(coronavirus_page.slug), alert: message

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -1,6 +1,5 @@
 class ReorderSubSectionsController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
-  before_action :redirect_to_index_if_slug_unknown
   layout "admin_layout"
 
   def index
@@ -11,17 +10,17 @@ class ReorderSubSectionsController < ApplicationController
     current_positions
     set_positions(submitted_positions)
     if draft_updater.send
-      redirect_to coronavirus_page_path(slug), notice: "Sections were successfully reordered."
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Sections were successfully reordered."
     else
       message = "Sorry! Sections have not been reordered: #{draft_updater.errors.to_sentence}."
-      redirect_to reorder_coronavirus_page_sub_sections_path(slug), alert: message
+      redirect_to reorder_coronavirus_page_sub_sections_path(coronavirus_page.slug), alert: message
     end
   end
 
 private
 
   def coronavirus_page
-    @coronavirus_page ||= CoronavirusPages::ModelBuilder.call(slug)
+    @coronavirus_page ||= CoronavirusPage.find_by!(slug: params[:coronavirus_page_slug])
   end
 
   def current_positions
@@ -42,21 +41,6 @@ private
 
   def draft_updater
     @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
-  end
-
-  def redirect_to_index_if_slug_unknown
-    if slug_unknown?
-      flash[:alert] = "'#{slug}' is not a valid page.  Please select from one of those below."
-      redirect_to coronavirus_pages_path
-    end
-  end
-
-  def slug
-    params[:slug] || params[:coronavirus_page_slug]
-  end
-
-  def slug_unknown?
-    !page_configs.key?(slug.to_sym)
   end
 
   def page_configs

--- a/app/controllers/reorder_sub_sections_controller.rb
+++ b/app/controllers/reorder_sub_sections_controller.rb
@@ -35,7 +35,7 @@ private
 
   def set_positions(positions)
     positions.each do |sub_section|
-      SubSection.find(sub_section["id"]).update(position: sub_section["position"])
+      SubSection.find(sub_section["id"]).update_column(:position, sub_section["position"])
     end
   end
 

--- a/app/controllers/reorder_timeline_entries_controller.rb
+++ b/app/controllers/reorder_timeline_entries_controller.rb
@@ -7,11 +7,38 @@ class ReorderTimelineEntriesController < ApplicationController
     coronavirus_page
   end
 
-  def update; end
+  def update
+    success = true
+    reordered_timeline_entries = JSON.parse(params[:timeline_entry_order_save])
+
+    TimelineEntry.transaction do
+      reordered_timeline_entries.each do |timeline_entry_data|
+        timeline_entry = coronavirus_page.timeline_entries.find(timeline_entry_data["id"])
+        timeline_entry.update_column(:position, timeline_entry_data["position"])
+      end
+
+      unless draft_updater.send
+        success = false
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    if success
+      message = "Timeline entries were successfully reordered."
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: message
+    else
+      message = "Sorry! Timeline entries have not been reordered: #{draft_updater.errors.to_sentence}."
+      redirect_to reorder_coronavirus_page_timeline_entries_path(coronavirus_page.slug), alert: message
+    end
+  end
 
 private
 
   def coronavirus_page
     @coronavirus_page ||= CoronavirusPage.find_by!(slug: params[:coronavirus_page_slug])
+  end
+
+  def draft_updater
+    @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
   end
 end

--- a/app/controllers/reorder_timeline_entries_controller.rb
+++ b/app/controllers/reorder_timeline_entries_controller.rb
@@ -1,0 +1,17 @@
+class ReorderTimelineEntriesController < ApplicationController
+  before_action :require_unreleased_feature_permissions!
+  before_action :require_coronavirus_editor_permissions!
+  layout "admin_layout"
+
+  def index
+    coronavirus_page
+  end
+
+  def update; end
+
+private
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPage.find_by!(slug: params[:coronavirus_page_slug])
+  end
+end

--- a/app/controllers/reorder_timeline_entries_controller.rb
+++ b/app/controllers/reorder_timeline_entries_controller.rb
@@ -24,10 +24,10 @@ class ReorderTimelineEntriesController < ApplicationController
     end
 
     if success
-      message = "Timeline entries were successfully reordered."
+      message = I18n.t("coronavirus_pages.timeline_entries.reorder.success")
       redirect_to coronavirus_page_path(coronavirus_page.slug), notice: message
     else
-      message = "Sorry! Timeline entries have not been reordered: #{draft_updater.errors.to_sentence}."
+      message = I18n.t("coronavirus_pages.timeline_entries.reorder.error", error: draft_updater.errors.to_sentence)
       redirect_to reorder_coronavirus_page_timeline_entries_path(coronavirus_page.slug), alert: message
     end
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -10,7 +10,7 @@ class Announcement < ApplicationRecord
 private
 
   def set_position
-    update!(position: coronavirus_page.announcements.count)
+    update_column(:position, coronavirus_page.announcements.count)
   end
 
   def set_parent_positions

--- a/app/views/coronavirus_pages/_timeline_entries.html.erb
+++ b/app/views/coronavirus_pages/_timeline_entries.html.erb
@@ -20,7 +20,7 @@
     items: timeline_entries,
     edit: {
       link_text: "Reorder",
-      href: coronavirus_page_path(@coronavirus_page.slug)
+      href: reorder_coronavirus_page_timeline_entries_path(@coronavirus_page.slug)
     }
   } %>
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/reorder_timeline_entries/_reorder_list.html.erb
+++ b/app/views/reorder_timeline_entries/_reorder_list.html.erb
@@ -1,0 +1,17 @@
+<% timeline_entries = @coronavirus_page.timeline_entries.order(:position) %>
+
+<div class="covid-manage-page__summary-list">
+  <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
+    <% timeline_entries.each_with_index do |timeline_entry, index| %>
+      <li class="js-reorder" data-id="<%= timeline_entry.id %>">
+        <div class="govuk-grid-row" id="step-<%= index %>">
+          <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
+            <%= timeline_entry.heading %>
+          </div>
+          <div class="govuk-grid-column-one-quarter js-order-controls">
+          </div>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/reorder_timeline_entries/index.html.erb
+++ b/app/views/reorder_timeline_entries/index.html.erb
@@ -9,17 +9,17 @@
       href: coronavirus_page_path(slug: @coronavirus_page.slug)
     },
     {
-      text: "Reorder timeline entries"
+      text: t("coronavirus_pages.timeline_entries.reorder.heading")
     },
   ]
 %>
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@coronavirus_page)%>
-<% content_for :context, "Reorder timeline entries" %>
+<% content_for :context, t("coronavirus_pages.timeline_entries.reorder.heading") %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_markdown "Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop." %>
+    <%= render_markdown t("coronavirus_pages.timeline_entries.reorder.form.markdown_hint") %>
     <%= render "reorder_list" %>
 
     <%= form_with method: :put, url: reorder_coronavirus_page_timeline_entries_path do |form| %>

--- a/app/views/reorder_timeline_entries/index.html.erb
+++ b/app/views/reorder_timeline_entries/index.html.erb
@@ -1,0 +1,36 @@
+<%
+  links = [
+    {
+      text: 'Coronavirus pages',
+      href: coronavirus_pages_path
+    },
+    {
+      text: "#{@coronavirus_page.name}",
+      href: coronavirus_page_path(slug: @coronavirus_page.slug)
+    },
+    {
+      text: "Reorder timeline entries"
+    },
+  ]
+%>
+<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<% content_for :title, formatted_title(@coronavirus_page)%>
+<% content_for :context, "Reorder timeline entries" %>
+
+<div class="covid-manage-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_markdown "Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop." %>
+
+    <%= form_with method: :put, url: reorder_coronavirus_page_timeline_entries_path do |form| %>
+      <input type="hidden" name="timeline_entry_order_save" id="js_order_save" value="" />
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save"
+          } %>
+          <%= link_to 'Cancel', coronavirus_page_path(@coronavirus_page.slug), class: "govuk-link govuk-button" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reorder_timeline_entries/index.html.erb
+++ b/app/views/reorder_timeline_entries/index.html.erb
@@ -20,6 +20,7 @@
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown "Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop." %>
+    <%= render "reorder_list" %>
 
     <%= form_with method: :put, url: reorder_coronavirus_page_timeline_entries_path do |form| %>
       <input type="hidden" name="timeline_entry_order_save" id="js_order_save" value="" />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,13 @@ en:
       confirm: Are you sure?
       reorder: Reorder
       add: Add accordion
+    timeline_entries:
+      reorder:
+        heading: Reorder timeline entries
+        success: Timeline entries were successfully reordered.
+        error: "Sorry! Timeline entries have not been reordered: %{error}."
+        form:
+          markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
   step_by_step_page:
     statuses:
       draft: Draft

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,12 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :timeline_entries, only: %i[new create edit update]
+    resources :timeline_entries, only: %i[new create edit update] do
+      collection do
+        get "reorder", to: "reorder_timeline_entries#index"
+        put "reorder", to: "reorder_timeline_entries#update"
+      end
+    end
   end
 
   resources :step_by_step_pages, path: "step-by-step-pages" do

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-RSpec.describe AnnouncementsController, type: :controller do
+RSpec.describe AnnouncementsController do
+  include CoronavirusFeatureSteps
+
   render_views
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
@@ -20,7 +22,7 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "POST /coronavirus/:coronavirus_page_slug/announcements" do
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
     end
 
@@ -50,7 +52,7 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "DELETE /coronavirus/:coronavirus_page_slug/announcements/:id" do
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
     end
 
@@ -100,7 +102,7 @@ RSpec.describe AnnouncementsController, type: :controller do
 
   describe "PATCH /coronavirus/:coronavirus_page_slug/announcement" do
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
     end
 
@@ -139,11 +141,5 @@ RSpec.describe AnnouncementsController, type: :controller do
       expect(announcement.path).to eq(updated_announcement_params[:path])
       expect(announcement.published_at).to eq(published_at_time)
     end
-  end
-
-  def setup_github_data
-    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/controllers/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/reorder_announcements_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-RSpec.describe ReorderAnnouncementsController, type: :controller do
+RSpec.describe ReorderAnnouncementsController do
+  include CoronavirusFeatureSteps
+
   let(:coronavirus_page) { create(:coronavirus_page) }
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
 
@@ -23,7 +25,7 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
     let!(:another_announcement) { create(:announcement, position: 1, coronavirus_page: coronavirus_page) }
 
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
     end
 
@@ -94,11 +96,5 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
       expect(another_announcement.reload.position).to eq 2
       expect(subject).to redirect_to(reorder_coronavirus_page_announcements_path(coronavirus_page.slug))
     end
-  end
-
-  def setup_github_data
-    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/controllers/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/reorder_announcements_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
   end
 
   describe "PUT Coronavirus reorder announcements page" do
-    let(:announcement) { create(:announcement, position: 0, coronavirus_page: coronavirus_page) }
-    let(:another_announcement) { create(:announcement, position: 1, coronavirus_page: coronavirus_page) }
+    let!(:announcement) { create(:announcement, position: 0, coronavirus_page: coronavirus_page) }
+    let!(:another_announcement) { create(:announcement, position: 1, coronavirus_page: coronavirus_page) }
 
     before do
       setup_github_data
@@ -71,17 +71,17 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
       expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
     end
 
-    it "keeps the new ordering if updating the draft fails" do
+    it "keeps the existing order if updating the draft fails" do
       stub_publishing_api_isnt_available
 
       announcement_params = [
         {
           id: announcement.id,
-          position: 1,
+          position: 2,
         },
         {
           id: another_announcement.id,
-          position: 0,
+          position: 1,
         },
       ]
 
@@ -91,7 +91,7 @@ RSpec.describe ReorderAnnouncementsController, type: :controller do
       }
 
       expect(announcement.reload.position).to eq 1
-      expect(another_announcement.reload.position).to eq 0
+      expect(another_announcement.reload.position).to eq 2
       expect(subject).to redirect_to(reorder_coronavirus_page_announcements_path(coronavirus_page.slug))
     end
   end

--- a/spec/controllers/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/reorder_sub_sections_controller_spec.rb
@@ -1,13 +1,12 @@
 require "rails_helper"
 
-RSpec.describe ReorderSubSectionsController, type: :controller do
+RSpec.describe ReorderSubSectionsController do
+  include CoronavirusFeatureSteps
+
   render_views
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
-  let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
-  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
-  let(:raw_content) { File.read(fixture_path) }
 
   describe "GET /coronavirus/:coronavirus_page_slug/sub_sections/reorder" do
     it "renders page successfuly" do
@@ -18,8 +17,7 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
 
   describe "PUT /coronavirus/:coronavirus_page_slug/sub_sections/reorder" do
     before do
-      stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-        .to_return(status: 200, body: raw_content)
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
     end
     let(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }

--- a/spec/controllers/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/reorder_sub_sections_controller_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe ReorderSubSectionsController, type: :controller do
         stub_any_publishing_api_put_content.to_return(status: 500)
       end
 
-      it "does not reinstates the previous order if draft updater fails" do
+      it "keeps the existing order if draft updater fails" do
         subject
-        expect(sub_section_0.reload.position).to eq 1
-        expect(sub_section_1.reload.position).to eq 0
+        expect(sub_section_0.reload.position).to eq 0
+        expect(sub_section_1.reload.position).to eq 1
       end
 
       it "redirects to coronavirus page on success" do

--- a/spec/controllers/reorder_timeline_entries_controller_spec.rb
+++ b/spec/controllers/reorder_timeline_entries_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ReorderTimelineEntriesController do
+  include CoronavirusFeatureSteps
+
   let(:coronavirus_page) { create(:coronavirus_page) }
   let(:stub_user) { create :user, name: "Name Surname" }
 
@@ -32,7 +34,7 @@ RSpec.describe ReorderTimelineEntriesController do
     let!(:first_timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
 
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
       stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
@@ -104,11 +106,5 @@ RSpec.describe ReorderTimelineEntriesController do
       expect(second_timeline_entry.reload.position).to eq 2
       expect(response).to redirect_to(reorder_coronavirus_page_timeline_entries_path(coronavirus_page.slug))
     end
-  end
-
-  def setup_github_data
-    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/controllers/reorder_timeline_entries_controller_spec.rb
+++ b/spec/controllers/reorder_timeline_entries_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ReorderTimelineEntriesController do
+  let(:coronavirus_page) { create(:coronavirus_page) }
+  let(:stub_user) { create :user, name: "Name Surname" }
+
+  describe "Coronavirus reorder timeline entries page" do
+    it "can only be accessed by users with Coronavirus editor permissions" do
+      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "cannot be accessed by users without Unreleased feature permissions" do
+      stub_user.permissions << "Coronavirus editor"
+      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "cannot be accessed by users without Coronavirus editor permissions" do
+      stub_user.permissions << "Unreleased feature"
+      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-RSpec.describe SubSectionsController, type: :controller do
+RSpec.describe SubSectionsController do
+  include CoronavirusFeatureSteps
+
   render_views
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe TimelineEntriesController do
+  include CoronavirusFeatureSteps
+
   let(:stub_user) { create :user, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :landing }
 
@@ -38,7 +40,7 @@ RSpec.describe TimelineEntriesController do
     end
 
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_any_publishing_api_call
       stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
@@ -115,7 +117,7 @@ RSpec.describe TimelineEntriesController do
     end
 
     before do
-      setup_github_data
+      stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
       stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
@@ -143,11 +145,5 @@ RSpec.describe TimelineEntriesController do
 
       expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
     end
-  end
-
-  def setup_github_data
-    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/features/access_control_spec.rb
+++ b/spec/features/access_control_spec.rb
@@ -3,6 +3,7 @@ require "gds_api/test_helpers/publishing_api"
 
 RSpec.feature "Access control" do
   include CommonFeatureSteps
+  include CoronavirusFeatureSteps
   include NavigationSteps
   include GdsApi::TestHelpers::PublishingApi
 

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -3,6 +3,7 @@ require "gds_api/test_helpers/publishing_api"
 
 RSpec.feature "Publish updates to Coronavirus pages" do
   include CommonFeatureSteps
+  include CoronavirusFeatureSteps
   include GdsApi::TestHelpers::PublishingApi
 
   describe "Index page" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -171,12 +171,22 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         then_i_see_the_timeline_entry_has_been_updated
       end
 
+      scenario "Reordering timeline entries", js: true do
+        given_i_can_access_unreleased_features
+        given_there_is_a_coronavirus_page_with_timeline_entries
+        when_i_visit_the_reorder_timeline_entries_page
+        then_i_see_the_timeline_entries_in_order
+        when_i_move_timeline_entry_one_down
+        then_i_see_timeline_entries_updated_message
+        and_i_see_the_timeline_entries_have_changed_order
+      end
+
       scenario "Viewing timeline entries" do
         given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
         when_i_visit_a_coronavirus_page
         then_i_can_see_a_timeline_entries_section
-        and_i_can_see_an_existing_timeline_entry
+        and_i_can_see_existing_timeline_entries
       end
 
       scenario "Timeline entries should only be visable on the landing page" do

--- a/spec/features/live_stream_page_spec.rb
+++ b/spec/features/live_stream_page_spec.rb
@@ -3,6 +3,7 @@ require "gds_api/test_helpers/publishing_api"
 
 RSpec.feature "Make changes to the live stream URL" do
   include CommonFeatureSteps
+  include CoronavirusFeatureSteps
   include GdsApi::TestHelpers::PublishingApi
 
   before do

--- a/spec/presenters/announcement_json_presenter_spec.rb
+++ b/spec/presenters/announcement_json_presenter_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 RSpec.describe AnnouncementJsonPresenter do
+  include CoronavirusHelpers
+
   let!(:announcement) { create :announcement }
 
   before do
-    setup_github_data
+    stub_coronavirus_landing_page_content(announcement.coronavirus_page)
   end
 
   describe "#output" do
@@ -17,11 +19,5 @@ RSpec.describe AnnouncementJsonPresenter do
 
       expect(described_class.new(announcement).output).to eq(expected)
     end
-  end
-
-  def setup_github_data
-    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-    stub_request(:get, /#{announcement.coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-      .to_return(status: 200, body: raw_content)
   end
 end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPagePresenter do
+  include CoronavirusFeatureSteps
   include GovukContentSchemaTestHelpers
 
   let(:coronavirus_page) { create :coronavirus_page, :landing }

--- a/spec/services/coronavirus_pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus_pages/draft_updater_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe CoronavirusPages::DraftUpdater do
+  include CoronavirusFeatureSteps
+
   let(:coronavirus_page) { create :coronavirus_page }
   let(:content_builder) { CoronavirusPages::ContentBuilder.new(coronavirus_page) }
   let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }

--- a/spec/services/live_stream_updater_spec.rb
+++ b/spec/services/live_stream_updater_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 require "gds_api/test_helpers/publishing_api"
 
 RSpec.describe LiveStreamUpdater do
+  include CoronavirusFeatureSteps
   include GdsApi::TestHelpers::PublishingApi
 
   before do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -1,616 +1,612 @@
-def given_i_am_a_coronavirus_editor
-  stub_user.permissions << "Coronavirus editor"
-  stub_user.name = "Test author"
-end
+require_relative "coronavirus_helpers"
 
-def given_i_can_access_unreleased_features
-  stub_user.permissions << "Unreleased feature"
-end
+module CoronavirusFeatureSteps
+  include CoronavirusHelpers
 
-def given_a_livestream_exists
-  FactoryBot.create(:live_stream, :without_validations)
-end
+  def given_i_am_a_coronavirus_editor
+    stub_user.permissions << "Coronavirus editor"
+    stub_user.name = "Test author"
+  end
 
-def given_there_is_a_coronavirus_page
-  @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
-end
+  def given_i_can_access_unreleased_features
+    stub_user.permissions << "Unreleased feature"
+  end
 
-def given_there_is_coronavirus_page_with_announcements
-  @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
-  @announcement_one = FactoryBot.create(:announcement, position: 0, coronavirus_page: @coronavirus_page)
-  @announcement_two = FactoryBot.create(:announcement, position: 1, coronavirus_page: @coronavirus_page)
-end
+  def given_a_livestream_exists
+    FactoryBot.create(:live_stream, :without_validations)
+  end
 
-def given_there_is_a_coronavirus_page_with_timeline_entries
-  @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
-  @timeline_entry_two = FactoryBot.create(:timeline_entry, coronavirus_page: @coronavirus_page, heading: "Two")
-  @timeline_entry_one = FactoryBot.create(:timeline_entry, coronavirus_page: @coronavirus_page, heading: "One")
-end
+  def given_there_is_a_coronavirus_page
+    @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
+  end
 
-def the_payload_contains_the_valid_url
-  live_stream_payload = coronavirus_live_stream_hash.merge(
-    {
-      "video_url" => valid_url,
-      "date" => todays_date,
-    },
-  )
-  assert_publishing_api_put_content(
-    coronavirus_content_id,
-    request_json_includes(
-      "details" => {
-        "announcements_label" => "Announcements",
-        "live_stream" => live_stream_payload,
+  def given_there_is_coronavirus_page_with_announcements
+    @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
+    @announcement_one = FactoryBot.create(:announcement, position: 0, coronavirus_page: @coronavirus_page)
+    @announcement_two = FactoryBot.create(:announcement, position: 1, coronavirus_page: @coronavirus_page)
+  end
+
+  def given_there_is_a_coronavirus_page_with_timeline_entries
+    @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
+    @timeline_entry_two = FactoryBot.create(:timeline_entry, coronavirus_page: @coronavirus_page, heading: "Two")
+    @timeline_entry_one = FactoryBot.create(:timeline_entry, coronavirus_page: @coronavirus_page, heading: "One")
+  end
+
+  def the_payload_contains_the_valid_url
+    live_stream_payload = coronavirus_live_stream_hash.merge(
+      {
+        "video_url" => valid_url,
+        "date" => todays_date,
       },
-    ),
-  )
-end
+    )
+    assert_publishing_api_put_content(
+      coronavirus_content_id,
+      request_json_includes(
+        "details" => {
+          "announcements_label" => "Announcements",
+          "live_stream" => live_stream_payload,
+        },
+      ),
+    )
+  end
 
-def live_coronavirus_content_item
-  File.read(Rails.root.join("spec/fixtures/coronavirus_content_item.json"))
-end
+  def live_coronavirus_content_item
+    File.read(Rails.root.join("spec/fixtures/coronavirus_content_item.json"))
+  end
 
-def coronavirus_content_json
-  @coronavirus_content_json ||= JSON.parse(live_coronavirus_content_item)
-end
+  def coronavirus_content_json
+    @coronavirus_content_json ||= JSON.parse(live_coronavirus_content_item)
+  end
 
-def coronavirus_live_stream_hash
-  coronavirus_content_json.dig("details", "live_stream")
-end
+  def coronavirus_live_stream_hash
+    coronavirus_content_json.dig("details", "live_stream")
+  end
 
-def coronavirus_content_id
-  coronavirus_content_json["content_id"]
-end
+  def coronavirus_content_id
+    coronavirus_content_json["content_id"]
+  end
 
-def todays_date
-  Time.zone.now.strftime("%-d %B %Y")
-end
+  def todays_date
+    Time.zone.now.strftime("%-d %B %Y")
+  end
 
-def invalid_url
-  "https://www.yotbe.com/watch?v=UF8mC-T0u6k"
-end
+  def invalid_url
+    "https://www.yotbe.com/watch?v=UF8mC-T0u6k"
+  end
 
-def valid_url
-  "https://www.youtube.com/watch?v=UF8mC-T0u6k"
-end
+  def valid_url
+    "https://www.youtube.com/watch?v=UF8mC-T0u6k"
+  end
 
-def stub_youtube
-  stub_request(:get, valid_url)
-end
+  def stub_youtube
+    stub_request(:get, valid_url)
+  end
 
-def stub_coronavirus_publishing_api
-  stub_live_coronavirus_content_request
-  stub_any_publishing_api_put_content
-  stub_any_publishing_api_publish
-end
+  def stub_coronavirus_publishing_api
+    stub_live_coronavirus_content_request
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+  end
 
-def stub_live_coronavirus_content_request
-  stub_publishing_api_has_item(coronavirus_content_json)
-end
+  def stub_live_coronavirus_content_request
+    stub_publishing_api_has_item(coronavirus_content_json)
+  end
 
-def raw_content_urls
-  @raw_content_urls ||=
-    CoronavirusPages::Configuration.all_pages.map do |config|
-      config.second[:raw_content_url]
+  def raw_content_urls
+    @raw_content_urls ||=
+      CoronavirusPages::Configuration.all_pages.map do |config|
+        config.second[:raw_content_url]
+      end
+  end
+
+  def stub_all_github_requests
+    raw_content_urls.each do |url|
+      stub_request(:get, Regexp.new(url))
+        .to_return(status: 200, body: github_response)
     end
-end
-
-def stub_all_github_requests
-  raw_content_urls.each do |url|
-    stub_request(:get, Regexp.new(url))
-      .to_return(status: 200, body: github_response)
   end
-end
 
-def stub_github_business_request
-  stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml"))
-    .to_return(status: 200, body: github_business_response)
-end
-
-def github_response
-  File.read(Rails.root.join + "spec/fixtures/coronavirus_landing_page.yml")
-end
-
-def github_business_response
-  File.read(Rails.root.join + "spec/fixtures/coronavirus_business_page.yml")
-end
-
-def then_the_content_is_sent_to_publishing_api
-  assert_publishing_api_put_content(
-    "774cee22-d896-44c1-a611-e3109cce8eae",
-    request_json_includes(
-      "title" => "Coronavirus (COVID-19): what you need to do",
-    ),
-  )
-end
-
-def then_the_business_content_is_sent_to_publishing_api
-  assert_publishing_api_put_content(
-    "09944b84-02ba-4742-a696-9e562fc9b29d",
-    request_json_includes(
-      "title" => "Business support",
-    ),
-  )
-end
-
-def i_see_a_publish_landing_page_link
-  expect(page).to have_link("Edit something else on the landing page")
-end
-
-def i_see_a_publish_business_page_link
-  expect(page).to have_link("Edit something else on the business hub")
-end
-
-def i_see_livestream_button
-  expect(page).to have_link("Edit live stream URL")
-end
-
-def and_i_select_landing_page
-  click_link("Edit something else on the landing page")
-end
-
-def and_i_select_business_page
-  click_link("Edit something else on the business hub")
-end
-
-def and_i_select_live_stream
-  click_link("Edit live stream URL")
-  expect(page).to have_text("Update live stream URL")
-end
-
-def i_am_able_to_update_draft_content_with_valid_url
-  fill_in("url", with: valid_url)
-  click_on("Update draft")
-  the_payload_contains_the_valid_url
-end
-
-def and_i_can_publish_the_url
-  click_on("Publish")
-  assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
-end
-
-def and_i_can_check_the_preview
-  expect(page).to have_link("Preview", href: "https://draft-origin.test.gov.uk/coronavirus")
-end
-
-def i_am_able_to_submit_an_invalid_url
-  fill_in("url", with: invalid_url)
-  click_on("Update draft")
-end
-
-def when_i_visit_the_coronavirus_index_page
-  visit "/coronavirus"
-end
-
-def when_i_visit_a_non_existent_page
-  visit "/coronavirus/flimflam/prepare"
-end
-
-def when_i_visit_a_coronavirus_page
-  visit "/coronavirus/landing"
-end
-
-### Reordering sections spec ##
-
-def when_i_visit_the_reorder_page
-  visit "/coronavirus/landing/sub_sections/reorder"
-end
-
-def when_i_visit_the_reorder_announcements_page
-  visit "/coronavirus/landing/announcements/reorder"
-end
-
-def then_i_can_see_an_announcements_section
-  expect(page).to have_content("Announcements")
-  expect(page).to have_link("Reorder", href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug))
-  expect(page).to have_link("Add announcement")
-end
-
-def then_i_can_see_a_timeline_entries_section
-  expect(page).to have_content("Timeline entries")
-  expect(page).to have_link("Reorder", href: reorder_coronavirus_page_timeline_entries_path(@coronavirus_page.slug))
-  expect(page).to have_link("Add timeline entry")
-end
-
-def then_i_cannot_see_an_announcements_section
-  expect(page).to_not have_content("Announcements")
-end
-
-def then_i_cannot_see_a_timeline_entries_section
-  expect(page).to_not have_content("Timeline entries")
-end
-
-def and_i_can_see_existing_announcements
-  expect(page).to have_content(@announcement_one.title)
-  expect(page).to have_content(@announcement_two.title)
-end
-
-def and_i_can_see_existing_timeline_entries
-  expect(page).to have_content(@timeline_entry_one.heading)
-  expect(page).to have_content(@timeline_entry_two.heading)
-end
-
-def then_i_see_the_announcements_in_order
-  expect(page).to have_content(
-    /#{@announcement_one.title}.*#{@announcement_two.title}/,
-    normalize_ws: true,
-  )
-end
-
-def when_i_move_announcement_one_down
-  raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-  stub_request(:get, /#{@coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-    .to_return(status: 200, body: raw_content)
-
-  within("#step-0") { click_button "Down" }
-  click_button "Save"
-end
-
-def then_i_see_announcement_updated_message
-  expect(page).to have_content "Announcements were successfully reordered."
-end
-
-def and_i_see_the_announcements_have_changed_order
-  expect(page).to have_content(
-    /#{@announcement_two.title}.*#{@announcement_one.title}/,
-    normalize_ws: true,
-  )
-end
-
-# Adding an announcement
-
-def set_up_github_data(coronavirus_page)
-  raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-  stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-    .to_return(status: 200, body: raw_content)
-end
-
-def and_i_add_a_new_announcement
-  click_on("Add announcement")
-end
-
-def then_i_see_the_create_announcement_form
-  expect(page).to have_text("Enter the title of the announcement")
-  expect(page).to have_text("Enter the path to the announcement")
-  expect(page).to have_text("Enter the date of publication")
-end
-
-def when_i_fill_in_the_announcement_form_with_valid_data
-  set_up_github_data(@coronavirus_page)
-  fill_in("title", with: "fancy title")
-  fill_in("path", with: "/government")
-  fill_in("announcement[published_at][day]", with: "12")
-  fill_in("announcement[published_at][month]", with: "1")
-  fill_in("announcement[published_at][year]", with: "2020")
-  click_on("Save")
-end
-
-def then_i_can_see_a_new_announcement_has_been_created
-  expect(current_path).to eq("/coronavirus/landing")
-  expect(expect(page).to(have_text("fancy title")))
-end
-
-def when_i_delete_an_announcement
-  set_up_github_data(@coronavirus_page)
-
-  page.accept_alert "Are you sure?" do
-    page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}\"]", text: "Delete").click
+  def stub_github_business_request
+    stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml"))
+      .to_return(status: 200, body: github_business_response)
   end
-end
 
-def then_i_can_see_an_announcement_has_been_deleted
-  expect(page).to have_text("Announcement was successfully deleted.")
-  expect(page).not_to(have_text(@announcement_one.title))
-end
+  def github_response
+    File.read(Rails.root.join + "spec/fixtures/coronavirus_landing_page.yml")
+  end
 
-def when_i_can_click_change_for_an_announcement
-  page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}/edit\"]", text: "Change").click
-end
+  def github_business_response
+    File.read(Rails.root.join + "spec/fixtures/coronavirus_business_page.yml")
+  end
 
-def then_i_see_the_edit_announcement_form
-  expect(page).to have_text("Edit announcement")
-end
+  def then_the_content_is_sent_to_publishing_api
+    assert_publishing_api_put_content(
+      "774cee22-d896-44c1-a611-e3109cce8eae",
+      request_json_includes(
+        "title" => "Coronavirus (COVID-19): what you need to do",
+      ),
+    )
+  end
 
-def when_i_can_edit_the_announcement_form_with_valid_data
-  set_up_github_data(@coronavirus_page)
-  fill_in("title", with: "Updated title")
-  click_on("Save")
-end
+  def then_the_business_content_is_sent_to_publishing_api
+    assert_publishing_api_put_content(
+      "09944b84-02ba-4742-a696-9e562fc9b29d",
+      request_json_includes(
+        "title" => "Business support",
+      ),
+    )
+  end
 
-def then_i_can_see_that_the_announcement_has_been_updated
-  expect(page).to have_content("Announcement was successfully updated.")
-  expect(page).to have_content("Updated title")
-end
+  def i_see_a_publish_landing_page_link
+    expect(page).to have_link("Edit something else on the landing page")
+  end
 
-# Adding a timeline entry
+  def i_see_a_publish_business_page_link
+    expect(page).to have_link("Edit something else on the business hub")
+  end
 
-def and_i_add_a_new_timeline_entry
-  click_on("Add timeline entry")
-end
+  def i_see_livestream_button
+    expect(page).to have_link("Edit live stream URL")
+  end
 
-def then_i_see_the_timeline_entry_form
-  expect(page).to have_text("Enter the heading of the timeline entry")
-  expect(page).to have_text("Content")
-end
+  def and_i_select_landing_page
+    click_link("Edit something else on the landing page")
+  end
 
-def when_i_fill_in_the_timeline_entry_form_with_valid_data
-  set_up_github_data(@coronavirus_page)
-  fill_in("heading", with: "Fancy title")
-  fill_in("content", with: "##Form content")
-  click_on("Save")
-end
+  def and_i_select_business_page
+    click_link("Edit something else on the business hub")
+  end
 
-def then_i_see_a_new_timeline_entry_has_been_created
-  expect(current_path).to eq("/coronavirus/landing")
-  expect(expect(page).to(have_text("Fancy title")))
-end
+  def and_i_select_live_stream
+    click_link("Edit live stream URL")
+    expect(page).to have_text("Update live stream URL")
+  end
 
-# Editing timeline entries
+  def i_am_able_to_update_draft_content_with_valid_url
+    fill_in("url", with: valid_url)
+    click_on("Update draft")
+    the_payload_contains_the_valid_url
+  end
 
-def and_i_change_a_timeline_entry
-  page.find("a[href=\"/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}/edit\"]", text: "Change").click
-end
+  def and_i_can_publish_the_url
+    click_on("Publish")
+    assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
+  end
 
-def when_i_visit_the_edit_timeline_entry_page
-  visit "/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}/edit"
-end
+  def and_i_can_check_the_preview
+    expect(page).to have_link("Preview", href: "https://draft-origin.test.gov.uk/coronavirus")
+  end
 
-def and_i_see_the_existing_timeline_entry_data
-  expect(page).to have_selector("input[value='#{@timeline_entry_one.heading}']")
-  expect(page).to have_content(@timeline_entry_one.content)
-end
+  def i_am_able_to_submit_an_invalid_url
+    fill_in("url", with: invalid_url)
+    click_on("Update draft")
+  end
 
-def then_i_see_the_timeline_entry_has_been_updated
-  expect(@timeline_entry_one.reload.content).to eq("##Form content")
-end
+  def when_i_visit_the_coronavirus_index_page
+    visit "/coronavirus"
+  end
 
-# Reordering timeline entries
+  def when_i_visit_a_non_existent_page
+    visit "/coronavirus/flimflam/prepare"
+  end
 
-def when_i_visit_the_reorder_timeline_entries_page
-  visit "/coronavirus/landing/timeline_entries/reorder"
-end
+  def when_i_visit_a_coronavirus_page
+    visit "/coronavirus/landing"
+  end
 
-def then_i_see_the_timeline_entries_in_order
-  expect(page).to have_content(
-    /#{@timeline_entry_one.heading}.*#{@timeline_entry_two.heading}/,
-    normalize_ws: true,
-  )
-end
+  ### Reordering sections spec ##
 
-def when_i_move_timeline_entry_one_down
-  raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
-  stub_request(:get, /#{@coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-    .to_return(status: 200, body: raw_content)
+  def when_i_visit_the_reorder_page
+    visit "/coronavirus/landing/sub_sections/reorder"
+  end
 
-  within("#step-0") { click_button "Down" }
-  click_button "Save"
-end
+  def when_i_visit_the_reorder_announcements_page
+    visit "/coronavirus/landing/announcements/reorder"
+  end
 
-def then_i_see_timeline_entries_updated_message
-  expect(page).to have_content I18n.t("coronavirus_pages.timeline_entries.reorder.success")
-end
+  def then_i_can_see_an_announcements_section
+    expect(page).to have_content("Announcements")
+    expect(page).to have_link("Reorder", href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug))
+    expect(page).to have_link("Add announcement")
+  end
 
-def and_i_see_the_timeline_entries_have_changed_order
-  expect(page).to have_content(
-    /#{@timeline_entry_two.heading}.*#{@timeline_entry_one.heading}/,
-    normalize_ws: true,
-  )
-end
+  def then_i_can_see_a_timeline_entries_section
+    expect(page).to have_content("Timeline entries")
+    expect(page).to have_link("Reorder", href: reorder_coronavirus_page_timeline_entries_path(@coronavirus_page.slug))
+    expect(page).to have_link("Add timeline entry")
+  end
 
-def set_up_basic_sub_sections
-  coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
-  FactoryBot.create(:sub_section,
-                    coronavirus_page_id: coronavirus_page.id,
-                    position: 0,
-                    title: "I am first",
-                    content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
-  FactoryBot.create(:sub_section,
-                    coronavirus_page_id: coronavirus_page.id,
-                    position: 1,
-                    title: "I am second",
-                    content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
-  path = Rails.root.join "spec/fixtures/simple_coronavirus_page.yml"
-  github_yaml_content = File.read(path)
-  stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
-    .to_return(status: 200, body: github_yaml_content)
-  stub_live_sub_sections_content_request(coronavirus_page.content_id)
-end
+  def then_i_cannot_see_an_announcements_section
+    expect(page).to_not have_content("Announcements")
+  end
 
-def coronavirus_content_json_with_sections(content_id)
-  path = Rails.root.join("spec/fixtures/coronavirus_page_sections.json")
-  JSON.parse(File.read(path).gsub("774cee22-d896-44c1-a611-e3109cce8eae", content_id))
-end
+  def then_i_cannot_see_a_timeline_entries_section
+    expect(page).to_not have_content("Timeline entries")
+  end
 
-def stub_live_sub_sections_content_request(content_id)
-  content = coronavirus_content_json_with_sections(content_id)
-  stub_publishing_api_has_item(content)
-end
+  def and_i_can_see_existing_announcements
+    expect(page).to have_content(@announcement_one.title)
+    expect(page).to have_content(@announcement_two.title)
+  end
 
-def stub_discard_subsection_changes
-  stub_publishing_api_discard_draft(CoronavirusPage.topic_page.first.content_id)
-end
+  def and_i_can_see_existing_timeline_entries
+    expect(page).to have_content(@timeline_entry_one.heading)
+    expect(page).to have_content(@timeline_entry_two.heading)
+  end
 
-def stub_discard_coronavirus_page_draft
-  stub_publishing_api_discard_draft(coronavirus_content_id)
-end
+  def then_i_see_the_announcements_in_order
+    expect(page).to have_content(
+      /#{@announcement_one.title}.*#{@announcement_two.title}/,
+      normalize_ws: true,
+    )
+  end
 
-def stub_discard_coronavirus_page_no_draft
-  stub_any_publishing_api_discard_draft
-    .to_return(status: 422, body: "You do not have a draft to discard")
-end
+  def when_i_move_announcement_one_down
+    stub_coronavirus_landing_page_content(@coronavirus_page)
 
-def i_see_subsection_one_in_position_one
-  element = find("#step-0")
-  expect(element).to have_content "I am first"
-end
+    within("#step-0") { click_button "Down" }
+    click_button "Save"
+  end
 
-def and_i_move_section_one_down
-  within("#step-0") { click_button "Down" }
-  click_button "Save"
-  expect(page).to have_content "Sections were successfully reordered."
-end
+  def then_i_see_announcement_updated_message
+    expect(page).to have_content "Announcements were successfully reordered."
+  end
 
-def then_the_reordered_subsections_are_sent_to_publishing_api
-  section = { "title" => "title", "list" => [{ "label" => "label", "url" => "/url?priority-taxon=#{CoronavirusPage.topic_page.first.content_id}" }] }
-  reordered_sections = [
-    {
-      "title" => "I am second",
-      "sub_sections" => [section],
-    },
-    {
-      "title" => "I am first",
-      "sub_sections" => [section],
-    },
-  ]
+  def and_i_see_the_announcements_have_changed_order
+    expect(page).to have_content(
+      /#{@announcement_two.title}.*#{@announcement_one.title}/,
+      normalize_ws: true,
+    )
+  end
 
-  hidden_search_terms = reordered_sections.map do |reordered_section|
-    [
-      reordered_section["title"],
-      section["title"],
-      section["list"].first["label"],
+  # Adding an announcement
+
+  def and_i_add_a_new_announcement
+    click_on("Add announcement")
+  end
+
+  def then_i_see_the_create_announcement_form
+    expect(page).to have_text("Enter the title of the announcement")
+    expect(page).to have_text("Enter the path to the announcement")
+    expect(page).to have_text("Enter the date of publication")
+  end
+
+  def when_i_fill_in_the_announcement_form_with_valid_data
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+    fill_in("title", with: "fancy title")
+    fill_in("path", with: "/government")
+    fill_in("announcement[published_at][day]", with: "12")
+    fill_in("announcement[published_at][month]", with: "1")
+    fill_in("announcement[published_at][year]", with: "2020")
+    click_on("Save")
+  end
+
+  def then_i_can_see_a_new_announcement_has_been_created
+    expect(current_path).to eq("/coronavirus/landing")
+    expect(expect(page).to(have_text("fancy title")))
+  end
+
+  def when_i_delete_an_announcement
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+
+    page.accept_alert "Are you sure?" do
+      page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}\"]", text: "Delete").click
+    end
+  end
+
+  def then_i_can_see_an_announcement_has_been_deleted
+    expect(page).to have_text("Announcement was successfully deleted.")
+    expect(page).not_to(have_text(@announcement_one.title))
+  end
+
+  def when_i_can_click_change_for_an_announcement
+    page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}/edit\"]", text: "Change").click
+  end
+
+  def then_i_see_the_edit_announcement_form
+    expect(page).to have_text("Edit announcement")
+  end
+
+  def when_i_can_edit_the_announcement_form_with_valid_data
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+    fill_in("title", with: "Updated title")
+    click_on("Save")
+  end
+
+  def then_i_can_see_that_the_announcement_has_been_updated
+    expect(page).to have_content("Announcement was successfully updated.")
+    expect(page).to have_content("Updated title")
+  end
+
+  # Adding a timeline entry
+
+  def and_i_add_a_new_timeline_entry
+    click_on("Add timeline entry")
+  end
+
+  def then_i_see_the_timeline_entry_form
+    expect(page).to have_text("Enter the heading of the timeline entry")
+    expect(page).to have_text("Content")
+  end
+
+  def when_i_fill_in_the_timeline_entry_form_with_valid_data
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+    fill_in("heading", with: "Fancy title")
+    fill_in("content", with: "##Form content")
+    click_on("Save")
+  end
+
+  def then_i_see_a_new_timeline_entry_has_been_created
+    expect(current_path).to eq("/coronavirus/landing")
+    expect(expect(page).to(have_text("Fancy title")))
+  end
+
+  # Editing timeline entries
+
+  def and_i_change_a_timeline_entry
+    page.find("a[href=\"/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}/edit\"]", text: "Change").click
+  end
+
+  def when_i_visit_the_edit_timeline_entry_page
+    visit "/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}/edit"
+  end
+
+  def and_i_see_the_existing_timeline_entry_data
+    expect(page).to have_selector("input[value='#{@timeline_entry_one.heading}']")
+    expect(page).to have_content(@timeline_entry_one.content)
+  end
+
+  def then_i_see_the_timeline_entry_has_been_updated
+    expect(@timeline_entry_one.reload.content).to eq("##Form content")
+  end
+
+  # Reordering timeline entries
+
+  def when_i_visit_the_reorder_timeline_entries_page
+    visit "/coronavirus/landing/timeline_entries/reorder"
+  end
+
+  def then_i_see_the_timeline_entries_in_order
+    expect(page).to have_content(
+      /#{@timeline_entry_one.heading}.*#{@timeline_entry_two.heading}/,
+      normalize_ws: true,
+    )
+  end
+
+  def when_i_move_timeline_entry_one_down
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+
+    within("#step-0") { click_button "Down" }
+    click_button "Save"
+  end
+
+  def then_i_see_timeline_entries_updated_message
+    expect(page).to have_content I18n.t("coronavirus_pages.timeline_entries.reorder.success")
+  end
+
+  def and_i_see_the_timeline_entries_have_changed_order
+    expect(page).to have_content(
+      /#{@timeline_entry_two.heading}.*#{@timeline_entry_one.heading}/,
+      normalize_ws: true,
+    )
+  end
+
+  def set_up_basic_sub_sections
+    coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
+    FactoryBot.create(:sub_section,
+                      coronavirus_page_id: coronavirus_page.id,
+                      position: 0,
+                      title: "I am first",
+                      content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
+    FactoryBot.create(:sub_section,
+                      coronavirus_page_id: coronavirus_page.id,
+                      position: 1,
+                      title: "I am second",
+                      content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
+    path = Rails.root.join "spec/fixtures/simple_coronavirus_page.yml"
+    github_yaml_content = File.read(path)
+    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+      .to_return(status: 200, body: github_yaml_content)
+    stub_live_sub_sections_content_request(coronavirus_page.content_id)
+  end
+
+  def coronavirus_content_json_with_sections(content_id)
+    path = Rails.root.join("spec/fixtures/coronavirus_page_sections.json")
+    JSON.parse(File.read(path).gsub("774cee22-d896-44c1-a611-e3109cce8eae", content_id))
+  end
+
+  def stub_live_sub_sections_content_request(content_id)
+    content = coronavirus_content_json_with_sections(content_id)
+    stub_publishing_api_has_item(content)
+  end
+
+  def stub_discard_subsection_changes
+    stub_publishing_api_discard_draft(CoronavirusPage.topic_page.first.content_id)
+  end
+
+  def stub_discard_coronavirus_page_draft
+    stub_publishing_api_discard_draft(coronavirus_content_id)
+  end
+
+  def stub_discard_coronavirus_page_no_draft
+    stub_any_publishing_api_discard_draft
+      .to_return(status: 422, body: "You do not have a draft to discard")
+  end
+
+  def i_see_subsection_one_in_position_one
+    element = find("#step-0")
+    expect(element).to have_content "I am first"
+  end
+
+  def and_i_move_section_one_down
+    within("#step-0") { click_button "Down" }
+    click_button "Save"
+    expect(page).to have_content "Sections were successfully reordered."
+  end
+
+  def then_the_reordered_subsections_are_sent_to_publishing_api
+    section = { "title" => "title", "list" => [{ "label" => "label", "url" => "/url?priority-taxon=#{CoronavirusPage.topic_page.first.content_id}" }] }
+    reordered_sections = [
+      {
+        "title" => "I am second",
+        "sub_sections" => [section],
+      },
+      {
+        "title" => "I am first",
+        "sub_sections" => [section],
+      },
     ]
+
+    hidden_search_terms = reordered_sections.map do |reordered_section|
+      [
+        reordered_section["title"],
+        section["title"],
+        section["list"].first["label"],
+      ]
+    end
+
+    assert_publishing_api_put_content(
+      CoronavirusPage.topic_page.first.content_id,
+      lambda do |request|
+        details = JSON.parse(request.body)["details"]
+        expect(details).to match hash_including({
+          "sections" => reordered_sections,
+          "hidden_search_terms" => hidden_search_terms.flatten.select(&:present?).uniq,
+        })
+      end,
+    )
   end
 
-  assert_publishing_api_put_content(
-    CoronavirusPage.topic_page.first.content_id,
-    lambda do |request|
-      details = JSON.parse(request.body)["details"]
-      expect(details).to match hash_including({
-        "sections" => reordered_sections,
-        "hidden_search_terms" => hidden_search_terms.flatten.select(&:present?).uniq,
-      })
-    end,
-  )
-end
+  def then_i_see_section_updated_message
+    expect(page).to have_text("Sections were successfully reordered.")
+  end
 
-def then_i_see_section_updated_message
-  expect(page).to have_text("Sections were successfully reordered.")
-end
+  def and_i_see_state_is_published
+    expect(CoronavirusPage.topic_page.first.state).to eq "published"
+    expect(page).to have_text("Status: Published", normalize_ws: true)
+  end
 
-def and_i_see_state_is_published
-  expect(CoronavirusPage.topic_page.first.state).to eq "published"
-  expect(page).to have_text("Status: Published", normalize_ws: true)
-end
+  def and_i_see_state_is_draft
+    expect(CoronavirusPage.topic_page.first.state).to eq "draft"
+    expect(page).to have_text("Status: Draft", normalize_ws: true)
+  end
 
-def and_i_see_state_is_draft
-  expect(CoronavirusPage.topic_page.first.state).to eq "draft"
-  expect(page).to have_text("Status: Draft", normalize_ws: true)
-end
+  def and_i_discard_my_changes
+    click_link("Discard changes")
+  end
 
-def and_i_discard_my_changes
-  click_link("Discard changes")
-end
+  def i_see_error_message_no_changes_to_discard
+    expect(page).to have_text("You do not have a draft to discard")
+  end
 
-def i_see_error_message_no_changes_to_discard
-  expect(page).to have_text("You do not have a draft to discard")
-end
+  def then_i_am_redirected_to_the_index_page
+    expect(current_path).to eq("/coronavirus")
+  end
 
-def then_i_am_redirected_to_the_index_page
-  expect(current_path).to eq("/coronavirus")
-end
+  def and_i_see_a_message_telling_me_that_the_page_does_not_exist
+    expect(page).to have_text("'flimflam' is not a valid page")
+  end
 
-def and_i_see_a_message_telling_me_that_the_page_does_not_exist
-  expect(page).to have_text("'flimflam' is not a valid page")
-end
+  def i_see_an_update_draft_button
+    expect(page).to have_button("Update draft")
+  end
 
-def i_see_an_update_draft_button
-  expect(page).to have_button("Update draft")
-end
+  def and_a_preview_button
+    expect(page).to have_link("Preview")
+    expect(find_link("Preview")[:target]).to eq("_blank")
+  end
 
-def and_a_preview_button
-  expect(page).to have_link("Preview")
-  expect(find_link("Preview")[:target]).to eq("_blank")
-end
+  def and_a_publish_button
+    expect(page).to have_button("Publish")
+  end
 
-def and_a_publish_button
-  expect(page).to have_button("Publish")
-end
+  def and_a_view_live_business_content_button
+    expect(page).to have_link("View live version", href: "https://www.test.gov.uk/coronavirus/business-support")
+  end
 
-def and_a_view_live_business_content_button
-  expect(page).to have_link("View live version", href: "https://www.test.gov.uk/coronavirus/business-support")
-end
+  def and_i_push_a_new_draft_version
+    click_on("Update draft")
+  end
 
-def and_i_push_a_new_draft_version
-  click_on("Update draft")
-end
+  def and_i_push_a_new_draft_version_with_invalid_content
+    stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml"))
+    .to_return(status: 200, body: invalid_github_response)
 
-def and_i_push_a_new_draft_version_with_invalid_content
-  stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_landing_page.yml"))
-  .to_return(status: 200, body: invalid_github_response)
+    and_i_push_a_new_draft_version
+  end
 
-  and_i_push_a_new_draft_version
-end
+  def and_i_push_a_new_draft_business_version_with_invalid_content
+    stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml"))
+    .to_return(status: 200, body: invalid_github_response)
 
-def and_i_push_a_new_draft_business_version_with_invalid_content
-  stub_request(:get, Regexp.new("https://raw.githubusercontent.com/alphagov/govuk-coronavirus-content/master/content/coronavirus_business_page.yml"))
-  .to_return(status: 200, body: invalid_github_response)
+    and_i_push_a_new_draft_version
+  end
 
-  and_i_push_a_new_draft_version
-end
+  def invalid_github_response
+    File.read(Rails.root.join + "spec/fixtures/invalid_corona_page.yml")
+  end
 
-def invalid_github_response
-  File.read(Rails.root.join + "spec/fixtures/invalid_corona_page.yml")
-end
+  def and_i_see_an_alert
+    expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, announcements_label, announcements, nhs_banner, sections, topic_section, notifications, live_stream.")
+  end
 
-def and_i_see_an_alert
-  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, announcements_label, announcements, nhs_banner, sections, topic_section, notifications, live_stream.")
-end
+  def and_i_see_an_alert_for_missing_hub_page_keys
+    expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, sections, topic_section, notifications.")
+  end
 
-def and_i_see_an_alert_for_missing_hub_page_keys
-  expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, sections, topic_section, notifications.")
-end
+  def and_i_see_a_draft_updated_message
+    expect(page).to have_text("Draft content updated")
+  end
 
-def and_i_see_a_draft_updated_message
-  expect(page).to have_text("Draft content updated")
-end
+  def and_i_choose_a_major_update
+    choose("Major")
+  end
 
-def and_i_choose_a_major_update
-  choose("Major")
-end
+  def and_i_publish_the_page
+    click_on("Publish")
+  end
 
-def and_i_publish_the_page
-  click_on("Publish")
-end
+  def then_the_page_publishes
+    assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "major")
+  end
 
-def then_the_page_publishes
-  assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "major")
-end
+  def then_the_page_publishes_a_minor_update
+    assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
+  end
 
-def then_the_page_publishes_a_minor_update
-  assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
-end
+  def then_the_business_page_publishes
+    assert_publishing_api_publish("09944b84-02ba-4742-a696-9e562fc9b29d", update_type: "major")
+  end
 
-def then_the_business_page_publishes
-  assert_publishing_api_publish("09944b84-02ba-4742-a696-9e562fc9b29d", update_type: "major")
-end
+  def and_i_remain_on_the_coronavirus_page
+    expect(current_path).to eq("/coronavirus/landing")
+  end
 
-def and_i_remain_on_the_coronavirus_page
-  expect(current_path).to eq("/coronavirus/landing")
-end
+  def and_i_remain_on_the_coronavirus_prepare_page
+    expect(current_path).to eq("/coronavirus/landing/prepare")
+  end
 
-def and_i_remain_on_the_coronavirus_prepare_page
-  expect(current_path).to eq("/coronavirus/landing/prepare")
-end
+  def and_i_see_a_page_published_message
+    expect(page).to have_text("Page published!")
+  end
 
-def and_i_see_a_page_published_message
-  expect(page).to have_text("Page published!")
-end
+  def and_i_see_live_stream_is_updated_message
+    expect(page).to have_text("Draft live stream url updated!")
+  end
 
-def and_i_see_live_stream_is_updated_message
-  expect(page).to have_text("Draft live stream url updated!")
-end
+  def and_i_see_live_stream_is_published_message
+    expect(page).to have_text("New live stream url published!")
+  end
 
-def and_i_see_live_stream_is_published_message
-  expect(page).to have_text("New live stream url published!")
-end
+  def and_i_see_the_error_message
+    expect(page).to have_text("Url is not valid. Please check it and try again.")
+  end
 
-def and_i_see_the_error_message
-  expect(page).to have_text("Url is not valid. Please check it and try again.")
-end
+  def and_nothing_is_sent_publishing_api
+    assert_publishing_api_not_published("774cee22-d896-44c1-a611-e3109cce8eae")
+  end
 
-def and_nothing_is_sent_publishing_api
-  assert_publishing_api_not_published("774cee22-d896-44c1-a611-e3109cce8eae")
-end
-
-def and_i_see_a_link_to_the_landing_page
-  expect(page).to have_link("Check live", href: "https://www.test.gov.uk/coronavirus")
+  def and_i_see_a_link_to_the_landing_page
+    expect(page).to have_link("Check live", href: "https://www.test.gov.uk/coronavirus")
+  end
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -230,11 +230,10 @@ def and_i_can_see_existing_timeline_entries
 end
 
 def then_i_see_the_announcements_in_order
-  element = find("#step-0").find(".step-by-step-reorder__step-title")
-  expect(element).to have_content @announcement_one.title
-
-  element = find("#step-1").find(".step-by-step-reorder__step-title")
-  expect(element).to have_content @announcement_two.title
+  expect(page).to have_content(
+    /#{@announcement_one.title}.*#{@announcement_two.title}/,
+    normalize_ws: true,
+  )
 end
 
 def when_i_move_announcement_one_down
@@ -242,7 +241,7 @@ def when_i_move_announcement_one_down
   stub_request(:get, /#{@coronavirus_page.raw_content_url}\?cache-bust=\d+/)
     .to_return(status: 200, body: raw_content)
 
-  find("#step-0").find(".js-order-controls").find(".js-down").click
+  within("#step-0") { click_button "Down" }
   click_button "Save"
 end
 
@@ -251,8 +250,10 @@ def then_i_see_announcement_updated_message
 end
 
 def and_i_see_the_announcements_have_changed_order
-  expect(page).to have_css(".covid-manage-page__summary-list--divider .gem-c-summary-list .govuk-summary-list__row:nth-child(1)", text: @announcement_two.title)
-  expect(page).to have_css(".covid-manage-page__summary-list--divider .gem-c-summary-list .govuk-summary-list__row:nth-child(2)", text: @announcement_one.title)
+  expect(page).to have_content(
+    /#{@announcement_two.title}.*#{@announcement_one.title}/,
+    normalize_ws: true,
+  )
 end
 
 # Adding an announcement
@@ -438,12 +439,12 @@ def stub_discard_coronavirus_page_no_draft
 end
 
 def i_see_subsection_one_in_position_one
-  element = find("#step-0").find(".step-by-step-reorder__step-title")
+  element = find("#step-0")
   expect(element).to have_content "I am first"
 end
 
 def and_i_move_section_one_down
-  find("#step-0").find(".js-order-controls").find(".js-down").click
+  within("#step-0") { click_button "Down" }
   click_button "Save"
   expect(page).to have_content "Sections were successfully reordered."
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -385,7 +385,7 @@ def when_i_move_timeline_entry_one_down
 end
 
 def then_i_see_timeline_entries_updated_message
-  expect(page).to have_content "Timeline entries were successfully reordered."
+  expect(page).to have_content I18n.t("coronavirus_pages.timeline_entries.reorder.success")
 end
 
 def and_i_see_the_timeline_entries_have_changed_order

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -206,7 +206,7 @@ end
 
 def then_i_can_see_a_timeline_entries_section
   expect(page).to have_content("Timeline entries")
-  expect(page).to have_link("Reorder", href: coronavirus_page_path(@coronavirus_page.slug))
+  expect(page).to have_link("Reorder", href: reorder_coronavirus_page_timeline_entries_path(@coronavirus_page.slug))
   expect(page).to have_link("Add timeline entry")
 end
 

--- a/spec/support/coronavirus_helpers.rb
+++ b/spec/support/coronavirus_helpers.rb
@@ -1,0 +1,7 @@
+module CoronavirusHelpers
+  def stub_coronavirus_landing_page_content(coronavirus_page)
+    raw_content = File.read(Rails.root.join("spec/fixtures/coronavirus_landing_page.yml"))
+    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+      .to_return(status: 200, body: raw_content)
+  end
+end


### PR DESCRIPTION
Follows on from PR #1253
Trello: https://trello.com/c/d1it4WEP

# What?
Creates a page to allow content designers to reorder timeline entries using the UI.

This follows the existing pattern (design) for the other reorder pages (i.e. announcements and sub-sections)

# Expected changes
![screenshot-collections-publisher dev gov uk-2021 01 22-16_41_45](https://user-images.githubusercontent.com/5793815/105522616-6196e300-5cd5-11eb-8223-cbb0df6f6055.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
