### PR TITLE
[Dangerous deployment] Improve schema configuration for coronavirus_announcements fields

### DIFF
--- a/app/controllers/coronavirus/announcements_controller.rb
+++ b/app/controllers/coronavirus/announcements_controller.rb
@@ -71,7 +71,7 @@ module Coronavirus
     def announcement_params
       params
         .require(:announcement)
-        .permit(:title, :url, published_at: %i[day month year])
+        .permit(:title, :url, published_on: %i[day month year])
     end
 
     def draft_updater

--- a/app/models/coronavirus/announcement.rb
+++ b/app/models/coronavirus/announcement.rb
@@ -5,7 +5,7 @@ class Coronavirus::Announcement < ApplicationRecord
   validates :title, presence: true
   validates :url, presence: true, absolute_path_or_https_url: { allow_blank: true }
   validate :valid_published_on
-  after_create :set_position
+  before_create :set_position
   after_destroy :set_parent_positions
 
   def published_on=(published_on)
@@ -27,7 +27,7 @@ private
   attr_reader :published_on_hash
 
   def set_position
-    update_column(:position, page.announcements.count)
+    self.position = page.announcements.count + 1
   end
 
   def set_parent_positions

--- a/app/models/coronavirus/announcement.rb
+++ b/app/models/coronavirus/announcement.rb
@@ -4,27 +4,27 @@ class Coronavirus::Announcement < ApplicationRecord
   belongs_to :page, foreign_key: "coronavirus_page_id", optional: false
   validates :title, presence: true
   validates :url, presence: true, absolute_path_or_https_url: { allow_blank: true }
-  validate :valid_published_at
+  validate :valid_published_on
   after_create :set_position
   after_destroy :set_parent_positions
 
-  def published_at=(published_at)
-    unless published_at.is_a?(Hash)
-      @published_at_hash = nil
+  def published_on=(published_on)
+    unless published_on.is_a?(Hash)
+      @published_on_hash = nil
       super
       return
     end
 
-    @published_at_hash = published_at.reject { |_, value| value.blank? }
+    @published_on_hash = published_on.reject { |_, value| value.blank? }
                                      .presence
 
-    value = published_at_hash ? parsed_published_at_hash : nil
+    value = published_on_hash ? parsed_published_on_hash : nil
     super(value)
   end
 
 private
 
-  attr_reader :published_at_hash
+  attr_reader :published_on_hash
 
   def set_position
     update_column(:position, page.announcements.count)
@@ -34,20 +34,20 @@ private
     page.make_announcement_positions_sequential
   end
 
-  def parsed_published_at_hash
-    day, month, year = published_at_hash.values_at("day", "month", "year").map(&:to_i)
+  def parsed_published_on_hash
+    day, month, year = published_on_hash.values_at("day", "month", "year").map(&:to_i)
     Date.strptime("#{day}-#{month}-#{year}", "%d-%m-%Y")
   rescue ArgumentError
     nil
   end
 
-  def valid_published_at
-    if published_at_hash && !published_at
-      errors.add(:published_at, "must be a valid date")
-    elsif published_at && published_at.year < 2000
-      errors.add(:published_at, "must be this century")
-    elsif published_at&.future?
-      errors.add(:published_at, "must not be in the future")
+  def valid_published_on
+    if published_on_hash && !published_on
+      errors.add(:published_on, "must be a valid date")
+    elsif published_on && published_on.year < 2000
+      errors.add(:published_on, "must be this century")
+    elsif published_on&.future?
+      errors.add(:published_on, "must not be in the future")
     end
   end
 end

--- a/app/presenters/coronavirus/announcement_json_presenter.rb
+++ b/app/presenters/coronavirus/announcement_json_presenter.rb
@@ -10,7 +10,7 @@ class Coronavirus::AnnouncementJsonPresenter
     {
       "text" => announcement.title,
       "href" => remove_govuk_from_url(announcement.url),
-      "published_text" => announcement.published_at&.strftime("Published %-d %B %Y"),
+      "published_text" => announcement.published_on&.strftime("Published %-d %B %Y"),
     }.compact
   end
 end

