### PR TITLE
Raise exceptions and rollback failures in coronavirus pages

### DIFF
--- a/app/controllers/coronavirus/announcements_controller.rb
+++ b/app/controllers/coronavirus/announcements_controller.rb
@@ -29,18 +29,15 @@ module Coronavirus
 
     def destroy
       announcement = page.announcements.find(params[:id])
-      message = { notice: helpers.t("coronavirus.announcements.destroy.success") }
 
       Announcement.transaction do
         announcement.destroy!
-
-        unless draft_updater.send
-          message = { alert: helpers.t("coronavirus.announcements.destroy.failed") }
-          raise ActiveRecord::Rollback
-        end
+        draft_updater.send
       end
 
-      redirect_to coronavirus_page_path(page.slug), message
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.destroy.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError
+      redirect_to coronavirus_page_path(page.slug), alert: helpers.t("coronavirus.announcements.destroy.failed")
     end
 
     def edit

--- a/app/controllers/coronavirus/announcements_controller.rb
+++ b/app/controllers/coronavirus/announcements_controller.rb
@@ -10,11 +10,21 @@ module Coronavirus
 
     def create
       @announcement = page.announcements.new(announcement_params)
-      if @announcement.save && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.create.success")
-      else
-        render :new
+
+      unless @announcement.valid?
+        render :new, status: :unprocessable_entity
+        return
       end
+
+      Announcement.transaction do
+        @announcement.save!
+        draft_updater.send
+      end
+
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.create.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      flash.now[:alert] = e.message
+      render :new, status: :internal_server_error
     end
 
     def destroy

--- a/app/controllers/coronavirus/announcements_controller.rb
+++ b/app/controllers/coronavirus/announcements_controller.rb
@@ -49,12 +49,22 @@ module Coronavirus
 
     def update
       @announcement = page.announcements.find(params[:id])
+      @announcement.assign_attributes(announcement_params)
 
-      if @announcement.update(announcement_params) && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.update.success")
-      else
-        render :edit
+      unless @announcement.valid?
+        render :edit, status: :unprocessable_entity
+        return
       end
+
+      Announcement.transaction do
+        @announcement.update!(announcement_params)
+        draft_updater.send
+      end
+
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.announcements.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      flash.now[:alert] = e.message
+      render :edit, status: :internal_server_error
     end
 
   private

--- a/app/controllers/coronavirus/github_changes_controller.rb
+++ b/app/controllers/coronavirus/github_changes_controller.rb
@@ -8,13 +8,10 @@ module Coronavirus
     end
 
     def update
-      message = if draft_updater.send
-                  { notice: helpers.t("coronavirus.github_changes.update.success") }
-                else
-                  { alert: draft_updater.errors.to_sentence }
-                end
-
-      redirect_to github_changes_coronavirus_page_path(page.slug), message
+      draft_updater.send
+      redirect_to github_changes_coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.github_changes.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      redirect_to github_changes_coronavirus_page_path(page.slug), alert: e.message
     end
 
     def publish

--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -19,13 +19,11 @@ module Coronavirus
     end
 
     def discard
-      if draft_updater.discarded?
-        Pages::DraftDiscarder.new(page).call
-        message = { notice: helpers.t("coronavirus.pages.discard.success") }
-      else
-        message = { alert: draft_updater.errors.to_sentence }
-      end
-      redirect_to coronavirus_page_path(page.slug), message
+      draft_updater.discard
+      Pages::DraftDiscarder.new(page).call
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.pages.discard.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      redirect_to coronavirus_page_path(page.slug), alert: e.message
     end
 
   private

--- a/app/controllers/coronavirus/reorder_announcements_controller.rb
+++ b/app/controllers/coronavirus/reorder_announcements_controller.rb
@@ -8,8 +8,6 @@ module Coronavirus
     end
 
     def update
-      success = true
-
       reordered_announcements = page.announcements.sort_by do |announcement|
         params.require(:announcement_order_save).fetch(announcement.id.to_s, announcement.position).to_i
       end
