### PR TITLE
Action link MVP

### DIFF
--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -70,7 +70,7 @@ module Coronavirus
     end
 
     def sub_section_params
-      params.require(:sub_section).permit(:title, :content, :featured_link)
+      params.require(:sub_section).permit(:title, :content, :action_link_url)
     end
 
     def draft_updater

--- a/app/controllers/coronavirus/sub_sections_controller.rb
+++ b/app/controllers/coronavirus/sub_sections_controller.rb
@@ -70,7 +70,7 @@ module Coronavirus
     end
 
     def sub_section_params
-      params.require(:sub_section).permit(:title, :content, :action_link_url)
+      params.require(:sub_section).permit(:title, :content, :action_link_url, :action_link_content, :action_link_summary)
     end
 
     def draft_updater

--- a/app/models/coronavirus/sub_section.rb
+++ b/app/models/coronavirus/sub_section.rb
@@ -8,6 +8,7 @@ class Coronavirus::SubSection < ApplicationRecord
             :action_link_content,
             :action_link_summary,
             presence: true,
+            length: { maximum: 255 },
             if: -> { [action_link_url, action_link_content, action_link_summary].any?(&:present?) }
   validates :action_link_url, allow_blank: true, absolute_path_or_https_url: true
   validate :all_structured_content_valid

--- a/app/models/coronavirus/sub_section.rb
+++ b/app/models/coronavirus/sub_section.rb
@@ -4,21 +4,17 @@ class Coronavirus::SubSection < ApplicationRecord
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :title, :content, presence: true
   validates :page, presence: true
-  validate :action_link_url_must_be_in_content
+  validates :action_link_url,
+            :action_link_content,
+            :action_link_summary,
+            presence: true,
+            if: -> { [action_link_url, action_link_content, action_link_summary].any?(&:present?) }
   validate :all_structured_content_valid
   after_initialize :populate_structured_content
   attr_reader :structured_content
 
   def content=(content)
     super.tap { populate_structured_content }
-  end
-
-  def action_link_url_must_be_in_content
-    return if action_link_url.blank? || !structured_content
-
-    unless structured_content.links.any? { |l| l.url == action_link_url }
-      errors.add(:action_link_url, "does not exist in accordion content")
-    end
   end
 
 private

--- a/app/models/coronavirus/sub_section.rb
+++ b/app/models/coronavirus/sub_section.rb
@@ -4,7 +4,7 @@ class Coronavirus::SubSection < ApplicationRecord
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :title, :content, presence: true
   validates :page, presence: true
-  validate :featured_link_must_be_in_content
+  validate :action_link_url_must_be_in_content
   validate :all_structured_content_valid
   after_initialize :populate_structured_content
   attr_reader :structured_content
@@ -13,11 +13,11 @@ class Coronavirus::SubSection < ApplicationRecord
     super.tap { populate_structured_content }
   end
 
-  def featured_link_must_be_in_content
-    return if featured_link.blank? || !structured_content
+  def action_link_url_must_be_in_content
+    return if action_link_url.blank? || !structured_content
 
-    unless structured_content.links.any? { |l| l.url == featured_link }
-      errors.add(:featured_link, "does not exist in accordion content")
+    unless structured_content.links.any? { |l| l.url == action_link_url }
+      errors.add(:action_link_url, "does not exist in accordion content")
     end
   end
 

--- a/app/models/coronavirus/sub_section.rb
+++ b/app/models/coronavirus/sub_section.rb
@@ -9,6 +9,7 @@ class Coronavirus::SubSection < ApplicationRecord
             :action_link_summary,
             presence: true,
             if: -> { [action_link_url, action_link_content, action_link_summary].any?(&:present?) }
+  validates :action_link_url, allow_blank: true, absolute_path_or_https_url: true
   validate :all_structured_content_valid
   after_initialize :populate_structured_content
   attr_reader :structured_content

--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -36,22 +36,10 @@ class Coronavirus::SubSectionJsonPresenter
   end
 
   def build_link(label, url)
-    link = { label: label, url: append_priority_taxon_query_param(url) }
-    if subtopic_paths.keys.include?(link[:url])
-      link[:description] = description_from_raw_content(link[:url])
-      link[:featured_link] = true
-    end
-    link
-  end
-
-  def description_from_raw_content(url)
-    raw_content_url = subtopic_paths[url]
-    raw_content = YamlFetcher.new(raw_content_url).body_as_hash
-    raw_content.dig("content", "meta_description")
-  end
-
-  def subtopic_paths
-    @subtopic_paths ||= Coronavirus::Page.subtopic_pages.pluck(:base_path, :raw_content_url).to_h
+    {
+      label: label,
+      url: append_priority_taxon_query_param(url),
+    }
   end
 
 private

