### PR TITLE
Move sub-sections content to locale file

### DIFF
--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -24,7 +24,7 @@ module Coronavirus
         flash.now["alert"] = draft_updater.errors.to_sentence
         render :new, status: :internal_server_error
       else
-        redirect_to coronavirus_page_path(page.slug), { notice: "Sub-section was successfully created." }
+        redirect_to coronavirus_page_path(page.slug), { notice: helpers.t("coronavirus.sub_sections.create.success") }
       end
     end
 
@@ -50,19 +50,19 @@ module Coronavirus
         flash.now["alert"] = draft_updater.errors.to_sentence
         render :edit, status: :internal_server_error
       else
-        redirect_to coronavirus_page_path(page.slug), { notice: "Sub-section was successfully updated." }
+        redirect_to coronavirus_page_path(page.slug), { notice: helpers.t("coronavirus.sub_sections.update.success") }
       end
     end
 
     def destroy
       sub_section = page.sub_sections.find(params[:id])
-      message = { notice: "Sub-section was successfully deleted." }
+      message = { notice: helpers.t("coronavirus.sub_sections.destroy.success") }
 
       SubSection.transaction do
         sub_section.destroy!
 
         unless draft_updater.send
-          message = { alert: "Sub-section couldn't be deleted" }
+          message = { alert: helpers.t("coronavirus.sub_sections.destroy.failed") }
           raise ActiveRecord::Rollback
         end
       end

--- a/app/views/coronavirus/sub_sections/_form.html.erb
+++ b/app/views/coronavirus/sub_sections/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Accordion name",
+    text: t("coronavirus.sub_sections.form.title.label"),
     bold: true
   },
   name: "sub_section[title]",
@@ -9,7 +9,7 @@
 } %>
 <%= render "components/markdown_editor", {
   label: {
-    text: "Links and link text",
+    text: t("coronavirus.sub_sections.form.content.label"),
     bold: true
   },
   textarea: {
@@ -21,7 +21,7 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Featured link",
+    text: t("coronavirus.sub_sections.form.featured_link.label"),
     bold: true
   },
   name: "sub_section[featured_link]",

--- a/app/views/coronavirus/sub_sections/edit.html.erb
+++ b/app/views/coronavirus/sub_sections/edit.html.erb
@@ -5,11 +5,11 @@ links = [
     href: coronavirus_pages_path
   },
   {
-    text: "#{@page.name} accordions",
+    text: @page.name,
     href: coronavirus_page_path(slug: @page.slug)
   },
   {
-    text: "Edit"
+    text: t("coronavirus.sub_sections.edit.title")
   },
 ]
 
@@ -21,7 +21,7 @@ links = [
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, @page.title %>
-<% content_for :context, 'Edit guidance and support accordion' %>
+<% content_for :context, t("coronavirus.sub_sections.edit.title") %>
 <% if @sub_section.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @sub_section %>
 <% end %>

--- a/app/views/coronavirus/sub_sections/new.html.erb
+++ b/app/views/coronavirus/sub_sections/new.html.erb
@@ -5,11 +5,11 @@
       href: coronavirus_pages_path
     },
     {
-      text: "#{@page.name} accordions",
+      text: @page.name,
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: "Add accordion"
+      text: t("coronavirus.sub_sections.new.title")
     },
   ]
 
@@ -21,7 +21,7 @@
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page) %>
-<% content_for :context, "Add accordion" %>
+<% content_for :context, t("coronavirus.sub_sections.new.title") %>
 <% if @sub_section.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @sub_section %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,25 @@ en:
           error: "Sorry! Timeline entries have not been reordered: %{error}."
           form:
             markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
+    sub_sections:
+      new:
+        title: Add accordion
+      create:
+        success: Sub-section was successfully created.
+      edit:
+        title: Edit guidance and support accordion
+      destroy:
+        success: Sub-section was successfully deleted.
+        failed: Sub-section couldn't be deleted
+      update:
+        success: Sub-section was successfully updated.
+      form:
+        title:
+          label: Accordion name
+        content:
+          label: Links and link text
+        featured_link:
+          label: Featured link
     timeline_entries:
       new:
         title: Add timeline entry


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves controller and view content for sub-sections (accordions) to a locale file


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
