### PR TITLE
Tidy-up `SubSectionJSONPresenter` tests

### DIFF
--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -8,12 +8,10 @@ class Coronavirus::SubSectionJsonPresenter
     @priority_taxon = priority_taxon
   end
 
-  delegate :title, to: :sub_section
-
   def output
     @output ||=
       {
-        title: title,
+        title: sub_section.title,
         sub_sections: sub_sections,
       }
   end

--- a/app/presenters/coronavirus/sub_section_json_presenter.rb
+++ b/app/presenters/coronavirus/sub_section_json_presenter.rb
@@ -16,6 +16,8 @@ class Coronavirus::SubSectionJsonPresenter
       }
   end
 
+private
+
   def sub_sections
     sub_sections = [build_action_link].compact
     sub_sections += sub_section.structured_content.items.each_with_object([]) do |item, memo|
@@ -39,8 +41,6 @@ class Coronavirus::SubSectionJsonPresenter
       url: append_priority_taxon_query_param(url),
     }
   end
-
-private
 
   def append_priority_taxon_query_param(url)
     return url unless priority_taxon.present? && url.starts_with?("/")

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     let(:link) { "[#{label}](#{path})" }
     let(:content) { [title_markup, link].join("\n") }
 
-    let(:expected) do
-      {
+    it "has expected content" do
+      expected_output = {
         title: sub_section.title,
         sub_sections: [
           {
@@ -31,11 +31,9 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
           },
         ],
       }
-    end
 
-    it "has expected content" do
       presenter = described_class.new(sub_section)
-      expect(presenter.output).to eq(expected)
+      expect(presenter.output).to eq(expected_output)
     end
   end
 

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -162,22 +162,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
           hash_including(url: link_url),
         )
       end
-    end
 
-    context "when a priority taxon is not provided" do
-      it "does not append the priority-taxon to list urls" do
-        link_url = "/coronavirus"
-        sub_section.content = "[test](#{link_url})"
-
-        presenter = described_class.new(sub_section)
-        sub_sections_list = presenter.output[:sub_sections].first[:list]
-
-        expect(sub_sections_list).to include(hash_including(url: link_url))
-      end
-    end
-
-    context "when a sub-section has an action link and a priority taxon is provided" do
-      it "appends the priority_taxon to the action link url" do
+      it "appends the priority_taxon to action link urls" do
         link_url = "/bananas"
         sub_section.action_link_url = link_url
         priority_taxon = SecureRandom.uuid

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -29,154 +29,154 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
       presenter = described_class.new(sub_section)
       expect(presenter.output).to eq(expected_output)
     end
-  end
 
-  context "given multiple titles" do
-    let(:content) { "#title \n [test](/coronavirus) \n #title2 \n [test2](/government)" }
-    let(:sub_section) { build :coronavirus_sub_section, content: content }
+    context "given multiple titles" do
+      let(:content) { "#title \n [test](/coronavirus) \n #title2 \n [test2](/government)" }
+      let(:sub_section) { build :coronavirus_sub_section, content: content }
 
-    it "creates multiple groups" do
-      expected_output = {
-        title: sub_section.title,
-        sub_sections: [
-          {
-            list: [{ label: "test", url: "/coronavirus" }],
-            title: "title",
-          },
-          {
-            list: [{ label: "test2", url: "/government" }],
-            title: "title2",
-          },
-        ],
-      }
+      it "creates multiple groups" do
+        expected_output = {
+          title: sub_section.title,
+          sub_sections: [
+            {
+              list: [{ label: "test", url: "/coronavirus" }],
+              title: "title",
+            },
+            {
+              list: [{ label: "test2", url: "/government" }],
+              title: "title2",
+            },
+          ],
+        }
 
-      presenter = described_class.new(sub_section)
-      expect(presenter.output).to eq(expected_output)
-    end
-  end
-
-  context "when the first group has no title" do
-    let(:content) { "[test](/coronavirus) \n #title2 \n [test2](/government)" }
-    let(:sub_section) { build :coronavirus_sub_section, content: content }
-
-    it "groups the links as expected" do
-      expected_output = {
-        title: sub_section.title,
-        sub_sections: [
-          {
-            list: [{ label: "test", url: "/coronavirus" }],
-            title: nil,
-          },
-          {
-            list: [{ label: "test2", url: "/government" }],
-            title: "title2",
-          },
-        ],
-      }
-
-      presenter = described_class.new(sub_section)
-      expect(presenter.output).to eq(expected_output)
-    end
-  end
-
-  context "when a sub-section contains an action link" do
-    let(:title) { Faker::Lorem.sentence }
-    let(:label) { Faker::Lorem.sentence }
-    let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
-    let(:sub_section) do
-      create :coronavirus_sub_section, content: "###{title}\n[#{label}](#{path})"
+        presenter = described_class.new(sub_section)
+        expect(presenter.output).to eq(expected_output)
+      end
     end
 
