### PR TITLE
Tidy up `PagesController`

### DIFF
--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -31,25 +31,12 @@ module Coronavirus
 
   private
 
-    def initialise_pages
-      page_configs.keys.map do |page|
-        Pages::ModelBuilder.new(page.to_s).page
-      end
-    end
-
     def page
       @page ||= Pages::ModelBuilder.call(slug)
     end
 
     def draft_updater
       @draft_updater ||= Pages::DraftUpdater.new(page)
-    end
-
-    def redirect_to_index_if_slug_unknown
-      if slug_unknown?
-        flash[:alert] = "'#{slug}' is not a valid page.  Please select from one of those below."
-        redirect_to coronavirus_pages_path
-      end
     end
 
     def publish_page
@@ -64,8 +51,21 @@ module Coronavirus
       params[:slug]
     end
 
+    def redirect_to_index_if_slug_unknown
+      if slug_unknown?
+        flash[:alert] = "'#{slug}' is not a valid page.  Please select from one of those below."
+        redirect_to coronavirus_pages_path
+      end
+    end
+
     def slug_unknown?
       !page_configs.key?(slug.to_sym)
+    end
+
+    def initialise_pages
+      page_configs.keys.map do |page_config|
+        Pages::ModelBuilder.new(page_config.to_s).page
+      end
     end
 
     def page_configs

--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -54,21 +54,10 @@ module Coronavirus
 
     def publish_page
       Services.publishing_api.publish(page.content_id, "minor")
-      change_state("published")
+      page.update!(state: "published")
       flash["notice"] = "Page published!"
     rescue GdsApi::HTTPConflict
       flash["alert"] = "You have already published this page."
-    end
-
-    def with_longer_timeout
-      prior_timeout = Services.publishing_api.client.options[:timeout]
-      Services.publishing_api.client.options[:timeout] = 10
-
-      begin
-        yield
-      ensure
-        Services.publishing_api.client.options[:timeout] = prior_timeout
-      end
     end
 
     def slug
@@ -81,10 +70,6 @@ module Coronavirus
 
     def page_configs
       Pages::Configuration.all_pages
-    end
-
-    def change_state(state)
-      page.update(state: state)
     end
   end
 end

--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -16,7 +16,7 @@ module Coronavirus
 
     def publish
       publish_page
-      redirect_to coronavirus_page_path(slug)
+      redirect_to coronavirus_page_path(page.slug)
     end
 
     def discard
@@ -26,13 +26,13 @@ module Coronavirus
       else
         message = { alert: draft_updater.errors.to_sentence }
       end
-      redirect_to coronavirus_page_path(slug), message
+      redirect_to coronavirus_page_path(page.slug), message
     end
 
   private
 
     def page
-      @page ||= Pages::ModelBuilder.call(slug)
+      @page ||= Page.find_by(slug: slug)
     end
 
     def draft_updater

--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -1,7 +1,6 @@
 module Coronavirus
   class PagesController < ApplicationController
     before_action :require_coronavirus_editor_permissions!
-    before_action :redirect_to_index_if_slug_unknown, only: %w[show]
     before_action :initialise_pages, only: %w[index]
     layout "admin_layout"
 
@@ -32,7 +31,7 @@ module Coronavirus
   private
 
     def page
-      @page ||= Page.find_by(slug: slug)
+      @page ||= Page.find_by!(slug: params[:slug])
     end
 
     def draft_updater
@@ -45,21 +44,6 @@ module Coronavirus
       flash["notice"] = "Page published!"
     rescue GdsApi::HTTPConflict
       flash["alert"] = "You have already published this page."
-    end
-
-    def slug
-      params[:slug]
-    end
-
-    def redirect_to_index_if_slug_unknown
-      if slug_unknown?
-        flash[:alert] = "'#{slug}' is not a valid page.  Please select from one of those below."
-        redirect_to coronavirus_pages_path
-      end
-    end
-
-    def slug_unknown?
-      !page_configs.key?(slug.to_sym)
     end
 
     def initialise_pages

--- a/spec/controllers/coronavirus/pages_controller_spec.rb
+++ b/spec/controllers/coronavirus/pages_controller_spec.rb
@@ -35,11 +35,6 @@ RSpec.describe Coronavirus::PagesController do
       get :show, params: { slug: page.slug }
       expect(response).to have_http_status(:success)
     end
-
-    it "redirects to index with an unknown slug" do
-      get :show, params: { slug: "unknown" }
-      expect(response).to redirect_to(coronavirus_pages_path)
-    end
   end
 
   describe "GET /coronavirus/:slug/discard" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -245,12 +245,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         and_i_see_a_page_published_message
       end
 
-      scenario "Unconfigured page" do
-        when_i_visit_a_non_existent_page
-        then_i_am_redirected_to_the_index_page
-        and_i_see_a_message_telling_me_that_the_page_does_not_exist
-      end
-
       scenario "Viewing announcements" do
         when_i_visit_the_coronavirus_index_page
         and_i_select_business_page

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Publishing landing page" do
+      given_there_is_a_coronavirus_page
       when_i_visit_a_coronavirus_page
       and_i_publish_the_page
       then_the_page_publishes_a_minor_update
@@ -54,7 +55,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Discarding changes" do
-      stub_live_sub_sections_content_request(coronavirus_content_id)
+      given_there_is_a_published_coronavirus_page
       stub_discard_coronavirus_page_no_draft
       when_i_visit_a_coronavirus_page
       and_i_see_state_is_published

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -32,6 +32,10 @@ module CoronavirusFeatureSteps
     @timeline_entry_one = FactoryBot.create(:coronavirus_timeline_entry, page: @coronavirus_page, heading: "One")
   end
 
