### PR TITLE
Tidy up featured link testing

### DIFF
--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -29,12 +29,6 @@ class Coronavirus::SubSectionJsonPresenter
         title: title,
         sub_sections: sub_sections,
       }
-
-    if @sub_section.featured_link.present? && !link_set_as_featured?
-      errors << "Featured link does not exist in accordion content"
-    end
-
-    @output
   end
 
   def errors
@@ -48,14 +42,6 @@ class Coronavirus::SubSectionJsonPresenter
 
   def sub_sections
     content_groups.map { |content_group| sub_section_hash_from_content_group(content_group) }
-  end
-
-  def link_set_as_featured?
-    featured_links = @output[:sub_sections].flat_map do |section|
-      section[:list].map { |item| item[:featured_link] }
-    end
-
-    featured_links.any?
   end
 
   # Groups the sub section content into an array of arrays, such that:

--- a/spec/models/coronavirus/sub_section_spec.rb
+++ b/spec/models/coronavirus/sub_section_spec.rb
@@ -33,5 +33,19 @@ RSpec.describe Coronavirus::SubSection do
       expect(sub_section).not_to be_valid
       expect(sub_section.errors).to have_key(:content)
     end
+
+    it "validates that the featured link is in content" do
+      sub_section.content = "[test](/bananas)"
+      sub_section.featured_link = "/bananas"
+
+      expect(sub_section).to be_valid
+    end
+
+    it "fails if featured link is not in content" do
+      sub_section.featured_link = "/bananas"
+
+      expect(sub_section).not_to be_valid
+      expect(sub_section.errors).to have_key(:featured_link)
+    end
   end
 end

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -100,13 +100,6 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
           ),
         )
       end
-
-      it "has an error when content does not contain the featured link" do
-        featured_link = "/#{SecureRandom.urlsafe_base64}"
-        sub_section.featured_link = featured_link
-
-        expect { subject.output }.to change { subject.errors.length }.by(1)
-      end
     end
   end
 


### PR DESCRIPTION
As inclusion of featured links is handled at a model level this adds a
test to ensure that the model is validating featured links correctly.
It also removes old functionality that gave the json presenter
responsibility for featured link errors.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
