### PR TITLE
Rename factories of Coronavirus models for consistency

### DIFF
--- a/spec/controllers/coronavirus/announcements_controller_spec.rb
+++ b/spec/controllers/coronavirus/announcements_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Coronavirus::AnnouncementsController do
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:page) { create :coronavirus_page, :landing }
-  let!(:announcement) { create :announcement, page: page }
+  let!(:announcement) { create :coronavirus_announcement, page: page }
   let(:title) { Faker::Lorem.sentence }
   let(:path) { "/government/foo/vader/baby/yoda" }
   let(:published_at) { { "day" => "12", "month" => "12", "year" => "1980" } }

--- a/spec/controllers/coronavirus/pages_controller_spec.rb
+++ b/spec/controllers/coronavirus/pages_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Coronavirus::PagesController do
              base_path: live_content_item["base_path"],
              slug: slug
     end
-    let!(:subsection) { create :sub_section, page: page, title: "foo" }
+    let!(:subsection) { create :coronavirus_sub_section, page: page, title: "foo" }
     subject { get :discard, params: { slug: slug } }
 
     before do

--- a/spec/controllers/coronavirus/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/coronavirus/reorder_announcements_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Coronavirus::ReorderAnnouncementsController do
   end
 
   describe "PUT Coronavirus reorder announcements page" do
-    let!(:announcement) { create(:announcement, position: 0, page: page) }
-    let!(:another_announcement) { create(:announcement, position: 1, page: page) }
+    let!(:announcement) { create(:coronavirus_announcement, position: 0, page: page) }
+    let!(:another_announcement) { create(:coronavirus_announcement, position: 1, page: page) }
 
     before do
       stub_coronavirus_landing_page_content(page)

--- a/spec/controllers/coronavirus/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/coronavirus/reorder_sub_sections_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Coronavirus::ReorderSubSectionsController do
       stub_coronavirus_publishing_api
     end
 
-    let(:sub_section_0) { create :sub_section, position: 0, page: page }
-    let(:sub_section_1) { create :sub_section, position: 1, page: page }
+    let(:sub_section_0) { create :coronavirus_sub_section, position: 0, page: page }
+    let(:sub_section_1) { create :coronavirus_sub_section, position: 1, page: page }
     let(:sub_section_0_params) { { id: sub_section_0.id, position: 1 } }
     let(:sub_section_1_params) { { id: sub_section_1.id, position: 0 } }
     let(:section_params) { [sub_section_0_params, sub_section_1_params].to_json }

--- a/spec/controllers/coronavirus/reorder_timeline_entries_controller_spec.rb
+++ b/spec/controllers/coronavirus/reorder_timeline_entries_controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Coronavirus::ReorderTimelineEntriesController do
 
   describe "PUT Coronavirus reorder timeline entries page" do
     let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
