### PR TITLE
Move PagesController content to locale file

### DIFF
--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -21,7 +21,7 @@ module Coronavirus
     def discard
       if draft_updater.discarded?
         Pages::DraftDiscarder.new(page).call
-        message = { notice: "Changes to subsections have been discarded" }
+        message = { notice: helpers.t("coronavirus.pages.discard.success") }
       else
         message = { alert: draft_updater.errors.to_sentence }
       end
@@ -41,9 +41,9 @@ module Coronavirus
     def publish_page
       Services.publishing_api.publish(page.content_id, "minor")
       page.update!(state: "published")
-      flash["notice"] = "Page published!"
+      flash["notice"] = helpers.t("coronavirus.pages.publish.success")
     rescue GdsApi::HTTPConflict
-      flash["alert"] = "You have already published this page."
+      flash["alert"] = helpers.t("coronavirus.pages.publish.failed")
     end
 
     def initialise_pages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,11 @@ en:
           confirm: Are you sure?
           reorder: Reorder
           add: Add announcement
+      publish:
+        success: Page published!
+        failed: You have already published this page.
+      discard:
+        success: Changes to subsections have been discarded
       timeline_entries:
         reorder:
           heading: Reorder timeline entries

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         and_i_publish_the_page
         and_i_remain_on_the_coronavirus_github_changes_page
         then_the_page_publishes
-        and_i_see_a_page_published_message
+        and_i_see_github_changes_published_message
       end
 
       scenario "Viewing announcements" do
@@ -242,7 +242,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         and_i_choose_a_major_update
         and_i_publish_the_page
         then_the_business_page_publishes
-        and_i_see_a_page_published_message
+        and_i_see_github_changes_published_message
       end
 
       scenario "Viewing announcements" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -603,7 +603,11 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_see_a_page_published_message
-    expect(page).to have_text("Page published!")
+    expect(page).to have_text(I18n.t("coronavirus.pages.publish.success"))
+  end
+
+  def and_i_see_github_changes_published_message
+    expect(page).to have_text(I18n.t("coronavirus.github_changes.publish.success"))
   end
 
   def and_i_see_live_stream_is_updated_message


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves `PagesController` content to locale file.

The feature tests have also been updated to highlight that the summary pages and the github changes content pull in their "published" messages from different places even though the content is the same at the moment.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
