### PR TITLE
Delete timeline entries

### DIFF
--- a/app/controllers/sub_sections_controller.rb
+++ b/app/controllers/sub_sections_controller.rb
@@ -3,15 +3,13 @@ class SubSectionsController < ApplicationController
   layout "admin_layout"
 
   def new
-    @coronavirus_page = CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
-    @sub_section = @coronavirus_page.sub_sections.new
+    @sub_section = coronavirus_page.sub_sections.new
   end
 
   def create
-    @coronavirus_page = CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
-    @sub_section = @coronavirus_page.sub_sections.new(sub_section_params)
+    @sub_section = coronavirus_page.sub_sections.new(sub_section_params)
     if @sub_section.save && draft_updater.send
-      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Sub-section was successfully created."
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Sub-section was successfully created."
     else
       @sub_section.errors.add :base, draft_updater.errors.to_sentence
       render :new
@@ -19,15 +17,13 @@ class SubSectionsController < ApplicationController
   end
 
   def edit
-    @coronavirus_page = CoronavirusPage.find_by(slug: params[:coronavirus_page_slug])
-    @sub_section = @coronavirus_page.sub_sections.find(params[:id])
+    @sub_section = coronavirus_page.sub_sections.find(params[:id])
   end
 
   def update
-    @sub_section = SubSection.find(params[:id])
-    @coronavirus_page = @sub_section.coronavirus_page
+    @sub_section = coronavirus_page.sub_sections.find(params[:id])
     if @sub_section.update(sub_section_params) && draft_updater.send
-      redirect_to coronavirus_page_path(@coronavirus_page.slug), notice: "Sub-section was successfully updated."
+      redirect_to coronavirus_page_path(coronavirus_page.slug), notice: "Sub-section was successfully updated."
     else
       @sub_section.errors.add :base, draft_updater.errors.to_sentence
       render :edit
@@ -35,8 +31,7 @@ class SubSectionsController < ApplicationController
   end
 
   def destroy
-    @sub_section = SubSection.find(params[:id])
-    @coronavirus_page = @sub_section.coronavirus_page
+    @sub_section = coronavirus_page.sub_sections.find(params[:id])
     attrs = @sub_section.attributes.except("id", "created_at", "updated_at")
     if @sub_section.delete && draft_updater.send
       message = { notice: "Sub-section was successfully deleted." }
@@ -44,10 +39,14 @@ class SubSectionsController < ApplicationController
       draft_updater.rebuild_sub_section(attrs)
       message = { alert: "Sub-section couldn't be deleted" }
     end
-    redirect_to coronavirus_page_path(@coronavirus_page.slug), message
+    redirect_to coronavirus_page_path(coronavirus_page.slug), message
   end
 
 private
+
+  def coronavirus_page
+    @coronavirus_page ||= CoronavirusPage.find_by!(slug: params[:coronavirus_page_slug])
+  end
 
   def sub_section_params
     params.require(:sub_section).permit(:title, :content, :featured_link)

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -31,6 +31,18 @@ class TimelineEntriesController < ApplicationController
     end
   end
 
+  def destroy
+    timeline_entry = coronavirus_page.timeline_entries.find(params[:id])
+
+    message = if timeline_entry.destroy && draft_updater.send
+                { notice: "Timeline entry was successfully deleted." }
+              else
+                { alert: "Timeline entry couldn't be deleted" }
+              end
+
+    redirect_to coronavirus_page_path(@coronavirus_page.slug), message
+  end
+
 private
 
   def timeline_entry_params

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -33,13 +33,13 @@ class TimelineEntriesController < ApplicationController
 
   def destroy
     timeline_entry = coronavirus_page.timeline_entries.find(params[:id])
-    message = { notice: "Timeline entry was successfully deleted." }
+    message = { notice: I18n.t("coronavirus_pages.timeline_entries.delete.success") }
 
     TimelineEntry.transaction do
       timeline_entry.destroy!
 
       unless draft_updater.send
