### PR TITLE
Move coronavirus livestream content to locale file

### DIFF
--- a/app/controllers/coronavirus/live_stream_controller.rb
+++ b/app/controllers/coronavirus/live_stream_controller.rb
@@ -11,9 +11,9 @@ module Coronavirus
       @live_stream = LiveStream.last
       if @live_stream.update(url: url_params, formatted_stream_date: formatted_date)
         if updater.update
-          flash[:notice] = "Draft live stream url updated!"
+          flash[:notice] = I18n.t("coronavirus.live_stream.update.success")
         else
-          flash[:alert] = "Live stream url has not been updated - please try again"
+          flash[:alert] = I18n.t("coronavirus.live_stream.update.failed")
         end
       else
         flash[:alert] = @live_stream.errors.full_messages.join(", ")
@@ -23,9 +23,9 @@ module Coronavirus
 
     def publish
       if updater.publish
-        flash[:notice] = "New live stream url published!"
+        flash[:notice] = I18n.t("coronavirus.live_stream.publish.success")
       else
-        flash[:alert] = "Live stream url has not been published - please try again"
+        flash[:alert] = I18n.t("coronavirus.live_stream.publish.failed")
       end
       redirect_to coronavirus_live_stream_index_path
     end

--- a/app/controllers/coronavirus/live_stream_controller.rb
+++ b/app/controllers/coronavirus/live_stream_controller.rb
@@ -11,9 +11,9 @@ module Coronavirus
       @live_stream = LiveStream.last
       if @live_stream.update(url: url_params, formatted_stream_date: formatted_date)
         if updater.update
-          flash[:notice] = I18n.t("coronavirus.live_stream.update.success")
+          flash[:notice] = helpers.t("coronavirus.live_stream.update.success")
         else
-          flash[:alert] = I18n.t("coronavirus.live_stream.update.failed")
+          flash[:alert] = helpers.t("coronavirus.live_stream.update.failed")
         end
       else
         flash[:alert] = @live_stream.errors.full_messages.join(", ")
@@ -23,9 +23,9 @@ module Coronavirus
 
     def publish
       if updater.publish
-        flash[:notice] = I18n.t("coronavirus.live_stream.publish.success")
+        flash[:notice] = helpers.t("coronavirus.live_stream.publish.success")
       else
-        flash[:alert] = I18n.t("coronavirus.live_stream.publish.failed")
+        flash[:alert] = helpers.t("coronavirus.live_stream.publish.failed")
       end
       redirect_to coronavirus_live_stream_index_path
     end

--- a/app/views/coronavirus/live_stream/index.html.erb
+++ b/app/views/coronavirus/live_stream/index.html.erb
@@ -1,61 +1,57 @@
-<% content_for :title, "Update live stream URL" %>
+<% content_for :title, t("coronavirus.live_stream.index.title") %>
 <% content_for :context, "Make changes to the coronavirus landing page live stream" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <div class="govuk-form-group">
       <%= render "govuk_publishing_components/components/heading", {
-        text: "1. Add the URL",
+        text: t("coronavirus.live_stream.index.instructions.one.step"),
         padding: true
       } %>
       <% unless livestream_editor? %>
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              Help with YouTube
+              <%= t("coronavirus.live_stream.index.instructions.one.summary.title") %>
             </span>
           </summary>
           <div class="govuk-details__text">
-            <p>Every afternoon, No.10 adds a video link to the upcoming press conference to this <a href="https://www.youtube.com/user/Number10gov/videos?view=2">page</a>.</p>
-            <p>The video will appear in the 'Uploads' section of the page and is labelled as 'Live'.</p>
-            <p>The video is added at around 4.30pm on weekdays, and 3.30pm on weekends.</p>
-            <p>If the most recent video has yesterday's date, or there is no video labelled 'Live' check again in a few minutes.</p>
-            <p>Click on the video, and copy its URL.</p>
+            <%= render_markdown t("coronavirus.live_stream.index.instructions.one.summary.content_markdown") %>
           </div>
         </details>
       <% end %>
-      <%= form_with(url: coronavirus_live_stream_path(@live_stream), method: "put", local: true) do %>
-        <%= label_tag(:url, "YouTube URL", class: "govuk-label" ) %>
+      <%= form_with(url: coronavirus_live_stream_path(@live_stream), method: :put) do %>
+        <%= label_tag(:url, t("coronavirus.live_stream.index.instructions.one.label"), class: "govuk-label" ) %>
         <%= text_field_tag(:url, nil,
           class: "govuk-input govuk-!-margin-bottom-6",
-          placeholder: "eg. https://www.youtube.com/watch?v=d3ieIwP4FKg"
+          placeholder: t("coronavirus.live_stream.index.instructions.one.url_placeholder")
           ) %>
 
-        <%= submit_tag("Update draft", class: "govuk-button") %>
+        <%= submit_tag(t("coronavirus.live_stream.index.instructions.one.button_text"), class: "govuk-button") %>
       <% end %>
       <%= render "govuk_publishing_components/components/heading", {
-        text: "2. Preview your changes",
+        text: t("coronavirus.live_stream.index.instructions.two.step"),
         padding: true
       } %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Preview",
