### PR TITLE
Change coronavirus_pages locale key to coronavirus.pages

### DIFF
--- a/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
@@ -24,10 +24,10 @@ module Coronavirus
       end
 
       if success
-        message = I18n.t("coronavirus_pages.timeline_entries.reorder.success")
+        message = I18n.t("coronavirus.pages.timeline_entries.reorder.success")
         redirect_to coronavirus_page_path(page.slug), notice: message
       else
-        message = I18n.t("coronavirus_pages.timeline_entries.reorder.error", error: draft_updater.errors.to_sentence)
+        message = I18n.t("coronavirus.pages.timeline_entries.reorder.error", error: draft_updater.errors.to_sentence)
         redirect_to reorder_coronavirus_page_timeline_entries_path(page.slug), alert: message
       end
     end

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -33,13 +33,13 @@ module Coronavirus
 
     def destroy
       timeline_entry = page.timeline_entries.find(params[:id])
-      message = { notice: I18n.t("coronavirus_pages.timeline_entries.delete.success") }
+      message = { notice: I18n.t("coronavirus.pages.timeline_entries.delete.success") }
 
       TimelineEntry.transaction do
         timeline_entry.destroy!
 
         unless draft_updater.send
-          message = { alert: I18n.t("coronavirus_pages.timeline_entries.delete.failed") }
+          message = { alert: I18n.t("coronavirus.pages.timeline_entries.delete.failed") }
           raise ActiveRecord::Rollback
         end
       end

--- a/app/views/coronavirus/pages/_actions.html.erb
+++ b/app/views/coronavirus/pages/_actions.html.erb
@@ -1,18 +1,18 @@
 <div class="app-side">
   <div class="app-side__actions">
     <%= form_with(url: publish_coronavirus_page_path(@page.slug)) do %>
-      <%= render "govuk_publishing_components/components/button", { text: t("coronavirus_pages.actions.publish") } %>
+      <%= render "govuk_publishing_components/components/button", { text: t("coronavirus.pages.actions.publish") } %>
     <% end %>
     <%= render "govuk_publishing_components/components/button", {
-      text: t("coronavirus_pages.actions.preview"),
+      text: t("coronavirus.pages.actions.preview"),
       href: draft_govuk_url(@page.base_path),
       target: "_blank",
       secondary: true
     } %>
 
-    <%= link_to t("coronavirus_pages.actions.discard_changes"), discard_coronavirus_page_path,class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
+    <%= link_to t("coronavirus.pages.actions.discard_changes"), discard_coronavirus_page_path,class: %w(govuk-link govuk-link--no-visited-state app-link--destructive) %>
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-    <%= link_to t("coronavirus_pages.actions.view_on_govuk"), published_url(@page.base_path.delete_prefix("/")), target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
+    <%= link_to t("coronavirus.pages.actions.view_on_govuk"), published_url(@page.base_path.delete_prefix("/")), target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>

--- a/app/views/coronavirus/pages/_announcements.html.erb
+++ b/app/views/coronavirus/pages/_announcements.html.erb
@@ -7,7 +7,7 @@
      delete: {
        href: coronavirus_page_announcement_path(@page.slug, announcement),
        data_attributes: {
-         confirm: t("coronavirus_pages.announcements.confirm"),
+         confirm: t("coronavirus.pages.announcements.confirm"),
          method: "delete"
        }
      }
@@ -19,12 +19,12 @@
     title: "Announcements",
     items: announcements,
     edit: {
-      link_text: t("coronavirus_pages.announcements.reorder"),
+      link_text: t("coronavirus.pages.announcements.reorder"),
       href: reorder_coronavirus_page_announcements_path(@page.slug)
     }
   } %>
   <%= render "govuk_publishing_components/components/button", {
-    text: t("coronavirus_pages.announcements.add"),
+    text: t("coronavirus.pages.announcements.add"),
     href: new_coronavirus_page_announcement_path(@page.slug)
   } %>
 </div>

--- a/app/views/coronavirus/pages/_sub_sections.html.erb
+++ b/app/views/coronavirus/pages/_sub_sections.html.erb
@@ -7,7 +7,7 @@
      delete: {
        href: coronavirus_page_sub_section_path(@page.slug, sub_section),
        data_attributes: {
-         confirm: t("coronavirus_pages.sub_sections.confirm"),
+         confirm: t("coronavirus.pages.sub_sections.confirm"),
          method: "delete"
        }
      }
