### PR TITLE
Raise error in sub section json presenter

### DIFF
--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Coronavirus::SubSectionJsonPresenter
+  class MarkdownInvalidError < RuntimeError; end
+
   HEADER_PATTERN = PatternMaker.call(
     "starts_with hashes then perhaps_spaces then capture(title) and nothing_else",
     hashes: "#+",
@@ -29,15 +31,6 @@ class Coronavirus::SubSectionJsonPresenter
         title: title,
         sub_sections: sub_sections,
       }
-  end
-
-  def errors
-    @errors ||= []
-  end
-
-  def success?
-    output
-    errors.empty?
   end
 
   def sub_sections
@@ -84,7 +77,7 @@ class Coronavirus::SubSectionJsonPresenter
         hash[:list] ||= []
         hash[:list] << build_link(line)
       else
-        errors << "Unable to parse markdown: '#{line}'"
+        raise MarkdownInvalidError, "Unable to parse markdown: '#{line}'"
       end
     end
   end

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -86,8 +86,9 @@ module Coronavirus::Pages
     def sub_sections_data
       page.sub_sections.order(:position).map do |sub_section|
         presenter = Coronavirus::SubSectionJsonPresenter.new(sub_section, page.content_id)
-        add_error(presenter.errors) unless presenter.success?
         presenter.output
+      rescue Coronavirus::SubSectionJsonPresenter::MarkdownInvalidError => e
+        add_error(e.message)
       end
     end
 

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -129,6 +129,8 @@ module Coronavirus::Pages
 
     def search_terms_in_sections
       sections = sub_sections_data.map do |section|
+        next if section.blank?
+
         [section[:title], search_terms_in_sub_sections(section[:sub_sections])]
       end
 

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -44,20 +44,11 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
       expect(subject.output).to eq(expected)
     end
 
-    it "has no errors" do
-      subject.output
-      expect(subject.errors).to be_blank
-    end
-
     context "with unknown content" do
       let(:content) { [title_markup, link, "unknown"].join("\n") }
 
-      it "has expected content" do
-        expect(subject.output).to eq(expected)
-      end
-
-      it "has an error" do
-        expect { subject.output }.to change { subject.errors.length }.by(1)
+      it "raises an error" do
+        expect { subject.output }.to raise_error(Coronavirus::SubSectionJsonPresenter::MarkdownInvalidError)
       end
     end
 
@@ -119,11 +110,6 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     it "has a null title" do
       expect(sub_section_hash.keys).to include(:title)
       expect(sub_section_hash[:title]).to be_nil
-    end
-
-    it "creates no errors" do
-      sub_section_hash
-      expect(subject.errors).to be_blank
     end
 
     context "with a title" do
@@ -200,12 +186,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     context "with unknown content" do
       let(:group) { %w[unknown] }
 
-      it "does not populate list" do
-        expect(sub_section_hash.keys).not_to include(:list)
-      end
-
       it "adds an error" do
-        expect { sub_section_hash }.to change { subject.errors.length }.by(1)
+        expect { sub_section_hash }.to raise_error(Coronavirus::SubSectionJsonPresenter::MarkdownInvalidError)
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/fIY7Oy1L

# What's changed?
Raise an error in `SubSectionJsonPresenter` when a sub-section contains invalid markdown.

# Why?
This is part of the work to apply a consistent approach to error handling for Coronavirus pages. 

Rather than storing errors in a list, we want to surface these errors back up to the controller so that when we start saving changes to the page in transactions, we can rely on the exceptions being thrown at different points in the code to force the database changes to be rolled back.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
