### PR TITLE
Put Coronavirus presenters under Coronavirus namespace

### DIFF
--- a/app/presenters/coronavirus/announcement_json_presenter.rb
+++ b/app/presenters/coronavirus/announcement_json_presenter.rb
@@ -1,4 +1,4 @@
-class AnnouncementJsonPresenter
+class Coronavirus::AnnouncementJsonPresenter
   attr_reader :announcement
   def initialize(announcement)
     @announcement = announcement

--- a/app/presenters/coronavirus/coronavirus_page_presenter.rb
+++ b/app/presenters/coronavirus/coronavirus_page_presenter.rb
@@ -1,4 +1,4 @@
-class CoronavirusPagePresenter
+class Coronavirus::CoronavirusPagePresenter
   attr_reader :description, :details, :title, :path
 
   def initialize(corona_content, path)

--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubSectionJsonPresenter
+class Coronavirus::SubSectionJsonPresenter
   HEADER_PATTERN = PatternMaker.call(
     "starts_with hashes then perhaps_spaces then capture(title) and nothing_else",
     hashes: "#+",

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -85,7 +85,7 @@ module Coronavirus::Pages
 
     def sub_sections_data
       coronavirus_page.sub_sections.order(:position).map do |sub_section|
-        presenter = SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id)
+        presenter = Coronavirus::SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id)
         add_error(presenter.errors) unless presenter.success?
         presenter.output
       end
@@ -93,7 +93,7 @@ module Coronavirus::Pages
 
     def announcements_data
       coronavirus_page.announcements.order(:position).map do |announcement|
-        presenter = AnnouncementJsonPresenter.new(announcement)
+        presenter = Coronavirus::AnnouncementJsonPresenter.new(announcement)
         presenter.output
       end
     end

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -16,7 +16,7 @@ module Coronavirus::Pages
 
     def payload
       if content_builder.success?
-        CoronavirusPagePresenter.new(content_builder.data, base_path).payload
+        Coronavirus::CoronavirusPagePresenter.new(content_builder.data, base_path).payload
       else
         raise DraftUpdaterError, content_builder.errors.to_sentence
       end

--- a/app/services/live_stream_updater.rb
+++ b/app/services/live_stream_updater.rb
@@ -64,7 +64,7 @@ private
   end
 
   def presenter
-    CoronavirusPagePresenter.new(live_content_item["details"], "/coronavirus")
+    Coronavirus::CoronavirusPagePresenter.new(live_content_item["details"], "/coronavirus")
   end
 
   def payload

--- a/spec/presenters/coronavirus/announcement_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/announcement_json_presenter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AnnouncementJsonPresenter do
+RSpec.describe Coronavirus::AnnouncementJsonPresenter do
   include CoronavirusHelpers
 
   let!(:announcement) { create :announcement }

--- a/spec/presenters/coronavirus/coronavirus_page_presenter_spec.rb
+++ b/spec/presenters/coronavirus/coronavirus_page_presenter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CoronavirusPagePresenter do
+RSpec.describe Coronavirus::CoronavirusPagePresenter do
   include CoronavirusFeatureSteps
   include GovukContentSchemaTestHelpers
 

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SubSectionJsonPresenter do
+RSpec.describe Coronavirus::SubSectionJsonPresenter do
   let(:link_one) { random_link_markdown }
   let(:link_two) { random_link_markdown }
   let(:link_three) { random_link_markdown }

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
   let(:coronavirus_page) { create :coronavirus_page, :landing }
   let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
-  let(:sub_section_json) { SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id).output }
-  let(:announcement_json) { AnnouncementJsonPresenter.new(announcement).output }
+  let(:sub_section_json) { Coronavirus::SubSectionJsonPresenter.new(sub_section, coronavirus_page.content_id).output }
+  let(:announcement_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement).output }
   let(:timeline_json) { { "heading" => timeline_entry["heading"], "paragraph" => timeline_entry["content"] } }
 
   subject { described_class.new(coronavirus_page) }
@@ -70,8 +70,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     context "with subsections" do
       let!(:sub_section_0) { create :sub_section, position: 0, coronavirus_page: coronavirus_page }
       let!(:sub_section_1) { create :sub_section, position: 1, coronavirus_page: coronavirus_page }
-      let(:sub_section_0_json) { SubSectionJsonPresenter.new(sub_section_0).output }
-      let(:sub_section_1_json) { SubSectionJsonPresenter.new(sub_section_1).output }
+      let(:sub_section_0_json) { Coronavirus::SubSectionJsonPresenter.new(sub_section_0).output }
+      let(:sub_section_1_json) { Coronavirus::SubSectionJsonPresenter.new(sub_section_1).output }
 
       it "returns the sub_section JSON ordered by position" do
         expect(subject.sub_sections_data).to eq [sub_section_0_json, sub_section_1_json]
@@ -83,8 +83,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     context "with announcements" do
       let!(:announcement_0) { create :announcement, published_at: Time.zone.local(2020, 9, 10), coronavirus_page: coronavirus_page  }
       let!(:announcement_1) { create :announcement, published_at: Time.zone.local(2020, 9, 11), coronavirus_page: coronavirus_page  }
-      let!(:announcement_0_json) { AnnouncementJsonPresenter.new(announcement_0).output }
-      let!(:announcement_1_json) { AnnouncementJsonPresenter.new(announcement_1).output }
+      let!(:announcement_0_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement_0).output }
+      let!(:announcement_1_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement_1).output }
 
       it "returns the announcements JSON ordered by position" do
         announcement_0.position = 3

--- a/spec/services/coronavirus/pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus/pages/draft_updater_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Coronavirus::Pages::DraftUpdater do
 
   let(:coronavirus_page) { create :coronavirus_page }
   let(:content_builder) { Coronavirus::Pages::ContentBuilder.new(coronavirus_page) }
-  let(:payload) { CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
+  let(:payload) { Coronavirus::CoronavirusPagePresenter.new(content_builder.data, coronavirus_page.base_path).payload }
   let(:github_fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(github_fixture_path)) }
 


### PR DESCRIPTION
Trello: https://trello.com/c/wl8IRixm/1060-name-space-the-models-in-collections-publisher

This is open as a draft as it depends on https://github.com/alphagov/collections-publisher/pull/1265. I've set that as the base branch for this PR

This continues the work to move Coronavirus related code under the same
namespace. These names match their models, for example
Coronavirus::AnnouncementJsonPresenter is for
Coronavirus::Announcement.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