-    it "includes an action link with a description and featured set to true" do
-      sub_section.action_link_url = "/bananas"
-      sub_section.action_link_content = "Bananas"
-      sub_section.action_link_summary = "Bananas"
+    context "when the first group has no title" do
+      let(:content) { "[test](/coronavirus) \n #title2 \n [test2](/government)" }
+      let(:sub_section) { build :coronavirus_sub_section, content: content }
 
-      expected_output = {
-        title: sub_section.title,
-        sub_sections: [
-          {
-            list: [
-              {
-                url: "/bananas",
-                label: "Bananas",
-                description: "Bananas",
-                featured_link: true,
-              },
-            ],
-            title: nil,
-          },
-          {
-            list: [
-              {
-                url: path,
-                label: label,
-              },
-            ],
-            title: title,
-          },
-        ],
-      }
+      it "groups the links as expected" do
+        expected_output = {
+          title: sub_section.title,
+          sub_sections: [
+            {
+              list: [{ label: "test", url: "/coronavirus" }],
+              title: nil,
+            },
+            {
+              list: [{ label: "test2", url: "/government" }],
+              title: "title2",
+            },
+          ],
+        }
 
-      presenter = described_class.new(sub_section)
-      expect(presenter.output).to eq(expected_output)
-    end
-  end
-
-  context "when a priority taxon is provided" do
-    it "appends the priority_taxon to the url if the link is relative" do
-      link_url = "/hello-there"
-      sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
-      priority_taxon = SecureRandom.uuid
-
-      presenter = described_class.new(sub_section, priority_taxon)
-      sub_sections_list = presenter.output[:sub_sections].first[:list]
-
-      expect(sub_sections_list).to include(
-        hash_including(url: "#{link_url}?priority-taxon=#{priority_taxon}"),
-      )
+        presenter = described_class.new(sub_section)
+        expect(presenter.output).to eq(expected_output)
+      end
     end
 
-    it "does not append a priority_taxon to the url if the link is external" do
-      link_url = "http://www.hello-there.com"
-      sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
+    context "when a sub-section contains an action link" do
+      let(:title) { Faker::Lorem.sentence }
+      let(:label) { Faker::Lorem.sentence }
+      let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
+      let(:sub_section) do
+        create :coronavirus_sub_section, content: "###{title}\n[#{label}](#{path})"
+      end
 
-      presenter = described_class.new(sub_section)
-      sub_sections_list = presenter.output[:sub_sections].first[:list]
+      it "includes an action link with a description and featured set to true" do
+        sub_section.action_link_url = "/bananas"
+        sub_section.action_link_content = "Bananas"
+        sub_section.action_link_summary = "Bananas"
 
-      expect(sub_sections_list).to include(
-        hash_including(url: link_url),
-      )
+        expected_output = {
+          title: sub_section.title,
+          sub_sections: [
+            {
+              list: [
+                {
+                  url: "/bananas",
+                  label: "Bananas",
+                  description: "Bananas",
+                  featured_link: true,
+                },
+              ],
+              title: nil,
+            },
+            {
+              list: [
+                {
+                  url: path,
+                  label: label,
+                },
+              ],
+              title: title,
+            },
+          ],
+        }
+
+        presenter = described_class.new(sub_section)
+        expect(presenter.output).to eq(expected_output)
+      end
     end
-  end
 
-  context "when a priority taxon is not provided" do
-    it "does not append the priority-taxon to list urls" do
-      sub_section = build(:coronavirus_sub_section, content: "[test](/coronavirus)")
+    context "when a priority taxon is provided" do
+      it "appends the priority_taxon to the url if the link is relative" do
+        link_url = "/hello-there"
+        sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
+        priority_taxon = SecureRandom.uuid
 