-        message = { alert: "Timeline entry couldn't be deleted" }
+        message = { alert: I18n.t("coronavirus_pages.timeline_entries.delete.failed") }
         raise ActiveRecord::Rollback
       end
     end

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -14,10 +14,6 @@ module CoronavirusPages
       @content_builder ||= CoronavirusPages::ContentBuilder.new(coronavirus_page)
     end
 
-    def rebuild_sub_section(attrs)
-      coronavirus_page.sub_sections.create(attrs)
-    end
-
     def payload
       if content_builder.success?
         CoronavirusPagePresenter.new(content_builder.data, base_path).payload

--- a/app/services/coronavirus_pages/draft_updater.rb
+++ b/app/services/coronavirus_pages/draft_updater.rb
@@ -18,10 +18,6 @@ module CoronavirusPages
       coronavirus_page.sub_sections.create(attrs)
     end
 
-    def rebuild_announcement(attrs)
-      coronavirus_page.announcements.create(attrs)
-    end
-
     def payload
       if content_builder.success?
         CoronavirusPagePresenter.new(content_builder.data, base_path).payload

--- a/app/views/coronavirus_pages/_timeline_entries.html.erb
+++ b/app/views/coronavirus_pages/_timeline_entries.html.erb
@@ -5,7 +5,7 @@
      field: timeline_entry.heading,
      edit: { href: edit_coronavirus_page_timeline_entry_path(@coronavirus_page.slug, timeline_entry) },
      delete: {
-       href: coronavirus_page_path(@coronavirus_page.slug),
+       href: coronavirus_page_timeline_entry_path(@coronavirus_page.slug, timeline_entry),
        data_attributes: {
          confirm: "Are you sure?",
          method: "delete"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,9 @@ en:
       reorder: Reorder
       add: Add accordion
     timeline_entries:
+      delete:
+        success: Timeline entry was successfully deleted.
+        failed: Timeline entry couldn't be deleted
       reorder:
         heading: Reorder timeline entries
         success: Timeline entries were successfully reordered.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :timeline_entries, only: %i[new create edit update] do
+    resources :timeline_entries, only: %i[new create edit update destroy] do
       collection do
         get "reorder", to: "reorder_timeline_entries#index"
         put "reorder", to: "reorder_timeline_entries#update"

--- a/spec/controllers/sub_sections_controller_spec.rb
+++ b/spec/controllers/sub_sections_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe SubSectionsController do
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
-  let(:sub_section) { create :sub_section, coronavirus_page: coronavirus_page }
+  let!(:sub_section) { create :sub_section, coronavirus_page: coronavirus_page }
   let(:title) { Faker::Lorem.sentence }
   let(:content) { "###{Faker::Lorem.sentence}" }
   let(:sub_section_params) do
@@ -136,7 +136,6 @@ RSpec.describe SubSectionsController do
     end
 
     it "updates the sub_section" do
-      sub_section
       expect { subject }.not_to(change { SubSection.count })
     end
 
@@ -167,18 +166,13 @@ RSpec.describe SubSectionsController do
     end
 
     it "deletes the subsection" do
-      sub_section
       expect { subject }.to change { SubSection.count }.by(-1)
     end
 
-    it "recreates the subsection if draft_updater fails" do
-      sub_section
-      stub_any_publishing_api_put_content
-        .to_return(status: 500)
-      expect { subject }.not_to(change { SubSection.count })
-      expect(sub_section.title).to eq SubSection.last.title
-      expect(sub_section.content).to eq SubSection.last.content
-      expect(sub_section.id).not_to eq SubSection.last.id
+    it "doesn't delete the subsection if draft_updater fails" do
+      stub_publishing_api_isnt_available
+
+      expect { subject }.to_not(change { coronavirus_page.reload.sub_sections.to_a })
     end
   end
 end

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe TimelineEntriesController do
              timeline_entry: timeline_entry_params,
            }
 
-      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+      expect(response).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
     end
   end
 
@@ -143,7 +143,37 @@ RSpec.describe TimelineEntriesController do
               timeline_entry: updated_timeline_entry_params,
             }
 
