### PR TITLE
Restructure reorder timeline entries content

### DIFF
--- a/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
@@ -26,10 +26,10 @@ module Coronavirus
       end
 
       if success
-        message = I18n.t("coronavirus.pages.timeline_entries.reorder.success")
+        message = helpers.t("coronavirus.reorder_timeline_entries.update.success")
         redirect_to coronavirus_page_path(page.slug), notice: message
       else
-        message = I18n.t("coronavirus.pages.timeline_entries.reorder.error", error: draft_updater.errors.to_sentence)
+        message = helpers.t("coronavirus.reorder_timeline_entries.update.failed", error: draft_updater.errors.to_sentence)
         redirect_to reorder_coronavirus_page_timeline_entries_path(page.slug), alert: message
       end
     end

--- a/app/views/coronavirus/reorder_timeline_entries/index.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/index.html.erb
@@ -9,17 +9,17 @@
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: t("coronavirus.pages.timeline_entries.reorder.heading")
+      text: t("coronavirus.reorder_timeline_entries.index.title")
     },
   ]
 %>
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page)%>
-<% content_for :context, t("coronavirus.pages.timeline_entries.reorder.heading") %>
+<% content_for :context, t("coronavirus.reorder_timeline_entries.index.title") %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_markdown t("coronavirus.pages.timeline_entries.reorder.form.markdown_hint") %>
+    <%= render_markdown t("coronavirus.reorder_timeline_entries.index.hint_markdown") %>
 
     <%= form_with method: :put, url: reorder_coronavirus_page_timeline_entries_path do |form| %>
       <%= render "reorder_list" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,13 +123,6 @@ en:
         failed: You have already published this page.
       discard:
         success: Changes to subsections have been discarded
-      timeline_entries:
-        reorder:
-          heading: Reorder timeline entries
-          success: Timeline entries were successfully reordered.
-          error: "Sorry! Timeline entries have not been reordered: %{error}."
-          form:
-            markdown_hint: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
     reorder_announcements:
       index:
         title: Reorder announcements
@@ -137,6 +130,13 @@ en:
       update:
         success: Announcements were successfully reordered.
         failed: "Sorry! Announcements have not been reordered: %{error}."
+    reorder_timeline_entries:
+      index:
+        title: Reorder timeline entries
+        hint_markdown: Use the up/down buttons on the right to reorder the timeline entries, or click and hold on a section to reorder using drag and drop.
+      update:
+        success: Timeline entries were successfully reordered.
+        failed: "Sorry! Timeline entries have not been reordered: %{error}."
     sub_sections:
       new:
         title: Add accordion

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -382,7 +382,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_timeline_entries_updated_message
-    expect(page).to have_content I18n.t("coronavirus.pages.timeline_entries.reorder.success")
+    expect(page).to have_content I18n.t("coronavirus.reorder_timeline_entries.update.success")
   end
 
   def and_i_see_the_timeline_entries_have_changed_order


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Restructures the reorder timeline entries content to match that of the content in the other controllers/views

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
