### PR TITLE
Remove "accordions" from summary page breadcrumb

### DIFF
--- a/app/views/coronavirus/pages/show.html.erb
+++ b/app/views/coronavirus/pages/show.html.erb
@@ -5,7 +5,7 @@
       href: coronavirus_pages_path
     },
     {
-      text: t("coronavirus.pages.show.accordion_text", coronavirus_page_name: @page.name)
+      text: @page.name
     }
   ]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,6 @@ en:
         button_text: Publish
       show:
         link_text: Coronavirus pages
-        accordion_text: "%{coronavirus_page_name} accordions"
       sub_sections:
         confirm: Are you sure?
         reorder: Reorder


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What?

The summary page allows more than just accordions (sub-sections) to be edited now

# Expected changes
## Before
![screenshot-collections-publisher integration publishing service gov uk-2021 02 19-14_30_02](https://user-images.githubusercontent.com/5793815/108517245-144f6680-72bf-11eb-8c02-ab67c6a11921.png)


## After
![screenshot-collections-publisher dev gov uk-2021 02 19-14_29_10](https://user-images.githubusercontent.com/5793815/108517231-10234900-72bf-11eb-9b33-b3050a4f23af.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