-    let!(:second_timeline_entry) { create(:timeline_entry, page: page) }
-    let!(:first_timeline_entry) { create(:timeline_entry, page: page) }
+    let!(:second_timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
+    let!(:first_timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
 
     before do
       stub_coronavirus_landing_page_content(page)

--- a/spec/controllers/coronavirus/sub_sections_controller_spec.rb
+++ b/spec/controllers/coronavirus/sub_sections_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Coronavirus::SubSectionsController do
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
   let(:page) { create :coronavirus_page, :of_known_type }
-  let!(:sub_section) { create :sub_section, page: page }
+  let!(:sub_section) { create :coronavirus_sub_section, page: page }
   let(:title) { Faker::Lorem.sentence }
   let(:content) { "###{Faker::Lorem.sentence}" }
   let(:sub_section_params) do

--- a/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
+++ b/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Coronavirus::TimelineEntriesController do
   end
 
   describe "GET /coronavirus/:page_slug/timeline_entries/:id/edit" do
-    let(:timeline_entry) { create(:timeline_entry, page: page) }
+    let(:timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
 
     it "can only be accessed by users with Coronavirus editor permissions" do
       stub_user.permissions << "Coronavirus editor"
@@ -88,7 +88,7 @@ RSpec.describe Coronavirus::TimelineEntriesController do
 
   describe "PATCH /coronavirus/:page_slug/timeline_entries/:id" do
     let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
-    let(:timeline_entry) { create(:timeline_entry, page: page) }
+    let(:timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
 
     let(:updated_timeline_entry_params) do
       {
@@ -129,7 +129,7 @@ RSpec.describe Coronavirus::TimelineEntriesController do
 
   describe "DELETE /coronavirus/:page_slug/timeline_entries/:id" do
     let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
-    let!(:timeline_entry) { create(:timeline_entry, page: page, heading: "Skywalker") }
+    let!(:timeline_entry) { create(:coronavirus_timeline_entry, page: page, heading: "Skywalker") }
 
     before do
       stub_coronavirus_landing_page_content(page)
@@ -158,7 +158,7 @@ RSpec.describe Coronavirus::TimelineEntriesController do
 
     it "doesn't delete the timeline_entry if draft_updater fails" do
       stub_publishing_api_isnt_available
-      create(:timeline_entry, page: page, heading: "Amidala")
+      create(:coronavirus_timeline_entry, page: page, heading: "Amidala")
 
       params = {
         id: timeline_entry.id,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -239,14 +239,14 @@ FactoryBot.define do
     end
   end
 
-  factory :sub_section, class: Coronavirus::SubSection do
+  factory :coronavirus_sub_section, class: Coronavirus::SubSection do
     title { Faker::Lorem.sentence }
     content { "[#{Faker::Lorem.sentence}](/#{File.join(Faker::Lorem.words)}?priority-taxon=#{page.content_id})" }
     position { (Coronavirus::SubSection.maximum(:position) || 0) + 1 }
     page factory: :coronavirus_page
   end
 
-  factory :live_stream, class: Coronavirus::LiveStream do
+  factory :coronavirus_live_stream, class: Coronavirus::LiveStream do
     url { "https://www.youtube.com/watch?v=NiplUCnwc5A" }
     formatted_stream_date { "1 April 2020" }
     trait :without_validations do
@@ -254,14 +254,14 @@ FactoryBot.define do
     end
   end
 
-  factory :announcement, class: Coronavirus::Announcement do
+  factory :coronavirus_announcement, class: Coronavirus::Announcement do
     title { Faker::Lorem.words }
     path { "/government/foo/vader/baby/yoda" }
     published_at { Time.zone.local(2020, 9, 11) }
     page factory: :coronavirus_page
   end
 
-  factory :timeline_entry, class: Coronavirus::TimelineEntry do
+  factory :coronavirus_timeline_entry, class: Coronavirus::TimelineEntry do
     content { "Amazing fantastic content" }
     heading { "Unbelievable heading" }
     page factory: :coronavirus_page

--- a/spec/models/coronavirus/announcement_spec.rb
+++ b/spec/models/coronavirus/announcement_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Coronavirus::Announcement, type: :model do
-  let(:announcement) { create :announcement }
+  let(:announcement) { create :coronavirus_announcement }
 
   describe "validations" do
     it "should belong to a page" do
@@ -61,23 +61,23 @@ RSpec.describe Coronavirus::Announcement, type: :model do
       page = create(:coronavirus_page)
       expect(page.announcements.count).to eq 0
 
-      announcement = create(:announcement, page: page)
+      announcement = create(:coronavirus_announcement, page: page)
       expect(announcement.position).to eq 1
     end
 
     it "should increment if there are existing announcements" do
       page = create(:coronavirus_page)
-      create(:announcement, page: page)
+      create(:coronavirus_announcement, page: page)
       expect(page.announcements.count).to eq 1
 
-      announcement = create(:announcement, page: page)
+      announcement = create(:coronavirus_announcement, page: page)
       expect(announcement.position).to eq 2
     end
 
     it "should update announcement positions when an announcement is deleted" do
       page = create(:coronavirus_page)
-      create(:announcement, page: page)
-      create(:announcement, page: page)
+      create(:coronavirus_announcement, page: page)
+      create(:coronavirus_announcement, page: page)
       expect(page.announcements.count).to eq 2
 
       original_announcement_one = page.announcements.first

--- a/spec/models/coronavirus/live_stream_spec.rb
+++ b/spec/models/coronavirus/live_stream_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Coronavirus::LiveStream do
     end
 
     it "is invalid without a url" do
-      expect(build(:live_stream, url: nil)).not_to be_valid
+      expect(build(:coronavirus_live_stream, url: nil)).not_to be_valid
     end
 
     it "it requires a valid url" do
-      expect(build(:live_stream, url: bad_url)).not_to be_valid
-      expect(build(:live_stream, url: good_url)).to be_valid
+      expect(build(:coronavirus_live_stream, url: bad_url)).not_to be_valid
+      expect(build(:coronavirus_live_stream, url: good_url)).to be_valid
     end
   end
 end

--- a/spec/models/coronavirus/page_spec.rb
+++ b/spec/models/coronavirus/page_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Coronavirus::Page do
 
   describe "dependencies" do
     let!(:workers) { create :coronavirus_page, :workers }
-    let!(:sub_section) { create :sub_section, page: workers }
+    let!(:sub_section) { create :coronavirus_sub_section, page: workers }
 
     it "deletion destroys all child subsections" do
       expect { workers.destroy }

--- a/spec/models/coronavirus/sub_section_spec.rb
+++ b/spec/models/coronavirus/sub_section_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Coronavirus::SubSection do
-  let(:sub_section) { create :sub_section }
+  let(:sub_section) { create :coronavirus_sub_section }
 
   describe "validations" do
     it "should belong to a page" do

--- a/spec/models/coronavirus/timeline_entry_spec.rb
+++ b/spec/models/coronavirus/timeline_entry_spec.rb
@@ -11,25 +11,25 @@ RSpec.describe Coronavirus::TimelineEntry do
     it "should default to position 1 if it is the first timeline entry to have been added" do
       expect(page.timeline_entries.count).to eq 0
 
-      timeline_entry = create(:timeline_entry, page: page)
+      timeline_entry = create(:coronavirus_timeline_entry, page: page)
       expect(timeline_entry.reload.position).to eq 1
     end
 
     it "if more timeline entries are added, the previous entries will increment position by 1" do
       expect(page.timeline_entries.count).to eq 0
 
-      first_timeline_entry = create(:timeline_entry, page: page, heading: "one")
+      first_timeline_entry = create(:coronavirus_timeline_entry, page: page, heading: "one")
       expect(first_timeline_entry.reload.position).to eq 1
 
-      second_timeline_entry = create(:timeline_entry, page: page, heading: "two")
+      second_timeline_entry = create(:coronavirus_timeline_entry, page: page, heading: "two")
 
       expect(first_timeline_entry.reload.position).to eq 2
       expect(second_timeline_entry.reload.position).to eq 1
     end
 
     it "should update timeline entry positions when a timeline entry is deleted" do
-      original_timeline_entry_one = create(:timeline_entry, page: page)
-      original_timeline_entry_two = create(:timeline_entry, page: page)
+      original_timeline_entry_one = create(:coronavirus_timeline_entry, page: page)
+      original_timeline_entry_two = create(:coronavirus_timeline_entry, page: page)
       expect(page.timeline_entries.count).to eq 2
 
       expect(original_timeline_entry_one.reload.position).to eq 2

--- a/spec/presenters/coronavirus/announcement_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/announcement_json_presenter_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Coronavirus::AnnouncementJsonPresenter do
   include CoronavirusHelpers
 
-  let!(:announcement) { create :announcement }
+  let!(:announcement) { create :coronavirus_announcement }
 
   before do
     stub_coronavirus_landing_page_content(announcement.page)

--- a/spec/presenters/coronavirus/page_presenter_spec.rb
+++ b/spec/presenters/coronavirus/page_presenter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Coronavirus::PagePresenter do
     end
 
     it "includes announcements" do
-      announcement = create(:announcement, page: page)
+      announcement = create(:coronavirus_announcement, page: page)
       expect(subject.payload["details"]["announcements"].count).to eq 1
       expect(subject.payload["details"]["announcements"].first).to eq({
         "href" => announcement.path,

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
   let(:link_three) { random_link_markdown }
   let(:content) { link_one }
 
-  let(:sub_section) { build :sub_section, content: content }
+  let(:sub_section) { build :coronavirus_sub_section, content: content }
   subject { described_class.new(sub_section) }
 
   describe "#title" do

--- a/spec/services/coronavirus/live_stream_updater_spec.rb
+++ b/spec/services/coronavirus/live_stream_updater_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Coronavirus::LiveStreamUpdater do
     end
 
     it "returns live_stream object from the database if it exists" do
-      create(:live_stream, url: todays_link, formatted_stream_date: todays_date)
+      create(:coronavirus_live_stream, url: todays_link, formatted_stream_date: todays_date)
       updater = described_class.new
       expect(updater.object.url).to eq todays_link
       expect(updater.object.formatted_stream_date).to eq todays_date
@@ -30,7 +30,7 @@ RSpec.describe Coronavirus::LiveStreamUpdater do
 
   context "Succesful interaction with publishing api" do
     it "#update and #publish" do
-      create(:live_stream, url: todays_link, formatted_stream_date: todays_date)
+      create(:coronavirus_live_stream, url: todays_link, formatted_stream_date: todays_date)
       updater = described_class.new
 
       expect(updater.update).to be true
@@ -43,7 +43,7 @@ RSpec.describe Coronavirus::LiveStreamUpdater do
 
   context "Unsuccesful interaction with publishing api" do
     it "#update" do
-      create(:live_stream, url: todays_link, formatted_stream_date: todays_date)
+      create(:coronavirus_live_stream, url: todays_link, formatted_stream_date: todays_date)
       updater = described_class.new
 
       expect(updater.object.url).to eql todays_link

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
   end
 
   describe "#data" do
-    let!(:sub_section) { create :sub_section, page: page }
-    let!(:announcement) { create :announcement, page: page }
-    let!(:timeline_entry) { create :timeline_entry, page: page }
-    let!(:live_stream) { create :live_stream, :without_validations }
+    let!(:sub_section) { create :coronavirus_sub_section, page: page }
+    let!(:announcement) { create :coronavirus_announcement, page: page }
+    let!(:timeline_entry) { create :coronavirus_timeline_entry, page: page }
+    let!(:live_stream) { create :coronavirus_live_stream, :without_validations }
     let(:github_livestream_data) { github_content.dig("content", "live_stream") }
 
     let(:live_stream_data) do
@@ -68,8 +68,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     end
 
     context "with subsections" do
-      let!(:sub_section_0) { create :sub_section, position: 0, page: page }
-      let!(:sub_section_1) { create :sub_section, position: 1, page: page }
+      let!(:sub_section_0) { create :coronavirus_sub_section, position: 0, page: page }
+      let!(:sub_section_1) { create :coronavirus_sub_section, position: 1, page: page }
       let(:sub_section_0_json) { Coronavirus::SubSectionJsonPresenter.new(sub_section_0).output }
       let(:sub_section_1_json) { Coronavirus::SubSectionJsonPresenter.new(sub_section_1).output }
 
@@ -81,8 +81,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
 
   describe "#announcements_data" do
     context "with announcements" do
-      let!(:announcement_0) { create :announcement, published_at: Time.zone.local(2020, 9, 10), page: page  }
-      let!(:announcement_1) { create :announcement, published_at: Time.zone.local(2020, 9, 11), page: page  }
+      let!(:announcement_0) { create :coronavirus_announcement, published_at: Time.zone.local(2020, 9, 10), page: page  }
+      let!(:announcement_1) { create :coronavirus_announcement, published_at: Time.zone.local(2020, 9, 11), page: page  }
       let!(:announcement_0_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement_0).output }
       let!(:announcement_1_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement_1).output }
 
@@ -95,8 +95,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
   end
 
   describe "#timeline_data" do
-    let!(:timeline_entry_0) { create :timeline_entry, position: 2, page: page  }
-    let!(:timeline_entry_1) { create :timeline_entry, position: 1, page: page  }
+    let!(:timeline_entry_0) { create :coronavirus_timeline_entry, position: 2, page: page  }
+    let!(:timeline_entry_1) { create :coronavirus_timeline_entry, position: 1, page: page  }
 
     it "returns the timeline JSON ordered by position" do
       expect(subject.timeline_data).to eq [
@@ -110,7 +110,7 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     let(:data) { github_content["content"] }
 
     it "adds livestream data from github and the database" do
-      live_stream = create(:live_stream, :without_validations)
+      live_stream = create(:coronavirus_live_stream, :without_validations)
 
       subject.add_live_stream(data)
       expect(data["live_stream"]["video_url"]).to eq(live_stream.url)

--- a/spec/services/coronavirus/pages/draft_discarder_spec.rb
+++ b/spec/services/coronavirus/pages/draft_discarder_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
 
   describe "announcements" do
     it "replaces the existing announcement" do
-      create(:announcement, page: page, title: "Foo")
+      create(:coronavirus_announcement, page: page, title: "Foo")
 
       stub_publishing_api_has_item(payload_from_publishing_api)
 
@@ -29,7 +29,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
     end
 
     it "removes the announcements if there aren't any announcements in publishing_api" do
-      create(:announcement, page: page)
+      create(:coronavirus_announcement, page: page)
 
       payload = payload_from_publishing_api
       payload["details"]["announcements"].clear
@@ -45,7 +45,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
 
   describe "sub_sections" do
     it "replaces the existing sub_sections" do
-      create(:sub_section, page: page, title: "Foo")
+      create(:coronavirus_sub_section, page: page, title: "Foo")
 
       stub_publishing_api_has_item(payload_from_publishing_api)
 
@@ -58,7 +58,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
     end
 
     it "removes the sub_sections if there aren't any sub_sections in publishing_api" do
-      create(:sub_section, page: page)
+      create(:coronavirus_sub_section, page: page)
 
       payload = payload_from_publishing_api
       payload["details"]["sections"].clear
@@ -102,7 +102,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
 
   describe "timeline entries" do
     it "replaces the existing timeline entries in the correct position order" do
-      create(:timeline_entry, page: page, heading: "Foo")
+      create(:coronavirus_timeline_entry, page: page, heading: "Foo")
 
       stub_publishing_api_has_item(payload_from_publishing_api)
 
@@ -117,7 +117,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
     end
 
     it "removes the timeline entries if there isn't a timeline list in Publishing API" do
-      create(:timeline_entry, page: page)
+      create(:coronavirus_timeline_entry, page: page)
 
       payload = payload_from_publishing_api
       payload["details"]["timeline"]["list"].clear

--- a/spec/services/coronavirus/pages/timeline_entry_builder_spec.rb
+++ b/spec/services/coronavirus/pages/timeline_entry_builder_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Coronavirus::Pages::TimelineEntryBuilder do
   end
 
   it "removes existing timeline entries before creating new ones" do
-    create(:timeline_entry, page: page)
-    create(:timeline_entry, page: page)
-    create(:timeline_entry, page: page)
+    create(:coronavirus_timeline_entry, page: page)
+    create(:coronavirus_timeline_entry, page: page)
+    create(:coronavirus_timeline_entry, page: page)
 
     described_class.new.create_timeline_entries
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -13,7 +13,7 @@ module CoronavirusFeatureSteps
   end
 
   def given_a_livestream_exists
-    FactoryBot.create(:live_stream, :without_validations)
+    FactoryBot.create(:coronavirus_live_stream, :without_validations)
   end
 
   def given_there_is_a_coronavirus_page
@@ -22,14 +22,14 @@ module CoronavirusFeatureSteps
 
   def given_there_is_coronavirus_page_with_announcements
     @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
-    @announcement_one = FactoryBot.create(:announcement, position: 0, page: @coronavirus_page)
-    @announcement_two = FactoryBot.create(:announcement, position: 1, page: @coronavirus_page)
+    @announcement_one = FactoryBot.create(:coronavirus_announcement, position: 0, page: @coronavirus_page)
+    @announcement_two = FactoryBot.create(:coronavirus_announcement, position: 1, page: @coronavirus_page)
   end
 
   def given_there_is_a_coronavirus_page_with_timeline_entries
     @coronavirus_page = FactoryBot.create(:coronavirus_page, slug: "landing")
-    @timeline_entry_two = FactoryBot.create(:timeline_entry, page: @coronavirus_page, heading: "Two")
-    @timeline_entry_one = FactoryBot.create(:timeline_entry, page: @coronavirus_page, heading: "One")
+    @timeline_entry_two = FactoryBot.create(:coronavirus_timeline_entry, page: @coronavirus_page, heading: "Two")
+    @timeline_entry_one = FactoryBot.create(:coronavirus_timeline_entry, page: @coronavirus_page, heading: "One")
   end
 
   def the_payload_contains_the_valid_url
@@ -409,12 +409,12 @@ module CoronavirusFeatureSteps
 
   def set_up_basic_sub_sections
     coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
-    FactoryBot.create(:sub_section,
+    FactoryBot.create(:coronavirus_sub_section,
                       page: coronavirus_page,
                       position: 0,
                       title: "I am first",
                       content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
-    FactoryBot.create(:sub_section,
+    FactoryBot.create(:coronavirus_sub_section,
                       page: coronavirus_page,
                       position: 1,
                       title: "I am second",


### PR DESCRIPTION
Trello: https://trello.com/c/wl8IRixm/1060-name-space-the-models-in-collections-publisher

This makes the various factories of models that are under the
Coronavirus consistent in their naming by having a prefix of
`coronavirus_`. Prior to this commit there was only a prefix on the
`coronavirus_page` factory.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
