### PR TITLE
Move reorder announcements content to locale file

### DIFF
--- a/app/controllers/coronavirus/reorder_announcements_controller.rb
+++ b/app/controllers/coronavirus/reorder_announcements_controller.rb
@@ -26,10 +26,10 @@ module Coronavirus
       end
 
       if success
-        message = "Announcements were successfully reordered."
+        message = helpers.t("coronavirus.reorder_announcements.update.success")
         redirect_to coronavirus_page_path(page.slug), notice: message
       else
-        message = "Sorry! Announcements have not been reordered: #{draft_updater.errors.to_sentence}."
+        message = helpers.t("coronavirus.reorder_announcements.update.failed", error: draft_updater.errors.to_sentence)
         redirect_to reorder_coronavirus_page_announcements_path(page.slug), alert: message
       end
     end

--- a/app/views/coronavirus/reorder_announcements/index.html.erb
+++ b/app/views/coronavirus/reorder_announcements/index.html.erb
@@ -5,21 +5,21 @@
       href: coronavirus_pages_path
     },
     {
-      text: "#{@page.name}",
+      text: @page.name,
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: "Reorder announcements"
+      text: t("coronavirus.reorder_announcements.index.title")
     },
   ]
 %>
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page)%>
-<% content_for :context, "Reorder announcements" %>
+<% content_for :context, t("coronavirus.reorder_announcements.index.title") %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_markdown "Use the up/down buttons on the right to reorder the announcements, or click and hold on a section to reorder using drag and drop." %>
+    <%= render_markdown t("coronavirus.reorder_announcements.index.hint_markdown") %>
 
     <%= form_for(@page, url: reorder_coronavirus_page_announcements_path, method: :put) do |form| %>
       <%= render "reorder_list" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,13 @@ en:
           error: "Sorry! Timeline entries have not been reordered: %{error}."
           form:
             markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
+    reorder_announcements:
+      index:
+        title: Reorder announcements
+        hint_markdown: Use the up/down buttons on the right to reorder the announcements, or click and hold on a section to reorder using drag and drop.
+      update:
+        success: Announcements were successfully reordered.
+        failed: "Sorry! Announcements have not been reordered: %{error}."
     sub_sections:
       new:
         title: Add accordion

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -249,7 +249,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_announcement_updated_message
-    expect(page).to have_content "Announcements were successfully reordered."
+    expect(page).to have_content I18n.t("coronavirus.reorder_announcements.update.success")
   end
 
   def and_i_see_the_announcements_have_changed_order


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves controller and view content for reordering announcements to a locale file


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
