### PR TITLE
Make DraftUpdater errors more specific

### DIFF
--- a/app/controllers/coronavirus/github_changes_controller.rb
+++ b/app/controllers/coronavirus/github_changes_controller.rb
@@ -8,13 +8,11 @@ module Coronavirus
     end
 
     def update
-      message = if draft_updater.send
-                  { notice: helpers.t("coronavirus.github_changes.update.success") }
-                else
-                  { alert: draft_updater.errors.to_sentence }
-                end
+      draft_updater.send
 
-      redirect_to github_changes_coronavirus_page_path(page.slug), message
+      redirect_to github_changes_coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.github_changes.update.success")
+    rescue Coronavirus::Pages::DraftUpdater::PayloadInvalidError => e
+      redirect_to github_changes_coronavirus_page_path(page.slug), alert: e.message
     end
 
     def publish

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -1,6 +1,7 @@
 module Coronavirus::Pages
   class DraftUpdater
-    DraftUpdaterError = Class.new(StandardError)
+    class UpdateFailedError < StandardError; end
+    class PayloadInvalidError < StandardError; end
 
     attr_reader :page
 
@@ -18,7 +19,7 @@ module Coronavirus::Pages
       if content_builder.success?
         Coronavirus::PagePresenter.new(content_builder.data, base_path).payload
       else
-        raise DraftUpdaterError, content_builder.errors.to_sentence
+        raise PayloadInvalidError, content_builder.errors.to_sentence
       end
     end
 
@@ -27,7 +28,7 @@ module Coronavirus::Pages
       page.update!(state: "draft")
     rescue GdsApi::HTTPErrorResponse => e
       error_handler(e, "Failed to update the draft content item. Try saving again.")
-    rescue DraftUpdaterError => e
+    rescue UpdateFailedError => e
       error_handler(e)
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/fIY7Oy1L

# What's changed and why?

The first step to wrapping Coronavirus controller actions in transactions is to return "useful" errors from DraftUpdater.
I've made an attempt by splitting the existing `DraftUpdaterError` into two more specific errors.

I'd appreciate feedback on whether this is the right starting point for the transactions work.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