--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -38,7 +38,7 @@ class Coronavirus::SubSectionJsonPresenter
     if subtopic_paths.keys.include?(link[:url])
       link[:description] = description_from_raw_content(link[:url])
       link[:featured_link] = true
-    elsif @sub_section.featured_link == link[:url]
+    elsif @sub_section.action_link_url == link[:url]
       link[:description] = description_for_featured_link(link[:url])
       link[:featured_link] = true
     end

--- a/app/services/coronavirus/pages/draft_discarder.rb
+++ b/app/services/coronavirus/pages/draft_discarder.rb
@@ -52,6 +52,9 @@ module Coronavirus::Pages
           title: attributes[:title],
           content: attributes[:content],
           position: index,
+          action_link_url: attributes[:action_link_url],
+          action_link_content: attributes[:action_link_content],
+          action_link_summary: attributes[:action_link_summary],
         )
       end
 

--- a/app/services/coronavirus/pages/sections_presenter.rb
+++ b/app/services/coronavirus/pages/sections_presenter.rb
@@ -18,6 +18,8 @@ module Coronavirus::Pages
         "title": hash["title"],
         "content": sub_section_data[:content],
         "action_link_url": sub_section_data[:action_link_url],
+        "action_link_content": sub_section_data[:action_link_content],
+        "action_link_summary": sub_section_data[:action_link_summary],
       }
     end
   end

--- a/app/services/coronavirus/pages/sections_presenter.rb
+++ b/app/services/coronavirus/pages/sections_presenter.rb
@@ -17,7 +17,7 @@ module Coronavirus::Pages
       {
         "title": hash["title"],
         "content": sub_section_data[:content],
-        "featured_link": sub_section_data[:featured_link],
+        "action_link_url": sub_section_data[:action_link_url],
       }
     end
   end

--- a/app/services/coronavirus/pages/sub_section_processor.rb
+++ b/app/services/coronavirus/pages/sub_section_processor.rb
@@ -4,18 +4,18 @@ module Coronavirus::Pages
       new(*args).output
     end
 
-    attr_reader :sub_sections, :featured_link
+    attr_reader :sub_sections, :action_link_url
 
     def initialize(sub_sections)
       @sub_sections = [sub_sections].flatten
-      @featured_link = nil
+      @action_link_url = nil
     end
 
     def output
       process
       {
         content: output_array.join("\n"),
-        featured_link: featured_link,
+        action_link_url: action_link_url,
       }
     end
 
@@ -27,8 +27,8 @@ module Coronavirus::Pages
       output_array << text
     end
 
-    def add_featured_link(url)
-      @featured_link = url
+    def add_action_link_url(url)
+      @action_link_url = url
     end
 
     def process
@@ -36,7 +36,7 @@ module Coronavirus::Pages
         add_string("####{sub_section['title']}") if sub_section["title"].present?
         sub_section["list"].each do |item|
           add_string "[#{item['label']}](#{remove_priority_taxon_param(item['url'])})"
-          add_featured_link(item["url"]) if item["featured_link"]
+          add_action_link_url(item["url"]) if item["featured_link"]
         end
       end
     end

--- a/app/services/coronavirus/pages/sub_section_processor.rb
+++ b/app/services/coronavirus/pages/sub_section_processor.rb
@@ -4,18 +4,20 @@ module Coronavirus::Pages
       new(*args).output
     end
 
-    attr_reader :sub_sections, :action_link_url
+    attr_reader :sub_sections, :action_link
 
     def initialize(sub_sections)
       @sub_sections = [sub_sections].flatten
-      @action_link_url = nil
+      @action_link = {}
     end
 
     def output
       process
       {
         content: output_array.join("\n"),
-        action_link_url: action_link_url,
+        action_link_url: action_link[:url],
+        action_link_content: action_link[:content],
+        action_link_summary: action_link[:summary],
       }
     end
 
@@ -27,16 +29,21 @@ module Coronavirus::Pages
       output_array << text
     end
 
-    def add_action_link_url(url)
-      @action_link_url = url
+    def add_action_link(item)
+      action_link[:url] = remove_priority_taxon_param(item["url"])
+      action_link[:content] = item["label"]
+      action_link[:summary] = item["description"]
     end
 
     def process
       sub_sections.each do |sub_section|
         add_string("####{sub_section['title']}") if sub_section["title"].present?
         sub_section["list"].each do |item|