@@ -19,13 +19,13 @@
     title: @page.sections_title,
     items: sub_sections,
     edit: {
-      link_text: t("coronavirus_pages.sub_sections.reorder"),
+      link_text: t("coronavirus.pages.sub_sections.reorder"),
       href: reorder_coronavirus_page_sub_sections_path(@page.slug)
     }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: t("coronavirus_pages.sub_sections.add"),
+    text: t("coronavirus.pages.sub_sections.add"),
     href: new_coronavirus_page_sub_section_path(@page.slug)
   } %>
 </div>

--- a/app/views/coronavirus/pages/index.html.erb
+++ b/app/views/coronavirus/pages/index.html.erb
@@ -2,15 +2,15 @@
 
 <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Coronavirus landing page</h2>
 <ul class="govuk-list">
-  <li><%= link_to t("coronavirus_pages.index.landing_page_edit.accordions"), coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
-  <li><%= link_to t("coronavirus_pages.index.landing_page_edit.live_stream_url"), coronavirus_live_stream_index_path, class:"govuk-link" %></li>
-  <li><%= link_to t("coronavirus_pages.index.landing_page_edit.something_else"), prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
+  <li><%= link_to t("coronavirus.pages.index.landing_page_edit.accordions"), coronavirus_page_path(slug: @topic_page.slug), class:"govuk-link" %></li>
+  <li><%= link_to t("coronavirus.pages.index.landing_page_edit.live_stream_url"), coronavirus_live_stream_index_path, class:"govuk-link" %></li>
+  <li><%= link_to t("coronavirus.pages.index.landing_page_edit.something_else"), prepare_coronavirus_page_path(slug: @topic_page[:slug]), class:"govuk-link" %></li>
 </ul>
 
 <% @subtopic_pages.each do |page| %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%=page.name%></h2>
   <ul class="govuk-list">
-    <li class="covid__spaced-list-item"><%= link_to t("coronavirus_pages.index.subtopic_edit.accordions", page_name: page.name.downcase), coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
-    <li class="covid__spaced-list-item"><%= link_to "#{t("coronavirus_pages.index.subtopic_edit.something")} #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to t("coronavirus.pages.index.subtopic_edit.accordions", page_name: page.name.downcase), coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to "#{t("coronavirus.pages.index.subtopic_edit.something")} #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   </ul>
 <% end %>

--- a/app/views/coronavirus/pages/prepare.html.erb
+++ b/app/views/coronavirus/pages/prepare.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Edit the #{@page.name}" %>
 <% content_for :context, "www.gov.uk#{@page.base_path}" %>
 <%= render "govuk_publishing_components/components/lead_paragraph", {
-  text: t("coronavirus_pages.prepare.lead_paragraph", coronavirus_page_name: @page.name)
+  text: t("coronavirus.pages.prepare.lead_paragraph", coronavirus_page_name: @page.name)
 } %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/coronavirus/pages/shared/_draft.html.erb
+++ b/app/views/coronavirus/pages/shared/_draft.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-!-padding-bottom-6">
   <%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_pages.draft.heading"),
+    text: t("coronavirus.pages.draft.heading"),
     padding: true
   } %>
   <%= form_with(url: coronavirus_page_path, method: "put", local: true) do %>
     <%= render "govuk_publishing_components/components/button", {
-        text: t("coronavirus_pages.draft.button_text"),
+        text: t("coronavirus.pages.draft.button_text"),
         margin_bottom: false
     } %>
   <% end %>

--- a/app/views/coronavirus/pages/shared/_github.html.erb
+++ b/app/views/coronavirus/pages/shared/_github.html.erb
@@ -1,18 +1,18 @@
 <div class="govuk-!-padding-bottom-1">
   <%= render "govuk_publishing_components/components/heading", {
-  text: t("coronavirus_pages.github.update_heading"),
+  text: t("coronavirus.pages.github.update_heading"),
   padding: true
   } %>
   <p class="govuk-body">
-    <%= t("coronavirus_pages.github.update_sub_heading_html", github_url: github_url) %>
+    <%= t("coronavirus.pages.github.update_sub_heading_html", github_url: github_url) %>
   </p>
 </div>
 <div class="govuk-!-padding-bottom-1">
   <%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_pages.github.review_heading"),
+    text: t("coronavirus.pages.github.review_heading"),
     padding: true
   } %>
   <p class="govuk-body">
-    <%= t("coronavirus_pages.github.approve_sub_heading") %>
+    <%= t("coronavirus.pages.github.approve_sub_heading") %>
   </p>
 </div>

