### PR TITLE
Add reorder-able lists component

### DIFF
--- a/app/assets/javascripts/admin_layout.js
+++ b/app/assets/javascripts/admin_layout.js
@@ -14,6 +14,7 @@
 //= require @webcomponents/custom-elements/custom-elements.min.js
 
 //= require components/markdown-editor.js
+//= require components/reorderable-list.js
 //= require sections.js
 
 $(document).ready(function () {

--- a/app/assets/javascripts/components/reorderable-list.js
+++ b/app/assets/javascripts/components/reorderable-list.js
@@ -1,0 +1,108 @@
+//= require sortablejs/Sortable.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ReorderableList () { }
+
+  ReorderableList.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$upButtons = this.$module.querySelectorAll('.js-reorderable-list-up')
+    this.$downButtons = this.$module.querySelectorAll('.js-reorderable-list-down')
+
+    this.sortable = window.Sortable.create(this.$module, { // eslint-disable-line new-cap
+      chosenClass: 'app-c-reorderable-list__item--chosen',
+      dragClass: 'app-c-reorderable-list__item--drag',
+      onSort: function () {
+        this.updateOrderIndexes()
+        this.triggerEvent(this.$module, 'reorder-drag')
+      }.bind(this)
+    })
+
+    if (typeof window.matchMedia === 'function') {
+      this.setupResponsiveChecks()
+    } else {
+      this.sortable.option('disabled', true)
+    }
+
+    var boundOnClickUpButton = this.onClickUpButton.bind(this)
+    this.$upButtons.forEach(function (button) {
+      button.addEventListener('click', boundOnClickUpButton)
+    })
+
+    var boundOnClickDownButton = this.onClickDownButton.bind(this)
+    this.$downButtons.forEach(function (button) {
+      button.addEventListener('click', boundOnClickDownButton)
+    })
+  }
+
+  ReorderableList.prototype.setupResponsiveChecks = function () {
+    var tabletBreakpoint = '40.0625em' // ~640px
+    this.mediaQueryList = window.matchMedia('(min-width: ' + tabletBreakpoint + ')')
+    this.mediaQueryList.addListener(this.checkMode.bind(this))
+    this.checkMode()
+  }
+
+  ReorderableList.prototype.checkMode = function () {
+    this.sortable.option('disabled', !this.mediaQueryList.matches)
+  }
+
+  ReorderableList.prototype.onClickUpButton = function (e) {
+    var item = e.target.closest('.app-c-reorderable-list__item')
+    var previousItem = item.previousElementSibling
+    if (item && previousItem) {
+      item.parentNode.insertBefore(item, previousItem)
+      this.updateOrderIndexes()
+    }
+    // if triggered by keyboard preserve focus on button
+    if (e.detail === 0) {
+      if (item !== item.parentNode.firstElementChild) {
+        e.target.focus()
+      } else {
+        e.target.nextElementSibling.focus()
+      }
+    }
+    this.triggerEvent(e.target, 'reorder-move-up')
+  }
+
+  ReorderableList.prototype.onClickDownButton = function (e) {
+    var item = e.target.closest('.app-c-reorderable-list__item')
+    var nextItem = item.nextElementSibling
+    if (item && nextItem) {
+      item.parentNode.insertBefore(item, nextItem.nextElementSibling)
+      this.updateOrderIndexes()
+    }
+    // if triggered by keyboard preserve focus on button
+    if (e.detail === 0) {
+      if (item !== item.parentNode.lastElementChild) {
+        e.target.focus()
+      } else {
+        e.target.previousElementSibling.focus()
+      }
+    }
+    this.triggerEvent(e.target, 'reorder-move-down')
+  }
+
+  ReorderableList.prototype.updateOrderIndexes = function () {
+    var $orderInputs = this.$module.querySelectorAll('.app-c-reorderable-list__actions input')
+    $orderInputs.forEach(function (input, index) {
+      input.setAttribute('value', index + 1)
+    })
+  }
+
+  ReorderableList.prototype.triggerEvent = function (element, eventName) {
+    var params = { bubbles: true, cancelable: true }
+    var event
+
+    if (typeof window.CustomEvent === 'function') {
+      event = new window.CustomEvent(eventName, params)
+    } else {
+      event = document.createEvent('CustomEvent')
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable)
+    }
+
+    element.dispatchEvent(event)
+  }
+
+  Modules.ReorderableList = ReorderableList
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,2 +1,3 @@
 @import "./markdown-editor";
 @import "./timeline-entry";
+@import "./reorderable-list";