-          add_string "[#{item['label']}](#{remove_priority_taxon_param(item['url'])})"
-          add_action_link_url(item["url"]) if item["featured_link"]
+          if item["featured_link"]
+            add_action_link(item)
+          else
+            add_string "[#{item['label']}](#{remove_priority_taxon_param(item['url'])})"
+          end
         end
       end
     end

--- a/app/views/coronavirus/sub_sections/_form.html.erb
+++ b/app/views/coronavirus/sub_sections/_form.html.erb
@@ -1,11 +1,57 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus.sub_sections.form.heading.title"),
+  heading_level: 4,
+  margin_bottom: 5
+} %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t("coronavirus.sub_sections.form.title.label"),
+    text: t("coronavirus.sub_sections.form.heading.label"),
     bold: true
   },
   name: "sub_section[title]",
   id: "title",
   value: @sub_section.title
+} %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus.sub_sections.form.action_link.title"),
+  heading_level: 4,
+  margin_bottom: 5
+} %>
+<%= render "govuk_publishing_components/components/hint", {
+  text: t("coronavirus.sub_sections.form.action_link.hint")
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t("coronavirus.sub_sections.form.action_link.action_link_content.label"),
+    bold: true
+  },
+  name: "sub_section[action_link_content]",
+  id: "action_link_content",
+  value: @sub_section.action_link_content
+} %>
+<%= render "govuk_publishing_components/components/textarea", {
+  label: {
+    text: t("coronavirus.sub_sections.form.action_link.action_link_summary.label"),
+    bold: true
+  },
+  name: "sub_section[action_link_summary]",
+  id: "action_link_summary",
+  value: @sub_section.action_link_summary,
+  rows: 5
+} %>
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t("coronavirus.sub_sections.form.action_link.action_link_url.label"),
+    bold: true
+  },
+  name: "sub_section[action_link_url]",
+  id: "action_link_url",
+  value: @sub_section.action_link_url
+} %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("coronavirus.sub_sections.form.content.title"),
+  heading_level: 4,
+  margin_bottom: 5
 } %>
 <%= render "components/markdown_editor", {
   label: {
@@ -18,15 +64,6 @@
     rows: 20,
     value: @sub_section.content
   }
-} %>
-<%= render "govuk_publishing_components/components/input", {
-  label: {
-    text: t("coronavirus.sub_sections.form.action_link_url.label"),
-    bold: true
-  },
-  name: "sub_section[action_link_url]",
-  id: "title",
-  value: @sub_section.action_link_url
 } %>
 <%= render "govuk_publishing_components/components/button", {
   text: "Save",

--- a/app/views/coronavirus/sub_sections/_form.html.erb
+++ b/app/views/coronavirus/sub_sections/_form.html.erb
@@ -27,7 +27,8 @@
   },
   name: "sub_section[action_link_content]",
   id: "action_link_content",
-  value: @sub_section.action_link_content
+  value: @sub_section.action_link_content,
+  error_message: error_items(@sub_section.errors.messages, :action_link_content)
 } %>
 <%= render "govuk_publishing_components/components/textarea", {
   label: {
@@ -37,7 +38,8 @@
   name: "sub_section[action_link_summary]",
   id: "action_link_summary",
   value: @sub_section.action_link_summary,
-  rows: 5
+  rows: 5,
+  error_message: error_items(@sub_section.errors.messages, :action_link_summary)
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
@@ -46,7 +48,8 @@
   },
   name: "sub_section[action_link_url]",
   id: "action_link_url",
-  value: @sub_section.action_link_url
+  value: @sub_section.action_link_url,
+  error_message: error_items(@sub_section.errors.messages, :action_link_url)
 } %>
 <%= render "govuk_publishing_components/components/heading", {
   text: t("coronavirus.sub_sections.form.content.title"),

--- a/app/views/coronavirus/sub_sections/_form.html.erb
+++ b/app/views/coronavirus/sub_sections/_form.html.erb
@@ -21,7 +21,7 @@
 } %>
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: t("coronavirus.sub_sections.form.featured_link.label"),
+    text: t("coronavirus.sub_sections.form.action_link_url.label"),
     bold: true
   },
   name: "sub_section[action_link_url]",

--- a/app/views/coronavirus/sub_sections/_form.html.erb
+++ b/app/views/coronavirus/sub_sections/_form.html.erb
@@ -24,9 +24,9 @@
     text: t("coronavirus.sub_sections.form.featured_link.label"),
     bold: true
   },
-  name: "sub_section[featured_link]",
+  name: "sub_section[action_link_url]",
   id: "title",
