### PR TITLE
Add support for new `smart_answer` schema

### DIFF
--- a/app/models/navigation_rule.rb
+++ b/app/models/navigation_rule.rb
@@ -7,7 +7,7 @@ class NavigationRule < ApplicationRecord
   scope :related_content_ids, -> { where(include_in_links: "conditionally").pluck(:content_id) }
 
   def smartanswer?
-    schema_name == "transaction" && publishing_app == "smartanswers"
+    schema_name == "smart_answer" || (schema_name == "transaction" && publishing_app == "smartanswers")
   end
 
   def display_text(value)

--- a/app/models/secondary_content_link.rb
+++ b/app/models/secondary_content_link.rb
@@ -6,6 +6,6 @@ class SecondaryContentLink < ApplicationRecord
   validates :base_path, uniqueness: { scope: :step_by_step_page_id, case_sensitive: false } # rubocop:disable Rails/UniqueValidationWithoutIndex
 
   def smartanswer?
-    schema_name == "transaction" && publishing_app == "smartanswers"
+    schema_name == "smart_answer" || (schema_name == "transaction" && publishing_app == "smartanswers")
   end
 end

--- a/spec/models/navigation_rule_spec.rb
+++ b/spec/models/navigation_rule_spec.rb
@@ -113,7 +113,20 @@ RSpec.describe NavigationRule do
       allow(Services.publishing_api).to receive(:lookup_content_id)
     end
 
-    it "is a smartanswer start page" do
+    it "returns true for smart_answer schema" do
+      resource = described_class.new(
+        title: "A Title",
+        base_path: "/a-base-path",
+        content_id: "A-CONTENT-ID-BOOM",
+        step_by_step_page: step_by_step_page,
+        publishing_app: "smartanswers",
+        schema_name: "smart_answer",
+      )
+
+      expect(resource.smartanswer?).to be true
+    end
+
+    it "returns true for transaction schema published by smartanswers" do
       resource = described_class.new(
         title: "A Title",
         base_path: "/a-base-path",
@@ -126,7 +139,7 @@ RSpec.describe NavigationRule do
       expect(resource.smartanswer?).to be true
     end
 
-    it "is not a smartanswer start page" do
+    it "returns false for transaction schema not published by smartanswers" do
       resource = described_class.new(
         title: "A Title",
         base_path: "/a-base-path",

--- a/spec/models/secondary_content_link_spec.rb
+++ b/spec/models/secondary_content_link_spec.rb
@@ -78,12 +78,23 @@ RSpec.describe SecondaryContentLink do
       expect(secondary_content_link.smartanswer?).to be false
     end
 
-    it "is a smartanswer start page" do
+    it "returns true for transaction schema published by smartanswers" do
       secondary_content_link = build(
         :secondary_content_link,
         step_by_step_page: step_by_step_page,
         publishing_app: "smartanswers",
         schema_name: "transaction",
+      )
+
+      expect(secondary_content_link.smartanswer?).to be true
+    end
+
+    it "returns true for smart_answer schema" do
+      secondary_content_link = build(
+        :secondary_content_link,
+        step_by_step_page: step_by_step_page,
+        publishing_app: "smartanswers",
+        schema_name: "smart_answer",
       )
 
       expect(secondary_content_link.smartanswer?).to be true


### PR DESCRIPTION
This adds support to detect smart answers published with the new `smart_answer` schema and continue to detect smart answers that are published as `transaction` pages. This is required as smart answers will be republished with the new content schema.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