-      presenter = described_class.new(sub_section)
-      sub_sections_list = presenter.output[:sub_sections].first[:list]
+        presenter = described_class.new(sub_section, priority_taxon)
+        sub_sections_list = presenter.output[:sub_sections].first[:list]
 
-      expect(sub_sections_list).to include(hash_including(url: "/coronavirus"))
+        expect(sub_sections_list).to include(
+          hash_including(url: "#{link_url}?priority-taxon=#{priority_taxon}"),
+        )
+      end
+
+      it "does not append a priority_taxon to the url if the link is external" do
+        link_url = "http://www.hello-there.com"
+        sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
+
+        presenter = described_class.new(sub_section)
+        sub_sections_list = presenter.output[:sub_sections].first[:list]
+
+        expect(sub_sections_list).to include(
+          hash_including(url: link_url),
+        )
+      end
     end
-  end
 
-  context "when a sub-section has an action link and a priority taxon is provided" do
-    it "appends the priority_taxon to the action link url" do
-      sub_section = build(:coronavirus_sub_section,
-                          content: "#Title",
-                          action_link_url: "/bananas",
-                          action_link_content: Faker::Lorem.sentence,
-                          action_link_summary: Faker::Lorem.sentence)
+    context "when a priority taxon is not provided" do
+      it "does not append the priority-taxon to list urls" do
+        sub_section = build(:coronavirus_sub_section, content: "[test](/coronavirus)")
 
-      priority_taxon = SecureRandom.uuid
+        presenter = described_class.new(sub_section)
+        sub_sections_list = presenter.output[:sub_sections].first[:list]
 
-      presenter = described_class.new(sub_section, priority_taxon)
-      sub_sections_list = presenter.output[:sub_sections].first[:list]
+        expect(sub_sections_list).to include(hash_including(url: "/coronavirus"))
+      end
+    end
 
-      expect(sub_sections_list).to include(
-        hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),
-      )
+    context "when a sub-section has an action link and a priority taxon is provided" do
+      it "appends the priority_taxon to the action link url" do
+        sub_section = build(:coronavirus_sub_section,
+                            content: "#Title",
+                            action_link_url: "/bananas",
+                            action_link_content: Faker::Lorem.sentence,
+                            action_link_summary: Faker::Lorem.sentence)
+
+        priority_taxon = SecureRandom.uuid
+
+        presenter = described_class.new(sub_section, priority_taxon)
+        sub_sections_list = presenter.output[:sub_sections].first[:list]
+
+        expect(sub_sections_list).to include(
+          hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),
+        )
+      end
     end
   end
 end

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
   let(:sub_section) { build :coronavirus_sub_section, content: content }
   subject { described_class.new(sub_section) }
 
-  describe "#title" do
-    it "returns the sub section title" do
-      expect(subject.title).to eq(sub_section.title)
-    end
-  end
-
   describe "#output" do
     let(:title) { Faker::Lorem.sentence }
     let(:title_markup) { "###{title}" }