-  value: @sub_section.featured_link
+  value: @sub_section.action_link_url
 } %>
 <%= render "govuk_publishing_components/components/button", {
   text: "Save",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,8 +165,8 @@ en:
           label: Accordion name
         content:
           label: Links and link text
-        featured_link:
-          label: Featured link
+        action_link_url:
+          label: Action link URL
     timeline_entries:
       new:
         title: Add timeline entry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,12 +161,21 @@ en:
       update:
         success: Sub-section was successfully updated.
       form:
-        title:
-          label: Accordion name
+        heading:
+          title: Accordion heading
+          label: Accordion heading content
+        action_link:
+          title: Accordion action link (optional)
+          hint: All fields below must be completed in order to display an action link within the accordion.
+          action_link_url:
+            label: Action link URL
+          action_link_content:
+            label: Action link content
+          action_link_summary:
+            label: Action link summary
         content:
-          label: Links and link text
-        action_link_url:
-          label: Action link URL
+          title: Accordion content
+          label: Accordion link and texts
     timeline_entries:
       new:
         title: Add timeline entry

--- a/db/migrate/20210325103947_rename_featured_link_to_action_link_url.rb
+++ b/db/migrate/20210325103947_rename_featured_link_to_action_link_url.rb
@@ -1,0 +1,5 @@
+class RenameFeaturedLinkToActionLinkUrl < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :coronavirus_sub_sections, :featured_link, :action_link_url
+  end
+end

--- a/db/migrate/20210325112605_add_action_link_fields_to_coronavirus_sub_sections.rb
+++ b/db/migrate/20210325112605_add_action_link_fields_to_coronavirus_sub_sections.rb
@@ -1,0 +1,8 @@
+class AddActionLinkFieldsToCoronavirusSubSections < ActiveRecord::Migration[6.0]
+  def change
+    change_table :coronavirus_sub_sections, bulk: true do |t|
+      t.string :action_link_content
+      t.string :action_link_summary
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2021_03_29_150719) do
     t.datetime "updated_at", null: false
     t.integer "position"
     t.string "action_link_url"
+    t.string "action_link_content"
+    t.string "action_link_summary"
     t.index ["coronavirus_page_id"], name: "index_coronavirus_sub_sections_on_coronavirus_page_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_150719) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
