### PR TITLE
Move subsection content validation to model

### DIFF
--- a/app/models/coronavirus/sub_section.rb
+++ b/app/models/coronavirus/sub_section.rb
@@ -5,10 +5,34 @@ class Coronavirus::SubSection < ApplicationRecord
   validates :title, :content, presence: true
   validates :page, presence: true
   validate :featured_link_must_be_in_content
+  validate :all_structured_content_valid
+  after_initialize :populate_structured_content
+  attr_reader :structured_content
+
+  def content=(content)
+    super.tap { populate_structured_content }
+  end
 
   def featured_link_must_be_in_content
-    if featured_link.present? && !content.include?(featured_link)
+    return if featured_link.blank? || !structured_content
+
+    unless structured_content.links.any? { |l| l.url == featured_link }
       errors.add(:featured_link, "does not exist in accordion content")
     end
+  end
+
+private
+
+  def populate_structured_content
+    @structured_content = if StructuredContent.parseable?(content)
+                            StructuredContent.parse(content)
+                          end
+  end
+
+  def all_structured_content_valid
+    StructuredContent.error_lines(content).each do |line|
+      errors.add(:content, "unable to parse markdown: #{line}")
+    end
+    errors.present?
   end
 end

--- a/app/models/coronavirus/sub_section/structured_content.rb
+++ b/app/models/coronavirus/sub_section/structured_content.rb
@@ -1,0 +1,56 @@
+class Coronavirus::SubSection::StructuredContent
+  HEADER_PATTERN = PatternMaker.call(
+    "starts_with hashes then perhaps_spaces then capture(text) and nothing_else",
+    hashes: "#+",
+    text: '\w.+',
+  )
+
+  LINK_PATTERN = PatternMaker.call(
+    "starts_with perhaps_spaces within(sq_brackets,capture(label)) then perhaps_spaces and within(brackets,capture(url))",
+    label: '\s*\w.+',
+    url: '\s*(\b(https?)://)?[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]\s*',
+  )
+
+  Header = Struct.new(:text)
+  Link = Struct.new(:label, :url)
+
+  attr_reader :items
+
+  def self.error_lines(raw_content)
+    return [] unless raw_content
+
+    raw_content.lines.filter_map do |line|
+      stripped = line.strip
+      next if stripped.empty?
+
+      stripped if HEADER_PATTERN.match(stripped).blank? && LINK_PATTERN.match(stripped).blank?
+    end
+  end
+
+  def self.parseable?(raw_content)
+    raw_content.present? && error_lines(raw_content).empty?
+  end
+
+  def self.parse(raw_content)
+    items = raw_content.lines.filter_map do |line|
+      header_match = HEADER_PATTERN.match(line.strip)
+      link_match = LINK_PATTERN.match(line.strip)
+
+      if header_match
+        Header.new(header_match[:text])
+      elsif link_match
+        Link.new(link_match[:label], link_match[:url])
+      end
+    end
+
+    new(items)
+  end
+
+  def initialize(items)
+    @items = items
+  end
+
+  def links
+    items.select { |i| i.is_a?(Link) }
+  end
+end

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -2,7 +2,6 @@ module Coronavirus::Pages
   class ContentBuilder
     class GitHubConnectionError < RuntimeError; end
     class GitHubInvalidContentError < RuntimeError; end
-    class InvalidContentError < RuntimeError; end
 
     attr_reader :page
 
@@ -81,8 +80,6 @@ module Coronavirus::Pages
       page.sub_sections.order(:position).map do |sub_section|
         presenter = Coronavirus::SubSectionJsonPresenter.new(sub_section, page.content_id)
         presenter.output
-      rescue Coronavirus::SubSectionJsonPresenter::MarkdownInvalidError => e
-        raise InvalidContentError, e.message
       end
     end
 

--- a/app/services/coronavirus/pages/draft_updater.rb
+++ b/app/services/coronavirus/pages/draft_updater.rb
@@ -16,8 +16,6 @@ module Coronavirus::Pages
 
     def payload
       Coronavirus::PagePresenter.new(content_builder.data, base_path).payload
-    rescue ContentBuilder::InvalidContentError
-      raise DraftUpdaterError, "Invalid content in one of the sub-sections"
     rescue ContentBuilder::GitHubInvalidContentError
       raise DraftUpdaterError, "Invalid content in GitHub YAML"
     rescue ContentBuilder::GitHubConnectionError