--- a/app/views/coronavirus/pages/shared/_live.html.erb
+++ b/app/views/coronavirus/pages/shared/_live.html.erb
@@ -1,9 +1,9 @@
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("coronavirus_pages.live.heading"),
+  text: t("coronavirus.pages.live.heading"),
   padding: true
 } %>
 <%= render "govuk_publishing_components/components/button", {
-    text: t("coronavirus_pages.live.button_text"),
+    text: t("coronavirus.pages.live.button_text"),
     href: published_url(path.delete_prefix("/")),
     target: "_blank",
     secondary: true

--- a/app/views/coronavirus/pages/shared/_preview.html.erb
+++ b/app/views/coronavirus/pages/shared/_preview.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-!-padding-bottom-2">
   <%= render "govuk_publishing_components/components/heading", {
-    text: t("coronavirus_pages.preview.heading"),
+    text: t("coronavirus.pages.preview.heading"),
     padding: true
   } %>
   <div class="govuk-!-padding-bottom-3">
     <%= render "govuk_publishing_components/components/button", {
-      text: t("coronavirus_pages.preview.button_text"),
+      text: t("coronavirus.pages.preview.button_text"),
       href: draft_govuk_url(path),
       target: "_blank",
       secondary: true

--- a/app/views/coronavirus/pages/shared/_publish.html.erb
+++ b/app/views/coronavirus/pages/shared/_publish.html.erb
@@ -1,28 +1,28 @@
 <div class="govuk-!-padding-bottom-4">
     <%= render "govuk_publishing_components/components/heading", {
-      text: t("coronavirus_pages.publish.heading"),
+      text: t("coronavirus.pages.publish.heading"),
       padding: true
     } %>
     <%= form_with(url: publish_coronavirus_page_path(params[:slug])) do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "update-type",
-        heading: t("coronavirus_pages.publish.radio_heading"),
+        heading: t("coronavirus.pages.publish.radio_heading"),
         heading_size: "s",
         small: true,
         items: [
           {
             value: "minor",
-            text: t("coronavirus_pages.publish.minor_type"),
+            text: t("coronavirus.pages.publish.minor_type"),
             checked: true
           },
           {
             value: "major",
-            text: t("coronavirus_pages.publish.major_type")
+            text: t("coronavirus.pages.publish.major_type")
           }
         ]
       } %>
       <%= render "govuk_publishing_components/components/button", {
-          text: t("coronavirus_pages.publish.button_text"),
+          text: t("coronavirus.pages.publish.button_text"),
       } %>
     <% end %>
 </div>

--- a/app/views/coronavirus/pages/show.html.erb
+++ b/app/views/coronavirus/pages/show.html.erb
@@ -1,11 +1,11 @@
 <%
   links = [
     {
-      text: t("coronavirus_pages.show.link_text"),
+      text: t("coronavirus.pages.show.link_text"),
       href: coronavirus_pages_path
     },
     {
-      text: t("coronavirus_pages.show.accordion_text", coronavirus_page_name: @page.name)
+      text: t("coronavirus.pages.show.accordion_text", coronavirus_page_name: @page.name)
     }
   ]
 

--- a/app/views/coronavirus/reorder_timeline_entries/index.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/index.html.erb
@@ -9,17 +9,17 @@
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: t("coronavirus_pages.timeline_entries.reorder.heading")
+      text: t("coronavirus.pages.timeline_entries.reorder.heading")
     },
   ]
 %>
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page)%>
-<% content_for :context, t("coronavirus_pages.timeline_entries.reorder.heading") %>
+<% content_for :context, t("coronavirus.pages.timeline_entries.reorder.heading") %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_markdown t("coronavirus_pages.timeline_entries.reorder.form.markdown_hint") %>
+    <%= render_markdown t("coronavirus.pages.timeline_entries.reorder.form.markdown_hint") %>
     <%= render "reorder_list" %>
 
     <%= form_with method: :put, url: reorder_coronavirus_page_timeline_entries_path do |form| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,61 +1,62 @@
 en:
