### PR TITLE
Move reorder subsections content to locale file

### DIFF
--- a/app/controllers/coronavirus/reorder_sub_sections_controller.rb
+++ b/app/controllers/coronavirus/reorder_sub_sections_controller.rb
@@ -20,10 +20,10 @@ module Coronavirus
       end
 
       if success
-        message = "Sections were successfully reordered."
+        message = helpers.t("coronavirus.reorder_sub_sections.update.success")
         redirect_to coronavirus_page_path(page.slug), notice: message
       else
-        message = "Sorry! Sections have not been reordered: #{draft_updater.errors.to_sentence}."
+        message = helpers.t("coronavirus.reorder_sub_sections.update.failed", error: draft_updater.errors.to_sentence)
         redirect_to reorder_coronavirus_page_sub_sections_path(page.slug), alert: message
       end
     end

--- a/app/views/coronavirus/reorder_sub_sections/index.html.erb
+++ b/app/views/coronavirus/reorder_sub_sections/index.html.erb
@@ -5,21 +5,21 @@
       href: coronavirus_pages_path
     },
     {
-      text: "#{@page.name} accordions",
+      text: @page.name,
       href: coronavirus_page_path(slug: @page.slug)
     },
     {
-      text: "Reorder"
+      text: t("coronavirus.reorder_sub_sections.index.title", section: @page.sections_title.downcase)
     },
   ]
 %>
 <% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
 <% content_for :title, formatted_title(@page)%>
-<% content_for :context, "Reorder #{@page.sections_title.downcase} accordion" %>
+<% content_for :context, t("coronavirus.reorder_sub_sections.index.title", section: @page.sections_title.downcase) %>
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_markdown "Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop." %>
+    <%= render_markdown t("coronavirus.reorder_sub_sections.index.hint_markdown") %>
 
     <%= form_for(@page, url: reorder_coronavirus_page_sub_sections_path, method: :put) do |form| %>
       <%= render "reorder_list" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,13 @@ en:
       update:
         success: Announcements were successfully reordered.
         failed: "Sorry! Announcements have not been reordered: %{error}."
+    reorder_sub_sections:
+      index:
+        title: "Reorder %{section} accordion"
+        hint_markdown: Use the up/down buttons on the right to reorder the sections, or click and hold on a section to reorder using drag and drop.
+      update:
+        success: Sections were successfully reordered.
+        failed: "Sorry! Sections have not been reordered: %{error}."
     reorder_timeline_entries:
       index:
         title: Reorder timeline entries

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -457,7 +457,7 @@ module CoronavirusFeatureSteps
   def and_i_move_section_one_down
     all("button", text: "Down").first.click
     click_button "Save"
-    expect(page).to have_content "Sections were successfully reordered."
+    expect(page).to have_content(I18n.t("coronavirus.reorder_sub_sections.update.success"))
   end
 
   def then_the_reordered_subsections_are_sent_to_publishing_api
@@ -502,7 +502,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_section_updated_message
-    expect(page).to have_text("Sections were successfully reordered.")
+    expect(page).to have_text(I18n.t("coronavirus.reorder_sub_sections.update.success"))
   end
 
   def and_i_see_state_is_published


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves reorder sub-sections content to locale file.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