@@ -19,19 +17,13 @@ module Coronavirus
           announcement.update_column(:position, index)
         end
 
-        unless draft_updater.send
-          success = false
-          raise ActiveRecord::Rollback
-        end
+        draft_updater.send
       end
 
-      if success
-        message = helpers.t("coronavirus.reorder_announcements.update.success")
-        redirect_to coronavirus_page_path(page.slug), notice: message
-      else
-        message = helpers.t("coronavirus.reorder_announcements.update.failed", error: draft_updater.errors.to_sentence)
-        redirect_to reorder_coronavirus_page_announcements_path(page.slug), alert: message
-      end
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.reorder_announcements.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      message = helpers.t("coronavirus.reorder_announcements.update.failed", error: e.message)
+      redirect_to reorder_coronavirus_page_announcements_path(page.slug), alert: message
     end
 
   private

--- a/app/controllers/coronavirus/reorder_sub_sections_controller.rb
+++ b/app/controllers/coronavirus/reorder_sub_sections_controller.rb
@@ -8,24 +8,15 @@ module Coronavirus
     end
 
     def update
-      success = true
-
       SubSection.transaction do
         set_positions
-
-        unless draft_updater.send
-          success = false
-          raise ActiveRecord::Rollback
-        end
+        draft_updater.send
       end
 
-      if success
-        message = helpers.t("coronavirus.reorder_sub_sections.update.success")
-        redirect_to coronavirus_page_path(page.slug), notice: message
-      else
-        message = helpers.t("coronavirus.reorder_sub_sections.update.failed", error: draft_updater.errors.to_sentence)
-        redirect_to reorder_coronavirus_page_sub_sections_path(page.slug), alert: message
-      end
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.reorder_sub_sections.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      message = helpers.t("coronavirus.reorder_sub_sections.update.failed", error: e.message)
+      redirect_to reorder_coronavirus_page_sub_sections_path(page.slug), alert: message
     end
 
   private

--- a/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/reorder_timeline_entries_controller.rb
@@ -8,8 +8,6 @@ module Coronavirus
     end
 
     def update
-      success = true
-
       reordered_timeline_entries = page.timeline_entries.sort_by do |entry|
         params.require(:timeline_entry_order_save).fetch(entry.id.to_s, entry.position).to_i
       end
@@ -19,19 +17,13 @@ module Coronavirus
           entry.update_column(:position, index)
         end
 
-        unless draft_updater.send
-          success = false
-          raise ActiveRecord::Rollback
-        end
+        draft_updater.send
       end
 
-      if success
-        message = helpers.t("coronavirus.reorder_timeline_entries.update.success")
-        redirect_to coronavirus_page_path(page.slug), notice: message
-      else
-        message = helpers.t("coronavirus.reorder_timeline_entries.update.failed", error: draft_updater.errors.to_sentence)
-        redirect_to reorder_coronavirus_page_timeline_entries_path(page.slug), alert: message
-      end
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.reorder_timeline_entries.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      message = helpers.t("coronavirus.reorder_timeline_entries.update.failed", error: e.message)
+      redirect_to reorder_coronavirus_page_timeline_entries_path(page.slug), alert: message
     end
 
   private

--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -52,18 +52,15 @@ module Coronavirus
 
     def destroy
       sub_section = page.sub_sections.find(params[:id])
-      message = { notice: helpers.t("coronavirus.sub_sections.destroy.success") }
 
       SubSection.transaction do
         sub_section.destroy!
-
-        unless draft_updater.send
-          message = { alert: helpers.t("coronavirus.sub_sections.destroy.failed") }
-          raise ActiveRecord::Rollback
-        end
+        draft_updater.send
       end
 
-      redirect_to coronavirus_page_path(page.slug), message
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.sub_sections.destroy.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError
+      redirect_to coronavirus_page_path(page.slug), alert: helpers.t("coronavirus.sub_sections.destroy.failed")
     end
 
   private

