### PR TITLE
Move coronavirus breadcrumbs to partial

### DIFF
--- a/app/views/coronavirus/announcements/edit.html.erb
+++ b/app/views/coronavirus/announcements/edit.html.erb
@@ -1,25 +1,4 @@
-<%
-links = [
-  {
-    text: 'Coronavirus pages',
-    href: coronavirus_pages_path
-  },
-  {
-    text: @page.name,
-    href: coronavirus_page_path(slug: @page.slug)
-  },
-  {
-    text: t("coronavirus.announcements.edit.title")
-  },
-]
-
-  metadata = {
-    "Status" => "Draft",
-    "Last saved" => format_full_date_and_time(DateTime.now),
-  }
-%>
-
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.announcements.edit.title")  %>
 <% content_for :title, formatted_title(@page) %>
 <% content_for :context, t("coronavirus.announcements.edit.title") %>
 <% if @announcement.errors.any? %>

--- a/app/views/coronavirus/announcements/new.html.erb
+++ b/app/views/coronavirus/announcements/new.html.erb
@@ -1,25 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: @page.name,
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.announcements.new.title")
-    },
-  ]
-
-  metadata = {
-    "Status" => "Draft",
-    "Last saved" => format_full_date_and_time(DateTime.now),
-  }
-%>
-
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.announcements.new.title")  %>
 <% content_for :title, formatted_title(@page) %>
 <% content_for :context, t("coronavirus.announcements.new.title") %>
 <% if @announcement.errors.any? %>

--- a/app/views/coronavirus/reorder_announcements/index.html.erb
+++ b/app/views/coronavirus/reorder_announcements/index.html.erb
@@ -1,19 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: @page.name,
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.reorder_announcements.index.title")
-    },
-  ]
-%>
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.reorder_announcements.index.title")  %>
 <% content_for :title, formatted_title(@page)%>
 <% content_for :context, t("coronavirus.reorder_announcements.index.title") %>
 

--- a/app/views/coronavirus/reorder_sub_sections/index.html.erb
+++ b/app/views/coronavirus/reorder_sub_sections/index.html.erb
@@ -1,19 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: @page.name,
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.reorder_sub_sections.index.title", section: @page.sections_title.downcase)
-    },
-  ]
-%>
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.reorder_sub_sections.index.title", section: @page.sections_title.downcase)  %>
 <% content_for :title, formatted_title(@page)%>
 <% content_for :context, t("coronavirus.reorder_sub_sections.index.title", section: @page.sections_title.downcase) %>
 

--- a/app/views/coronavirus/reorder_timeline_entries/index.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/index.html.erb
@@ -1,19 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: "#{@page.name}",
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.reorder_timeline_entries.index.title")
-    },
-  ]
-%>
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.reorder_timeline_entries.index.title")  %>
 <% content_for :title, formatted_title(@page)%>
 <% content_for :context, t("coronavirus.reorder_timeline_entries.index.title") %>
 

--- a/app/views/coronavirus/shared/_breadcrumbs.html.erb
+++ b/app/views/coronavirus/shared/_breadcrumbs.html.erb
@@ -1,0 +1,16 @@
+<%
+  links = [
+    {
+      text: t("coronavirus.shared.breadcrumbs.link_text"),
+      href: coronavirus_pages_path
+    },
+    {
+      text: @page.name,
+      href: coronavirus_page_path(slug: @page.slug)
+    },
+    {
+      text: text
+    },
+  ]
+%>
+<%= render 'shared/steps/step_breadcrumb', links: links %>

--- a/app/views/coronavirus/sub_sections/edit.html.erb
+++ b/app/views/coronavirus/sub_sections/edit.html.erb
@@ -1,25 +1,4 @@
-<%
-links = [
-  {
-    text: 'Coronavirus pages',
-    href: coronavirus_pages_path
-  },
-  {
-    text: @page.name,
-    href: coronavirus_page_path(slug: @page.slug)
-  },
-  {
-    text: t("coronavirus.sub_sections.edit.title")
-  },
-]
-
-  metadata = {
-    "Status" => "Draft",
-    "Last saved" => format_full_date_and_time(DateTime.now),
-  }
-%>
-
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.sub_sections.edit.title")  %>
 <% content_for :title, @page.title %>
 <% content_for :context, t("coronavirus.sub_sections.edit.title") %>
 <% if @sub_section.errors.any? %>

--- a/app/views/coronavirus/sub_sections/new.html.erb
+++ b/app/views/coronavirus/sub_sections/new.html.erb
@@ -1,25 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: @page.name,
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.sub_sections.new.title")
-    },
-  ]
-
-  metadata = {
-    "Status" => "Draft",
-    "Last saved" => format_full_date_and_time(DateTime.now),
-  }
-%>
-
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.sub_sections.new.title")  %>
 <% content_for :title, formatted_title(@page) %>
 <% content_for :context, t("coronavirus.sub_sections.new.title") %>
 <% if @sub_section.errors.any? %>

--- a/app/views/coronavirus/timeline_entries/edit.html.erb
+++ b/app/views/coronavirus/timeline_entries/edit.html.erb
@@ -1,20 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: @page.name,
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.timeline_entries.edit.title")
-    },
-  ]
-%>
-
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.timeline_entries.edit.title")  %>
 <% content_for :title, formatted_title(@page) %>
 <% content_for :context, t("coronavirus.timeline_entries.edit.title") %>
 <% if @timeline_entry.errors.any? %>

--- a/app/views/coronavirus/timeline_entries/new.html.erb
+++ b/app/views/coronavirus/timeline_entries/new.html.erb
@@ -1,20 +1,4 @@
-<%
-  links = [
-    {
-      text: 'Coronavirus pages',
-      href: coronavirus_pages_path
-    },
-    {
-      text: @page.name,
-      href: coronavirus_page_path(slug: @page.slug)
-    },
-    {
-      text: t("coronavirus.timeline_entries.new.title")
-    },
-  ]
-%>
-
-<% content_for :breadcrumbs, render('shared/steps/step_breadcrumb', links: links) %>
+<%= render 'coronavirus/shared/breadcrumbs', text: t("coronavirus.timeline_entries.new.title")  %>
 <% content_for :title, formatted_title(@page) %>
 <% content_for :context, t("coronavirus.timeline_entries.new.title") %>
 <% if @timeline_entry.errors.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   coronavirus:
+    shared:
+      breadcrumbs:
+        link_text: Coronavirus pages
     announcements:
       new:
         title: Add announcement


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?

Moves breadcrumbs on coronavirus pages to a shared partial.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