--- a/spec/controllers/coronavirus/sub_sections_controller_spec.rb
+++ b/spec/controllers/coronavirus/sub_sections_controller_spec.rb
@@ -54,21 +54,37 @@ RSpec.describe Coronavirus::SubSectionsController do
     end
 
     context "when the subsection is invalid" do
-      let(:title) { "" }
+      context "when the title is invalid" do
+        let(:title) { "" }
 
-      it "doesn't create a subsection" do
-        expect { post :create, params: params }
-          .not_to(change { Coronavirus::SubSection.count })
+        it "doesn't create a subsection" do
+          expect { post :create, params: params }
+            .not_to(change { Coronavirus::SubSection.count })
+        end
+
+        it "returns an unprocessable entity response" do
+          post :create, params: params
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "renders the errors" do
+          post :create, params: params
+          expect(response.body).to include(CGI.escapeHTML("Title can't be blank"))
+        end
       end
 
-      it "returns an unprocessable entity response" do
-        post :create, params: params
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
+      context "when the content is invalid" do
+        let(:content) { "###Title \n [label](/brexit" }
 
-      it "renders the errors" do
-        post :create, params: params
-        expect(response.body).to include(CGI.escapeHTML("Title can't be blank"))
+        it "doesn't create a subsection" do
+          expect { post :create, params: params }
+            .not_to(change { Coronavirus::SubSection.count })
+        end
+
+        it "renders the errors" do
+          post :create, params: params
+          expect(response.body).to include(CGI.escapeHTML("unable to parse markdown"))
+        end
       end
     end
 
@@ -126,21 +142,37 @@ RSpec.describe Coronavirus::SubSectionsController do
     end
 
     context "when the subsection is invalid" do
-      let(:title) { "" }
+      context "when the title is invalid" do
+        let(:title) { "" }
 
-      it "doesn't update a subsection" do
-        expect { patch :update, params: params }
-          .not_to(change { sub_section.reload.title })
+        it "doesn't update a subsection" do
+          expect { patch :update, params: params }
+            .not_to(change { sub_section.reload.title })
+        end
+
+        it "returns an unprocessable entity response" do
+          patch :update, params: params
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "renders the errors" do
+          patch :update, params: params
+          expect(response.body).to include(CGI.escapeHTML("Title can't be blank"))
+        end
       end
 
-      it "returns an unprocessable entity response" do
-        patch :update, params: params
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
+      context "when the content is invalid" do
+        let(:content) { "###Title \n [label](/brexit" }
 
-      it "renders the errors" do
-        patch :update, params: params
-        expect(response.body).to include(CGI.escapeHTML("Title can't be blank"))
+        it "doesn't update the structured content" do
+          expect { patch :update, params: params }
+            .not_to(change { sub_section.reload.structured_content })
+        end
+
+        it "renders the errors" do
+          patch :update, params: params
+          expect(response.body).to include(CGI.escapeHTML("unable to parse markdown"))
+        end
       end
     end
 