-    t.string "featured_link"
+    t.string "action_link_url"
     t.index ["coronavirus_page_id"], name: "index_coronavirus_sub_sections_on_coronavirus_page_id"
   end
 

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -1,5 +1,6 @@
-{ "content_id": "774cee22-d896-44c1-a611-e3109cce8eae",
-  "base_path" : "/coronavirus",
+{
+  "content_id": "774cee22-d896-44c1-a611-e3109cce8eae",
+  "base_path": "/coronavirus",
   "details": {
     "announcements_label": "Announcements",
     "announcements": [
@@ -13,6 +14,17 @@
       {
         "title": "Protect yourself and others from coronavirus",
         "sub_sections": [
+          {
+            "list": [
+              {
+                "url": "/bananas",
+                "label": "Bananas",
+                "description": "Bananas",
+                "featured_link": true
+              }
+            ],
+            "title": null
+          },
           {
             "list": [
               {
@@ -64,5 +76,7 @@
       "heading": "Recent and upcoming changes"
     }
   },
-  "state_history": { "1": "published" }
+  "state_history": {
+    "1": "published"
+  }
 }

--- a/spec/models/coronavirus/sub_section_spec.rb
+++ b/spec/models/coronavirus/sub_section_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Coronavirus::SubSection do
     end
 
     describe "action link fields" do
+      it { should validate_length_of(:action_link_url).is_at_most(255) }
+      it { should validate_length_of(:action_link_content).is_at_most(255) }
+      it { should validate_length_of(:action_link_summary).is_at_most(255) }
+
       it "validates if none of the action link fields are filled in" do
         sub_section.action_link_url = ""
         sub_section.action_link_content = nil

--- a/spec/models/coronavirus/sub_section_spec.rb
+++ b/spec/models/coronavirus/sub_section_spec.rb
@@ -36,16 +36,16 @@ RSpec.describe Coronavirus::SubSection do
 
     it "validates that the featured link is in content" do
       sub_section.content = "[test](/bananas)"
-      sub_section.featured_link = "/bananas"
+      sub_section.action_link_url = "/bananas"
 
       expect(sub_section).to be_valid
     end
 
     it "fails if featured link is not in content" do
-      sub_section.featured_link = "/bananas"
+      sub_section.action_link_url = "/bananas"
 
       expect(sub_section).not_to be_valid
-      expect(sub_section.errors).to have_key(:featured_link)
+      expect(sub_section.errors).to have_key(:action_link_url)
     end
   end
 end

--- a/spec/models/coronavirus/sub_section_spec.rb
+++ b/spec/models/coronavirus/sub_section_spec.rb
@@ -34,18 +34,32 @@ RSpec.describe Coronavirus::SubSection do
       expect(sub_section.errors).to have_key(:content)
     end
 
-    it "validates that the featured link is in content" do
-      sub_section.content = "[test](/bananas)"
-      sub_section.action_link_url = "/bananas"
+    describe "action link fields" do
+      it "validates if none of the action link fields are filled in" do
+        sub_section.action_link_url = ""
+        sub_section.action_link_content = nil
+        sub_section.action_link_summary = ""
 
-      expect(sub_section).to be_valid
-    end
+        expect(sub_section).to be_valid
+      end
 
-    it "fails if featured link is not in content" do
-      sub_section.action_link_url = "/bananas"
+      it "validates if all of the action link fields are filled in" do
+        sub_section.action_link_url = "/bananas"
+        sub_section.action_link_content = "Bananas"
+        sub_section.action_link_summary = "Bananas"
 
-      expect(sub_section).not_to be_valid
-      expect(sub_section.errors).to have_key(:action_link_url)
+        expect(sub_section).to be_valid
+      end
+
+      it "fails if not all of the action link fields are filled in" do
+        sub_section.action_link_url = "/bananas"
+        sub_section.action_link_content = ""
+        sub_section.action_link_summary = nil
+
+        expect(sub_section).not_to be_valid
+        expect(sub_section.errors).to have_key(:action_link_content)
+        expect(sub_section.errors).to have_key(:action_link_summary)
+      end
     end
   end
 end

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -52,21 +52,6 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
         expect(subject.build_link("title", "/link")).to eq(expected_output)
       end
     end
-
-    context "when link is to a subtopic path" do
-      let(:business) { create :coronavirus_page, :business }
-      let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
-      let(:subtopic_content_item_description) { "Find out about the government response to coronavirus (COVID-19) and what you need to do." }
-
-      before do
-        stub_request(:get, Regexp.new(business.raw_content_url))
-          .to_return(body: File.read(fixture_path))
-      end
-      it "builds a link hash for the publishing api with a featured link" do
-        expected_output = { label: "business", url: business.base_path, description: subtopic_content_item_description, featured_link: true }
-        expect(subject.build_link("business", business.base_path)).to eq(expected_output)
-      end
-    end
   end
 
   describe "#sub_sections" do

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -43,63 +43,12 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     it "has expected content" do
       expect(subject.output).to eq(expected)
     end
-
-    context "with action link" do
-      it "looks up the description in Publishing API for a relative action link" do
-        sub_section.action_link_url = path
-        description = Faker::Lorem.sentence
-
-        content_id = SecureRandom.uuid
-        stub_publishing_api_has_item(
-          base_path: path,
-          content_id: content_id,
-          description: description,
-        )
-        stub_publishing_api_has_lookups(path.to_s => content_id)
-
-        sub_sections_list = subject.output[:sub_sections].first[:list]
-
-        expect(sub_sections_list).to include(
-          hash_including(
-            url: path,
-            featured_link: true,
-            description: description,
-          ),
-        )
-      end
-
-      it "sets a nil description for an absolute action link" do
-        link = "https://example.com/path"
-        sub_section.action_link_url = link
-        sub_section.content = "[text](#{link})"
-
-        sub_sections_list = subject.output[:sub_sections].first[:list]
-
-        expect(sub_sections_list).to include(
-          hash_including(
-            url: link,
-            featured_link: true,
-            description: nil,
-          ),
-        )
-      end
-    end
   end
 
   describe "#build_link" do
     context "given a normal link" do
       it "builds a link hash for the publishing api" do
         expected_output = { label: "title", url: "/link" }
-        expect(subject.build_link("title", "/link")).to eq(expected_output)
-      end
-    end
-
-    context "given a action link" do
-      it "builds a link hash for the publishing api with a featured link" do
-        allow(subject).to receive(:description_for_featured_link).and_return("description")
-
-        sub_section.action_link_url = "/link"
-        expected_output = { label: "title", url: "/link", description: "description", featured_link: true }
         expect(subject.build_link("title", "/link")).to eq(expected_output)
       end
     end
@@ -154,6 +103,103 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
             },
           ]
         expect(subject.sub_sections).to eq(expected_output)
+      end
+    end
+
+    context "when a sub-section contains an action link" do
+      let(:title) { Faker::Lorem.sentence }
+      let(:label) { Faker::Lorem.sentence }
+      let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
+      let(:sub_section) do
+        create :coronavirus_sub_section, content: "###{title}\n[#{label}](#{path})"
+      end
+
+      it "includes an action link with a description and featured set to true" do
+        sub_section.action_link_url = "/bananas"
+        sub_section.action_link_content = "Bananas"
+        sub_section.action_link_summary = "Bananas"
+
+        expected = [
+          {
+            list: [
+              {
+                url: "/bananas",
+                label: "Bananas",
+                description: "Bananas",
+                featured_link: true,
+              },
+            ],
+            title: nil,
+          },
+          {
+            list: [
+              {
+                url: path,
+                label: label,
+              },
+            ],
+            title: title,
+          },
+        ]
+
+        expect(subject.sub_sections).to eq(expected)
+      end
+    end
+
+    context "when a priority taxon is provided" do
+      it "appends the priority_taxon to the url if the link is relative" do
+        link_url = "/hello-there"
+        sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
+        priority_taxon = SecureRandom.uuid
+
+        subject = described_class.new(sub_section, priority_taxon)
+        sub_sections_list = subject.sub_sections.first[:list]
+
+        expect(sub_sections_list).to include(
+          hash_including(url: "#{link_url}?priority-taxon=#{priority_taxon}"),
+        )
+      end
+
+      it "does not append a priority_taxon to the url if the link is external" do
+        link_url = "http://www.hello-there.com"
+        sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
+
+        subject = described_class.new(sub_section)
+        sub_sections_list = subject.output[:sub_sections].first[:list]
+
+        expect(sub_sections_list).to include(
+          hash_including(url: link_url),
+        )
+      end
+    end
+
+    context "when a priority taxon is not provided" do
+      it "does not append the priority-taxon to list urls" do
+        sub_section = build(:coronavirus_sub_section, content: "[test](/coronavirus)")
+
+        subject = described_class.new(sub_section)
+        sub_sections_list = subject.sub_sections.first[:list]
+
+        expect(sub_sections_list).to include(hash_including(url: "/coronavirus"))
+      end
+    end
+
+    context "when a sub-section has an action link and a priority taxon is provided" do
+      it "appends the priority_taxon to the action link url" do
+        sub_section = build(:coronavirus_sub_section,
+                            content: "#Title",
+                            action_link_url: "/bananas",
+                            action_link_content: Faker::Lorem.sentence,
+                            action_link_summary: Faker::Lorem.sentence)
+
+        priority_taxon = SecureRandom.uuid
+
+        subject = described_class.new(sub_section, priority_taxon)
+        sub_sections_list = subject.sub_sections.first[:list]
+
+        expect(sub_sections_list).to include(
+          hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),
+        )
       end
     end
   end

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
       expect(subject.output).to eq(expected)
     end
 
-    context "with featured links" do
-      it "looks up the description in Publishing API for a relative featured link" do
-        sub_section.featured_link = path
+    context "with action link" do
+      it "looks up the description in Publishing API for a relative action link" do
+        sub_section.action_link_url = path
         description = Faker::Lorem.sentence
 
         content_id = SecureRandom.uuid
@@ -68,9 +68,9 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
         )
       end
 
-      it "sets a nil description for an absolute featured link" do
+      it "sets a nil description for an absolute action link" do
         link = "https://example.com/path"
-        sub_section.featured_link = link
+        sub_section.action_link_url = link
         sub_section.content = "[text](#{link})"
 
         sub_sections_list = subject.output[:sub_sections].first[:list]
@@ -94,11 +94,11 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
       end
     end
 
-    context "given a featured link" do
+    context "given a action link" do
       it "builds a link hash for the publishing api with a featured link" do
         allow(subject).to receive(:description_for_featured_link).and_return("description")
 
-        sub_section.featured_link = "/link"
+        sub_section.action_link_url = "/link"
         expected_output = { label: "title", url: "/link", description: "description", featured_link: true }
         expect(subject.build_link("title", "/link")).to eq(expected_output)
       end

--- a/spec/services/coronavirus/pages/draft_discarder_spec.rb
+++ b/spec/services/coronavirus/pages/draft_discarder_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
       expect(page.sub_sections.count).to eq(3)
       expect(page.sub_sections.first.title).to eq("Protect yourself and others from coronavirus")
       expect(page.sub_sections.first.position).to eq(0)
+      expect(page.sub_sections.first.content).to eq(
+        "[Stay at home if you think you have coronavirus (self-isolating)](/government/publications/covid-19-stay-at-home-guidance)",
+      )
+
+      expect(page.sub_sections.first.action_link_url).to eq("/bananas")
+      expect(page.sub_sections.first.action_link_content).to eq("Bananas")
+      expect(page.sub_sections.first.action_link_summary).to eq("Bananas")
     end
 
     it "removes the sub_sections if there aren't any sub_sections in publishing_api" do
@@ -87,7 +94,7 @@ RSpec.describe Coronavirus::Pages::DraftDiscarder do
     end
 
     it "removes any priority-taxons query parameters from the live content" do
-      expect(payload_from_publishing_api["details"]["sections"].first["sub_sections"].first["list"].first["url"])
+      expect(payload_from_publishing_api["details"]["sections"].first["sub_sections"].second["list"].first["url"])
         .to eq("/government/publications/covid-19-stay-at-home-guidance?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae")
 
       stub_publishing_api_has_item(payload_from_publishing_api)

--- a/spec/services/coronavirus/pages/sections_presenter_spec.rb
+++ b/spec/services/coronavirus/pages/sections_presenter_spec.rb
@@ -33,7 +33,13 @@ RSpec.describe Coronavirus::Pages::SectionsPresenter do
     it "produces an array of hashes" do
       expect(subject).to be_an(Array)
       expect(subject.first).to be_a(Hash)
-      expect(subject.first.keys).to contain_exactly(:title, :content, :action_link_url)
+      expect(subject.first.keys).to contain_exactly(
+        :title,
+        :content,
+        :action_link_url,
+        :action_link_content,
+        :action_link_summary,
+      )
     end
 
     it "parses the title" do
@@ -42,10 +48,10 @@ RSpec.describe Coronavirus::Pages::SectionsPresenter do
 
     it "parses the content" do
       expect(subject.first[:content]).to be_a(String)
-      expect(subject.first[:content].lines.count).to eq 3
+      expect(subject.first[:content].lines.count).to eq 2
     end
 
-    it "gets the featured link" do
+    it "gets the action link" do
       expect(subject.first[:action_link_url]).to be_a(String)
     end
   end

--- a/spec/services/coronavirus/pages/sections_presenter_spec.rb
+++ b/spec/services/coronavirus/pages/sections_presenter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Coronavirus::Pages::SectionsPresenter do
     it "produces an array of hashes" do
       expect(subject).to be_an(Array)
       expect(subject.first).to be_a(Hash)
-      expect(subject.first.keys).to contain_exactly(:title, :content, :featured_link)
+      expect(subject.first.keys).to contain_exactly(:title, :content, :action_link_url)
     end
 
     it "parses the title" do
@@ -46,7 +46,7 @@ RSpec.describe Coronavirus::Pages::SectionsPresenter do
     end
 
     it "gets the featured link" do
-      expect(subject.first[:featured_link]).to be_a(String)
+      expect(subject.first[:action_link_url]).to be_a(String)
     end
   end
 end

--- a/spec/services/coronavirus/pages/sub_section_processor_spec.rb
+++ b/spec/services/coronavirus/pages/sub_section_processor_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Coronavirus::Pages::SubSectionProcessor do
   let(:title) { Faker::Lorem.sentence }
   let(:label) { Faker::Lorem.sentence }
+  let(:description) { Faker::Lorem.sentence }
   let(:url) { "/#{File.join(Faker::Lorem.words)}" }
   let(:label_1) { Faker::Lorem.sentence }
   let(:url_1) { "/#{File.join(Faker::Lorem.words)}?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae" }
@@ -15,7 +16,7 @@ RSpec.describe Coronavirus::Pages::SubSectionProcessor do
             "label" => label,
             "url" => url,
             "featured_link" => true,
-            "description" => Faker::Lorem.sentence,
+            "description" => description,
           },
           {
             "label" => label_1,
@@ -31,28 +32,38 @@ RSpec.describe Coronavirus::Pages::SubSectionProcessor do
     let(:lines) { subject[:content].split("\n") }
 
     it "creates the correct number of lines" do
-      # 3 = 1 title plus 2 links
-      expect(lines.count).to eq 3
+      # 2 = 1 title plus 1 link - feature_link's aren't created
+      expect(lines.count).to eq(2)
     end
 
     it "has title as the first line" do
       expect(lines.first).to eq "####{title}"
     end
 
-    it "has the first link as the second line" do
-      expect(lines.second).to eq "[#{label}](#{url})"
+    it "stores the url, label and description in the appropriate action_link fields" do
+      expect(subject).to match hash_including(
+        action_link_url: url,
+        action_link_content: label,
+        action_link_summary: description,
+      )
     end
 
-    it "removes any priority-taxons query parameters from the url" do
-      expect(lines.third).to eq "[#{label_1}](#{url_1.gsub('?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae', '')})"
-    end
-
-    it "returns the featured link" do
-      expect(subject[:action_link_url]).to eq(url)
+    it "removes any priority-taxons query parameters from any non-featured links" do
+      expect(lines.second).to eq "[#{label_1}](#{url_1.gsub('?priority-taxon=774cee22-d896-44c1-a611-e3109cce8eae', '')})"
     end
 
     context "with blank title" do
-      let(:title) { "" }
+      let(:data) do
+        {
+          "title" => nil,
+          "list" => [
+            {
+              "label" => label,
+              "url" => url,
+            },
+          ],
+        }
+      end
 
       it "has the first link as its first line" do
         expect(lines.first).to eq "[#{label}](#{url})"

--- a/spec/services/coronavirus/pages/sub_section_processor_spec.rb
+++ b/spec/services/coronavirus/pages/sub_section_processor_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Coronavirus::Pages::SubSectionProcessor do
     end
 
     it "returns the featured link" do
-      expect(subject[:featured_link]).to eq(url)
+      expect(subject[:action_link_url]).to eq(url)
     end
 
     context "with blank title" do


### PR DESCRIPTION
[Trello](https://trello.com/c/B7f0bkef/257-mvp-create-new-input-fields-for-action-link-content-publishing-tool)

## What?

This updates an existing sub section field (from `featured_link` to `action_link_url`) and adds two new fields:

1. `action_link_content` - which will be used to contain the link text, and
2. `action_link_summary` - which will be used to hold the description of the page being linked to.  A content item for example.

Together these three fields (`action_link_url`, `action_link_content` and `action_link_summary`) constitute an `action link`.

In addition, we also update the existing JSON presenter that is used to store this data in the `publishing-api` and the various data structures that are used to re-create a draft edition of the content when a user discards an existing draft from the current live version in the `publishing-api`, and add two validation rules on the sub section model:

1. The model should only be considered 'valid' - and can therefore be saved - if either all three `action link` fields (`action_link_url`, `action_link_content` and `action_link_summary`) are present or they are all empty. The presence of any single field or any two of them means the model is invalid and the missing field(s) will be highlighted to the user.
2. The `action_link_url` field can accept both internal and external links.

## Why?

These three fields: `action_link_url`, `action_link_content` and `action_link_summary` will allow content designers to add action links to the accordions featured on the Coronavirus landing page where they are styled with a "jarrow".  This makes it possible to highlight links to external (the NHS website for example) or internal pages, making it easier for users to find information about testing and vaccinations.

## Assumptions

1. There will only be one action link in each accordion/sub-section.
2. The action link will appear at the top of the accordion/sub-section.
3. In the MVP none of the fields will be pre-populated.

## Screenshots

### Before

![screencapture-collections-publisher-integration-publishing-service-gov-uk-coronavirus-landing-sub-sections-127-edit-2021-03-26-10_07_53](https://user-images.githubusercontent.com/44037625/112616039-291d9d80-8e1b-11eb-9735-79638733f348.png)

### After

![screencapture-collections-publisher-integration-publishing-service-gov-uk-coronavirus-landing-sub-sections-140-edit-2021-04-01-15_45_19](https://user-images.githubusercontent.com/44037625/113313433-26331900-9303-11eb-8460-6b46e7a420c6.png)

![screencapture-collections-publisher-integration-publishing-service-gov-uk-coronavirus-landing-sub-sections-140-2021-04-01-15_45_44](https://user-images.githubusercontent.com/44037625/113313416-2206fb80-9303-11eb-8236-c6edf4b130d9.png)

![screencapture-collections-publisher-dev-gov-uk-coronavirus-landing-sub-sections-2-2021-04-13-15_08_30](https://user-images.githubusercontent.com/44037625/114566784-82cef600-9c6a-11eb-9b30-4dd4d7f04dc7.png)

![screencapture-collections-publisher-integration-publishing-service-gov-uk-coronavirus-landing-sub-sections-140-2021-04-01-15_46_46](https://user-images.githubusercontent.com/44037625/113313426-24695580-9303-11eb-9768-115897b0f4d2.png)

![Screenshot 2021-04-01 at 15 52 34](https://user-images.githubusercontent.com/44037625/113313443-28957300-9303-11eb-982f-6da702b08688.png)

![Screenshot 2021-04-01 at 15 57 00](https://user-images.githubusercontent.com/44037625/113313459-2cc19080-9303-11eb-81c8-7c41163b85d2.png)

### MVP Mock-up

![mvp_publishingTool](https://user-images.githubusercontent.com/44037625/112998204-bb98a680-9165-11eb-8baf-bd73a59c4a7a.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️