### PR TITLE
Fix components guide

### DIFF
--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -28,7 +28,8 @@ examples:
         id: markdown-editor
   with_bullet_list_button:
     data:
-      controls: [:bullets]
+      controls:
+        - :bullets
       label:
         text: Body
       textarea:
@@ -36,7 +37,8 @@ examples:
         id: markdown-editor
   with_headings_buttons:
     data:
-      controls: [:headings]
+      controls:
+        - :headings
       label:
         text: Body
       textarea:
@@ -44,7 +46,8 @@ examples:
         id: markdown-editor
   with_blockquote_button:
     data:
-      controls: [:blockquote]
+      controls:
+        - :blockquote
       label:
         text: Body
       textarea:
@@ -52,7 +55,8 @@ examples:
         id: markdown-editor
   with_numbered_list_button:
     data:
-      controls: [:numbered_list]
+      controls:
+        - :numbered_list
       label:
         text: Body
       textarea:

--- a/spec/features/components_guide_spec.rb
+++ b/spec/features/components_guide_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Visit Component Guide" do
+  scenario "User views the component guide page" do
+    when_i_visit_the_component_guide_index_page
+    then_i_receive_a_valid_response
+  end
+
+  def when_i_visit_the_component_guide_index_page
+    visit "/component-guide"
+  end
+
+  def then_i_receive_a_valid_response
+    expect(page.status_code).to eq(200)
+  end
+end


### PR DESCRIPTION
This change fixes the components guide endpoint in collections publisher. There was a bug in the yaml file which stopped the guide from rendering, this has now been fixed and a small test added to make sure the components guide loads.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
