### PR TITLE
Subsection bug

### DIFF
--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -23,11 +23,17 @@ module Coronavirus
 
     def update
       @sub_section = page.sub_sections.find(params[:id])
-      if @sub_section.update(sub_section_params) && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: "Sub-section was successfully updated."
-      else
+
+      SubSection.transaction do
+        @sub_section.update!(sub_section_params)
+        raise ActiveRecord::Rollback unless draft_updater.send
+      end
+
+      if draft_updater.errors.any?
         @sub_section.errors.add :base, draft_updater.errors.to_sentence
         render :edit
+      else
+        redirect_to coronavirus_page_path(page.slug), { notice: "Sub-section was successfully updated." }
       end
     end
 

--- a/spec/controllers/coronavirus/sub_sections_controller_spec.rb
+++ b/spec/controllers/coronavirus/sub_sections_controller_spec.rb
@@ -144,6 +144,15 @@ RSpec.describe Coronavirus::SubSectionsController do
       expect(sub_section.title).to eq(title)
       expect(sub_section.content).to eq(content)
     end
+
+    context "given invalid content" do
+      let(:content) { "invalid content" }
+
+      it "doesn't change the subsection" do
+        expect { subject }.not_to(change { sub_section.reload.attributes })
+        expect(subject.body).to include("Unable to parse markdown")
+      end
+    end
   end
 
   describe "DELETE /coronavirus/:page_slug/sub_sections/:id" do


### PR DESCRIPTION
In the previous configuration we had accidentally allowed the user to save changes to a sub-section even if there were errors with it. This wraps the sub-section changes in a transaction whilst we call on the draft updater, so they can be rolled back in the event that the draft updater finds errors.

There will be no visual changes for the user 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/p6Rq4Gj8/163-stop-saving-subsections-with-invalid-markdown-the-band-aid-method)