### PR TITLE
Only set featured link descriptions for relative links

### DIFF
--- a/app/presenters/sub_section_json_presenter.rb
+++ b/app/presenters/sub_section_json_presenter.rb
@@ -131,6 +131,8 @@ class SubSectionJsonPresenter
   end
 
   def description_for_featured_link(base_path)
+    return if URI.parse(base_path).absolute?
+
     content_item(base_path)["description"]
   end
 

--- a/spec/presenters/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/sub_section_json_presenter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SubSectionJsonPresenter do
     end
 
     context "with featured links" do
-      it "sets a link as a featured link" do
+      it "looks up the description in Publishing API for a relative featured link" do
         sub_section.featured_link = path
         description = Faker::Lorem.sentence
 
@@ -74,24 +74,31 @@ RSpec.describe SubSectionJsonPresenter do
         )
         stub_publishing_api_has_lookups(path.to_s => content_id)
 
-        expected = {
-          title: subject.title,
-          sub_sections: [
-            {
-              list: [
-                {
-                  url: path,
-                  label: label,
-                  featured_link: true,
-                  description: description,
-                },
-              ],
-              title: title,
-            },
-          ],
-        }
+        sub_sections_list = subject.output[:sub_sections].first[:list]
 
-        expect(subject.output).to eq(expected)
+        expect(sub_sections_list).to include(
+          hash_including(
+            url: path,
+            featured_link: true,
+            description: description,
+          ),
+        )
+      end
+
+      it "sets a nil description for an absolute featured link" do
+        link = "https://example.com/path"
+        sub_section.featured_link = link
+        sub_section.content = "[text](#{link})"
+
+        sub_sections_list = subject.output[:sub_sections].first[:list]
+
+        expect(sub_sections_list).to include(
+          hash_including(
+            url: link,
+            featured_link: true,
+            description: nil,
+          ),
+        )
       end
 
       it "has an error when content does not contain the featured link" do


### PR DESCRIPTION
Trello: https://trello.com/c/a8aT8ExJ/1051-allow-featured-links-in-accordions-to-link-to-external-links

We want to allow content designers to feature links that are to external
website (such as NHS). This was previously blocked due to needing to
pull a description from the Publishing API which required a relative
path. This adds a guard clause that doesn't pull in description for an
absolute link

It also does some refactoring to introduce the extra test so that they
are more succinct.

Co-authored-by: Alex Newton <alex.newton@digital.cabinet-office.gov.uk>
Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This is intended to supersede: https://github.com/alphagov/collections-publisher/pull/1254