### PR TITLE
Move index page content to locale file

### DIFF
--- a/app/views/coronavirus/pages/index.html.erb
+++ b/app/views/coronavirus/pages/index.html.erb
@@ -11,6 +11,6 @@
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2"><%=page.name%></h2>
   <ul class="govuk-list">
     <li class="covid__spaced-list-item"><%= link_to t("coronavirus.pages.index.subtopic_edit.accordions", page_name: page.name.downcase), coronavirus_page_path(slug: page.slug), class:"govuk-link" %></li>
-    <li class="covid__spaced-list-item"><%= link_to "#{t("coronavirus.pages.index.subtopic_edit.something")} #{page.name.downcase}", prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
+    <li class="covid__spaced-list-item"><%= link_to t("coronavirus.pages.index.subtopic_edit.something_else", page_name: page.name.downcase), prepare_coronavirus_page_path(slug: page[:slug]), class:"govuk-link" %></li>
   </ul>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
           something_else: Edit something else on the landing page
         subtopic_edit:
           accordions: "Edit %{page_name} accordions"
-          something: Edit something else on the
+          something_else: Edit something else on the %{page_name}
       live:
         heading: 6. Check live
         button_text: View live version

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -138,23 +138,23 @@ module CoronavirusFeatureSteps
   end
 
   def i_see_a_publish_landing_page_link
-    expect(page).to have_link("Edit something else on the landing page")
+    expect(page).to have_link(I18n.t("coronavirus.pages.index.landing_page_edit.something_else"))
   end
 
   def i_see_a_publish_business_page_link
-    expect(page).to have_link("Edit something else on the business hub")
+    expect(page).to have_link(I18n.t("coronavirus.pages.index.subtopic_edit.something_else", page_name: "business hub"))
   end
 
   def i_see_livestream_button
-    expect(page).to have_link("Edit live stream URL")
+    expect(page).to have_link(I18n.t("coronavirus.pages.index.landing_page_edit.live_stream_url"))
   end
 
   def and_i_select_landing_page
-    click_link("Edit something else on the landing page")
+    click_link(I18n.t("coronavirus.pages.index.landing_page_edit.something_else"))
   end
 
   def and_i_select_business_page
-    click_link("Edit something else on the business hub")
+    click_link(I18n.t("coronavirus.pages.index.subtopic_edit.something_else", page_name: "business hub"))
   end
 
   def and_i_select_live_stream


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: https://github.com/alphagov/collections-publisher/pull/1275

# What?
Moves index page content to locale file and updates the feature tests to read index page content from the locale file. 
Also changes a field name to be consistent with the landing page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