-      expect(subject).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+      expect(response).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+  end
+
+  describe "DELETE /coronavirus/:coronavirus_page_slug/timeline_entries/:id" do
+    let(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
+
+    before do
+      stub_coronavirus_landing_page_content(coronavirus_page)
+      stub_coronavirus_publishing_api
+      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+    end
+
+    it "redirects to the coronavirus page" do
+      delete :destroy,
+             params: {
+               id: timeline_entry.id,
+               coronavirus_page_slug: coronavirus_page.slug,
+             }
+
+      expect(response).to redirect_to(coronavirus_page_path(coronavirus_page.slug))
+    end
+
+    it "deletes the timeline entry" do
+      delete :destroy,
+             params: {
+               id: timeline_entry.id,
+               coronavirus_page_slug: coronavirus_page.slug,
+             }
+
+      expect(coronavirus_page.reload.timeline_entries.count).to eq(0)
     end
   end
 end

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe TimelineEntriesController do
   end
 
   describe "DELETE /coronavirus/:coronavirus_page_slug/timeline_entries/:id" do
-    let(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
+    let!(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page, heading: "Skywalker") }
 
     before do
       stub_coronavirus_landing_page_content(coronavirus_page)
@@ -174,6 +174,19 @@ RSpec.describe TimelineEntriesController do
              }
 
       expect(coronavirus_page.reload.timeline_entries.count).to eq(0)
+    end
+
+    it "doesn't delete the timeline_entry if draft_updater fails" do
+      stub_publishing_api_isnt_available
+      create(:timeline_entry, coronavirus_page: coronavirus_page, heading: "Amidala")
+
+      params = {
+        id: timeline_entry.id,
+        coronavirus_page_slug: coronavirus_page.slug,
+      }
+
+      expect { delete :destroy, params: params }
+        .to_not(change { coronavirus_page.reload.timeline_entries.to_a })
     end
   end
 end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -190,6 +190,15 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         and_i_can_see_existing_timeline_entries
       end
 
+      scenario "Deleting timeline entries", js: true do
+        given_i_can_access_unreleased_features
+        given_there_is_a_coronavirus_page_with_timeline_entries
+        when_i_visit_a_coronavirus_page
+        then_i_can_see_a_timeline_entries_section
+        when_i_delete_a_timeline_entry
+        then_i_can_see_the_timeline_entry_has_been_deleted
+      end
+
       scenario "Timeline entries should only be visable on the landing page" do
         when_i_visit_the_coronavirus_index_page
         and_i_select_business_page

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -391,6 +391,21 @@ module CoronavirusFeatureSteps
     )
   end
 
+  # Deleting timeline entries
+
+  def when_i_delete_a_timeline_entry
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+
+    page.accept_alert "Are you sure?" do
+      page.find("a[href=\"/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}\"]", text: "Delete").click
+    end
+  end
+
+  def then_i_can_see_the_timeline_entry_has_been_deleted
+    expect(page).to have_text("Timeline entry was successfully deleted.")
+    expect(page).not_to have_text(@timeline_entry_one.heading)
+  end
+
   def set_up_basic_sub_sections
     coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
     FactoryBot.create(:sub_section,

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -402,7 +402,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_the_timeline_entry_has_been_deleted
-    expect(page).to have_text("Timeline entry was successfully deleted.")
+    expect(page).to have_text(I18n.t("coronavirus_pages.timeline_entries.delete.success"))
     expect(page).not_to have_text(@timeline_entry_one.heading)
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/rwtOUXAZ

# What's changed?

Allow users to delete a timeline entry from the summary page.

<img width="1532" alt="Screenshot 2021-01-28 at 09 53 31" src="https://user-images.githubusercontent.com/5793815/106121146-22dab000-614f-11eb-95e3-1d82536ddc57.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