--- a/app/assets/stylesheets/components/_reorderable-list.scss
+++ b/app/assets/stylesheets/components/_reorderable-list.scss
@@ -1,0 +1,120 @@
+.app-c-reorderable-list {
+  @include govuk-font(19, bold);
+
+  list-style-type: none;
+  margin-bottom: govuk-spacing(6);
+  margin-top: 0;
+  padding-left: 0;
+  position: relative;
+
+  .govuk-form-group {
+    margin-bottom: 0;
+  }
+}
+
+.app-c-reorderable-list__item {
+  margin-bottom: govuk-spacing(3);
+  border: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(3);
+}
+
+.app-c-reorderable-list__item--chosen {
+  background-color: govuk-colour('light-grey');
+  outline: 2px dotted $govuk-border-colour;
+}
+
+.app-c-reorderable-list__item--drag {
+  background-color: govuk-colour('white');
+  list-style-type: none;
+
+  .app-c-reorderable-list__actions {
+    visibility: hidden;
+  }
+}
+
+.app-c-reorderable-list__wrapper {
+  display: block;
+
+  @include govuk-media-query($from: desktop) {
+    display: inline-flex;
+    width: 100%;
+  }
+}
+
+.app-c-reorderable-list__content,
+.app-c-reorderable-list__actions {
+  margin-bottom: govuk-spacing(2);
+}
+
+.app-c-reorderable-list__content {
+  @include govuk-media-query($from: desktop) {
+    flex: 0 1 auto;
+    min-width: 65%;
+  }
+}
+
+.app-c-reorderable-list__title {
+  margin: 0;
+}
+
+.app-c-reorderable-list__description {
+  @include govuk-font(16, regular);
+  margin: 0;
+}
+
+.app-c-reorderable-list__actions {
+  display: block;
+
+  @include govuk-media-query($from: desktop) {
+    flex: 1 0 auto;
+    text-align: right;
+  }
+
+  .gem-c-button {
+    display: none;
+  }
+}
+
+.js-enabled {
+  .app-c-reorderable-list__item {
+    @include govuk-media-query($from: desktop) {
+      cursor: move;
+    }
+  }
+
+  .app-c-reorderable-list__actions .govuk-form-group {
+    display: none;
+  }
+
+  .app-c-reorderable-list__actions .gem-c-button {
+    display: inline-block;
+    margin-left: govuk-spacing(3);
+    width: 80px;
+  }
+
+  .app-c-reorderable-list__actions .gem-c-button:first-of-type {
+    margin-left: 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin-left: govuk-spacing(3);
+    }
+  }
+
+  .app-c-reorderable-list__item:first-child .gem-c-button:first-of-type,
+  .app-c-reorderable-list__item:last-child .gem-c-button:last-of-type {
+    display: none;
+
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      visibility: hidden;
+    }
+  }
+
+  .app-c-reorderable-list__item:first-child .gem-c-button:last-of-type {
+    margin-left: 0;
+
+    @include govuk-media-query($from: desktop) {
+      margin-left: govuk-spacing(3);
+    }
+  }
+}

--- a/app/controllers/coronavirus/reorder_announcements_controller.rb
+++ b/app/controllers/coronavirus/reorder_announcements_controller.rb
@@ -9,12 +9,14 @@ module Coronavirus
 
     def update
       success = true
-      reordered_announcements = JSON.parse(params[:announcement_order_save])
+
+      reordered_announcements = page.announcements.sort_by do |announcement|
+        params.require(:announcement_order_save).fetch(announcement.id.to_s, announcement.position).to_i
+      end
 
       Announcement.transaction do
-        reordered_announcements.each do |announcement_data|
-          announcement = page.announcements.find(announcement_data["id"])
-          announcement.update_column(:position, announcement_data["position"])
+        reordered_announcements.each.with_index(1) do |announcement, index|
+          announcement.update_column(:position, index)
         end
 
         unless draft_updater.send

--- a/app/controllers/coronavirus/reorder_sub_sections_controller.rb
+++ b/app/controllers/coronavirus/reorder_sub_sections_controller.rb
@@ -35,10 +35,12 @@ module Coronavirus
     end
 
     def set_positions
-      reordered_subsections = JSON.parse(params[:section_order_save])
-      reordered_subsections.each do |sub_section_data|
-        sub_section = page.sub_sections.find(sub_section_data["id"])
-        sub_section.update_column(:position, sub_section_data["position"])
+      reordered_subsections = page.sub_sections.sort_by do |sub_section|
+        params.require(:section_order_save).fetch(sub_section.id.to_s, sub_section.position).to_i
+      end
+
+      reordered_subsections.each.with_index(1) do |sub_section, index|
+        sub_section.update_column(:position, index)
       end
     end
 

--- a/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
@@ -9,12 +9,14 @@ module Coronavirus
 
     def update
       success = true
-      reordered_timeline_entries = JSON.parse(params[:timeline_entry_order_save])
+
+      reordered_timeline_entries = page.timeline_entries.sort_by do |entry|
+        params.require(:timeline_entry_order_save).fetch(entry.id.to_s, entry.position).to_i
+      end
 
       TimelineEntry.transaction do
-        reordered_timeline_entries.each do |timeline_entry_data|
-          timeline_entry = page.timeline_entries.find(timeline_entry_data["id"])
-          timeline_entry.update_column(:position, timeline_entry_data["position"])
+        reordered_timeline_entries.each.with_index(1) do |entry, index|
+          entry.update_column(:position, index)
         end
 
         unless draft_updater.send

