### PR TITLE
Remove `success?` method from YamlFetcher

### DIFF
--- a/app/services/yaml_fetcher.rb
+++ b/app/services/yaml_fetcher.rb
@@ -11,12 +11,6 @@ class YamlFetcher
     @response ||= RestClient.get(cache_busted_url)
   end
 
-  def success?
-    response.code == 200
-  rescue RestClient::Unauthorized
-    false
-  end
-
   delegate :body, to: :response
 
   def body_as_hash

--- a/spec/services/yaml_fetcher_spec.rb
+++ b/spec/services/yaml_fetcher_spec.rb
@@ -41,18 +41,4 @@ RSpec.describe YamlFetcher do
       expect(subject.body_as_hash).to eq({ "this" => { "foo" => "bar" } })
     end
   end
-
-  describe "#success?" do
-    it "is true if all OK" do
-      expect(subject.success?).to be(true)
-    end
-
-    context "connection failure" do
-      let(:stub_response) { { body: body, status: 401 } }
-
-      it "is false" do
-        expect(subject.success?).to be(false)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/fIY7Oy1L

# What's changed and why?

Remove `success?` method from YamlFetcher as this method is not being used.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