@@ -25,7 +19,7 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
 
     let(:expected) do
       {
-        title: subject.title,
+        title: sub_section.title,
         sub_sections: [
           {
             list: [

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -1,13 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Coronavirus::SubSectionJsonPresenter do
-  let(:link_one) { random_link_markdown }
-  let(:link_two) { random_link_markdown }
-  let(:link_three) { random_link_markdown }
-  let(:content) { link_one }
-
-  let(:sub_section) { build :coronavirus_sub_section, content: content }
-
   describe "#output" do
     let(:title) { Faker::Lorem.sentence }
     let(:title_markup) { "###{title}" }
@@ -15,6 +8,7 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
     let(:link) { "[#{label}](#{path})" }
     let(:content) { [title_markup, link].join("\n") }
+    let(:sub_section) { build :coronavirus_sub_section, content: content }
 
     it "has expected content" do
       expected_output = {
@@ -39,6 +33,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
 
   context "given multiple titles" do
     let(:content) { "#title \n [test](/coronavirus) \n #title2 \n [test2](/government)" }
+    let(:sub_section) { build :coronavirus_sub_section, content: content }
+
     it "creates multiple groups" do
       expected_output = {
         title: sub_section.title,
@@ -61,6 +57,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
 
   context "when the first group has no title" do
     let(:content) { "[test](/coronavirus) \n #title2 \n [test2](/government)" }
+    let(:sub_section) { build :coronavirus_sub_section, content: content }
+
     it "groups the links as expected" do
       expected_output = {
         title: sub_section.title,
@@ -180,15 +178,5 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
         hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),
       )
     end
-  end
-
-  def random_link_markdown
-    label = Faker::Lorem.sentence
-    path = "/#{File.join(Faker::Lorem.words)}"
-    "[#{label}](#{path})"
-  end
-
-  def random_title
-    "### #{Faker::Lorem.sentence}"
   end
 end

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -37,11 +37,21 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
           title: sub_section.title,
           sub_sections: [
             {
-              list: [{ label: "test", url: "/coronavirus" }],
+              list: [
+                {
+                  label: "test",
+                  url: "/coronavirus",
+                },
+              ],
               title: "title",
             },
             {
-              list: [{ label: "test2", url: "/government" }],
+              list: [
+                {
+                  label: "test2",
+                  url: "/government",
+                },
+              ],
               title: "title2",
             },
           ],
@@ -60,11 +70,21 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
           title: sub_section.title,
           sub_sections: [
             {
-              list: [{ label: "test", url: "/coronavirus" }],
+              list: [
+                {
+                  label: "test",
+                  url: "/coronavirus",
+                },
+              ],
               title: nil,
             },
             {
-              list: [{ label: "test2", url: "/government" }],
+              list: [
+                {
+                  label: "test2",
+                  url: "/government",
+                },
+              ],
               title: "title2",
             },
           ],

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
   let(:content) { link_one }
 
   let(:sub_section) { build :coronavirus_sub_section, content: content }
-  subject { described_class.new(sub_section) }
 
   describe "#output" do
     let(:title) { Faker::Lorem.sentence }
@@ -35,7 +34,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     end
 
     it "has expected content" do
-      expect(subject.output).to eq(expected)
+      presenter = described_class.new(sub_section)
+      expect(presenter.output).to eq(expected)
     end
   end
 
@@ -56,7 +56,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
         ],
       }
 
-      expect(subject.output).to eq(expected_output)
+      presenter = described_class.new(sub_section)
+      expect(presenter.output).to eq(expected_output)
     end
   end
 
@@ -77,7 +78,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
         ],
       }
 
-      expect(subject.output).to eq(expected_output)
+      presenter = described_class.new(sub_section)
+      expect(presenter.output).to eq(expected_output)
     end
   end
 
@@ -120,7 +122,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
         ],
       }
 
-      expect(subject.output).to eq(expected_output)
+      presenter = described_class.new(sub_section)
+      expect(presenter.output).to eq(expected_output)
     end
   end
 
@@ -130,8 +133,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
       sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
       priority_taxon = SecureRandom.uuid
 
