### PR TITLE
Move timeline entries content to locale file

### DIFF
--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -11,7 +11,7 @@ module Coronavirus
       @timeline_entry = page.timeline_entries.new(timeline_entry_params)
 
       if @timeline_entry.save && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: "Timeline entry was successfully created."
+        redirect_to coronavirus_page_path(page.slug), notice: I18n.t("coronavirus.timeline_entries.create.success")
       else
         render :new, status: :unprocessable_entity
       end
@@ -25,7 +25,7 @@ module Coronavirus
       @timeline_entry = page.timeline_entries.find(params[:id])
 
       if @timeline_entry.update(timeline_entry_params) && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: "Timeline entry was successfully updated."
+        redirect_to coronavirus_page_path(page.slug), notice: I18n.t("coronavirus.timeline_entries.update.success")
       else
         render :edit, status: :unprocessable_entity
       end
@@ -33,13 +33,13 @@ module Coronavirus
 
     def destroy
       timeline_entry = page.timeline_entries.find(params[:id])
-      message = { notice: I18n.t("coronavirus.pages.timeline_entries.delete.success") }
+      message = { notice: I18n.t("coronavirus.timeline_entries.destroy.success") }
 
       TimelineEntry.transaction do
         timeline_entry.destroy!
 
         unless draft_updater.send
-          message = { alert: I18n.t("coronavirus.pages.timeline_entries.delete.failed") }
+          message = { alert: I18n.t("coronavirus.timeline_entries.destroy.failed") }
           raise ActiveRecord::Rollback
         end
       end

--- a/app/views/coronavirus/timeline_entries/_form.html.erb
+++ b/app/views/coronavirus/timeline_entries/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Enter the heading of the timeline entry",
+    text: t("coronavirus.timeline_entries.form.heading.label"),
     bold: true,
   },
   name: "timeline_entry[heading]",
@@ -11,7 +11,7 @@
 
 <%= render "components/markdown_editor", {
   label: {
-    text: "Content",
+    text: t("coronavirus.timeline_entries.form.content.label"),
     bold: true
   },
   textarea: {

--- a/app/views/coronavirus/timeline_entries/edit.html.erb
+++ b/app/views/coronavirus/timeline_entries/edit.html.erb
@@ -5,18 +5,18 @@
       href: coronavirus_pages_path
     },
     {
-      text: "#{@page.name} timeline entries",
+      text: @page.name,
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: "Edit timeline entry"
+      text: t("coronavirus.timeline_entries.edit.title")
     },
   ]
 %>
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page) %>
-<% content_for :context, "Edit timeline entry" %>
+<% content_for :context, t("coronavirus.timeline_entries.edit.title") %>
 <% if @timeline_entry.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @timeline_entry %>
 <% end %>

--- a/app/views/coronavirus/timeline_entries/new.html.erb
+++ b/app/views/coronavirus/timeline_entries/new.html.erb
@@ -5,18 +5,18 @@
       href: coronavirus_pages_path
     },
     {
-      text: "#{@page.name} timeline entries",
+      text: @page.name,
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: "Add timeline entry"
+      text: t("coronavirus.timeline_entries.new.title")
     },
   ]
 %>
 
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page) %>
-<% content_for :context, "Add timeline entry" %>
+<% content_for :context, t("coronavirus.timeline_entries.new.title") %>
 <% if @timeline_entry.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @timeline_entry %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,15 +118,20 @@ en:
           reorder: Reorder
           add: Add announcement
       timeline_entries:
-        delete:
-          success: Timeline entry was successfully deleted.
-          failed: Timeline entry couldn't be deleted
         reorder:
           heading: Reorder timeline entries
           success: Timeline entries were successfully reordered.
           error: "Sorry! Timeline entries have not been reordered: %{error}."
           form:
             markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
+    timeline_entries:
+      create:
+        success: Timeline entry was successfully created.
+      update:
+        success: Timeline entry was successfully updated.
+      destroy:
+        success: Timeline entry was successfully deleted.
+        failed: Timeline entry couldn't be deleted
   step_by_step_page:
     statuses:
       draft: Draft

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,13 +125,22 @@ en:
           form:
             markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
     timeline_entries:
+      new:
+        title: Add timeline entry
       create:
         success: Timeline entry was successfully created.
+      edit:
+        title: Edit timeline entry
       update:
         success: Timeline entry was successfully updated.
       destroy:
         success: Timeline entry was successfully deleted.
         failed: Timeline entry couldn't be deleted
+      form:
+        heading:
+          label: Enter the heading of the timeline entry
+        content:
+          label: Content
   step_by_step_page:
     statuses:
       draft: Draft

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,7 @@ en:
           publish: Publish
         link_text: Coronavirus pages
         timeline_entries:
+          title: Timeline entries
           confirm: Are you sure?
           reorder: Reorder
           add: Add timeline entry

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -211,9 +211,9 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_a_timeline_entries_section
-    expect(page).to have_content("Timeline entries")
-    expect(page).to have_link("Reorder", href: reorder_coronavirus_page_timeline_entries_path(@coronavirus_page.slug))
-    expect(page).to have_link("Add timeline entry")
+    expect(page).to have_content(I18n.t("coronavirus.pages.show.timeline_entries.title"))
+    expect(page).to have_link(I18n.t("coronavirus.pages.show.timeline_entries.reorder"), href: reorder_coronavirus_page_timeline_entries_path(@coronavirus_page.slug))
+    expect(page).to have_link(I18n.t("coronavirus.pages.show.timeline_entries.add"))
   end
 
   def then_i_cannot_see_an_announcements_section
@@ -221,7 +221,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_cannot_see_a_timeline_entries_section
-    expect(page).to_not have_content("Timeline entries")
+    expect(page).to_not have_content(I18n.t("coronavirus.pages.show.announcements.title"))
   end
 
   def and_i_can_see_existing_announcements
@@ -321,7 +321,7 @@ module CoronavirusFeatureSteps
   # Adding a timeline entry
 
   def and_i_add_a_new_timeline_entry
-    click_on("Add timeline entry")
+    click_on(I18n.t("coronavirus.pages.show.timeline_entries.add"))
   end
 
   def then_i_see_the_timeline_entry_form

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -403,7 +403,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_the_timeline_entry_has_been_deleted
-    expect(page).to have_text(I18n.t("coronavirus.pages.timeline_entries.delete.success"))
+    expect(page).to have_text(I18n.t("coronavirus.timeline_entries.destroy.success"))
     expect(page).not_to have_text(@timeline_entry_one.heading)
   end
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -325,8 +325,8 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_the_timeline_entry_form
-    expect(page).to have_text("Enter the heading of the timeline entry")
-    expect(page).to have_text("Content")
+    expect(page).to have_text(I18n.t("coronavirus.timeline_entries.form.heading.label"))
+    expect(page).to have_text(I18n.t("coronavirus.timeline_entries.form.content.label"))
   end
 
   def when_i_fill_in_the_timeline_entry_form_with_valid_data


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves controller and view content for timeline entries to a locale file


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