--- a/spec/models/coronavirus/sub_section/structured_content_spec.rb
+++ b/spec/models/coronavirus/sub_section/structured_content_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Coronavirus::SubSection::StructuredContent do
+  let(:content) { "###title \n [test](/coronavirus)" }
+
+  describe "#parseable?" do
+    it "returns true if content is valid" do
+      expect(described_class.parseable?(content)).to be true
+    end
+
+    it "returns false if hashes are missing from title" do
+      content = "title \n [test](/coronavirus)"
+      expect(described_class.parseable?(content)).to be false
+    end
+
+    it "returns false if a link is malformed" do
+      content = "###title \n [test](/coronavirus"
+      expect(described_class.parseable?(content)).to be false
+    end
+
+    it "returns false if there's a plaintext line in content" do
+      content = "###title \n [test](/coronavirus) \n plan text \n [another](/link)"
+      expect(described_class.parseable?(content)).to be false
+    end
+  end
+
+  describe "#parse" do
+    let(:parsed_content) { described_class.parse(content) }
+    it "converts a valid content string into a list of headers and links" do
+      expected_output = [
+        Coronavirus::SubSection::StructuredContent::Header.new("title"),
+        Coronavirus::SubSection::StructuredContent::Link.new("test", "/coronavirus"),
+      ]
+      expect(parsed_content.items).to eq(expected_output)
+    end
+  end
+
+  describe "#error_lines" do
+    it "returns an empty array for valid content" do
+      expect(described_class.error_lines(content)).to eq([])
+    end
+
+    it "returns an error when the header is wrong" do
+      content = "title \n [test](/coronavirus)"
+      expect(described_class.error_lines(content)).to eq(%w[title])
+    end
+
+    it "returns an error when a link is malformed" do
+      content = "###title \n [test](/coronavirus"
+      expect(described_class.error_lines(content)).to eq(%w[[test](/coronavirus])
+    end
+
+    it "can return multiple errors" do
+      content = "title \n [test](/coronavirus"
+      expect(described_class.error_lines(content).length).to eq(2)
+    end
+  end
+
+  describe "#links" do
+    it "only returns the link objects" do
+      links = described_class.parse(content).links
+      expected_output = [Coronavirus::SubSection::StructuredContent::Link.new("test", "/coronavirus")]
+      expect(links).to eq(expected_output)
+    end
+  end
+end

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -86,6 +86,40 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     end
   end
 
+  describe "#build_link" do
+    context "given a normal link" do
+      it "builds a link hash for the publishing api" do
+        expected_output = { label: "title", url: "/link" }
+        expect(subject.build_link("title", "/link")).to eq(expected_output)
+      end
+    end
+
+    context "given a featured link" do
+      it "builds a link hash for the publishing api with a featured link" do
+        allow(subject).to receive(:description_for_featured_link).and_return("description")
+
+        sub_section.featured_link = "/link"
+        expected_output = { label: "title", url: "/link", description: "description", featured_link: true }
+        expect(subject.build_link("title", "/link")).to eq(expected_output)
+      end
+    end
+
+    context "when link is to a subtopic path" do
+      let(:business) { create :coronavirus_page, :business }
+      let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+      let(:subtopic_content_item_description) { "Find out about the government response to coronavirus (COVID-19) and what you need to do." }
+
+      before do
+        stub_request(:get, Regexp.new(business.raw_content_url))
+          .to_return(body: File.read(fixture_path))
+      end
+      it "builds a link hash for the publishing api with a featured link" do
+        expected_output = { label: "business", url: business.base_path, description: subtopic_content_item_description, featured_link: true }
+        expect(subject.build_link("business", business.base_path)).to eq(expected_output)
+      end
+    end
+  end
+
   describe "#sub_sections" do
     context "given multiple titles" do
       let(:content) { "#title \n [test](/coronavirus) \n #title2 \n [test2](/government)" }

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -87,12 +87,6 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
       expect(subject.sub_sections_data).to eq []
     end
 
-    it "raises an error if the sub-section has invalid content" do
-      create(:coronavirus_sub_section, page: page, content: "I am invalid")
-
-      expect { subject.sub_sections_data }.to raise_error(Coronavirus::Pages::ContentBuilder::InvalidContentError)
-    end
-
     context "with subsections" do
       let!(:sub_section_0) { create :coronavirus_sub_section, position: 0, page: page }
       let!(:sub_section_1) { create :coronavirus_sub_section, position: 1, page: page }

--- a/spec/services/coronavirus/pages/draft_updater_spec.rb
+++ b/spec/services/coronavirus/pages/draft_updater_spec.rb
@@ -21,17 +21,6 @@ RSpec.describe Coronavirus::Pages::DraftUpdater do
       expect(described_class.new(page).payload).to eq expected_payload
     end
 
-    it "catches InvalidContentError from ContentBuilder and adds a user friendly message" do
-      allow(Coronavirus::Pages::ContentBuilder)
-        .to receive(:new)
-        .and_raise(Coronavirus::Pages::ContentBuilder::InvalidContentError)
-
-      expect { described_class.new(page).payload }.to raise_error(
-        Coronavirus::Pages::DraftUpdater::DraftUpdaterError,
-        "Invalid content in one of the sub-sections",
-      )
-    end
-
     it "catches GitHubInvalidContentError from ContentBuilder and adds a user friendly message" do
       allow(Coronavirus::Pages::ContentBuilder)
         .to receive(:new)


### PR DESCRIPTION
This attempts to remove validation that currently sits within the subsection json presenter. This is done by creating a structured content model within the subsection space that can create link objects and associated titles. The result of this is that the model layer has more information on what constitutes valid content.

We've been able to remove a lot of code from the json presenter and associated tests because the StructuredContent more closely resembles what's sent to the Publishing API and as such requires less logic.

Trello - https://trello.com/c/LwvWFlnk/160-move-subsection-presenter-validation-into-model-layer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
