### PR TITLE
Rename CoronavirusPages module to Coronavirus::Pages

### DIFF
--- a/app/controllers/coronavirus/announcements_controller.rb
+++ b/app/controllers/coronavirus/announcements_controller.rb
@@ -64,7 +64,7 @@ module Coronavirus
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(@coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(@coronavirus_page)
     end
   end
 end

--- a/app/controllers/coronavirus/coronavirus_pages_controller.rb
+++ b/app/controllers/coronavirus/coronavirus_pages_controller.rb
@@ -37,7 +37,7 @@ module Coronavirus
 
     def discard
       if draft_updater.discarded?
-        CoronavirusPages::DraftDiscarder.new(coronavirus_page).call
+        Pages::DraftDiscarder.new(coronavirus_page).call
         message = { notice: "Changes to subsections have been discarded" }
       else
         message = { alert: draft_updater.errors.to_sentence }
@@ -49,16 +49,16 @@ module Coronavirus
 
     def initialise_coronavirus_pages
       page_configs.keys.map do |page|
-        CoronavirusPages::ModelBuilder.new(page.to_s).page
+        Pages::ModelBuilder.new(page.to_s).page
       end
     end
 
     def coronavirus_page
-      @coronavirus_page ||= CoronavirusPages::ModelBuilder.call(slug)
+      @coronavirus_page ||= Pages::ModelBuilder.call(slug)
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(coronavirus_page)
     end
 
     def slug_unknown_for_update
@@ -109,7 +109,7 @@ module Coronavirus
     end
 
     def page_configs
-      CoronavirusPages::Configuration.all_pages
+      Pages::Configuration.all_pages
     end
 
     def change_state(state)

--- a/app/controllers/coronavirus/reorder_announcements_controller.rb
+++ b/app/controllers/coronavirus/reorder_announcements_controller.rb
@@ -39,7 +39,7 @@ module Coronavirus
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(coronavirus_page)
     end
   end
 end

--- a/app/controllers/coronavirus/reorder_sub_sections_controller.rb
+++ b/app/controllers/coronavirus/reorder_sub_sections_controller.rb
@@ -43,11 +43,11 @@ module Coronavirus
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(coronavirus_page)
     end
 
     def page_configs
-      CoronavirusPages::Configuration.all_pages
+      Pages::Configuration.all_pages
     end
   end
 end

--- a/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
@@ -39,7 +39,7 @@ module Coronavirus
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(coronavirus_page)
     end
   end
 end

--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -58,7 +58,7 @@ module Coronavirus
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(@coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(@coronavirus_page)
     end
   end
 end

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -58,7 +58,7 @@ module Coronavirus
     end
 
     def draft_updater
-      @draft_updater ||= CoronavirusPages::DraftUpdater.new(coronavirus_page)
+      @draft_updater ||= Pages::DraftUpdater.new(coronavirus_page)
     end
   end
 end

--- a/app/services/coronavirus/pages/configuration.rb
+++ b/app/services/coronavirus/pages/configuration.rb
@@ -1,4 +1,4 @@
-module CoronavirusPages
+module Coronavirus::Pages
   class Configuration
     def self.page(key)
       all_pages[key.to_sym]

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -1,158 +1,160 @@
-class Coronavirus::Pages::ContentBuilder
-  attr_reader :coronavirus_page, :errors
+module Coronavirus::Pages
+  class ContentBuilder
+    attr_reader :coronavirus_page, :errors
 
-  def initialize(coronavirus_page)
-    @coronavirus_page = coronavirus_page
-    @errors = []
-  end
-
-  def data
-    @data ||= begin
-      validate_content
-      data = github_data
-      data["sections"] = sub_sections_data
-      data["announcements"] = announcements_data
-
-      data["timeline"] ||= {}
-      data["timeline"]["list"] = timeline_data
-
-      add_live_stream(data)
-      data["hidden_search_terms"] = hidden_search_terms
-      data
-    end
-  rescue RestClient::Exception => e
-    add_error(e.message)
-  end
-
-  def success?
-    data
-    errors.empty?
-  end
-
-  def add_error(error)
-    errors << error
-    errors.flatten!
-  end
-
-  def validate_content
-    required_keys =
-      type.to_sym == :landing ? required_landing_page_keys : required_hub_page_keys
-    missing_keys = (required_keys - github_data.keys)
-    add_error("Invalid content - please recheck GitHub and add #{missing_keys.join(', ')}.") if missing_keys.any?
-  end
-
-  def type
-    coronavirus_page.slug.to_sym
-  end
-
-  def required_landing_page_keys
-    %w[
-      title
-      meta_description
-      header_section
-      announcements_label
-      announcements
-      nhs_banner
-      sections
-      topic_section
-      notifications
-      live_stream
-    ]
-  end
-
-  def required_hub_page_keys
-    %w[
-      title
-      header_section
-      sections
-      topic_section
-      notifications
-    ]
-  end
-
-  def github_raw_data
-    YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
-  end
-
-  def github_data
-    @github_data ||= github_raw_data["content"]
-  end
-
-  def github_live_stream_data
-    github_data["live_stream"] || {}
-  end
-
-  def sub_sections_data
-    coronavirus_page.sub_sections.order(:position).map do |sub_section|
-      presenter = SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id)
-      add_error(presenter.errors) unless presenter.success?
-      presenter.output
-    end
-  end
-
-  def announcements_data
-    coronavirus_page.announcements.order(:position).map do |announcement|
-      presenter = AnnouncementJsonPresenter.new(announcement)
-      presenter.output
-    end
-  end
-
-  def timeline_data
-    coronavirus_page
-      .timeline_entries
-      .order(:position)
-      .pluck(:heading, :content)
-      .map { |(heading, content)| { "heading" => heading, "paragraph" => content } }
-  end
-
-  def persisted_live_stream_data
-    return {} unless LiveStream.any?
-
-    live_stream = LiveStream.last
-    {
-      "video_url" => live_stream.url,
-      "date" => live_stream.formatted_stream_date,
-    }
-  end
-
-  def add_live_stream(data)
-    if coronavirus_page.slug == "landing"
-      data["live_stream"] = github_live_stream_data.merge(persisted_live_stream_data)
-    end
-  end
-
-  def hidden_search_terms
-    search_terms_in_sections + search_terms_in_timeline
-  end
-
-  def search_terms_in_sections
-    sections = sub_sections_data.map do |section|
-      [section[:title], search_terms_in_sub_sections(section[:sub_sections])]
+    def initialize(coronavirus_page)
+      @coronavirus_page = coronavirus_page
+      @errors = []
     end
 
-    sections.flatten.select(&:present?).uniq
-  end
+    def data
+      @data ||= begin
+        validate_content
+        data = github_data
+        data["sections"] = sub_sections_data
+        data["announcements"] = announcements_data
 
-  def search_terms_in_sub_sections(items)
-    items.map do |subsection|
-      labels = subsection[:list]&.map do |list_item|
-        list_item[:label]
+        data["timeline"] ||= {}
+        data["timeline"]["list"] = timeline_data
+
+        add_live_stream(data)
+        data["hidden_search_terms"] = hidden_search_terms
+        data
       end
-
-      [subsection[:title], labels]
+    rescue RestClient::Exception => e
+      add_error(e.message)
     end
-  end
 
-  def search_terms_in_timeline
-    return [] if github_data["timeline"].blank?
+    def success?
+      data
+      errors.empty?
+    end
 
-    timeline = github_data["timeline"]["list"].map do |item|
-      [
-        item["heading"],
-        MarkdownService.new.strip_markdown(item["paragraph"]),
+    def add_error(error)
+      errors << error
+      errors.flatten!
+    end
+
+    def validate_content
+      required_keys =
+        type.to_sym == :landing ? required_landing_page_keys : required_hub_page_keys
+      missing_keys = (required_keys - github_data.keys)
+      add_error("Invalid content - please recheck GitHub and add #{missing_keys.join(', ')}.") if missing_keys.any?
+    end
+
+    def type
+      coronavirus_page.slug.to_sym
+    end
+
+    def required_landing_page_keys
+      %w[
+        title
+        meta_description
+        header_section
+        announcements_label
+        announcements
+        nhs_banner
+        sections
+        topic_section
+        notifications
+        live_stream
       ]
     end
 
-    timeline.flatten.select(&:present?).uniq
+    def required_hub_page_keys
+      %w[
+        title
+        header_section
+        sections
+        topic_section
+        notifications
+      ]
+    end
+
+    def github_raw_data
+      YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
+    end
+
+    def github_data
+      @github_data ||= github_raw_data["content"]
+    end
+
+    def github_live_stream_data
+      github_data["live_stream"] || {}
+    end
+
+    def sub_sections_data
+      coronavirus_page.sub_sections.order(:position).map do |sub_section|
+        presenter = SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id)
+        add_error(presenter.errors) unless presenter.success?
+        presenter.output
+      end
+    end
+
+    def announcements_data
+      coronavirus_page.announcements.order(:position).map do |announcement|
+        presenter = AnnouncementJsonPresenter.new(announcement)
+        presenter.output
+      end
+    end
+
+    def timeline_data
+      coronavirus_page
+        .timeline_entries
+        .order(:position)
+        .pluck(:heading, :content)
+        .map { |(heading, content)| { "heading" => heading, "paragraph" => content } }
+    end
+
+    def persisted_live_stream_data
+      return {} unless LiveStream.any?
+
+      live_stream = LiveStream.last
+      {
+        "video_url" => live_stream.url,
+        "date" => live_stream.formatted_stream_date,
+      }
+    end
+
+    def add_live_stream(data)
+      if coronavirus_page.slug == "landing"
+        data["live_stream"] = github_live_stream_data.merge(persisted_live_stream_data)
+      end
+    end
+
+    def hidden_search_terms
+      search_terms_in_sections + search_terms_in_timeline
+    end
+
+    def search_terms_in_sections
+      sections = sub_sections_data.map do |section|
+        [section[:title], search_terms_in_sub_sections(section[:sub_sections])]
+      end
+
+      sections.flatten.select(&:present?).uniq
+    end
+
+    def search_terms_in_sub_sections(items)
+      items.map do |subsection|
+        labels = subsection[:list]&.map do |list_item|
+          list_item[:label]
+        end
+
+        [subsection[:title], labels]
+      end
+    end
+
+    def search_terms_in_timeline
+      return [] if github_data["timeline"].blank?
+
+      timeline = github_data["timeline"]["list"].map do |item|
+        [
+          item["heading"],
+          MarkdownService.new.strip_markdown(item["paragraph"]),
+        ]
+      end
+
+      timeline.flatten.select(&:present?).uniq
+    end
   end
 end

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -1,4 +1,4 @@
-class CoronavirusPages::ContentBuilder
+class Coronavirus::Pages::ContentBuilder
   attr_reader :coronavirus_page, :errors
 
   def initialize(coronavirus_page)

--- a/app/services/coronavirus/pages/draft_discarder.rb
+++ b/app/services/coronavirus/pages/draft_discarder.rb
@@ -1,4 +1,4 @@
-module CoronavirusPages
+module Coronavirus::Pages
   class DraftDiscarder
     attr_reader :coronavirus_page
 

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -1,4 +1,4 @@
-module CoronavirusPages
+module Coronavirus::Pages
   class DraftUpdater
     DraftUpdaterError = Class.new(StandardError)
 
@@ -11,7 +11,7 @@ module CoronavirusPages
     delegate :content_id, :base_path, to: :coronavirus_page
 
     def content_builder
-      @content_builder ||= CoronavirusPages::ContentBuilder.new(coronavirus_page)
+      @content_builder ||= ContentBuilder.new(coronavirus_page)
     end
 
     def payload

--- a/app/services/coronavirus/pages/model_builder.rb
+++ b/app/services/coronavirus/pages/model_builder.rb
@@ -1,4 +1,4 @@
-module CoronavirusPages
+module Coronavirus::Pages
   class ModelBuilder
     def self.call(*args)
       new(*args).page
@@ -28,7 +28,7 @@ module CoronavirusPages
   private
 
     def page_config
-      CoronavirusPages::Configuration.page(slug)
+      Configuration.page(slug)
     end
 
     def coronavirus_page_attributes

--- a/app/services/coronavirus/pages/sections_presenter.rb
+++ b/app/services/coronavirus/pages/sections_presenter.rb
@@ -1,4 +1,4 @@
-module CoronavirusPages
+module Coronavirus::Pages
   class SectionsPresenter
     attr_reader :data
     def initialize(data)

--- a/app/services/coronavirus/pages/sub_section_processor.rb
+++ b/app/services/coronavirus/pages/sub_section_processor.rb
@@ -1,4 +1,4 @@
-module CoronavirusPages
+module Coronavirus::Pages
   class SubSectionProcessor
     def self.call(*args)
       new(*args).output

--- a/app/services/coronavirus/pages/timeline_entry_builder.rb
+++ b/app/services/coronavirus/pages/timeline_entry_builder.rb
@@ -1,4 +1,4 @@
-class CoronavirusPages::TimelineEntryBuilder
+class Coronavirus::Pages::TimelineEntryBuilder
   def create_timeline_entries
     return if timeline_entries_from_yaml.empty?
 

--- a/app/services/coronavirus/pages/timeline_entry_builder.rb
+++ b/app/services/coronavirus/pages/timeline_entry_builder.rb
@@ -1,27 +1,29 @@
-class Coronavirus::Pages::TimelineEntryBuilder
-  def create_timeline_entries
-    return if timeline_entries_from_yaml.empty?
+module Coronavirus::Pages
+  class TimelineEntryBuilder
+    def create_timeline_entries
+      return if timeline_entries_from_yaml.empty?
 
-    Coronavirus::TimelineEntry.transaction do
-      coronavirus_page.timeline_entries.delete_all
+      Coronavirus::TimelineEntry.transaction do
+        coronavirus_page.timeline_entries.delete_all
 
-      timeline_entries_from_yaml.reverse.each do |entry|
-        coronavirus_page.timeline_entries.create!(
-          heading: entry["heading"],
-          content: entry["paragraph"],
-        )
+        timeline_entries_from_yaml.reverse.each do |entry|
+          coronavirus_page.timeline_entries.create!(
+            heading: entry["heading"],
+            content: entry["paragraph"],
+          )
+        end
       end
     end
-  end
 
-private
+  private
 
-  def timeline_entries_from_yaml
-    @github_data ||= YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
-    @github_data.dig("content", "timeline", "list")
-  end
+    def timeline_entries_from_yaml
+      @github_data ||= YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
+      @github_data.dig("content", "timeline", "list")
+    end
 
-  def coronavirus_page
-    @coronavirus_page ||= Coronavirus::CoronavirusPage.find_by(slug: "landing")
+    def coronavirus_page
+      @coronavirus_page ||= Coronavirus::CoronavirusPage.find_by(slug: "landing")
+    end
   end
 end

--- a/docs/coronavirus_page_publishing_tool.md
+++ b/docs/coronavirus_page_publishing_tool.md
@@ -54,7 +54,7 @@ The accordion content is stored in the database as a SubSection:
 
 1. Create a new yaml file following the format of those currently in [govuk-coronavirus-content](https://github.com/alphagov/govuk-coronavirus-content/tree/master/content) repository, and add page content.
 2. Add a basic page configuration to [this file](app/services/coronavirus_pages/configuration.rb) in Collections Publisher.
-3. Visiting the Coronavirus page tab of collections publisher will create a coronavirus page model based on the configuration using the service CoronavirusPages::ModelBuilder.
+3. Visiting the Coronavirus page tab of collections publisher will create a coronavirus page model based on the configuration using the service Coronavirus::Pages::ModelBuilder.
 4. As a result two new links will be created on the [index page](https://collections-publisher.publishing.service.gov.uk/coronavirus):
   - Edit \<new hub> page accordions
   - Edit something else on the \<new hub> page

--- a/lib/tasks/coronavirus.rake
+++ b/lib/tasks/coronavirus.rake
@@ -4,7 +4,6 @@
 # are persisted in the collection publisher database, but they can still be updated in their relevant
 # yaml eg: https://github.com/alphagov/govuk-coronavirus-content/blob/master/content/coronavirus_landing_page.yml
 # If they get out of sync, this task can help.
-require_relative "../../app/services/coronavirus_pages/model_builder"
 
 namespace :coronavirus do
   desc "
@@ -13,8 +12,8 @@ namespace :coronavirus do
   rake coronavirus:resync_titles[slug]
   "
   task :resync_titles, [:slug] => [:environment] do |_task, args|
-    page = CoronavirusPage.find_by(slug: args.slug)
-    builder ||= CoronavirusPages::ModelBuilder.new(args.slug)
+    page = Coronavirus::CoronavirusPage.find_by(slug: args.slug)
+    builder ||= Coronavirus::Pages::ModelBuilder.new(args.slug)
     page.update!(
       title: builder.title,
       sections_title: builder.sections_heading,
@@ -26,7 +25,7 @@ namespace :coronavirus do
 
   desc "Sync timeline entries with entries in the yaml file"
   task sync_timeline_entries: :environment do
-    CoronavirusPages::TimelineEntryBuilder.new.create_timeline_entries
+    Coronavirus::Pages::TimelineEntryBuilder.new.create_timeline_entries
 
     puts "Timeline Entries synced for coronavirus landing page..."
   end

--- a/spec/controllers/coronavirus/coronavirus_pages_controller_spec.rb
+++ b/spec/controllers/coronavirus/coronavirus_pages_controller_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Coronavirus::CoronavirusPagesController do
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:coronavirus_page) { create :coronavirus_page, :of_known_type }
   let(:slug) { coronavirus_page.slug }
-  let(:raw_content_url) { CoronavirusPages::Configuration.page(slug)[:raw_content_url] }
+  let(:raw_content_url) { Coronavirus::Pages::Configuration.page(slug)[:raw_content_url] }
   let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
   let(:all_content_urls) do
-    CoronavirusPages::Configuration.all_pages.map do |config|
+    Coronavirus::Pages::Configuration.all_pages.map do |config|
       config.second[:raw_content_url]
     end
   end

--- a/spec/presenters/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus_page_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CoronavirusPagePresenter do
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
   let(:title) { github_content["content"]["title"] }
   let(:meta_description) { github_content["content"]["meta_description"] }
-  let(:data) { CoronavirusPages::ContentBuilder.new(coronavirus_page).data }
+  let(:data) { Coronavirus::Pages::ContentBuilder.new(coronavirus_page).data }
   let(:details) { data.except(title, meta_description) }
 
   let(:payload) do

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::ContentBuilder do
+RSpec.describe Coronavirus::Pages::ContentBuilder do
   let(:coronavirus_page) { create :coronavirus_page, :landing }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }

--- a/spec/services/coronavirus/pages/draft_discarder_spec.rb
+++ b/spec/services/coronavirus/pages/draft_discarder_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::DraftDiscarder do
+RSpec.describe Coronavirus::Pages::DraftDiscarder do
   let(:coronavirus_page) do
     create(
       :coronavirus_page,

--- a/spec/services/coronavirus/pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus/pages/draft_updater_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::DraftUpdater do
+RSpec.describe Coronavirus::Pages::DraftUpdater do
   include CoronavirusFeatureSteps
 
   let(:coronavirus_page) { create :coronavirus_page }
-  let(:content_builder) { CoronavirusPages::ContentBuilder.new(coronavirus_page) }
+  let(:content_builder) { Coronavirus::Pages::ContentBuilder.new(coronavirus_page) }
   let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
   let(:github_fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(github_fixture_path)) }

--- a/spec/services/coronavirus/pages/model_builder_spec.rb
+++ b/spec/services/coronavirus/pages/model_builder_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::ModelBuilder do
+RSpec.describe Coronavirus::Pages::ModelBuilder do
   let(:slug) { "landing" }
-  let(:model_builder) { CoronavirusPages::ModelBuilder.new(slug) }
-  let(:page_config) { CoronavirusPages::Configuration.page(slug) }
+  let(:model_builder) { Coronavirus::Pages::ModelBuilder.new(slug) }
+  let(:page_config) { Coronavirus::Pages::Configuration.page(slug) }
   let(:raw_content_url) { page_config[:raw_content_url] }
   let(:raw_content_url_regex) { Regexp.new(raw_content_url) }
   let(:yaml_fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }

--- a/spec/services/coronavirus/pages/sections_presenter_spec.rb
+++ b/spec/services/coronavirus/pages/sections_presenter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::SectionsPresenter do
+RSpec.describe Coronavirus::Pages::SectionsPresenter do
   let(:title) { Faker::Lorem.sentence }
   let(:data) do
     [

--- a/spec/services/coronavirus/pages/sub_section_processor_spec.rb
+++ b/spec/services/coronavirus/pages/sub_section_processor_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::SubSectionProcessor do
+RSpec.describe Coronavirus::Pages::SubSectionProcessor do
   let(:title) { Faker::Lorem.sentence }
   let(:label) { Faker::Lorem.sentence }
   let(:url) { "/#{File.join(Faker::Lorem.words)}" }

--- a/spec/services/coronavirus/pages/timeline_entry_builder_spec.rb
+++ b/spec/services/coronavirus/pages/timeline_entry_builder_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPages::TimelineEntryBuilder do
+RSpec.describe Coronavirus::Pages::TimelineEntryBuilder do
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -94,7 +94,7 @@ module CoronavirusFeatureSteps
 
   def raw_content_urls
     @raw_content_urls ||=
-      CoronavirusPages::Configuration.all_pages.map do |config|
+      Coronavirus::Pages::Configuration.all_pages.map do |config|
         config.second[:raw_content_url]
       end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/wl8IRixm/1060-name-space-the-models-in-collections-publisher

This is open as a draft as it depends on https://github.com/alphagov/collections-publisher/pull/1262. I've set that as the base branch for this PR

This change has been made so that these classes could be within the
Coronavirus namespace. These classes didn't seem to make much sense
without some relationship to page so I decided to create an additional
namespace of Pages with Coronavirus so they could be moved with minimal
changes.

There is probably scope to rethink the purpose of some of these classes
as they seem to venture outside of what would be considered to be a
service (Configuration) and there is a Presenter class here that seems
to have cross over with the presenters directory of classes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
