### PR TITLE
Update /coronavirus/landing link text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
       approve_sub_heading: Get the changes approved and merged into master.
     index:
       landing_page_edit:
-        accordions: Edit landing page accordions and announcements
+        accordions: Edit landing page accordions, announcements and timeline
         live_stream_url: Edit live stream URL
         something_else: Edit something else on the landing page
       subtopic_edit:


### PR DESCRIPTION
- Previously timeline entry content was updated via YML fetched from Github.
- Updates link text to inform the user that timeline entries can be edited using the publishing tool.

[Trello](https://trello.com/c/IvPyOzow/1062-make-publishing-timeline-entries-via-the-publishing-tool-live)

Merge after: https://github.com/alphagov/collections-publisher/pull/1261 

<img width="529" alt="edit-link-text-no-entries" src="https://user-images.githubusercontent.com/5963488/106763609-ea474480-662e-11eb-881e-499e296aca53.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