+  def given_there_is_a_published_coronavirus_page
+    @coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
+  end
+
   def the_payload_contains_the_valid_url
     live_stream_payload = coronavirus_live_stream_hash.merge(
       {
@@ -408,22 +412,22 @@ module CoronavirusFeatureSteps
   end
 
   def set_up_basic_sub_sections
-    coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
+    @coronavirus_page = FactoryBot.create(:coronavirus_page, :landing, state: "published")
     FactoryBot.create(:coronavirus_sub_section,
-                      page: coronavirus_page,
+                      page: @coronavirus_page,
                       position: 0,
                       title: "I am first",
-                      content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
+                      content: "###title\n[label](/url?priority-taxon=#{@coronavirus_page.content_id})")
     FactoryBot.create(:coronavirus_sub_section,
-                      page: coronavirus_page,
+                      page: @coronavirus_page,
                       position: 1,
                       title: "I am second",
-                      content: "###title\n[label](/url?priority-taxon=#{coronavirus_page.content_id})")
+                      content: "###title\n[label](/url?priority-taxon=#{@coronavirus_page.content_id})")
     path = Rails.root.join "spec/fixtures/simple_coronavirus_page.yml"
     github_yaml_content = File.read(path)
-    stub_request(:get, /#{coronavirus_page.raw_content_url}\?cache-bust=\d+/)
+    stub_request(:get, /#{@coronavirus_page.raw_content_url}\?cache-bust=\d+/)
       .to_return(status: 200, body: github_yaml_content)
-    stub_live_sub_sections_content_request(coronavirus_page.content_id)
+    stub_live_sub_sections_content_request(@coronavirus_page.content_id)
   end
 
   def coronavirus_content_json_with_sections(content_id)
@@ -445,6 +449,7 @@ module CoronavirusFeatureSteps
   end
 
   def stub_discard_coronavirus_page_no_draft
+    stub_live_sub_sections_content_request(@coronavirus_page.content_id)
     stub_any_publishing_api_discard_draft
       .to_return(status: 422, body: "You do not have a draft to discard")
   end
@@ -505,7 +510,7 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_see_state_is_published
-    expect(Coronavirus::Page.topic_page.first.state).to eq "published"
+    expect(@coronavirus_page.reload.state).to eq "published"
     expect(page).to have_text("Status: Published", normalize_ws: true)
   end
 
@@ -594,7 +599,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_the_page_publishes_a_minor_update
-    assert_publishing_api_publish("774cee22-d896-44c1-a611-e3109cce8eae", update_type: "minor")
+    assert_publishing_api_publish(@coronavirus_page.content_id, update_type: "minor")
   end
 
   def then_the_business_page_publishes

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -190,10 +190,6 @@ module CoronavirusFeatureSteps
     visit "/coronavirus"
   end
 
-  def when_i_visit_a_non_existent_page
-    visit "/coronavirus/flimflam"
-  end
-
   def when_i_visit_a_coronavirus_page
     visit "/coronavirus/landing"
   end
@@ -525,14 +521,6 @@ module CoronavirusFeatureSteps
 
   def i_see_error_message_no_changes_to_discard
     expect(page).to have_text("You do not have a draft to discard")
-  end
-
-  def then_i_am_redirected_to_the_index_page
-    expect(current_path).to eq("/coronavirus")
-  end
-
-  def and_i_see_a_message_telling_me_that_the_page_does_not_exist
-    expect(page).to have_text("'flimflam' is not a valid page")
   end
 
   def i_see_an_update_draft_button

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -441,7 +441,7 @@ module CoronavirusFeatureSteps
   end
 
   def stub_discard_subsection_changes
-    stub_publishing_api_discard_draft(Coronavirus::Page.topic_page.first.content_id)
+    stub_publishing_api_discard_draft(@coronavirus_page.content_id)
   end
 
   def stub_discard_coronavirus_page_draft
@@ -470,7 +470,7 @@ module CoronavirusFeatureSteps
       "list" => [
         {
           "label" => "label",
-          "url" => "/url?priority-taxon=#{Coronavirus::Page.topic_page.first.content_id}",
+          "url" => "/url?priority-taxon=#{@coronavirus_page.content_id}",
         },
       ],
     }
@@ -494,7 +494,7 @@ module CoronavirusFeatureSteps
     end
 
     assert_publishing_api_put_content(
-      Coronavirus::Page.topic_page.first.content_id,
+      @coronavirus_page.content_id,
       lambda do |request|
         details = JSON.parse(request.body)["details"]
         expect(details).to match hash_including({
@@ -515,7 +515,7 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_see_state_is_draft
-    expect(Coronavirus::Page.topic_page.first.state).to eq "draft"
+    expect(@coronavirus_page.reload.state).to eq "draft"
     expect(page).to have_text("Status: Draft", normalize_ws: true)
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1291

# What's changed and why?

In preparation for moving the content from the `PagesController` to a locale file, the controller has been tidied up a little. This means removing some unused methods, and retrieving models from the database rather than building them in memory.

There's also a rather controversial final commit that removes the redirect to the index page and instead throws a 404. The bonus to this is that we won't have to try to figure out where to put the content for "slug unknown" error message later.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