--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -17,15 +17,13 @@ module Coronavirus
 
       SubSection.transaction do
         @sub_section.save!
-        raise ActiveRecord::Rollback unless draft_updater.send
+        draft_updater.send
       end
 
-      if draft_updater.errors.any?
-        flash.now["alert"] = draft_updater.errors.to_sentence
-        render :new, status: :internal_server_error
-      else
-        redirect_to coronavirus_page_path(page.slug), { notice: helpers.t("coronavirus.sub_sections.create.success") }
-      end
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.sub_sections.create.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      flash.now[:alert] = e.message
+      render :new, status: :internal_server_error
     end
 
     def edit

--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -41,15 +41,13 @@ module Coronavirus
 
       SubSection.transaction do
         @sub_section.save!
-        raise ActiveRecord::Rollback unless draft_updater.send
+        draft_updater.send
       end
 
-      if draft_updater.errors.any?
-        flash.now["alert"] = draft_updater.errors.to_sentence
-        render :edit, status: :internal_server_error
-      else
-        redirect_to coronavirus_page_path(page.slug), { notice: helpers.t("coronavirus.sub_sections.update.success") }
-      end
+      redirect_to coronavirus_page_path(page.slug), notice: helpers.t("coronavirus.sub_sections.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      flash.now[:alert] = e.message
+      render :edit, status: :internal_server_error
     end
 
     def destroy

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -52,18 +52,15 @@ module Coronavirus
 
     def destroy
       timeline_entry = page.timeline_entries.find(params[:id])
-      message = { notice: I18n.t("coronavirus.timeline_entries.destroy.success") }
 
       TimelineEntry.transaction do
         timeline_entry.destroy!
-
-        unless draft_updater.send
-          message = { alert: I18n.t("coronavirus.timeline_entries.destroy.failed") }
-          raise ActiveRecord::Rollback
-        end
+        draft_updater.send
       end
 
-      redirect_to coronavirus_page_path(page.slug), message
+      redirect_to coronavirus_page_path(page.slug), notice: I18n.t("coronavirus.timeline_entries.destroy.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError
+      redirect_to coronavirus_page_path(page.slug), alert: I18n.t("coronavirus.timeline_entries.destroy.failed")
     end
 
   private

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -32,12 +32,22 @@ module Coronavirus
 
     def update
       @timeline_entry = page.timeline_entries.find(params[:id])
+      @timeline_entry.assign_attributes(timeline_entry_params)
 
-      if @timeline_entry.update(timeline_entry_params) && draft_updater.send
-        redirect_to coronavirus_page_path(page.slug), notice: I18n.t("coronavirus.timeline_entries.update.success")
-      else
+      unless @timeline_entry.valid?
         render :edit, status: :unprocessable_entity
+        return
       end
+
+      TimelineEntry.transaction do
+        @timeline_entry.update!(timeline_entry_params)
+        draft_updater.send
+      end
+
+      redirect_to coronavirus_page_path(page.slug), notice: I18n.t("coronavirus.timeline_entries.update.success")
+    rescue Pages::DraftUpdater::DraftUpdaterError => e
+      flash.now[:alert] = e.message
+      render :edit, status: :internal_server_error
     end
 
     def destroy

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -1,13 +1,13 @@
 module Coronavirus::Pages
   class ContentBuilder
-    attr_reader :page, :errors
     class GitHubConnectionError < RuntimeError; end
     class GitHubInvalidContentError < RuntimeError; end
     class InvalidContentError < RuntimeError; end
 
+    attr_reader :page
+
     def initialize(page)
       @page = page
-      @errors = []
     end
 
     def data
@@ -24,16 +24,6 @@ module Coronavirus::Pages
         data["hidden_search_terms"] = hidden_search_terms
         data
       end
-    end
-
-    def success?
-      data
-      errors.empty?
-    end
-
-    def add_error(error)
-      errors << error
-      errors.flatten!
     end
 
     def validate_content

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -1,6 +1,7 @@
 module Coronavirus::Pages
   class ContentBuilder
     attr_reader :page, :errors
+    class GitHubConnectionError < RuntimeError; end
 
     def initialize(page)
       @page = page
@@ -21,8 +22,6 @@ module Coronavirus::Pages
         data["hidden_search_terms"] = hidden_search_terms
         data
       end
-    rescue RestClient::Exception => e
-      add_error(e.message)
     end
 
     def success?
@@ -73,6 +72,8 @@ module Coronavirus::Pages
 
     def github_raw_data
       YamlFetcher.new(page.raw_content_url).body_as_hash
+    rescue RestClient::Exception
+      raise GitHubConnectionError
     end
 
     def github_data

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -2,6 +2,8 @@ module Coronavirus::Pages
   class ContentBuilder
     attr_reader :page, :errors
     class GitHubConnectionError < RuntimeError; end
+    class GitHubInvalidContentError < RuntimeError; end
+    class InvalidContentError < RuntimeError; end
 
     def initialize(page)
       @page = page
@@ -38,7 +40,8 @@ module Coronavirus::Pages
       required_keys =
         type.to_sym == :landing ? required_landing_page_keys : required_hub_page_keys
       missing_keys = (required_keys - github_data.keys)
-      add_error("Invalid content - please recheck GitHub and add #{missing_keys.join(', ')}.") if missing_keys.any?
+
+      raise GitHubInvalidContentError if missing_keys.any?
     end
 
     def type
@@ -89,7 +92,7 @@ module Coronavirus::Pages
         presenter = Coronavirus::SubSectionJsonPresenter.new(sub_section, page.content_id)
         presenter.output
       rescue Coronavirus::SubSectionJsonPresenter::MarkdownInvalidError => e
-        add_error(e.message)
+        raise InvalidContentError, e.message
       end
     end
 

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -33,15 +33,10 @@ module Coronavirus::Pages
 
     def discard
       Services.publishing_api.discard_draft(content_id)
-    rescue GdsApi::HTTPUnprocessableEntity => e
-      error_handler(e, "You do not have a draft to discard")
-    rescue GdsApi::HTTPErrorResponse => e
-      error_handler(e, "There has been an error discarding your changes. Try again.")
-    end
-
-    def discarded?
-      discard
-      errors.empty?
+    rescue GdsApi::HTTPUnprocessableEntity
+      raise DraftUpdaterError, "You do not have a draft to discard"
+    rescue GdsApi::HTTPErrorResponse
+      raise DraftUpdaterError, "There has been an error discarding your changes. Try again."
     end
 
     def errors

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -27,8 +27,8 @@ module Coronavirus::Pages
     def send
       @send ||= Services.publishing_api.put_content(content_id, payload)
       page.update!(state: "draft")
-    rescue GdsApi::HTTPErrorResponse => e
-      error_handler(e, "Failed to update the draft content item. Try saving again.")
+    rescue GdsApi::HTTPErrorResponse
+      raise DraftUpdaterError, "Failed to update the draft content item. Try saving again."
     end
 
     def discard
@@ -37,16 +37,6 @@ module Coronavirus::Pages
       raise DraftUpdaterError, "You do not have a draft to discard"
     rescue GdsApi::HTTPErrorResponse
       raise DraftUpdaterError, "There has been an error discarding your changes. Try again."
-    end
-
-    def errors
-      @errors ||= []
-    end
-
-    def error_handler(error, message = nil)
-      GovukError.notify(error, extra: { content_id: content_id, page_slug: page.slug })
-      errors << (message || error.message)
-      false
     end
   end
 end

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -29,8 +29,6 @@ module Coronavirus::Pages
       page.update!(state: "draft")
     rescue GdsApi::HTTPErrorResponse => e
       error_handler(e, "Failed to update the draft content item. Try saving again.")
-    rescue DraftUpdaterError => e
-      error_handler(e)
     end
 
     def discard

--- a/spec/controllers/coronavirus/announcements_controller_spec.rb
+++ b/spec/controllers/coronavirus/announcements_controller_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Coronavirus::AnnouncementsController do
 
     let(:updated_announcement_params) do
       {
-        title: "Updated title",
+        title: title,
         path: "/updated/path",
         published_at: published_at,
       }
@@ -150,23 +150,54 @@ RSpec.describe Coronavirus::AnnouncementsController do
       }
     end
 
-    subject { patch :update, params: params }
+    context "when an announcement is valid" do
+      it "updates an announcement" do
+        expect { patch :update, params: params }
+          .to change { announcement.reload.title }.to(title)
+      end
 
-    it "redirects to coronavirus page on success" do
-      expect(subject).to redirect_to(coronavirus_page_path(page.slug))
+      it "redirects to coronavirus page" do
+        patch :update, params: params
+        expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      end
     end
 
-    it "updates the announcements" do
-      expect { subject }.not_to(change { Coronavirus::Announcement.count })
+    context "when the announcement is invalid" do
+      let(:title) { "" }
+
+      it "doesn't update an announcement" do
+        expect { patch :update, params: params }
+          .not_to(change { announcement.reload.title })
+      end
+
+      it "returns an unprocessable entity response" do
+        patch :update, params: params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the errors" do
+        patch :update, params: params
+        expect(response.body).to include(CGI.escapeHTML("Title can't be blank"))
+      end
     end
 
-    it "changes the attributes of the announcement" do
-      subject
-      published_at_time = Time.zone.local(updated_announcement_params[:published_at]["year"], updated_announcement_params[:published_at]["month"], updated_announcement_params[:published_at]["day"])
-      announcement.reload
-      expect(announcement.title).to eq(updated_announcement_params[:title])
-      expect(announcement.path).to eq(updated_announcement_params[:path])
-      expect(announcement.published_at).to eq(published_at_time)
+    context "when there is a problem updating the Publishing API" do
+      before { stub_publishing_api_isnt_available }
+
+      it "doesn't update an announcement" do
+        expect { patch :update, params: params }
+          .not_to(change { announcement.reload.title })
+      end
+
+      it "returns a internal server error response" do
+        patch :update, params: params
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it "renders the errors" do
+        patch :update, params: params
+        expect(response.body).to include("Failed to update the draft content item. Try saving again.")
+      end
     end
   end
 end

--- a/spec/controllers/coronavirus/announcements_controller_spec.rb
+++ b/spec/controllers/coronavirus/announcements_controller_spec.rb
@@ -98,20 +98,21 @@ RSpec.describe Coronavirus::AnnouncementsController do
       }
     end
 
