### PR TITLE
Move announcements content to locale file

### DIFF
--- a/app/controllers/coronavirus/announcements_controller.rb
+++ b/app/controllers/coronavirus/announcements_controller.rb
@@ -11,7 +11,7 @@ module Coronavirus
     def create
       @announcement = page.announcements.new(announcement_params)
       if @announcement.save && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: "Announcement was successfully created."
+        redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.create.success")
       else
         render :new
       end
@@ -19,13 +19,13 @@ module Coronavirus
 
     def destroy
       announcement = page.announcements.find(params[:id])
-      message = { notice: "Announcement was successfully deleted." }
+      message = { notice: helpers.t("coronavirus.announcements.destroy.success") }
 
       Announcement.transaction do
         announcement.destroy!
 
         unless draft_updater.send
-          message = { alert: "Announcement couldn't be deleted" }
+          message = { alert: helpers.t("coronavirus.announcements.destroy.failed") }
           raise ActiveRecord::Rollback
         end
       end
@@ -41,7 +41,7 @@ module Coronavirus
       @announcement = page.announcements.find(params[:id])
 
       if @announcement.update(announcement_params) && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: "Announcement was successfully updated."
+        redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.update.success")
       else
         render :edit
       end

--- a/app/views/coronavirus/announcements/_form.html.erb
+++ b/app/views/coronavirus/announcements/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Enter the title of the announcement",
+    text: t("coronavirus.announcements.form.title.label"),
     bold: true,
   },
   name: "announcement[title]",
@@ -11,25 +11,25 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Enter the path to the announcement",
+    text: t("coronavirus.announcements.form.path.label"),
     bold: true,
   },
   name: "announcement[path]",
   value: @announcement.path,
   id: "path",
   error_message: error_items(@announcement.errors.messages, :path),
-  hint: "Example format: /government/news/coronavirus-covid-19",
+  hint: t("coronavirus.announcements.form.path.hint"),
 } %>
 
 <% legend = capture do %>
-  <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= "Enter the date of publication" %></span>
+  <span class="govuk-heading-s govuk-!-margin-bottom-0"><%= t("coronavirus.announcements.form.date.legend") %></span>
 <% end %>
 
 <%= render "govuk_publishing_components/components/date_input", {
   name: "announcement[published_at]",
   id: "published_at",
   legend_text: legend,
-  hint: "For example, 31 3 2020",
+  hint: t("coronavirus.announcements.form.date.hint"),
   error_message: error_items(@announcement.errors.messages, :published_at),
   items: [
     {

--- a/app/views/coronavirus/announcements/edit.html.erb
+++ b/app/views/coronavirus/announcements/edit.html.erb
@@ -5,11 +5,11 @@ links = [
     href: coronavirus_pages_path
   },
   {
-    text: "#{@page.name} announcements",
+    text: @page.name,
     href: coronavirus_page_path(slug: @page.slug)
   },
   {
-    text: "Edit"
+    text: t("coronavirus.announcements.edit.title")
   },
 ]
 
@@ -21,7 +21,7 @@ links = [
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page) %>
-<% content_for :context, 'Edit announcement' %>
+<% content_for :context, t("coronavirus.announcements.edit.title") %>
 <% if @announcement.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @announcement %>
 <% end %>

--- a/app/views/coronavirus/announcements/new.html.erb
+++ b/app/views/coronavirus/announcements/new.html.erb
@@ -5,11 +5,11 @@
       href: coronavirus_pages_path
     },
     {
-      text: "#{@page.name} announcements",
+      text: @page.name,
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: "Add announcement"
+      text: t("coronavirus.announcements.new.title")
     },
   ]
 
@@ -21,7 +21,7 @@
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page) %>
-<% content_for :context, "Add announcement" %>
+<% content_for :context, t("coronavirus.announcements.new.title") %>
 <% if @announcement.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @announcement %>
 <% end %>

