### PR TITLE
Add coronavirus prefix to coronavirus database tables (⚠️  dangerous PR)

### DIFF
--- a/app/models/coronavirus/announcement.rb
+++ b/app/models/coronavirus/announcement.rb
@@ -1,4 +1,6 @@
 class Coronavirus::Announcement < ApplicationRecord
+  self.table_name = "coronavirus_announcements"
+
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :title, :path, presence: true
   validates :page, presence: true

--- a/app/models/coronavirus/live_stream.rb
+++ b/app/models/coronavirus/live_stream.rb
@@ -1,3 +1,5 @@
 class Coronavirus::LiveStream < ApplicationRecord
+  self.table_name = "coronavirus_live_streams"
+
   validates :url, youtube_url: true, presence: true
 end

--- a/app/models/coronavirus/sub_section.rb
+++ b/app/models/coronavirus/sub_section.rb
@@ -1,8 +1,9 @@
 class Coronavirus::SubSection < ApplicationRecord
+  self.table_name = "coronavirus_sub_sections"
+
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :title, :content, presence: true
   validates :page, presence: true
-
   validate :featured_link_must_be_in_content
 
   def featured_link_must_be_in_content

--- a/app/models/coronavirus/timeline_entry.rb
+++ b/app/models/coronavirus/timeline_entry.rb
@@ -1,4 +1,6 @@
 class Coronavirus::TimelineEntry < ApplicationRecord
+  self.table_name = "coronavirus_timeline_entries"
+
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :heading, presence: true, length: { maximum: 255 }
   validates :content, presence: true

--- a/db/migrate/20210205143416_rename_coronavirus_tables.rb
+++ b/db/migrate/20210205143416_rename_coronavirus_tables.rb
@@ -1,0 +1,8 @@
+class RenameCoronavirusTables < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :announcements, :coronavirus_announcements
+    rename_table :live_streams, :coronavirus_live_streams
+    rename_table :sub_sections, :coronavirus_sub_sections
+    rename_table :timeline_entries, :coronavirus_timeline_entries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_26_122043) do
+ActiveRecord::Schema.define(version: 2021_02_05_143416) do
 
-  create_table "announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "coronavirus_announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
     t.string "title"
     t.string "path"
@@ -20,6 +20,13 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+  end
+
+  create_table "coronavirus_live_streams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.string "formatted_stream_date"
   end
 
   create_table "coronavirus_pages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -34,6 +41,27 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
     t.string "raw_content_url"
     t.string "state", default: "draft", null: false
     t.string "title"
+  end
+
+  create_table "coronavirus_sub_sections", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.bigint "coronavirus_page_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position"
+    t.string "featured_link"
+    t.index ["coronavirus_page_id"], name: "index_coronavirus_sub_sections_on_coronavirus_page_id"
+  end
+
+  create_table "coronavirus_timeline_entries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "coronavirus_page_id", null: false
+    t.text "content", null: false
+    t.string "heading", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coronavirus_page_id"], name: "index_coronavirus_timeline_entries_on_coronavirus_page_id"
   end
 
   create_table "internal_change_notes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -70,13 +98,6 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
     t.integer "index", default: 0, null: false
     t.integer "tag_id", null: false
     t.index ["tag_id"], name: "index_lists_on_tag_id"
-  end
-
-  create_table "live_streams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "url", null: false
-    t.string "formatted_stream_date"
   end
 
   create_table "navigation_rules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -160,17 +181,6 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
     t.index ["step_by_step_page_id"], name: "index_steps_on_step_by_step_page_id"
   end
 
-  create_table "sub_sections", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
-    t.bigint "coronavirus_page_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "position"
-    t.string "featured_link"
-    t.index ["coronavirus_page_id"], name: "index_sub_sections_on_coronavirus_page_id"
-  end
-
   create_table "tag_associations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "from_tag_id", null: false
     t.integer "to_tag_id", null: false
@@ -199,16 +209,6 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
     t.index ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true
   end
 
-  create_table "timeline_entries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "coronavirus_page_id", null: false
-    t.text "content", null: false
-    t.string "heading", null: false
-    t.integer "position", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["coronavirus_page_id"], name: "index_timeline_entries_on_coronavirus_page_id"
-  end
-
   create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -221,6 +221,8 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
+  add_foreign_key "coronavirus_sub_sections", "coronavirus_pages"
+  add_foreign_key "coronavirus_timeline_entries", "coronavirus_pages"
   add_foreign_key "internal_change_notes", "step_by_step_pages"
   add_foreign_key "link_reports", "steps"
   add_foreign_key "list_items", "lists", name: "list_items_list_id_fk", on_delete: :cascade
@@ -231,9 +233,7 @@ ActiveRecord::Schema.define(version: 2021_01_26_122043) do
   add_foreign_key "step_by_step_pages", "users", column: "review_requester_id", primary_key: "uid"
   add_foreign_key "step_by_step_pages", "users", column: "reviewer_id", primary_key: "uid"
   add_foreign_key "steps", "step_by_step_pages"
-  add_foreign_key "sub_sections", "coronavirus_pages"
   add_foreign_key "tag_associations", "tags", column: "from_tag_id", name: "tag_associations_from_tag_id_fk", on_delete: :cascade
   add_foreign_key "tag_associations", "tags", column: "to_tag_id", name: "tag_associations_to_tag_id_fk", on_delete: :cascade
   add_foreign_key "tags", "tags", column: "parent_id", name: "tags_parent_id_fk"
-  add_foreign_key "timeline_entries", "coronavirus_pages"
 end


### PR DESCRIPTION
Trello: https://trello.com/c/wl8IRixm/1060-name-space-the-models-in-collections-publisher

This makes these models consistent with `coronavirus_pages` in having a
`coronavirus_` prefix in the table name.

This migration must be applied at a quiet time for the application as
the deployment of it risks errors from when the migration has run until
a new instance of the app is running.

It's not ideal to deal with this risk of errors but the alternative is
far more painful - which would be creating new tables that are
backfilled and kept in sync until the tables are swapped. Given that
this application frequently goes many hours without a user request it
seems reasonable to take this risk.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
