### PR TITLE
Fetch coronavirus test content from locale file

### DIFF
--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -162,7 +162,7 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_select_live_stream
-    click_link("Edit live stream URL")
+    click_link(I18n.t("coronavirus.pages.index.landing_page_edit.live_stream_url"))
     expect(page).to have_text(I18n.t("coronavirus.live_stream.index.title"))
   end
 
@@ -516,7 +516,7 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_discard_my_changes
-    click_link("Discard changes")
+    click_link(I18n.t("coronavirus.pages.show.actions.discard_changes"))
   end
 
   def i_see_error_message_no_changes_to_discard


### PR DESCRIPTION
Trello: https://trello.com/c/Zf13e2Wy
Follows on from: #1275

# What's changed?


While the coronavirus controller and view content was being moved into a locale file, the test content was supposed to be updated as well. A couple of items were missed and are being corrected here.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