-    subject { delete :destroy, params: announcement_params }
-
     it "redirects to the coronavirus page" do
-      expect(subject).to redirect_to(coronavirus_page_path(page.slug))
+      delete :destroy, params: announcement_params
+      expect(response).to redirect_to(coronavirus_page_path(page.slug))
     end
 
     it "deletes the announcement" do
-      expect { subject }.to change { Coronavirus::Announcement.count }.by(-1)
+      expect { delete :destroy, params: announcement_params }
+        .to change { Coronavirus::Announcement.count }.by(-1)
     end
 
     it "doesn't delete the announcement if draft_updater fails" do
       stub_publishing_api_isnt_available
 
-      expect { subject }.to_not(change { page.reload.announcements.to_a })
+      expect { delete :destroy, params: announcement_params }
+        .not_to(change { Coronavirus::Announcement.count })
     end
   end
 

--- a/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
+++ b/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
@@ -118,12 +118,21 @@ RSpec.describe Coronavirus::TimelineEntriesController do
 
   describe "PATCH /coronavirus/:page_slug/timeline_entries/:id" do
     let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
-    let(:timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
+    let!(:timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
+    let(:heading) { "Updated heading" }
 
     let(:updated_timeline_entry_params) do
       {
-        heading: "Updated heading",
+        heading: heading,
         content: "##Updated content",
+      }
+    end
+
+    let(:params) do
+      {
+        id: timeline_entry.id,
+        page_slug: page.slug,
+        timeline_entry: updated_timeline_entry_params,
       }
     end
 
@@ -132,28 +141,54 @@ RSpec.describe Coronavirus::TimelineEntriesController do
       stub_coronavirus_publishing_api
     end
 
-    it "updates the timeline entry" do
-      patch :update,
-            params: {
-              id: timeline_entry.id,
-              page_slug: page.slug,
-              timeline_entry: updated_timeline_entry_params,
-            }
+    context "when a timeline entry is valid" do
+      it "updates a timeline entry" do
+        expect { patch :update, params: params }
+          .to change { timeline_entry.reload.heading }.to(heading)
+      end
 
-      timeline_entry.reload
-      expect(timeline_entry.heading).to eq(updated_timeline_entry_params[:heading])
-      expect(timeline_entry.content).to eq(updated_timeline_entry_params[:content])
+      it "redirects to coronavirus page" do
+        patch :update, params: params
+        expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      end
     end
 
-    it "redirects to coronavirus page on success" do
-      patch :update,
-            params: {
-              id: timeline_entry.id,
-              page_slug: page.slug,
-              timeline_entry: updated_timeline_entry_params,
-            }
+    context "when the timeline entry is invalid" do
+      let(:heading) { "" }
 
-      expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      it "doesn't update a timeline entry" do
+        expect { patch :update, params: params }
+          .not_to(change { timeline_entry.reload.heading })
+      end
+
+      it "returns an unprocessable entity response" do
+        patch :update, params: params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the errors" do
+        patch :update, params: params
+        expect(response.body).to include(CGI.escapeHTML("Heading can't be blank"))
+      end
+    end
+
+    context "when there is a problem updating the Publishing API" do
+      before { stub_publishing_api_isnt_available }
+
+      it "doesn't update a timeline entry" do
+        expect { patch :update, params: params }
+          .not_to(change { timeline_entry.reload.heading })
+      end
+
+      it "returns a internal server error response" do
+        patch :update, params: params
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it "renders the errors" do
+        patch :update, params: params
+        expect(response.body).to include("Failed to update the draft content item. Try saving again.")
+      end
     end
   end
 

--- a/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
+++ b/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe Coronavirus::TimelineEntriesController do
   include CoronavirusFeatureSteps
 
+  render_views
+
   let(:stub_user) { create :user, name: "Name Surname" }
   let(:page) { create :coronavirus_page, :landing }
 
@@ -37,27 +39,55 @@ RSpec.describe Coronavirus::TimelineEntriesController do
       stub_any_publishing_api_call
     end
 
-    it "saves a new timeline entry" do
-      post :create,
-           params: {
-             page_slug: page.slug,
-             timeline_entry: timeline_entry_params,
-           }
+    context "when a timeline entry is valid" do
+      it "creates a timeline entry" do
+        expect { post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params } }
+          .to change { Coronavirus::TimelineEntry.where(heading: heading).count }.by(1)
+      end
 
-      timeline_entry = page.timeline_entries.last
-
-      expect(timeline_entry.heading).to eq(heading)
-      expect(timeline_entry.content).to eq(content)
+      it "redirects to coronavirus page" do
+        post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params }
+        expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      end
     end
 