--- a/app/services/coronavirus/pages/draft_discarder.rb
+++ b/app/services/coronavirus/pages/draft_discarder.rb
@@ -29,7 +29,7 @@ module Coronavirus::Pages
         Coronavirus::Announcement.new(
           title: announcement[:text],
           url: announcement[:href],
-          published_at: Date.parse(announcement[:published_text]),
+          published_on: Date.parse(announcement[:published_text]),
           position: index + 1,
         )
       end

--- a/app/views/coronavirus/announcements/_form.html.erb
+++ b/app/views/coronavirus/announcements/_form.html.erb
@@ -27,26 +27,26 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/date_input", {
-  name: "announcement[published_at]",
-  id: "published_at",
+  name: "announcement[published_on]",
+  id: "published_on",
   legend_text: legend,
   hint: t("coronavirus.announcements.form.date.hint"),
-  error_message: error_items(@announcement.errors.messages, :published_at),
+  error_message: error_items(@announcement.errors.messages, :published_on),
   items: [
     {
       name: "day",
       width: 2,
-      value: @announcement.published_at&.day || params.dig("announcement", "published_at", "day"),
+      value: @announcement.published_on&.day || params.dig("announcement", "published_on", "day"),
     },
     {
       name: "month",
       width: 2,
-      value: @announcement.published_at&.month || params.dig("announcement", "published_at", "month"),
+      value: @announcement.published_on&.month || params.dig("announcement", "published_on", "month"),
     },
     {
       name: "year",
       width: 4,
-      value: @announcement.published_at&.year || params.dig("announcement", "published_at", "year"),
+      value: @announcement.published_on&.year || params.dig("announcement", "published_on", "year"),
     }
   ]
 } %>

--- a/db/migrate/20210329141909_backport_coronavirus_announcements_published_on_field.rb
+++ b/db/migrate/20210329141909_backport_coronavirus_announcements_published_on_field.rb
@@ -1,0 +1,11 @@
+class BackportCoronavirusAnnouncementsPublishedOnField < ActiveRecord::Migration[6.0]
+  class CoronavirusAnnouncement < ApplicationRecord; end
+
+  def change
+    add_column :coronavirus_announcements, :published_on, :date
+
+    CoronavirusAnnouncement.pluck(:id, :published_at).each do |id, time|
+      CoronavirusAnnouncement.where(id: id).update_all(published_on: time&.to_date)
+    end
+  end
+end

--- a/db/migrate/20210329143101_remove_published_at_from_coronavirus_announcements.rb
+++ b/db/migrate/20210329143101_remove_published_at_from_coronavirus_announcements.rb
@@ -1,0 +1,5 @@
+class RemovePublishedAtFromCoronavirusAnnouncements < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :coronavirus_announcements, :published_at, :datetime
+  end
+end

--- a/db/migrate/20210329150719_disallow_null_for_coronavirus_announcements_position.rb
+++ b/db/migrate/20210329150719_disallow_null_for_coronavirus_announcements_position.rb
@@ -1,0 +1,5 @@
+class DisallowNullForCoronavirusAnnouncementsPosition < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :coronavirus_announcements, :position, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_171835) do
+ActiveRecord::Schema.define(version: 2021_03_29_143101) do
 
   create_table "coronavirus_announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id", null: false
     t.string "title", null: false
     t.text "url", null: false
-    t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position"
+    t.date "published_on"
   end
 
   create_table "coronavirus_live_streams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_143101) do
+ActiveRecord::Schema.define(version: 2021_03_29_150719) do
 
   create_table "coronavirus_announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id", null: false
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_143101) do
     t.text "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "position"
+    t.integer "position", null: false
     t.date "published_on"
   end
 

--- a/spec/controllers/coronavirus/announcements_controller_spec.rb
+++ b/spec/controllers/coronavirus/announcements_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Coronavirus::AnnouncementsController do
   let!(:announcement) { create :coronavirus_announcement, page: page }
   let(:title) { Faker::Lorem.sentence }
   let(:url) { "/government/foo/vader/baby/yoda" }