--- a/app/views/coronavirus/pages/show/_announcements.html.erb
+++ b/app/views/coronavirus/pages/show/_announcements.html.erb
@@ -16,7 +16,7 @@
 
 <div class="covid-manage-page__summary-list--divider">
   <%= render "govuk_publishing_components/components/summary_list", {
-    title: "Announcements",
+    title: t("coronavirus.pages.show.announcements.title"),
     items: announcements,
     edit: {
       link_text: t("coronavirus.pages.show.announcements.reorder"),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
           reorder: Reorder
           add: Add accordion
         announcements:
+          title: Announcements
           confirm: Are you sure?
           reorder: Reorder
           add: Add announcement

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,13 +1,26 @@
 en:
   coronavirus:
     announcements:
+      new:
+        title: Add announcement
       create:
         success: Announcement was successfully created.
+      edit:
+        title: Edit announcement
       destroy:
         success: Announcement was successfully deleted.
         failed: Announcement couldn't be deleted
       update:
         success: Announcement was successfully updated.
+      form:
+        title:
+          label: Enter the title of the announcement
+        path:
+          label: Enter the path to the announcement
+          hint: "Example format: /government/news/coronavirus-covid-19"
+        date:
+          legend: Enter the date of publication
+          hint: For example, 31 3 2020
     github_changes:
       index:
         description: "Follow the steps below to make changes to any part of the %{coronavirus_page_name}, except the accordions."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,13 @@
 en:
   coronavirus:
+    announcements:
+      create:
+        success: Announcement was successfully created.
+      destroy:
+        success: Announcement was successfully deleted.
+        failed: Announcement couldn't be deleted
+      update:
+        success: Announcement was successfully updated.
     github_changes:
       index:
         description: "Follow the steps below to make changes to any part of the %{coronavirus_page_name}, except the accordions."

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -205,9 +205,9 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_an_announcements_section
-    expect(page).to have_content("Announcements")
-    expect(page).to have_link("Reorder", href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug))
-    expect(page).to have_link("Add announcement")
+    expect(page).to have_content(I18n.t("coronavirus.pages.show.announcements.title"))
+    expect(page).to have_link(I18n.t("coronavirus.pages.show.announcements.reorder"), href: reorder_coronavirus_page_announcements_path(@coronavirus_page.slug))
+    expect(page).to have_link(I18n.t("coronavirus.pages.show.announcements.add"))
   end
 
   def then_i_can_see_a_timeline_entries_section
@@ -217,7 +217,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_cannot_see_an_announcements_section
-    expect(page).to_not have_content("Announcements")
+    expect(page).to_not have_content(I18n.t("coronavirus.pages.show.announcements.title"))
   end
 
   def then_i_cannot_see_a_timeline_entries_section
@@ -262,7 +262,7 @@ module CoronavirusFeatureSteps
   # Adding an announcement
 
   def and_i_add_a_new_announcement
-    click_on("Add announcement")
+    click_on(I18n.t("coronavirus.pages.show.announcements.add"))
   end
 
   def then_i_see_the_create_announcement_form
@@ -289,7 +289,7 @@ module CoronavirusFeatureSteps
   def when_i_delete_an_announcement
     stub_coronavirus_landing_page_content(@coronavirus_page)
 
-    page.accept_alert "Are you sure?" do
+    page.accept_alert I18n.t("coronavirus.pages.show.announcements.confirm") do
       page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}\"]", text: "Delete").click
     end
   end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -266,9 +266,9 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_the_create_announcement_form
-    expect(page).to have_text("Enter the title of the announcement")
-    expect(page).to have_text("Enter the path to the announcement")
-    expect(page).to have_text("Enter the date of publication")
+    expect(page).to have_text(I18n.t("coronavirus.announcements.form.title.label"))
+    expect(page).to have_text(I18n.t("coronavirus.announcements.form.path.label"))
+    expect(page).to have_text(I18n.t("coronavirus.announcements.form.date.legend"))
   end
 
   def when_i_fill_in_the_announcement_form_with_valid_data
@@ -304,7 +304,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_the_edit_announcement_form
-    expect(page).to have_text("Edit announcement")
+    expect(page).to have_text(I18n.t("coronavirus.announcements.edit.title"))
   end
 
   def when_i_can_edit_the_announcement_form_with_valid_data

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -295,7 +295,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_an_announcement_has_been_deleted
-    expect(page).to have_text("Announcement was successfully deleted.")
+    expect(page).to have_text(I18n.t("coronavirus.announcements.destroy.success"))
     expect(page).not_to(have_text(@announcement_one.title))
   end
 
@@ -314,7 +314,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_that_the_announcement_has_been_updated
-    expect(page).to have_content("Announcement was successfully updated.")
+    expect(page).to have_content(I18n.t("coronavirus.announcements.update.success"))
     expect(page).to have_content("Updated title")
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves controller and view content for announcements to a locale file


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
