### PR TITLE
Change coronavirus_announcements schema for path -> url change

### DIFF
--- a/app/models/coronavirus/announcement.rb
+++ b/app/models/coronavirus/announcement.rb
@@ -1,6 +1,10 @@
 class Coronavirus::Announcement < ApplicationRecord
   self.table_name = "coronavirus_announcements"
 
+  # Maintain use of a path attribute in the model while we transition the app
+  # to use a url attribute instead.
+  alias_attribute :path, :url
+
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :title, :path, presence: true
   validates :page, presence: true

--- a/db/migrate/20210325171427_change_coronavirus_announcements_path_to_url.rb
+++ b/db/migrate/20210325171427_change_coronavirus_announcements_path_to_url.rb
@@ -1,0 +1,5 @@
+class ChangeCoronavirusAnnouncementsPathToUrl < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :coronavirus_announcements, :path, :url
+  end
+end

--- a/db/migrate/20210325171835_improve_coronavirus_announcements_schema.rb
+++ b/db/migrate/20210325171835_improve_coronavirus_announcements_schema.rb
@@ -1,0 +1,19 @@
+class ImproveCoronavirusAnnouncementsSchema < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Change from string to allow URL's longer than 255 characters
+        change_column :coronavirus_announcements, :url, :text, null: false
+      end
+
+      dir.down do
+        change_column :coronavirus_announcements, :url, :string
+      end
+    end
+
+    # These fields are all required so shouldn't allow null
+    change_column_null :coronavirus_announcements, :coronavirus_page_id, false
+    change_column_null :coronavirus_announcements, :title, false
+    change_column_null :coronavirus_announcements, :url, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_05_143416) do
+ActiveRecord::Schema.define(version: 2021_03_25_171427) do
 
   create_table "coronavirus_announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id"
     t.string "title"
-    t.string "path"
+    t.string "url"
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_171427) do
+ActiveRecord::Schema.define(version: 2021_03_25_171835) do
 
   create_table "coronavirus_announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "coronavirus_page_id"
-    t.string "title"
-    t.string "url"
+    t.bigint "coronavirus_page_id", null: false
+    t.string "title", null: false
+    t.text "url", null: false
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Trello: https://trello.com/c/CRwjuyqN/278-allow-external-links-from-announcements

This PR does the database changes needed to prepare the Coronavirus::Announcements model for a change from accepting a path to accepting a URL. It also resolves some ambiguity in the DB schema about what can be accepted by setting key fields to no longer accept null.

This is a somewhat dangerous PR, as the migration involves column changes (particularly rename) it can cause the app to error if it is being used during deployment. Therefore I will plan to carefully deploy it while the app is not being used (this seemed easier than a backfill process given this app is only sporadically used during a working day)

I've opened this a small PR to reflect that it's a bit dangerous to deploy so it doesn't get entangled with wider application changes. This reduces the risk that this will be deployed with bugs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