-  let(:published_at) { { "day" => "12", "month" => "12", "year" => "2020" } }
+  let(:published_on) { { "day" => "12", "month" => "12", "year" => "2020" } }
 
   describe "GET /coronavirus/:page_slug/announcements/new" do
     it "does not render successfully if the user does not have Coronavirus editor permissions" do
@@ -30,7 +30,7 @@ RSpec.describe Coronavirus::AnnouncementsController do
       {
         title: title,
         url: url,
-        published_at: published_at,
+        published_on: published_on,
       }
     end
 
@@ -139,7 +139,7 @@ RSpec.describe Coronavirus::AnnouncementsController do
       {
         title: title,
         url: "/updated/path",
-        published_at: published_at,
+        published_on: published_on,
       }
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -257,7 +257,7 @@ FactoryBot.define do
   factory :coronavirus_announcement, class: Coronavirus::Announcement do
     title { Faker::Lorem.words }
     url { "/government/foo/vader/baby/yoda" }
-    published_at { Time.zone.local(2020, 9, 11) }
+    published_on { Date.new(2020, 9, 11) }
     page factory: :coronavirus_page
   end
 

--- a/spec/models/coronavirus/announcement_spec.rb
+++ b/spec/models/coronavirus/announcement_spec.rb
@@ -18,26 +18,26 @@ RSpec.describe Coronavirus::Announcement, type: :model do
       end
     end
 
-    describe "published_at validations" do
-      it "validates that published_at is a valid date" do
-        announcement.published_at = { "day" => -1, "month" => 1, "year" => 2020 }
+    describe "published_on validations" do
+      it "validates that published_on is a valid date" do
+        announcement.published_on = { "day" => -1, "month" => 1, "year" => 2020 }
 
         expect(announcement).not_to be_valid
-        expect(announcement.errors[:published_at]).to eq(["must be a valid date"])
+        expect(announcement.errors[:published_on]).to eq(["must be a valid date"])
       end
 
-      it "validates that published_at was at least this century" do
-        announcement.published_at = Date.new(1999, 1, 1)
+      it "validates that published_on was at least this century" do
+        announcement.published_on = Date.new(1999, 1, 1)
 
         expect(announcement).not_to be_valid
-        expect(announcement.errors[:published_at]).to eq(["must be this century"])
+        expect(announcement.errors[:published_on]).to eq(["must be this century"])
       end
 
-      it "validates that published_at is not in the future" do
-        announcement.published_at = Date.tomorrow
+      it "validates that published_on is not in the future" do
+        announcement.published_on = Date.tomorrow
 
         expect(announcement).not_to be_valid
-        expect(announcement.errors[:published_at]).to eq(["must not be in the future"])
+        expect(announcement.errors[:published_on]).to eq(["must not be in the future"])
       end
     end
   end
@@ -81,28 +81,27 @@ RSpec.describe Coronavirus::Announcement, type: :model do
     end
   end
 
-  describe "#published_at=" do
+  describe "#published_on=" do
     let(:announcement) { build(:coronavirus_announcement) }
 
-    it "can accept published_at as a hash" do
-      announcement.published_at = { "day" => "1", "month" => "1", "year" => "2020" }
-      expect(announcement.published_at).to eq(Time.zone.local(2020, 1, 1))
+    it "can accept published_on as a hash" do
+      announcement.published_on = { "day" => "1", "month" => "1", "year" => "2020" }
+      expect(announcement.published_on).to eq(Date.new(2020, 1, 1))
     end
 
-    it "sets published_at to nil for an invalid date" do
-      announcement.published_at = { "day" => "1", "month" => "13", "year" => "2020" }
-      expect(announcement.published_at).to be_nil
+    it "sets published_on to nil for an invalid date" do
+      announcement.published_on = { "day" => "1", "month" => "13", "year" => "2020" }
+      expect(announcement.published_on).to be_nil
     end
 