-      subject = described_class.new(sub_section, priority_taxon)
-      sub_sections_list = subject.output[:sub_sections].first[:list]
+      presenter = described_class.new(sub_section, priority_taxon)
+      sub_sections_list = presenter.output[:sub_sections].first[:list]
 
       expect(sub_sections_list).to include(
         hash_including(url: "#{link_url}?priority-taxon=#{priority_taxon}"),
@@ -142,8 +145,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
       link_url = "http://www.hello-there.com"
       sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
 
-      subject = described_class.new(sub_section)
-      sub_sections_list = subject.output[:sub_sections].first[:list]
+      presenter = described_class.new(sub_section)
+      sub_sections_list = presenter.output[:sub_sections].first[:list]
 
       expect(sub_sections_list).to include(
         hash_including(url: link_url),
@@ -155,8 +158,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     it "does not append the priority-taxon to list urls" do
       sub_section = build(:coronavirus_sub_section, content: "[test](/coronavirus)")
 
-      subject = described_class.new(sub_section)
-      sub_sections_list = subject.output[:sub_sections].first[:list]
+      presenter = described_class.new(sub_section)
+      sub_sections_list = presenter.output[:sub_sections].first[:list]
 
       expect(sub_sections_list).to include(hash_including(url: "/coronavirus"))
     end
@@ -172,8 +175,8 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
 
       priority_taxon = SecureRandom.uuid
 
-      subject = described_class.new(sub_section, priority_taxon)
-      sub_sections_list = subject.output[:sub_sections].first[:list]
+      presenter = described_class.new(sub_section, priority_taxon)
+      sub_sections_list = presenter.output[:sub_sections].first[:list]
 
       expect(sub_sections_list).to include(
         hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),

--- a/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
+++ b/spec/presenters/coronavirus/sub_section_json_presenter_spec.rb
@@ -39,147 +39,145 @@ RSpec.describe Coronavirus::SubSectionJsonPresenter do
     end
   end
 
-  describe "#sub_sections" do
-    context "given multiple titles" do
-      let(:content) { "#title \n [test](/coronavirus) \n #title2 \n [test2](/government)" }
-      it "creates multiple groups" do
-        expected_output = {
-          title: sub_section.title,
-          sub_sections: [
-            {
-              list: [{ label: "test", url: "/coronavirus" }],
-              title: "title",
-            },
-            {
-              list: [{ label: "test2", url: "/government" }],
-              title: "title2",
-            },
-          ],
-        }
+  context "given multiple titles" do
+    let(:content) { "#title \n [test](/coronavirus) \n #title2 \n [test2](/government)" }
+    it "creates multiple groups" do
+      expected_output = {
+        title: sub_section.title,
+        sub_sections: [
+          {
+            list: [{ label: "test", url: "/coronavirus" }],
+            title: "title",
+          },
+          {
+            list: [{ label: "test2", url: "/government" }],
+            title: "title2",
+          },
+        ],
+      }
 
-        expect(subject.output).to eq(expected_output)
-      end
+      expect(subject.output).to eq(expected_output)
+    end
+  end
+
+  context "when the first group has no title" do
+    let(:content) { "[test](/coronavirus) \n #title2 \n [test2](/government)" }
+    it "groups the links as expected" do
+      expected_output = {
+        title: sub_section.title,
+        sub_sections: [
+          {
+            list: [{ label: "test", url: "/coronavirus" }],
+            title: nil,
+          },
+          {
+            list: [{ label: "test2", url: "/government" }],
+            title: "title2",
+          },
+        ],
+      }
+
+      expect(subject.output).to eq(expected_output)
+    end
+  end
+
+  context "when a sub-section contains an action link" do
+    let(:title) { Faker::Lorem.sentence }
+    let(:label) { Faker::Lorem.sentence }
+    let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
+    let(:sub_section) do
+      create :coronavirus_sub_section, content: "###{title}\n[#{label}](#{path})"
     end
 
-    context "when the first group has no title" do
-      let(:content) { "[test](/coronavirus) \n #title2 \n [test2](/government)" }
-      it "groups the links as expected" do
-        expected_output = {
-          title: sub_section.title,
-          sub_sections: [
-            {
-              list: [{ label: "test", url: "/coronavirus" }],
-              title: nil,
-            },
-            {
-              list: [{ label: "test2", url: "/government" }],
-              title: "title2",
-            },
-          ],
-        }
+    it "includes an action link with a description and featured set to true" do
+      sub_section.action_link_url = "/bananas"
+      sub_section.action_link_content = "Bananas"
+      sub_section.action_link_summary = "Bananas"
 
-        expect(subject.output).to eq(expected_output)
-      end
+      expected_output = {
+        title: sub_section.title,
+        sub_sections: [
+          {
+            list: [
+              {
+                url: "/bananas",
+                label: "Bananas",
+                description: "Bananas",
+                featured_link: true,
+              },
+            ],
+            title: nil,
+          },
+          {
+            list: [
+              {
+                url: path,
+                label: label,
+              },
+            ],
+            title: title,
+          },
+        ],
+      }
+
+      expect(subject.output).to eq(expected_output)
+    end
+  end
+
+  context "when a priority taxon is provided" do
+    it "appends the priority_taxon to the url if the link is relative" do
+      link_url = "/hello-there"
+      sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
+      priority_taxon = SecureRandom.uuid
+
+      subject = described_class.new(sub_section, priority_taxon)
+      sub_sections_list = subject.output[:sub_sections].first[:list]
+
+      expect(sub_sections_list).to include(
+        hash_including(url: "#{link_url}?priority-taxon=#{priority_taxon}"),
+      )
     end
 
-    context "when a sub-section contains an action link" do
-      let(:title) { Faker::Lorem.sentence }
-      let(:label) { Faker::Lorem.sentence }
-      let(:path)  { "/#{File.join(Faker::Lorem.words)}" }
-      let(:sub_section) do
-        create :coronavirus_sub_section, content: "###{title}\n[#{label}](#{path})"
-      end
+    it "does not append a priority_taxon to the url if the link is external" do
+      link_url = "http://www.hello-there.com"
+      sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
 
-      it "includes an action link with a description and featured set to true" do
-        sub_section.action_link_url = "/bananas"
-        sub_section.action_link_content = "Bananas"
-        sub_section.action_link_summary = "Bananas"
+      subject = described_class.new(sub_section)
+      sub_sections_list = subject.output[:sub_sections].first[:list]
 
-        expected_output = {
-          title: sub_section.title,
-          sub_sections: [
-            {
-              list: [
-                {
-                  url: "/bananas",
-                  label: "Bananas",
-                  description: "Bananas",
-                  featured_link: true,
-                },
-              ],
-              title: nil,
-            },
-            {
-              list: [
-                {
-                  url: path,
-                  label: label,
-                },
-              ],
-              title: title,
-            },
-          ],
-        }
-
-        expect(subject.output).to eq(expected_output)
-      end
+      expect(sub_sections_list).to include(
+        hash_including(url: link_url),
+      )
     end
+  end
 
-    context "when a priority taxon is provided" do
-      it "appends the priority_taxon to the url if the link is relative" do
-        link_url = "/hello-there"
-        sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
-        priority_taxon = SecureRandom.uuid
+  context "when a priority taxon is not provided" do
+    it "does not append the priority-taxon to list urls" do
+      sub_section = build(:coronavirus_sub_section, content: "[test](/coronavirus)")
 
-        subject = described_class.new(sub_section, priority_taxon)
-        sub_sections_list = subject.output[:sub_sections].first[:list]
+      subject = described_class.new(sub_section)
+      sub_sections_list = subject.output[:sub_sections].first[:list]
 
-        expect(sub_sections_list).to include(
-          hash_including(url: "#{link_url}?priority-taxon=#{priority_taxon}"),
-        )
-      end
-
-      it "does not append a priority_taxon to the url if the link is external" do
-        link_url = "http://www.hello-there.com"
-        sub_section = build(:coronavirus_sub_section, content: "[General Kenobi](#{link_url})")
-
-        subject = described_class.new(sub_section)
-        sub_sections_list = subject.output[:sub_sections].first[:list]
-
-        expect(sub_sections_list).to include(
-          hash_including(url: link_url),
-        )
-      end
+      expect(sub_sections_list).to include(hash_including(url: "/coronavirus"))
     end
+  end
 
-    context "when a priority taxon is not provided" do
-      it "does not append the priority-taxon to list urls" do
-        sub_section = build(:coronavirus_sub_section, content: "[test](/coronavirus)")
+  context "when a sub-section has an action link and a priority taxon is provided" do
+    it "appends the priority_taxon to the action link url" do
+      sub_section = build(:coronavirus_sub_section,
+                          content: "#Title",
+                          action_link_url: "/bananas",
+                          action_link_content: Faker::Lorem.sentence,
+                          action_link_summary: Faker::Lorem.sentence)
 
-        subject = described_class.new(sub_section)
-        sub_sections_list = subject.output[:sub_sections].first[:list]
+      priority_taxon = SecureRandom.uuid
 
-        expect(sub_sections_list).to include(hash_including(url: "/coronavirus"))
-      end
-    end
+      subject = described_class.new(sub_section, priority_taxon)
+      sub_sections_list = subject.output[:sub_sections].first[:list]
 
-    context "when a sub-section has an action link and a priority taxon is provided" do
-      it "appends the priority_taxon to the action link url" do
-        sub_section = build(:coronavirus_sub_section,
-                            content: "#Title",
-                            action_link_url: "/bananas",
-                            action_link_content: Faker::Lorem.sentence,
-                            action_link_summary: Faker::Lorem.sentence)
-
-        priority_taxon = SecureRandom.uuid
-
-        subject = described_class.new(sub_section, priority_taxon)
-        sub_sections_list = subject.output[:sub_sections].first[:list]
-
-        expect(sub_sections_list).to include(
-          hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),
-        )
-      end
+      expect(sub_sections_list).to include(
+        hash_including(url: "/bananas?priority-taxon=#{priority_taxon}"),
+      )
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/B6v2ONY0

# What's changed?

Make `SubSectionJSONPresenter` methods private where possible, and rationalise and refactor SubSectionJSONPresenter tests.

# Why?

Most of the methods are not used outside of the instance, so could be made private.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
