### PR TITLE
Attempt to fix flaky feature test

### DIFF
--- a/spec/support/step_nav_steps.rb
+++ b/spec/support/step_nav_steps.rb
@@ -141,14 +141,14 @@ module StepNavSteps
   end
 
   def given_a_step_by_step_has_an_empty_step_added_after_links_last_checked
+    step = create(:step)
+    stub_link_checker_report_success(step)
     @step_by_step_page = create(
       :step_by_step_with_unpublished_changes,
+      steps: [step],
       slug: "step-by-step-with-link-report-and-empty-step-added-since-links-checked",
       draft_updated_at: Time.zone.now,
     )
-
-    step_with_link_report = create(:step, step_by_step_page: @step_by_step_page)
-    stub_link_checker_report_success(step_with_link_report)
     create(:step, contents: "", step_by_step_page: @step_by_step_page)
   end
 


### PR DESCRIPTION
This test is flaky. I'm not entirely sure why, but this is my best guess.

The html below shows the "Check for broken links" message if the following things
are true:

* The step by step has steps. - The test one does.
* Any of the steps contain links. - The first step creates contains links
* The links haven't been checked since the last time the draft was updated.

This last point is where I think the test sometimes fails. I think that if the link
report is created after `@step_by_step_page` is created, then this check will
"fail" and the message won't be shown.

```
<div class="govuk-grid-row">
  <div class="govuk-grid-column-two-thirds">
      <div id="inset-text-c6cd2f9b" class="gem-c-inset-text govuk-inset-text">

    <h2 class="govuk-heading-m">To publish this step by step you need to</h2>

    <ul class="govuk-list">

        <li>
          Add content to all your steps
        </li>

        <li>
          Check for broken links
        </li>

        <li>
          <p class="govuk-body">Get 2i approval</p>
        </li>
    </ul>

</div>
```
[View template](https://github.com/alphagov/collections-publisher/blob/master/app/views/step_by_step_pages/show/_required_actions.html.erb#L18)

My hope that changing the order of when things are created, will mean that the
link report is always created after the `draft_updated_at` date is set on the step
by step, and hopefully mean that this test consistently passes

Before making the change, the test failed approximately, 19 out 1000 times:

```
Finished in 1 minute 50.04 seconds (files took 17.44 seconds to load)
1000 examples, 19 failures
```

After the change, all 1000 instances passed:

```
Finished in 4 minutes 22.9 seconds (files took 17.43 seconds to load)
1000 examples, 0 failures

Randomized with seed 56337
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