-    it "redirects to coronavirus page on success" do
-      post :create,
-           params: {
-             page_slug: page.slug,
-             timeline_entry: timeline_entry_params,
-           }
+    context "when the timeline entry is invalid" do
+      let(:heading) { "" }
 
-      expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      it "doesn't create a timeline entry" do
+        expect { post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params } }
+          .not_to(change { Coronavirus::TimelineEntry.count })
+      end
+
+      it "returns an unprocessable entity response" do
+        post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders the errors" do
+        post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params }
+        expect(response.body).to include(CGI.escapeHTML("Heading can't be blank"))
+      end
+    end
+
+    context "when there is a problem updating the Publishing API" do
+      before { stub_publishing_api_isnt_available }
+
+      it "doesn't create a timeline entry" do
+        expect {
+          post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params }
+        }.not_to(change { Coronavirus::TimelineEntry.count })
+      end
+
+      it "returns a internal server error response" do
+        post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params }
+        expect(response).to have_http_status(:internal_server_error)
+      end
+
+      it "renders the errors" do
+        post :create, params: { page_slug: page.slug, timeline_entry: timeline_entry_params }
+        expect(response.body).to include("Failed to update the draft content item. Try saving again.")
+      end
     end
   end
 

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -233,7 +233,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
         when_i_visit_the_coronavirus_index_page
         and_i_select_business_page
         and_i_push_a_new_draft_business_version_with_invalid_content
