### PR TITLE
Make timeline entries "live"

### DIFF
--- a/app/controllers/reorder_timeline_entries_controller.rb
+++ b/app/controllers/reorder_timeline_entries_controller.rb
@@ -1,5 +1,4 @@
 class ReorderTimelineEntriesController < ApplicationController
-  before_action :require_unreleased_feature_permissions!
   before_action :require_coronavirus_editor_permissions!
   layout "admin_layout"
 

--- a/app/controllers/timeline_entries_controller.rb
+++ b/app/controllers/timeline_entries_controller.rb
@@ -1,6 +1,5 @@
 class TimelineEntriesController < ApplicationController
   before_action :require_coronavirus_editor_permissions!
-  before_action :require_unreleased_feature_permissions!
   layout "admin_layout"
 
   def new

--- a/app/services/coronavirus_pages/content_builder.rb
+++ b/app/services/coronavirus_pages/content_builder.rb
@@ -13,10 +13,8 @@ class CoronavirusPages::ContentBuilder
       data["sections"] = sub_sections_data
       data["announcements"] = announcements_data
 
-      if Rails.configuration.unreleased_features
-        data["timeline"] ||= {}
-        data["timeline"]["list"] = timeline_data
-      end
+      data["timeline"] ||= {}
+      data["timeline"]["list"] = timeline_data
 
       add_live_stream(data)
       data["hidden_search_terms"] = hidden_search_terms

--- a/app/views/coronavirus_pages/show.html.erb
+++ b/app/views/coronavirus_pages/show.html.erb
@@ -21,7 +21,7 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if unreleased_feature_user? && @coronavirus_page.topic_page? %>
+    <% if @coronavirus_page.topic_page? %>
     <%= render "timeline_entries" %>
     <% end %>
     <%= render "sub_sections" %>

--- a/spec/controllers/reorder_timeline_entries_controller_spec.rb
+++ b/spec/controllers/reorder_timeline_entries_controller_spec.rb
@@ -4,25 +4,18 @@ RSpec.describe ReorderTimelineEntriesController do
   include CoronavirusFeatureSteps
 
   let(:coronavirus_page) { create(:coronavirus_page) }
-  let(:stub_user) { create :user, name: "Name Surname" }
 
   describe "GET Coronavirus reorder timeline entries page" do
+    let(:stub_user) { create :user, name: "Name Surname" }
+
     it "can only be accessed by users with Coronavirus editor permissions" do
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+      stub_user.permissions = ["signin", "Coronavirus editor"]
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
 
       expect(response).to have_http_status(:success)
     end
 
-    it "cannot be accessed by users without Unreleased feature permissions" do
-      stub_user.permissions << "Coronavirus editor"
-      get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
     it "cannot be accessed by users without Coronavirus editor permissions" do
-      stub_user.permissions << "Unreleased feature"
       get :index, params: { coronavirus_page_slug: coronavirus_page.slug }
 
       expect(response).to have_http_status(:forbidden)
@@ -30,13 +23,13 @@ RSpec.describe ReorderTimelineEntriesController do
   end
 
   describe "PUT Coronavirus reorder timeline entries page" do