--- a/app/views/components/_reorderable_list.html.erb
+++ b/app/views/components/_reorderable_list.html.erb
@@ -1,0 +1,47 @@
+<%
+  items ||= []
+  input_name ||= "ordering"
+  data_attributes ||= {}
+  data_attributes[:module] = "reorderable-list"
+%>
+
+<%= tag.ol class: "app-c-reorderable-list", data: data_attributes do %>
+  <% items.each_with_index do |item, index| %>
+    <%= tag.li class: "app-c-reorderable-list__item" do %>
+      <%= tag.div class: "app-c-reorderable-list__wrapper" do %>
+        <%= tag.div class: "app-c-reorderable-list__content" do %>
+          <%= tag.p item[:title], class: "app-c-reorderable-list__title" %>
+          <%= tag.p(item[:description], class: "app-c-reorderable-list__description") if item[:description].present? %>
+        <% end %>
+        <%= tag.div class: "app-c-reorderable-list__actions" do %>
+          <% label_text = capture do %>
+            Position<span class='govuk-visually-hidden'> for <%= item[:title] %></span>
+          <% end %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: sanitize(label_text)
+            },
+            name: "#{input_name}[#{item[:id]}]",
+            type: "number",
+            value: index + 1,
+            width: 2
+          } %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Up",
+            type: "button",
+            aria_label: "Move #{item[:title]} up",
+            classes: "js-reorderable-list-up",
+            secondary_solid: true
+          } %>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Down",
+            type: "button",
+            aria_label: "Move #{item[:title]} down",
+            classes: "js-reorderable-list-down",
+            secondary_solid: true
+          } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/reorderable_list.yml
+++ b/app/views/components/docs/reorderable_list.yml
@@ -1,0 +1,81 @@
+name: Reorderable list
+description: A list of items that can be reordered
+body: |
+  List items can be reordered by drag and drop or by using the up/down buttons.
+  On small viewports the drag and drop feature is disabled to prevent being triggered
+  when scrolling on touch devices.
+
+  This component uses SortableJS - a JavaScript library for drag and drop interactions.
+  When JavaScript is disabled a set of inputs will be shown allowing users to provide
+  an order index for each item.
+accessibility_criteria: |
+  Buttons in this component must:
+
+  * be keyboard focusable
+  * inform the user about which item they operate on
+  * preserve focus after interacting with them
+examples:
+  default:
+    data:
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+  with_description:
+    data:
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+          description: "PDF, 2.56MB, 48 pages"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+          description: "HTML attachment"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+          description: "PDF, 592KB, 48 pages"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+          description: "MS Excel Spreadsheet, 248KB"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+          description: "MS Excel Spreadsheet, 248KB"
+  within_form:
+    embed: |
+      <form>
+        <%= component %>
+        <button class="govuk-button" type="submit">Save order</button>
+      </form>
+    data:
+      items:
+        - id: "ce99dd60-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018"
+          description: "PDF, 2.56MB, 48 pages"
+        - id: "d321cb86-67dc-11eb-ae93-0242ac130002"
+          title: "Budget 2018 (web)"
+          description: "HTML attachment"
+        - id: "63a6d29e-6b6d-4157-9067-84c1a390e352"
+          title: "Impact on households: distributional analysis to accompany Budget 2018"
+          description: "PDF, 592KB, 48 pages"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Table 2.1: Budget 2018 policy decisions"
+          description: "MS Excel Spreadsheet, 248KB"
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
+          description: "MS Excel Spreadsheet, 248KB"
+  with_custom_input_name:
+    data:
+      input_name: "attachments[ordering]"
+      items:
+        - id: "5ebd75d7-6c37-4b93-b444-1b7c49757fb9"
+          title: "Budget 2018"
+          description: "PDF, 2.56MB, 48 pages"
+        - id: "0a4d377d-68f4-472f-b2e3-ef71dc750f85"
+          title: "Budget 2020"
+          description: "PDF, 2.56MB, 48 pages"

--- a/app/views/coronavirus/reorder_announcements/_reorder_list.html.erb
+++ b/app/views/coronavirus/reorder_announcements/_reorder_list.html.erb
@@ -1,17 +1,11 @@
-<% announcements = @page.announcements.order(:position) %>
+<%
+  announcements = @page.announcements.order(:position)
+  announcements = announcements.map { |a| { id: a.id, title: a.title } }
+%>
 
 <div class="covid-manage-page__summary-list">
-  <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
-    <% announcements.each_with_index do |announcement, index| %>
-      <li class="js-reorder" data-id="<%= announcement.id %>">
-        <div class="govuk-grid-row" id="step-<%= index %>">
-          <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
-            <%= announcement.title %>
-          </div>
-          <div class="govuk-grid-column-one-quarter js-order-controls">
-          </div>
-        </div>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'components/reorderable_list', {
+    input_name: "announcement_order_save",
+    items: announcements,
+  } %>
 </div>

--- a/app/views/coronavirus/reorder_announcements/index.html.erb
+++ b/app/views/coronavirus/reorder_announcements/index.html.erb
@@ -20,10 +20,9 @@
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown "Use the up/down buttons on the right to reorder the announcements, or click and hold on a section to reorder using drag and drop." %>
-    <%= render "reorder_list" %>
 
     <%= form_for(@page, url: reorder_coronavirus_page_announcements_path, method: :put) do |form| %>