-        and_i_see_an_alert_for_missing_hub_page_keys
+        and_i_see_an_alert
       end
 
       scenario "Publishing business page" do

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -147,21 +147,4 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
       expect(data["live_stream"]["video_url"]).to be_nil
     end
   end
-
-  describe "#success?" do
-    it "is true if call successful" do
-      expect(subject.success?).to be(true)
-    end
-
-    context "on failure" do
-      before do
-        stub_request(:get, Regexp.new(page.raw_content_url))
-          .to_return(status: 400)
-      end
-
-      it "is false" do
-        expect(subject.success?).to be(false)
-      end
-    end
-  end
 end

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     stub_request(:get, Regexp.new(page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
   end
+
+  describe "#github_raw_data" do
+    it "returns an error if GitHub is unavailable" do
+      stub_request(:get, Regexp.new(page.raw_content_url))
+        .to_return(status: 500)
+
+      expect { subject.github_raw_data }.to raise_error(Coronavirus::Pages::ContentBuilder::GitHubConnectionError)
+    end
+  end
+
   describe "#github_data" do
     it "returns github content" do
       expect(subject.github_data).to eq github_content["content"]

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     end
   end
 
+  describe "#validate_content" do
+    it "returns an error if GitHub is missing required keys" do
+      allow(subject)
+        .to receive(:github_data)
+        .and_return(github_content["content"].except("title"))
+
+      expect { subject.validate_content }.to raise_error(Coronavirus::Pages::ContentBuilder::GitHubInvalidContentError)
+    end
+  end
+
   describe "#github_data" do
     it "returns github content" do
       expect(subject.github_data).to eq github_content["content"]
@@ -75,6 +85,12 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
   describe "#sub_sections_data" do
     it "returns the sub_sections" do
       expect(subject.sub_sections_data).to eq []
+    end
+
+    it "raises an error if the sub-section has invalid content" do
+      create(:coronavirus_sub_section, page: page, content: "I am invalid")
+
+      expect { subject.sub_sections_data }.to raise_error(Coronavirus::Pages::ContentBuilder::InvalidContentError)
     end
 
     context "with subsections" do

--- a/spec/services/coronavirus/pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus/pages/draft_updater_spec.rb
@@ -4,20 +4,54 @@ RSpec.describe Coronavirus::Pages::DraftUpdater do
   include CoronavirusFeatureSteps
 
   let(:page) { create :coronavirus_page }
-  let(:content_builder) { Coronavirus::Pages::ContentBuilder.new(page) }
-  let(:payload) { Coronavirus::PagePresenter.new(content_builder.data, page.base_path).payload }
   let(:github_fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
   let(:github_content) { YAML.safe_load(File.read(github_fixture_path)) }
 
-  subject { described_class.new(page) }
-
   before do
-    stub_coronavirus_publishing_api
     stub_request(:get, Regexp.new(page.raw_content_url))
       .to_return(status: 200, body: github_content.to_json)
   end
 
-  it "#payload" do
-    expect(subject.payload).to eq payload
+  describe "#payload" do
+    it "returns the payload for publishing-api" do
+      stub_coronavirus_publishing_api
+      content_builder = Coronavirus::Pages::ContentBuilder.new(page)
+      expected_payload = Coronavirus::PagePresenter.new(content_builder.data, page.base_path).payload
+
+      expect(described_class.new(page).payload).to eq expected_payload
+    end
+
+    it "catches InvalidContentError from ContentBuilder and adds a user friendly message" do
+      allow(Coronavirus::Pages::ContentBuilder)
+        .to receive(:new)
+        .and_raise(Coronavirus::Pages::ContentBuilder::InvalidContentError)
+
+      expect { described_class.new(page).payload }.to raise_error(
+        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
+        "Invalid content in one of the sub-sections",
+      )
+    end
+
+    it "catches GitHubInvalidContentError from ContentBuilder and adds a user friendly message" do
+      allow(Coronavirus::Pages::ContentBuilder)
+        .to receive(:new)
+        .and_raise(Coronavirus::Pages::ContentBuilder::GitHubInvalidContentError)
+
+      expect { described_class.new(page).payload }.to raise_error(
+        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
+        "Invalid content in GitHub YAML",
+      )
+    end
+
+    it "catches GitHubConnectionError from ContentBuilder and adds a user friendly message" do
+      allow(Coronavirus::Pages::ContentBuilder)
+        .to receive(:new)
+        .and_raise(Coronavirus::Pages::ContentBuilder::GitHubConnectionError)
+
+      expect { described_class.new(page).payload }.to raise_error(
+        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
+        "Unable to load content from GitHub",
+      )
+    end
   end
 end

--- a/spec/services/coronavirus/pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus/pages/draft_updater_spec.rb
@@ -74,4 +74,15 @@ RSpec.describe Coronavirus::Pages::DraftUpdater do
       )
     end
   end
+
+  describe "#send" do
+    it "raises an error if publishing-api is not available" do
+      stub_publishing_api_isnt_available
+
+      expect { described_class.new(page).send }.to raise_error(
+        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
+        "Failed to update the draft content item. Try saving again.",
+      )
+    end
+  end
 end

--- a/spec/services/coronavirus/pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus/pages/draft_updater_spec.rb
@@ -54,4 +54,24 @@ RSpec.describe Coronavirus::Pages::DraftUpdater do
       )
     end
   end
+
+  describe "#discard" do
+    it "raises an error if there isn't a draft to discard" do
+      stub_any_publishing_api_discard_draft.to_return(status: 422)
+
+      expect { described_class.new(page).discard }.to raise_error(
+        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
+        "You do not have a draft to discard",
+      )
+    end
+
+    it "raises an error if publishing-api is not available" do
+      stub_publishing_api_isnt_available
+
+      expect { described_class.new(page).discard }.to raise_error(
+        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
+        "There has been an error discarding your changes. Try again.",
+      )
+    end
+  end
 end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -563,11 +563,7 @@ module CoronavirusFeatureSteps
   end
 
   def and_i_see_an_alert
-    expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, announcements_label, announcements, nhs_banner, sections, topic_section, notifications, live_stream.")
-  end
-
-  def and_i_see_an_alert_for_missing_hub_page_keys
-    expect(page).to have_text("Invalid content - please recheck GitHub and add title, header_section, sections, topic_section, notifications.")
+    expect(page).to have_text("Invalid content in GitHub YAML")
   end
 
   def and_i_see_a_draft_updated_message


### PR DESCRIPTION
Trello: https://trello.com/c/fIY7Oy1L

# What?

Add transactions to the controller methods. Transactions will automatically rollback if something inside them throws an exception. Previously all of the exceptions were being swallowed and instead we were returning a list of errors, and had to manually raise an `ActiveRecord::Rollback` exception to make the transaction rollback.

To that end `ContentBuilder` and parts of `DraftUpdater` have also been updated to start raising their own exceptions.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