-  coronavirus_pages:
-    actions:
-      discard_changes: Discard changes
-      view_on_govuk: View on GOV.UK
-      preview: Preview
-      publish: Publish
-    announcements:
-      confirm: Are you sure?
-      reorder: Reorder
-      add: Add announcement
-    draft:
-      heading: 3. Update draft
-      button_text: Update draft
-    github:
-      update_heading: 1. Update GitHub
-      review_heading: 2. Get changes reviewed and merged
-      update_sub_heading_html: "Update the <a href=\"%{github_url}\">coronavirus content on Github</a>"
-      approve_sub_heading: Get the changes approved and merged into master.
-    index:
-      landing_page_edit:
-        accordions: Edit landing page accordions, announcements and timeline
-        live_stream_url: Edit live stream URL
-        something_else: Edit something else on the landing page
-      subtopic_edit:
-        accordions: "Edit %{page_name} accordions"
-        something: Edit something else on the
-    live:
-      heading: 6. Check live
-      button_text: View live version
-    prepare:
-      lead_paragraph: "Follow the steps below to make changes to any part of the %{coronavirus_page_name}, except the accordions."
-    preview:
-      heading: 4. Preview changes
-      button_text: Preview
-    publish:
-      heading: 5. Publish changes
-      radio_heading: Update type
-      major_type: Major
-      minor_type: Minor
-      button_text: Publish
-    show:
-      link_text: Coronavirus pages
-      accordion_text: "%{coronavirus_page_name} accordions"
-    sub_sections:
-      confirm: Are you sure?
-      reorder: Reorder
-      add: Add accordion
-    timeline_entries:
-      delete:
-        success: Timeline entry was successfully deleted.
-        failed: Timeline entry couldn't be deleted
-      reorder:
-        heading: Reorder timeline entries
-        success: Timeline entries were successfully reordered.
-        error: "Sorry! Timeline entries have not been reordered: %{error}."
-        form:
-          markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
+  coronavirus:
+    pages:
+      actions:
+        discard_changes: Discard changes
+        view_on_govuk: View on GOV.UK
+        preview: Preview
+        publish: Publish
+      announcements:
+        confirm: Are you sure?
+        reorder: Reorder
+        add: Add announcement
+      draft:
+        heading: 3. Update draft
+        button_text: Update draft
+      github:
+        update_heading: 1. Update GitHub
+        review_heading: 2. Get changes reviewed and merged
+        update_sub_heading_html: "Update the <a href=\"%{github_url}\">coronavirus content on Github</a>"
+        approve_sub_heading: Get the changes approved and merged into master.
+      index:
+        landing_page_edit:
+          accordions: Edit landing page accordions, announcements and timeline
+          live_stream_url: Edit live stream URL
+          something_else: Edit something else on the landing page
+        subtopic_edit:
+          accordions: "Edit %{page_name} accordions"
+          something: Edit something else on the
+      live:
+        heading: 6. Check live
+        button_text: View live version
+      prepare:
+        lead_paragraph: "Follow the steps below to make changes to any part of the %{coronavirus_page_name}, except the accordions."
+      preview:
+        heading: 4. Preview changes
+        button_text: Preview
+      publish:
+        heading: 5. Publish changes
+        radio_heading: Update type
+        major_type: Major
+        minor_type: Minor
+        button_text: Publish
+      show:
+        link_text: Coronavirus pages
+        accordion_text: "%{coronavirus_page_name} accordions"
+      sub_sections:
+        confirm: Are you sure?
+        reorder: Reorder
+        add: Add accordion
+      timeline_entries:
+        delete:
+          success: Timeline entry was successfully deleted.
+          failed: Timeline entry couldn't be deleted
+        reorder:
+          heading: Reorder timeline entries
+          success: Timeline entries were successfully reordered.
+          error: "Sorry! Timeline entries have not been reordered: %{error}."
+          form:
+            markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
   step_by_step_page:
     statuses:
       draft: Draft

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -382,7 +382,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_timeline_entries_updated_message
-    expect(page).to have_content I18n.t("coronavirus_pages.timeline_entries.reorder.success")
+    expect(page).to have_content I18n.t("coronavirus.pages.timeline_entries.reorder.success")
   end
 
   def and_i_see_the_timeline_entries_have_changed_order
@@ -403,7 +403,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_the_timeline_entry_has_been_deleted
-    expect(page).to have_text(I18n.t("coronavirus_pages.timeline_entries.delete.success"))
+    expect(page).to have_text(I18n.t("coronavirus.pages.timeline_entries.delete.success"))
     expect(page).not_to have_text(@timeline_entry_one.heading)
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/wl8IRixm/1060-name-space-the-models-in-collections-publisher

This is to make this key consistent with the namespacing approach
applied in the rest of the application as having coronavirus and pages
as distinct namespaces.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