+        text: t("coronavirus.live_stream.index.instructions.two.button_text"),
         href: draft_govuk_url("/coronavirus"),
         target: "_blank",
         secondary: true
       } %>
       </div>
       <%= render "govuk_publishing_components/components/heading", {
-        text: "3. Publish your changes",
+        text: t("coronavirus.live_stream.index.instructions.three.step"),
         padding: true
       } %>
       <div>
-        <%= link_to "Publish", coronavirus_live_stream_publish_path(@live_stream), method: :post, class: "govuk-button" %>
+        <%= link_to t("coronavirus.live_stream.index.instructions.three.button_text"), coronavirus_live_stream_publish_path(@live_stream), method: :post, class: "govuk-button" %>
       </div>
       <%= render "govuk_publishing_components/components/heading", {
-        text: "4. Check the live landing page",
+        text: t("coronavirus.live_stream.index.instructions.four.step"),
         padding: true
       } %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Check live",
+        text: t("coronavirus.live_stream.index.instructions.four.button_text"),
         href: published_url("coronavirus"),
         target: "_blank",
         secondary: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,12 @@
 en:
   coronavirus:
+    live_stream:
+      update:
+        success: Draft live stream url updated!
+        failed: Live stream url has not been updated - please try again
+      publish:
+        success: New live stream url published!
+        failed: Live stream url has not been published - please try again
     pages:
       actions:
         discard_changes: Discard changes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,35 @@
 en:
   coronavirus:
     live_stream:
+      index:
+        title: Update live stream URL
+        instructions:
+          one:
+            step: 1. Add the URL
+            summary:
+              title: Help with YouTube
+              content_markdown: |
+                Every afternoon, No.10 adds a video link to the upcoming press conference to this [page](https://www.youtube.com/user/Number10gov/videos?view=2)
+
+                The video will appear in the 'Uploads' section of the page and is labelled as 'Live'.
+
+                The video is added at around 4.30pm on weekdays, and 3.30pm on weekends.
+
+                If the most recent video has yesterday's date, or there is no video labelled 'Live' check again in a few minutes.
+
+                Click on the video, and copy its URL.
+            label: YouTube URL
+            url_placeholder: e.g. https://www.youtube.com/watch?v=d3ieIwP4FKg
+            button_text: Update draft
+          two:
+            step: 2. Preview your changes
+            button_text: Preview
+          three:
+            step: 3. Publish your change
+            button_text: Publish
+          four:
+            step: 4. Check the live landing page
+            button_text: Check live
       update:
         success: Draft live stream url updated!
         failed: Live stream url has not been updated - please try again

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -614,11 +614,11 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_see_live_stream_is_updated_message
-    expect(page).to have_text("Draft live stream url updated!")
+    expect(page).to have_text(I18n.t("coronavirus.live_stream.update.success"))
   end
 
   def and_i_see_live_stream_is_published_message
-    expect(page).to have_text("New live stream url published!")
+    expect(page).to have_text(I18n.t("coronavirus.live_stream.publish.success"))
   end
 
   def and_i_see_the_error_message

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -159,27 +159,27 @@ module CoronavirusFeatureSteps
 
   def and_i_select_live_stream
     click_link("Edit live stream URL")
-    expect(page).to have_text("Update live stream URL")
+    expect(page).to have_text(I18n.t("coronavirus.live_stream.index.title"))
   end
 
   def i_am_able_to_update_draft_content_with_valid_url
     fill_in("url", with: valid_url)
-    click_on("Update draft")
+    click_on(I18n.t("coronavirus.live_stream.index.instructions.one.button_text"))
     the_payload_contains_the_valid_url
   end
 
   def and_i_can_publish_the_url
-    click_on("Publish")
+    click_on(I18n.t("coronavirus.live_stream.index.instructions.three.button_text"))
     assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
   end
 
   def and_i_can_check_the_preview
-    expect(page).to have_link("Preview", href: "https://draft-origin.test.gov.uk/coronavirus")
+    expect(page).to have_link(I18n.t("coronavirus.live_stream.index.instructions.two.button_text"), href: "https://draft-origin.test.gov.uk/coronavirus")
   end
 
   def i_am_able_to_submit_an_invalid_url
     fill_in("url", with: invalid_url)
-    click_on("Update draft")
+    click_on(I18n.t("coronavirus.live_stream.index.instructions.one.button_text"))
   end
 
   def when_i_visit_the_coronavirus_index_page
@@ -630,6 +630,9 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_see_a_link_to_the_landing_page
-    expect(page).to have_link("Check live", href: "https://www.test.gov.uk/coronavirus")
+    expect(page).to have_link(
+      I18n.t("coronavirus.live_stream.index.instructions.four.button_text"),
+      href: "https://www.test.gov.uk/coronavirus",
+    )
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What?
Moves live stream page content to locale file and updates the feature tests to read live stream page content from the locale file.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