+    let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
     let!(:second_timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
     let!(:first_timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
 
     before do
       stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
 
     it "reorders the timeline entries" do

--- a/spec/controllers/timeline_entries_controller_spec.rb
+++ b/spec/controllers/timeline_entries_controller_spec.rb
@@ -7,22 +7,14 @@ RSpec.describe TimelineEntriesController do
   let(:coronavirus_page) { create :coronavirus_page, :landing }
 
   describe "GET /coronavirus/:coronavirus_page_slug/timeline_entries/new" do
-    it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+    it "can only be accessed by users with Coronavirus editor permissions" do
+      stub_user.permissions << "Coronavirus editor"
       get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
 
       expect(response).to have_http_status(:ok)
     end
 
-    it "cannot be accessed by users without Unreleased feature permissions" do
-      stub_user.permissions << "Coronavirus editor"
-      get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
     it "cannot be accessed by users without Coronavirus editor permissions" do
-      stub_user.permissions << "Unreleased feature"
       get :new, params: { coronavirus_page_slug: coronavirus_page.slug }
 
       expect(response).to have_http_status(:forbidden)
@@ -30,6 +22,7 @@ RSpec.describe TimelineEntriesController do
   end
 
   describe "POST /coronavirus/:coronavirus_page_slug/timeline_entries" do
+    let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
     let(:heading) { Faker::Lorem.sentence }
     let(:content) { Faker::Lorem.sentence }
     let(:timeline_entry_params) do
@@ -42,7 +35,6 @@ RSpec.describe TimelineEntriesController do
     before do
       stub_coronavirus_landing_page_content(coronavirus_page)
       stub_any_publishing_api_call
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
 
     it "saves a new timeline entry" do
@@ -72,8 +64,8 @@ RSpec.describe TimelineEntriesController do
   describe "GET /coronavirus/:coronavirus_page_slug/timeline_entries/:id/edit" do
     let(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
 
-    it "can only be accessed by users with Coronavirus editor and Unreleased feature permissions" do
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
+    it "can only be accessed by users with Coronavirus editor permissions" do
+      stub_user.permissions << "Coronavirus editor"
       get :edit,
           params: {
             id: timeline_entry.id,
@@ -83,19 +75,7 @@ RSpec.describe TimelineEntriesController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "cannot be accessed by users without Unreleased feature permissions" do
-      stub_user.permissions << "Coronavirus editor"
-      get :edit,
-          params: {
-            id: timeline_entry.id,
-            coronavirus_page_slug: coronavirus_page.slug,
-          }
-
-      expect(response).to have_http_status(:forbidden)
-    end
-
     it "cannot be accessed by users without Coronavirus editor permissions" do
-      stub_user.permissions << "Unreleased feature"
       get :edit,
           params: {
             id: timeline_entry.id,
@@ -107,6 +87,7 @@ RSpec.describe TimelineEntriesController do
   end
 
   describe "PATCH /coronavirus/:coronavirus_page_slug/timeline_entries/:id" do
+    let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
     let(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page) }
 
     let(:updated_timeline_entry_params) do
@@ -119,7 +100,6 @@ RSpec.describe TimelineEntriesController do
     before do
       stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
 
     it "updates the timeline entry" do
@@ -148,12 +128,12 @@ RSpec.describe TimelineEntriesController do
   end
 
   describe "DELETE /coronavirus/:coronavirus_page_slug/timeline_entries/:id" do
+    let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
     let!(:timeline_entry) { create(:timeline_entry, coronavirus_page: coronavirus_page, heading: "Skywalker") }
 
     before do
       stub_coronavirus_landing_page_content(coronavirus_page)
       stub_coronavirus_publishing_api
-      stub_user.permissions = ["signin", "Coronavirus editor", "Unreleased feature"]
     end
 
     it "redirects to the coronavirus page" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -152,7 +152,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Adding timeline entries" do
-        given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page
         when_i_visit_a_coronavirus_page
         and_i_add_a_new_timeline_entry
@@ -162,7 +161,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Editing timeline entries" do
-        given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
         when_i_visit_a_coronavirus_page
         and_i_change_a_timeline_entry
@@ -173,7 +171,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Reordering timeline entries", js: true do
-        given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
         when_i_visit_the_reorder_timeline_entries_page
         then_i_see_the_timeline_entries_in_order
@@ -183,7 +180,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Viewing timeline entries" do
-        given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
         when_i_visit_a_coronavirus_page
         then_i_can_see_a_timeline_entries_section
@@ -191,7 +187,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       end
 
       scenario "Deleting timeline entries", js: true do
-        given_i_can_access_unreleased_features
         given_there_is_a_coronavirus_page_with_timeline_entries
         when_i_visit_a_coronavirus_page
         then_i_can_see_a_timeline_entries_section

--- a/spec/services/coronavirus_pages/content_builder_spec.rb
+++ b/spec/services/coronavirus_pages/content_builder_spec.rb
@@ -56,15 +56,9 @@ RSpec.describe CoronavirusPages::ContentBuilder do
       expect(subject.data).to eq data
     end
 
-    context "when unreleased features are off" do
-      before do
-        allow(Rails.configuration).to receive(:unreleased_features).and_return(false)
-      end
-
-      it "includes the timeline data from github" do
-        expect(subject.data["timeline"]["list"])
-          .to eq(github_content["content"]["timeline"]["list"])
-      end
+    it "includes the timeline data from github" do
+      expect(subject.data["timeline"]["list"])
+        .to eq([timeline_json])
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/IvPyOzow

# What?
Remove the unreleased features flag for timeline entries to make the feature live.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