-      <input type="hidden" name="announcement_order_save" id="js_order_save" value="" />
+      <%= render "reorder_list" %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= render "govuk_publishing_components/components/button", {

--- a/app/views/coronavirus/reorder_sub_sections/_reorder_list.html.erb
+++ b/app/views/coronavirus/reorder_sub_sections/_reorder_list.html.erb
@@ -1,17 +1,11 @@
-<% sub_sections = @page.sub_sections.order(:position) %>
+<%
+  sub_sections = @page.sub_sections.order(:position)
+  sub_sections = sub_sections.map { |ss| { id: ss.id, title: ss.title } }
+%>
 
 <div class="covid-manage-page__summary-list">
-  <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
-    <% sub_sections.each_with_index do |sub_section, index| %>
-      <li class="js-reorder" data-id="<%= sub_section.id %>">
-        <div class="govuk-grid-row" id="step-<%= index %>">
-          <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
-            <%= sub_section.title %>
-          </div>
-          <div class="govuk-grid-column-one-quarter js-order-controls">
-          </div>
-        </div>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'components/reorderable_list', {
+    input_name: "section_order_save",
+    items: sub_sections,
+  } %>
 </div>

--- a/app/views/coronavirus/reorder_sub_sections/index.html.erb
+++ b/app/views/coronavirus/reorder_sub_sections/index.html.erb
@@ -20,10 +20,9 @@
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown "Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop." %>
-    <%= render "reorder_list" %>
 
     <%= form_for(@page, url: reorder_coronavirus_page_sub_sections_path, method: :put) do |form| %>
-      <input type="hidden" name="section_order_save" id="js_order_save" value="" />
+      <%= render "reorder_list" %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= render "govuk_publishing_components/components/button", {

--- a/app/views/coronavirus/reorder_timeline_entries/_reorder_list.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/_reorder_list.html.erb
@@ -1,17 +1,11 @@
-<% timeline_entries = @page.timeline_entries.order(:position) %>
+<%
+  timeline_entries = @page.timeline_entries.order(:position)
+  timeline_entries = timeline_entries.map { |te| { id: te.id, title: te.heading } }
+%>
 
 <div class="covid-manage-page__summary-list">
-  <ul class="govuk-list step-by-step-reorder__list" id="js-reorder-group">
-    <% timeline_entries.each_with_index do |timeline_entry, index| %>
-      <li class="js-reorder" data-id="<%= timeline_entry.id %>">
-        <div class="govuk-grid-row" id="step-<%= index %>">
-          <div class="govuk-grid-column-three-quarters govuk-!-font-weight-bold step-by-step-reorder__step-title">
-            <%= timeline_entry.heading %>
-          </div>
-          <div class="govuk-grid-column-one-quarter js-order-controls">
-          </div>
-        </div>
-      </li>
-    <% end %>
-  </ul>
+  <%= render 'components/reorderable_list', {
+    input_name: "timeline_entry_order_save",
+    items: timeline_entries,
+  } %>
 </div>

--- a/app/views/coronavirus/reorder_timeline_entries/index.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/index.html.erb
@@ -20,10 +20,9 @@
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render_markdown t("coronavirus.pages.timeline_entries.reorder.form.markdown_hint") %>
-    <%= render "reorder_list" %>
 
     <%= form_with method: :put, url: reorder_coronavirus_page_timeline_entries_path do |form| %>
-      <input type="hidden" name="timeline_entry_order_save" id="js_order_save" value="" />
+      <%= render "reorder_list" %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <%= render "govuk_publishing_components/components/button", {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "accessible-autocomplete": "^2.0.3",
     "core-js-bundle": "^3.0.0-alpha.1",
     "es5-polyfill": "^0.0.6",
-    "markdown-toolbar-element": "^0.2.0"
+    "markdown-toolbar-element": "^0.2.0",
+    "sortablejs": "^1.13.0"
   },
   "devDependencies": {
     "standardx": "^7.0.0",

--- a/spec/components/reorderable_list_spec.rb
+++ b/spec/components/reorderable_list_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Reorderable list", type: :view do
+  def render_component(arguments)
+    render partial: "components/reorderable_list", locals: arguments
+  end
+
+  def items
+    [
+      {
+        id: "item-1",
+        title: "Budget 2018",
+        description: "PDF, 2.56MB, 48 pages",
+      },
+      {
+        id: "item-2",
+        title: "Budget 2018 (web)",
+        description: "HTML attachment",
+      },
+      {
+        id: "item-3",
+        title: "Impact on households: distributional analysis to accompany Budget 2018",
+        description: "PDF, 592KB, 48 pages",
+      },
+      {
+        id: "item-3",
+        title: "Table 2.1: Budget 2018 policy decisions",
+        description: "MS Excel Spreadsheet, 248KB",
+      },
+      {
+        id: "item-3",
+        title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)",
+        description: "MS Excel Spreadsheet, 248KB",
+      },
+    ]
+  end
+
+  it "renders a list of items" do
+    render_component(items: items)
+
+    assert_select ".app-c-reorderable-list"
+    assert_select ".app-c-reorderable-list__item", 5
+    assert_select ".app-c-reorderable-list__item" do |elements|
+      elements.each_with_index do |element, index|
+        assert_select element, ".app-c-reorderable-list__title", { text: items[index][:title] }
+        assert_select element, ".app-c-reorderable-list__description", { text: items[index][:description] }
+        assert_select element, ".app-c-reorderable-list__actions"
+        assert_select element, ".app-c-reorderable-list__actions .js-reorderable-list-up", { text: "Up" }
+        assert_select element, ".app-c-reorderable-list__actions .js-reorderable-list-down", { text: "Down" }
+        assert_select element, ".app-c-reorderable-list__actions input[name='ordering[#{items[index][:id]}]']"
+        assert_select element, ".app-c-reorderable-list__actions input[value='#{index + 1}']"
+      end
+    end
+  end
+
+  it "renders allows custom input names" do
+    render_component(items: items, input_name: "attachments[ordering]")
+
+    assert_select ".app-c-reorderable-list"
+    assert_select ".app-c-reorderable-list__item" do |elements|
+      elements.each_with_index do |element, index|
+        assert_select element, ".app-c-reorderable-list__actions input[name='attachments[ordering][#{items[index][:id]}]']"
+      end
+    end
+  end
+end

--- a/spec/controllers/coronavirus/reorder_announcements_controller_spec.rb
+++ b/spec/controllers/coronavirus/reorder_announcements_controller_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Coronavirus::ReorderAnnouncementsController do
   end
 
   describe "PUT Coronavirus reorder announcements page" do
-    let!(:announcement) { create(:coronavirus_announcement, position: 0, page: page) }
-    let!(:another_announcement) { create(:coronavirus_announcement, position: 1, page: page) }
+    let!(:announcement) { create(:coronavirus_announcement, position: 1, page: page) }
+    let!(:another_announcement) { create(:coronavirus_announcement, position: 2, page: page) }
 
     before do
       stub_coronavirus_landing_page_content(page)
@@ -30,71 +30,71 @@ RSpec.describe Coronavirus::ReorderAnnouncementsController do
     end
 
     it "reorders the announcements" do
-      announcement_params = [
-        {
-          id: announcement.id,
-          position: 1,
-        },
-        {
-          id: another_announcement.id,
-          position: 0,
-        },
-      ]
+      announcement_params = {
+        announcement.id => 2,
+        another_announcement.id => 1,
+      }
 
       put :update, params: {
         page_slug: page.slug,
-        announcement_order_save: announcement_params.to_json,
+        announcement_order_save: announcement_params,
       }
 
-      expect(announcement.reload.position).to eq 1
-      expect(another_announcement.reload.position).to eq 0
+      expect(announcement.reload.position).to eq 2
+      expect(another_announcement.reload.position).to eq 1
       expect(subject).to redirect_to(coronavirus_page_path(page.slug))
     end
 
     it "keeps the existing order if submitted without changes" do
-      announcement_params = [
-        {
-          id: announcement.id,
-          position: 0,
-        },
-        {
-          id: another_announcement.id,
-          position: 1,
-        },
-      ]
+      announcement_params = {
+        announcement.id => 1,
+        another_announcement.id => 2,
+      }
 
       put :update, params: {
         page_slug: page.slug,
-        announcement_order_save: announcement_params.to_json,
+        announcement_order_save: announcement_params,
       }
 
-      expect(announcement.reload.position).to eq 0
-      expect(another_announcement.reload.position).to eq 1
+      expect(announcement.reload.position).to eq 1
+      expect(another_announcement.reload.position).to eq 2
       expect(subject).to redirect_to(coronavirus_page_path(page.slug))
     end
 
     it "keeps the existing order if updating the draft fails" do
       stub_publishing_api_isnt_available
 
-      announcement_params = [
-        {
-          id: announcement.id,
-          position: 2,
-        },
-        {
-          id: another_announcement.id,
-          position: 1,
-        },
-      ]
+      announcement_params = {
+        announcement.id => 2,
+        another_announcement.id => 1,
+      }
 
       put :update, params: {
         page_slug: page.slug,
-        announcement_order_save: announcement_params.to_json,
+        announcement_order_save: announcement_params,
       }
 
       expect(announcement.reload.position).to eq 1
       expect(another_announcement.reload.position).to eq 2
       expect(subject).to redirect_to(reorder_coronavirus_page_announcements_path(page.slug))
+    end
+
+    context "when a user manually enters an unconventional ordering approach" do
+      it "applies our expected incremental ordering" do
+        announcement_params = {
+          announcement.id => 50,
+          another_announcement.id => 100,
+        }
+
+        put :update, params: {
+          page_slug: page.slug,
+          announcement_order_save: announcement_params,
+        }
+
+        expect(announcement.reload.position).to eq 1
+        expect(another_announcement.reload.position).to eq 2
+        expect(subject).to redirect_to(coronavirus_page_path(page.slug))
+      end
     end
   end
 end

--- a/spec/controllers/coronavirus/reorder_sub_sections_controller_spec.rb
+++ b/spec/controllers/coronavirus/reorder_sub_sections_controller_spec.rb
@@ -21,11 +21,9 @@ RSpec.describe Coronavirus::ReorderSubSectionsController do
       stub_coronavirus_publishing_api
     end
 
-    let(:sub_section_0) { create :coronavirus_sub_section, position: 0, page: page }
-    let(:sub_section_1) { create :coronavirus_sub_section, position: 1, page: page }
-    let(:sub_section_0_params) { { id: sub_section_0.id, position: 1 } }
-    let(:sub_section_1_params) { { id: sub_section_1.id, position: 0 } }
-    let(:section_params) { [sub_section_0_params, sub_section_1_params].to_json }
+    let(:sub_section_0) { create :coronavirus_sub_section, position: 1, page: page }
+    let(:sub_section_1) { create :coronavirus_sub_section, position: 2, page: page }
+    let(:section_params) { { sub_section_0.id => 2, sub_section_1.id => 1 } }
 
     subject { put :update, params: { page_slug: slug, section_order_save: section_params } }
 
@@ -35,18 +33,27 @@ RSpec.describe Coronavirus::ReorderSubSectionsController do
 
     it "reorders the sections" do
       subject
-      expect(sub_section_0.reload.position).to eq 1
-      expect(sub_section_1.reload.position).to eq 0
+      expect(sub_section_0.reload.position).to eq 2
+      expect(sub_section_1.reload.position).to eq 1
+    end
+
+    context "when a user manually enters an unconventional ordering approach" do
+      let(:section_params) { { sub_section_0.id => 50, sub_section_1.id => 100 } }
+
+      it "applies our expected incremental ordering" do
+        subject
+        expect(sub_section_0.reload.position).to eq 1
+        expect(sub_section_1.reload.position).to eq 2
+      end
     end
 
     context "when the submitted positions match the existing" do
-      let(:sub_section_0_params) { { id: sub_section_0.id, position: 0 } }
-      let(:sub_section_1_params) { { id: sub_section_1.id, position: 1 } }
+      let(:section_params) { { sub_section_0.id => 1, sub_section_1.id => 2 } }
 
       it "keeps the section order" do
         subject
-        expect(sub_section_0.reload.position).to eq 0
-        expect(sub_section_1.reload.position).to eq 1
+        expect(sub_section_0.reload.position).to eq 1
+        expect(sub_section_1.reload.position).to eq 2
       end
     end
 
@@ -57,8 +64,8 @@ RSpec.describe Coronavirus::ReorderSubSectionsController do
 
       it "keeps the existing order if draft updater fails" do
         subject
-        expect(sub_section_0.reload.position).to eq 0
-        expect(sub_section_1.reload.position).to eq 1
+        expect(sub_section_0.reload.position).to eq 1
+        expect(sub_section_1.reload.position).to eq 2
       end
 
       it "redirects to coronavirus page on success" do

--- a/spec/controllers/coronavirus/reorder_timeline_entries_controller_spec.rb
+++ b/spec/controllers/coronavirus/reorder_timeline_entries_controller_spec.rb
@@ -33,20 +33,14 @@ RSpec.describe Coronavirus::ReorderTimelineEntriesController do
     end
 
     it "reorders the timeline entries" do
-      timeline_entry_params = [
-        {
-          id: first_timeline_entry.id,
-          position: 2,
-        },
-        {
-          id: second_timeline_entry.id,
-          position: 1,
-        },
-      ]
+      timeline_entry_params = {
+        first_timeline_entry.id => 2,
+        second_timeline_entry.id => 1,
+      }
 
       put :update, params: {
         page_slug: page.slug,
-        timeline_entry_order_save: timeline_entry_params.to_json,
+        timeline_entry_order_save: timeline_entry_params,
       }
 
       expect(first_timeline_entry.reload.position).to eq 2
@@ -55,20 +49,14 @@ RSpec.describe Coronavirus::ReorderTimelineEntriesController do
     end
 
     it "keeps the existing order if submitted without changes" do
-      timeline_entry_params = [
-        {
-          id: first_timeline_entry.id,
-          position: 1,
-        },
-        {
-          id: second_timeline_entry.id,
-          position: 2,
-        },
-      ]
+      timeline_entry_params = {
+        first_timeline_entry.id => 1,
+        second_timeline_entry.id => 2,
+      }
 
       put :update, params: {
         page_slug: page.slug,
-        timeline_entry_order_save: timeline_entry_params.to_json,
+        timeline_entry_order_save: timeline_entry_params,
       }
 
       expect(first_timeline_entry.reload.position).to eq 1
@@ -79,25 +67,37 @@ RSpec.describe Coronavirus::ReorderTimelineEntriesController do
     it "keeps the existing order if updating the draft fails" do
       stub_publishing_api_isnt_available
 
-      timeline_entry_params = [
-        {
-          id: first_timeline_entry.id,
-          position: 2,
-        },
-        {
-          id: second_timeline_entry.id,
-          position: 1,
-        },
-      ]
+      timeline_entry_params = {
+        first_timeline_entry.id => 2,
+        second_timeline_entry.id => 1,
+      }
 
       put :update, params: {
         page_slug: page.slug,
-        timeline_entry_order_save: timeline_entry_params.to_json,
+        timeline_entry_order_save: timeline_entry_params,
       }
 
       expect(first_timeline_entry.reload.position).to eq 1
       expect(second_timeline_entry.reload.position).to eq 2
       expect(response).to redirect_to(reorder_coronavirus_page_timeline_entries_path(page.slug))
+    end
+
+    context "when a user manually enters an unconventional ordering approach" do
+      it "applies our expected incremental ordering" do
+        timeline_entry_params = {
+          first_timeline_entry.id => 50,
+          second_timeline_entry.id => 100,
+        }
+
+        put :update, params: {
+          page_slug: page.slug,
+          timeline_entry_order_save: timeline_entry_params,
+        }
+
+        expect(first_timeline_entry.reload.position).to eq 1
+        expect(second_timeline_entry.reload.position).to eq 2
+        expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      end
     end
   end
 end

--- a/spec/javascripts/components/reorderable-list-spec.js
+++ b/spec/javascripts/components/reorderable-list-spec.js
@@ -1,0 +1,205 @@
+/* global spyOnEvent */
+
+describe('Reorderable list component', function () {
+  'use strict'
+
+  var container
+  var element
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+    '<ol class="app-c-reorderable-list" data-module="reorderable-list">' +
+      '<li class="app-c-reorderable-list__item">' +
+        '<div class="app-c-reorderable-list__wrapper">' +
+          '<div class="app-c-reorderable-list__content">' +
+            '<p class="app-c-reorderable-list__title">First attachment</p>' +
+          '</div>' +
+          '<div class="app-c-reorderable-list__actions">' +
+            '<input name="new_order[]" value="1" class="gem-c-input govuk-input govuk-input--width-2" id="input-278a8924" type="text">' +
+            '<button type="button" class="js-reorderable-list-up">Up</button>' +
+            '<button type="button" class="js-reorderable-list-down">Down</button>' +
+          '</div>' +
+        '</div>' +
+      '</li>' +
+      '<li class="app-c-reorderable-list__item">' +
+        '<div class="app-c-reorderable-list__wrapper">' +
+          '<div class="app-c-reorderable-list__content">' +
+            '<p class="app-c-reorderable-list__title">Second attachment</p>' +
+          '</div>' +
+          '<div class="app-c-reorderable-list__actions">' +
+            '<input name="new_order[]" value="2" class="gem-c-input govuk-input govuk-input--width-2" id="input-278a8924" type="text">' +
+            '<button type="button" class="js-reorderable-list-up">Up</button>' +
+            '<button type="button" class="js-reorderable-list-down">Down</button>' +
+          '</div>' +
+        '</div>' +
+      '</li>' +
+    '</ol>'
+
+    document.body.classList.add('js-enabled')
+    document.body.appendChild(container)
+    element = document.querySelector('[data-module="reorderable-list"]')
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  describe('when `matchMedia` is not supported', function () {
+    var matchMedia = window.matchMedia
+    var mockMatchMedia
+    var reorderableList
+
+    beforeEach(function () {
+      window.matchMedia = mockMatchMedia
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      spyOn(reorderableList, 'setupResponsiveChecks')
+      reorderableList.start($(element))
+    })
+
+    afterEach(function () {
+      window.matchMedia = matchMedia
+    })
+
+    it('should not setup responsive checks', function () {
+      expect(reorderableList.setupResponsiveChecks).not.toHaveBeenCalled()
+    })
+
+    it('should disable drag and drop', function () {
+      expect(reorderableList.sortable.option('disabled')).toBe(true)
+    })
+  })
+
+  describe('when `matchMedia` is supported', function () {
+    var matchMedia = window.matchMedia
+    var mockMatchMedia = matchMedia
+    var reorderableList
+
+    var matchMediaMock = function (reorderableList, matches) {
+      var bindedcheckMode = reorderableList.checkMode.bind(reorderableList)
+      reorderableList.mediaQueryList = { matches: matches }
+      reorderableList.sortable = new window.Sortable.create(element) // eslint-disable-line new-cap
+      spyOn(reorderableList.sortable, 'option')
+      bindedcheckMode()
+    }
+
+    beforeEach(function () {
+      window.matchMedia = mockMatchMedia
+      reorderableList = new GOVUK.Modules.ReorderableList()
+    })
+
+    afterEach(function () {
+      window.matchMedia = matchMedia
+    })
+
+    it('should setup responsive checks', function () {
+      spyOn(reorderableList, 'setupResponsiveChecks')
+      reorderableList.start($(element))
+
+      expect(reorderableList.setupResponsiveChecks).toHaveBeenCalled()
+    })
+
+    it('should enable drag and drop if rendered on a large device', function () {
+      matchMediaMock(reorderableList, true)
+
+      expect(reorderableList.sortable.option).toHaveBeenCalledWith('disabled', false)
+    })
+
+    it('should disable drag and drop if rendered on a small device', function () {
+      matchMediaMock(reorderableList, false)
+
+      expect(reorderableList.sortable.option).toHaveBeenCalledWith('disabled', true)
+    })
+  })
+
+  describe('when dragging the first element to the bottom', function () {
+    var reorderableList
+    var sortable
+    beforeEach(function () {
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList.start($(element))
+      spyOnEvent($(element), 'reorder-drag')
+      sortable = reorderableList.sortable
+      sortable.sort(sortable.toArray().reverse())
+      sortable.options.onSort() // not triggered by 'sort'
+    })
+
+    it('should swaps current item with next item', function () {
+      var firstItemTitle = document.querySelector('li:nth-child(1) .app-c-reorderable-list__title').textContent
+      var secondItemTitle = document.querySelector('li:nth-child(2) .app-c-reorderable-list__title').textContent
+      expect(firstItemTitle).toEqual('Second attachment')
+      expect(secondItemTitle).toEqual('First attachment')
+    })
+
+    it('should update the associated indexes', function () {
+      var firstItemNewIndex = document.querySelector('li:nth-child(1) input[type=text]').value
+      var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
+      expect(firstItemNewIndex).toEqual('1')
+      expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-drag event', function () {
+      expect('reorder-drag').toHaveBeenTriggeredOn($(element))
+    })
+  })
+
+  describe('when clicking the Down button on first item', function () {
+    var reorderableList
+    var firstItemDownButton
+    beforeEach(function () {
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList.start($(element))
+      firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
+      spyOnEvent(firstItemDownButton, 'reorder-move-down')
+      firstItemDownButton.click()
+    })
+
+    it('should swaps current item with next item', function () {
+      var firstItemTitle = document.querySelector('li:nth-child(1) .app-c-reorderable-list__title').textContent
+      var secondItemTitle = document.querySelector('li:nth-child(2) .app-c-reorderable-list__title').textContent
+      expect(firstItemTitle).toEqual('Second attachment')
+      expect(secondItemTitle).toEqual('First attachment')
+    })
+
+    it('should update the associated indexes', function () {
+      var firstItemNewIndex = document.querySelector('li:nth-child(1) input[type=text]').value
+      var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
+      expect(firstItemNewIndex).toEqual('1')
+      expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-move-down event', function () {
+      expect('reorder-move-down').toHaveBeenTriggeredOn(firstItemDownButton)
+    })
+  })
+
+  describe('when clicking the Up button on the second item', function () {
+    var reorderableList
+    var secondItemUpButton
+    beforeEach(function () {
+      reorderableList = new GOVUK.Modules.ReorderableList()
+      reorderableList.start($(element))
+      secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
+      spyOnEvent(secondItemUpButton, 'reorder-move-up')
+      secondItemUpButton.click()
+    })
+
+    it('should swaps current item with previous item', function () {
+      var firstItemTitle = document.querySelector('li:nth-child(1) .app-c-reorderable-list__title').textContent
+      var secondItemTitle = document.querySelector('li:nth-child(2) .app-c-reorderable-list__title').textContent
+      expect(firstItemTitle).toEqual('Second attachment')
+      expect(secondItemTitle).toEqual('First attachment')
+    })
+
+    it('should update the associated indexes', function () {
+      var firstItemNewIndex = document.querySelector('li:nth-child(1) input[type=text]').value
+      var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
+      expect(firstItemNewIndex).toEqual('1')
+      expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-move-up event', function () {
+      expect('reorder-move-up').toHaveBeenTriggeredOn(secondItemUpButton)
+    })
+  })
+})

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -244,7 +244,7 @@ module CoronavirusFeatureSteps
   def when_i_move_announcement_one_down
     stub_coronavirus_landing_page_content(@coronavirus_page)
 
-    within("#step-0") { click_button "Down" }
+    within(".app-c-reorderable-list__item:first-child") { click_button "Down" }
     click_button "Save"
   end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -377,7 +377,7 @@ module CoronavirusFeatureSteps
   def when_i_move_timeline_entry_one_down
     stub_coronavirus_landing_page_content(@coronavirus_page)
 
-    within("#step-0") { click_button "Down" }
+    within(".app-c-reorderable-list__item:first-child") { click_button "Down" }
     click_button "Save"
   end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -450,12 +450,11 @@ module CoronavirusFeatureSteps
   end
 
   def i_see_subsection_one_in_position_one
-    element = find("#step-0")
-    expect(element).to have_content "I am first"
+    expect(find(".app-c-reorderable-list:first-child")).to have_content "I am first"
   end
 
   def and_i_move_section_one_down
-    within("#step-0") { click_button "Down" }
+    all("button", text: "Down").first.click
     click_button "Save"
     expect(page).to have_content "Sections were successfully reordered."
   end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,6 +2361,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+sortablejs@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.13.0.tgz#3ab2473f8c69ca63569e80b1cd1b5669b51269e9"
+  integrity sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg==
+
 source-map@^0.5.0:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"


### PR DESCRIPTION
## What

A list of items that can be reordered

List items can be reordered by drag and drop or by using the up/down buttons. On small viewports the drag and drop feature is disabled to prevent being triggered when scrolling on touch devices.

This component uses SortableJS - a JavaScript library for drag and drop interactions. When JavaScript is disabled a set of inputs will be shown allowing users to provide an order index for each item.

## Why

This is used by publishing tools to allow reordering of lists such as steps in step by step, entries in timelines and order of visual presentation of attachments.

## Disclaimer

This is a port/extension of the work that @alex-ju has done on the content publisher app.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/lC2JWGGa/1090-update-publishing-tools-to-use-new-component

![screenshot-collections-publisher dev gov uk_3000-2021 02 16-17_29_38](https://user-images.githubusercontent.com/4599889/108099673-d531d300-707c-11eb-9c67-4c6b59f2dfb9.png)
