### PR TITLE
Stop using the github_data method to gather timeline information

### DIFF
--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -91,7 +91,7 @@ module Coronavirus::Pages
     end
 
     def timeline_data
-      page
+      @timeline_data ||= page
         .timeline_entries
         .order(:position)
         .pluck(:heading, :content)
@@ -139,9 +139,9 @@ module Coronavirus::Pages
     end
 
     def search_terms_in_timeline
-      return [] if github_data["timeline"].blank?
+      return [] if timeline_data.blank?
 
-      timeline = github_data["timeline"]["list"].map do |item|
+      timeline = timeline_data.map do |item|
         [
           item["heading"],
           MarkdownService.new.strip_markdown(item["paragraph"]),


### PR DESCRIPTION
The github_data method makes calls to GitHub to gather information held in yaml files. This was done so that non developers could update content. The output of this method was being modified quite opaquely to include data from timelines that is being held in the database rather than the yaml. This changes things so that the `timeline_data` method is called directly which makes it clearer that timeline data is being accessed from the database rather than the yaml.

Trello - https://trello.com/c/rMnlfIq6/335-get-hidden-search-terms-for-timeline-from-database

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
