### PR TITLE
Apply no border option for document list on stp by step pages

### DIFF
--- a/app/views/step_by_step_pages/index/_results.erb
+++ b/app/views/step_by_step_pages/index/_results.erb
@@ -21,6 +21,7 @@
 
       <%= table.row do %>
         <%= table.cell render "govuk_publishing_components/components/document_list", {
+          remove_top_border: true,
           items: [
             {
               link: {


### PR DESCRIPTION
## What
Adds the new `no_top_border` attribute to calls to the [document list component](https://components.publishing.service.gov.uk/component-guide/document_list) on step by step pages to remove the visual top border element from component render within the step by step pages view.

## Why
This is to fix a visual discrepancy on the step by step list view caused by a recent design change to the document list component. [See this PR for more details including visual changes](https://github.com/alphagov/govuk_publishing_components/pull/1907).