-    it "sets published_at to nil for an empty date" do
-      announcement.published_at = { "day" => "", "month" => "", "year" => "" }
-      expect(announcement.published_at).to be_nil
+    it "sets published_on to nil for an empty date" do
+      announcement.published_on = { "day" => "", "month" => "", "year" => "" }
+      expect(announcement.published_on).to be_nil
     end
 
-    it "can still accept published_at as a time" do
-      time = Time.zone.now.noon # using noon to avoid sub-second precision concerns
-      announcement.published_at = time
-      expect(announcement.published_at).to eq(time)
+    it "can still accept published_on as a date" do
+      announcement.published_on = Time.zone.today
+      expect(announcement.published_on).to eq(Time.zone.today)
     end
   end
 end

--- a/spec/presenters/coronavirus/announcement_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/announcement_json_presenter_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Coronavirus::AnnouncementJsonPresenter do
       expected = {
         "text" => announcement.title,
         "href" => announcement.url,
-        "published_text" => announcement.published_at.strftime("Published %-d %B %Y"),
+        "published_text" => announcement.published_on.strftime("Published %-d %B %Y"),
       }
 
       expect(described_class.new(announcement).output).to eq(expected)
     end
 
-    it "doesn't include published text for an announcement without a published_at date" do
-      announcement = build(:coronavirus_announcement, published_at: nil)
+    it "doesn't include published text for an announcement without a published_on date" do
+      announcement = build(:coronavirus_announcement, published_on: nil)
       stub_coronavirus_landing_page_content(announcement.page)
 
       expect(described_class.new(announcement).output)

--- a/spec/presenters/coronavirus/page_presenter_spec.rb
+++ b/spec/presenters/coronavirus/page_presenter_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Coronavirus::PagePresenter do
       expect(subject.payload["details"]["announcements"].first).to eq({
         "href" => announcement.url,
         "text" => announcement.title,
-        "published_text" => announcement.published_at.strftime("Published %-d %B %Y"),
+        "published_text" => announcement.published_on.strftime("Published %-d %B %Y"),
       })
     end
   end

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
 
   describe "#announcements_data" do
     context "with announcements" do
-      let!(:announcement_0) { create :coronavirus_announcement, published_at: Time.zone.local(2020, 9, 10), page: page  }
-      let!(:announcement_1) { create :coronavirus_announcement, published_at: Time.zone.local(2020, 9, 11), page: page  }
+      let!(:announcement_0) { create :coronavirus_announcement, published_on: Date.new(2020, 9, 10), page: page  }
+      let!(:announcement_1) { create :coronavirus_announcement, published_on: Date.new(2020, 9, 11), page: page  }
       let!(:announcement_0_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement_0).output }
       let!(:announcement_1_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement_1).output }
 

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -275,9 +275,9 @@ module CoronavirusFeatureSteps
     stub_coronavirus_landing_page_content(@coronavirus_page)
     fill_in("title", with: "fancy title")
     fill_in("url", with: "/government")
-    fill_in("announcement[published_at][day]", with: "12")
-    fill_in("announcement[published_at][month]", with: "1")
-    fill_in("announcement[published_at][year]", with: "2020")
+    fill_in("announcement[published_on][day]", with: "12")
+    fill_in("announcement[published_on][month]", with: "1")
+    fill_in("announcement[published_on][year]", with: "2020")
     click_on("Save")
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/CRwjuyqN/278-allow-external-links-from-announcements

As a bonus (or a nuisance) I did some follow-up work on https://github.com/alphagov/collections-publisher/pull/1335 to set the published_at field to be a date (and rename to published_on as per Rails convention) and remove the ability to set a null position. This finishes work started in https://github.com/alphagov/collections-publisher/pull/1333/commits/724f69f18db4507e4b3d2916467362e6a7d21be9

This change will cause the app to error if someone is using it while the app is deployed. Since this app is used infrequently I plan to just carefully deploy this change rather than do defensive migration work.

This PR is intentionally branched off https://github.com/alphagov/collections-publisher/pull/1335 until that PR is merged.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️