### PR TITLE
Add nation selection to coronavirus timeline entries

### DIFF
--- a/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
+++ b/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
@@ -1,15 +1,15 @@
 .covid-manage-page__summary-list,
 .covid-manage-page__summary-list--divider {
   .govuk-summary-list__key {
-    width: 70%;
+    width: 50%;
   }
 
   .govuk-summary-list__value {
-    width: 0;
+    width: 10;
   }
 
   .govuk-summary-list__actions {
-    width: 30%;
+    width: 40%;
   }
 }
 

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -63,6 +63,19 @@ module Coronavirus
       redirect_to coronavirus_page_path(page.slug), alert: I18n.t("coronavirus.timeline_entries.destroy.failed")
     end
 
+    helper_method :national_applicability_options
+    def national_applicability_options
+      uk_nations = %w[england northen_ireland scotland wales]
+
+      uk_nations.map do |nation|
+        {
+          label: nation.titleize,
+          value: nation,
+          checked: @timeline_entry.national_applicability.include?(nation),
+        }
+      end
+    end
+
   private
 
     def timeline_entry_params

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -66,7 +66,7 @@ module Coronavirus
   private
 
     def timeline_entry_params
-      params.require(:timeline_entry).permit(:heading, :content)
+      params.require(:timeline_entry).permit(:heading, :content, national_applicability: [])
     end
 
     def page

--- a/app/controllers/coronavirus/timeline_entries_controller.rb
+++ b/app/controllers/coronavirus/timeline_entries_controller.rb
@@ -65,9 +65,7 @@ module Coronavirus
 
     helper_method :national_applicability_options
     def national_applicability_options
-      uk_nations = %w[england northen_ireland scotland wales]
-
-      uk_nations.map do |nation|
+      Coronavirus::TimelineEntry::UK_NATIONS.map do |nation|
         {
           label: nation.titleize,
           value: nation,

--- a/app/models/coronavirus/timeline_entry.rb
+++ b/app/models/coronavirus/timeline_entry.rb
@@ -12,6 +12,8 @@ class Coronavirus::TimelineEntry < ApplicationRecord
   before_create :set_position
   after_destroy :set_parent_positions
 
+  UK_NATIONS = %w[england northern_ireland scotland wales].freeze
+
   def set_position
     page.timeline_entries.update_all("position = position + 1")
     self.position = 1
@@ -24,10 +26,8 @@ class Coronavirus::TimelineEntry < ApplicationRecord
 private
 
   def applies_to_uk_nations
-    uk_nations = %w[england northern_ireland scotland wales]
-
     national_applicability.each do |nation|
-      unless uk_nations.include?(nation)
+      unless UK_NATIONS.include?(nation)
         errors.add(:national_applicability, "has an invalid nation selected")
       end
     end

--- a/app/models/coronavirus/timeline_entry.rb
+++ b/app/models/coronavirus/timeline_entry.rb
@@ -23,6 +23,14 @@ class Coronavirus::TimelineEntry < ApplicationRecord
     page.make_timeline_entry_positions_sequential
   end
 
+  def national_applicability_text
+    if national_applicability.uniq.sort == UK_NATIONS
+      "UK Wide"
+    else
+      national_applicability.join(", ").titleize
+    end
+  end
+
 private
 
   def applies_to_uk_nations

--- a/app/models/coronavirus/timeline_entry.rb
+++ b/app/models/coronavirus/timeline_entry.rb
@@ -5,6 +5,10 @@ class Coronavirus::TimelineEntry < ApplicationRecord
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :heading, presence: true, length: { maximum: 255 }
   validates :content, presence: true
+  validates :national_applicability, presence: true
+
+  validate :applies_to_uk_nations
+
   before_create :set_position
   after_destroy :set_parent_positions
 
@@ -15,5 +19,17 @@ class Coronavirus::TimelineEntry < ApplicationRecord
 
   def set_parent_positions
     page.make_timeline_entry_positions_sequential
+  end
+
+private
+
+  def applies_to_uk_nations
+    uk_nations = %w[england northern_ireland scotland wales]
+
+    national_applicability.each do |nation|
+      unless uk_nations.include?(nation)
+        errors.add(:national_applicability, "has an invalid nation selected")
+      end
+    end
   end
 end

--- a/app/models/coronavirus/timeline_entry.rb
+++ b/app/models/coronavirus/timeline_entry.rb
@@ -1,5 +1,6 @@
 class Coronavirus::TimelineEntry < ApplicationRecord
   self.table_name = "coronavirus_timeline_entries"
+  serialize :national_applicability, Array
 
   belongs_to :page, foreign_key: "coronavirus_page_id"
   validates :heading, presence: true, length: { maximum: 255 }

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -89,8 +89,14 @@ module Coronavirus::Pages
       @timeline_data ||= page
         .timeline_entries
         .order(:position)
-        .pluck(:heading, :content)
-        .map { |(heading, content)| { "heading" => heading, "paragraph" => content } }
+        .pluck(:heading, :content, :national_applicability)
+        .map do |(heading, content, national_applicability)|
+          {
+            "heading" => heading,
+            "paragraph" => content,
+            "national_applicability" => national_applicability,
+          }
+        end
     end
 
     def hidden_search_terms

--- a/app/services/coronavirus/pages/draft_discarder.rb
+++ b/app/services/coronavirus/pages/draft_discarder.rb
@@ -73,6 +73,7 @@ module Coronavirus::Pages
         Coronavirus::TimelineEntry.new(
           heading: attributes[:heading],
           content: attributes[:paragraph],
+          national_applicability: attributes[:national_applicability],
         )
       end
     end

--- a/app/views/coronavirus/pages/show/_timeline_entries.html.erb
+++ b/app/views/coronavirus/pages/show/_timeline_entries.html.erb
@@ -3,7 +3,7 @@
    {
      id: timeline_entry.id,
      field: timeline_entry.heading,
-     value: timeline_entry.national_applicability.join(", ").titleize,
+     value: timeline_entry.national_applicability_text,
      edit: { href: edit_coronavirus_page_timeline_entry_path(@page.slug, timeline_entry) },
      delete: {
        href: coronavirus_page_timeline_entry_path(@page.slug, timeline_entry),

--- a/app/views/coronavirus/pages/show/_timeline_entries.html.erb
+++ b/app/views/coronavirus/pages/show/_timeline_entries.html.erb
@@ -3,6 +3,7 @@
    {
      id: timeline_entry.id,
      field: timeline_entry.heading,
+     value: timeline_entry.national_applicability.join(", ").titleize,
      edit: { href: edit_coronavirus_page_timeline_entry_path(@page.slug, timeline_entry) },
      delete: {
        href: coronavirus_page_timeline_entry_path(@page.slug, timeline_entry),

--- a/app/views/coronavirus/reorder_timeline_entries/_reorder_list.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/_reorder_list.html.erb
@@ -1,6 +1,12 @@
 <%
   timeline_entries = @page.timeline_entries.order(:position)
-  timeline_entries = timeline_entries.map { |te| { id: te.id, title: te.heading } }
+  timeline_entries = timeline_entries.map do |te|
+    {
+      id: te.id,
+      title: te.heading,
+      description: te.national_applicability.join(", ").titleize
+    }
+  end
 %>
 
 <div class="covid-manage-page__summary-list">

--- a/app/views/coronavirus/reorder_timeline_entries/_reorder_list.html.erb
+++ b/app/views/coronavirus/reorder_timeline_entries/_reorder_list.html.erb
@@ -4,7 +4,7 @@
     {
       id: te.id,
       title: te.heading,
-      description: te.national_applicability.join(", ").titleize
+      description: te.national_applicability_text
     }
   end
 %>

--- a/app/views/coronavirus/timeline_entries/_form.html.erb
+++ b/app/views/coronavirus/timeline_entries/_form.html.erb
@@ -15,28 +15,7 @@
   heading_size: "s",
   no_hint_text: true,
   error: error_items(@timeline_entry.errors.messages, :national_applicability),
-  items: [
-    {
-      label: "England",
-      value: "england",
-      checked: false,
-    },
-    {
-      label: "Northen Ireland",
-      value: "northen_ireland",
-      checked: false,
-    },
-    {
-      label: "Scotland",
-      value: "scotland",
-      checked: false,
-    },
-    {
-      label: "Wales",
-      value: "wales",
-      checked: false,
-    },
-  ],
+  items: national_applicability_options,
 } %>
 
 <%= render "components/markdown_editor", {

--- a/app/views/coronavirus/timeline_entries/_form.html.erb
+++ b/app/views/coronavirus/timeline_entries/_form.html.erb
@@ -9,6 +9,35 @@
   error_message: error_items(@timeline_entry.errors.messages, :heading),
 } %>
 
+<%= render "govuk_publishing_components/components/checkboxes", {
+  name: "timeline_entry[national_applicability][]",
+  heading: "Entry applies to:",
+  heading_size: "s",
+  no_hint_text: true,
+  items: [
+    {
+      label: "England",
+      value: "england",
+      checked: false,
+    },
+    {
+      label: "Northen Ireland",
+      value: "northen_ireland",
+      checked: false,
+    },
+    {
+      label: "Scotland",
+      value: "scotland",
+      checked: false,
+    },
+    {
+      label: "Wales",
+      value: "wales",
+      checked: false,
+    },
+  ],
+} %>
+
 <%= render "components/markdown_editor", {
   label: {
     text: t("coronavirus.timeline_entries.form.content.label"),

--- a/app/views/coronavirus/timeline_entries/_form.html.erb
+++ b/app/views/coronavirus/timeline_entries/_form.html.erb
@@ -14,6 +14,7 @@
   heading: "Entry applies to:",
   heading_size: "s",
   no_hint_text: true,
+  error: error_items(@timeline_entry.errors.messages, :national_applicability),
   items: [
     {
       label: "England",

--- a/app/views/coronavirus/timeline_entries/_form.html.erb
+++ b/app/views/coronavirus/timeline_entries/_form.html.erb
@@ -11,7 +11,7 @@
 
 <%= render "govuk_publishing_components/components/checkboxes", {
   name: "timeline_entry[national_applicability][]",
-  heading: "Entry applies to:",
+  heading: t("coronavirus.timeline_entries.form.national_applicability.heading"),
   heading_size: "s",
   no_hint_text: true,
   error: error_items(@timeline_entry.errors.messages, :national_applicability),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,8 @@ en:
           label: Enter the heading of the timeline entry
         content:
           label: Content
+        national_applicability:
+          heading: "Entry applies to:"
   step_by_step_page:
     statuses:
       draft: Draft

--- a/db/migrate/20210702095110_add_national_applicability_to_coronavirus_timeline_entry.rb
+++ b/db/migrate/20210702095110_add_national_applicability_to_coronavirus_timeline_entry.rb
@@ -1,0 +1,5 @@
+class AddNationalApplicabilityToCoronavirusTimelineEntry < ActiveRecord::Migration[6.0]
+  def change
+    add_column :coronavirus_timeline_entries, :national_applicability, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_04_120417) do
+ActiveRecord::Schema.define(version: 2021_07_02_095110) do
 
   create_table "coronavirus_announcements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id", null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_05_04_120417) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "national_applicability"
     t.index ["coronavirus_page_id"], name: "index_coronavirus_timeline_entries_on_coronavirus_page_id"
   end
 

--- a/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
+++ b/spec/controllers/coronavirus/timeline_entries_controller_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe Coronavirus::TimelineEntriesController do
     let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
     let(:heading) { Faker::Lorem.sentence }
     let(:content) { Faker::Lorem.sentence }
+    let(:national_applicability) { %w[england wales] }
     let(:timeline_entry_params) do
       {
         heading: heading,
         content: content,
+        national_applicability: national_applicability,
       }
     end
 
@@ -120,11 +122,13 @@ RSpec.describe Coronavirus::TimelineEntriesController do
     let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
     let!(:timeline_entry) { create(:coronavirus_timeline_entry, page: page) }
     let(:heading) { "Updated heading" }
+    let(:national_applicability) { %w[england wales] }
 
     let(:updated_timeline_entry_params) do
       {
         heading: heading,
         content: "##Updated content",
+        national_applicability: national_applicability,
       }
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -256,6 +256,7 @@ FactoryBot.define do
   factory :coronavirus_timeline_entry, class: Coronavirus::TimelineEntry do
     content { "Amazing fantastic content" }
     heading { "Unbelievable heading" }
+    national_applicability { %w[england] }
     page factory: :coronavirus_page
   end
 end

--- a/spec/fixtures/coronavirus_page_sections.json
+++ b/spec/fixtures/coronavirus_page_sections.json
@@ -66,11 +66,13 @@
       "list": [
         {
           "heading": "5 January",
-          "paragraph": "[National lockdown rules apply in England](/guidance/national-lockdown-stay-at-home). Stay at home."
+          "paragraph": "[National lockdown rules apply in England](/guidance/national-lockdown-stay-at-home). Stay at home.",
+          "national_applicability": ["england", "wales"]
         },
         {
           "heading": "4 January",
-          "paragraph": "[Changes expected](/guidance/tiering-changes-expected). Watch this space."
+          "paragraph": "[Changes expected](/guidance/tiering-changes-expected). Watch this space.",
+          "national_applicability": ["england"]
         }
       ],
       "heading": "Recent and upcoming changes"

--- a/spec/models/coronavirus/timeline_entry_spec.rb
+++ b/spec/models/coronavirus/timeline_entry_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe Coronavirus::TimelineEntry do
       expect(timeline_entry).to be_valid
     end
   end
+
+  describe "national_applicability_text" do
+    let(:timeline_entry) { create(:coronavirus_timeline_entry) }
+
+    it "displays a list of nations" do
+      timeline_entry.national_applicability = %w[england wales]
+
+      expect(timeline_entry.national_applicability_text).to eq("England, Wales")
+    end
+
+    it "displays UK Wide when tagged to all nations" do
+      timeline_entry.national_applicability = %w[england wales northern_ireland scotland]
+
+      expect(timeline_entry.national_applicability_text).to eq("UK Wide")
+    end
+  end
 end

--- a/spec/models/coronavirus/timeline_entry_spec.rb
+++ b/spec/models/coronavirus/timeline_entry_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Coronavirus::TimelineEntry do
   it { should validate_presence_of(:heading) }
   it { should validate_length_of(:heading).is_at_most(255) }
   it { should validate_presence_of(:content) }
+  it { should validate_presence_of(:national_applicability) }
 
   describe "position" do
     let(:page) { create(:coronavirus_page) }
@@ -41,6 +42,29 @@ RSpec.describe Coronavirus::TimelineEntry do
 
       expect(original_timeline_entry_one.position).to eq 1
       expect(page.timeline_entries.count).to eq 1
+    end
+  end
+
+  describe "national_applicability" do
+    let(:timeline_entry) { create(:coronavirus_timeline_entry) }
+
+    it "must have valid UK nations" do
+      timeline_entry.national_applicability = %w[france]
+
+      expect(timeline_entry).not_to be_valid
+      expect(timeline_entry.errors).to have_key(:national_applicability)
+    end
+
+    it "allows national_applicability to be set to a UK nation" do
+      timeline_entry.national_applicability = %w[wales]
+
+      expect(timeline_entry).to be_valid
+    end
+
+    it "allows national_applicability to be set to multiple UK nations" do
+      timeline_entry.national_applicability = %w[england wales]
+
+      expect(timeline_entry).to be_valid
     end
   end
 end

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -6,7 +6,13 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
   let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
   let(:sub_section_json) { Coronavirus::SubSectionJsonPresenter.new(sub_section, page.content_id).output }
   let(:announcement_json) { Coronavirus::AnnouncementJsonPresenter.new(announcement).output }
-  let(:timeline_json) { { "heading" => timeline_entry["heading"], "paragraph" => timeline_entry["content"] } }
+  let(:timeline_json) do
+    {
+      "heading" => timeline_entry["heading"],
+      "paragraph" => timeline_entry["content"],
+      "national_applicability" => timeline_entry["national_applicability"],
+    }
+  end
 
   subject { described_class.new(page) }
   before do
@@ -109,8 +115,16 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
 
     it "returns the timeline JSON ordered by position" do
       expect(subject.timeline_data).to eq [
-        { "heading" => timeline_entry_1.heading, "paragraph" => timeline_entry_1.content },
-        { "heading" => timeline_entry_0.heading, "paragraph" => timeline_entry_0.content },
+        {
+          "heading" => timeline_entry_1.heading,
+          "paragraph" => timeline_entry_1.content,
+          "national_applicability" => timeline_entry_1.national_applicability,
+        },
+        {
+          "heading" => timeline_entry_0.heading,
+          "paragraph" => timeline_entry_0.content,
+          "national_applicability" => timeline_entry_0.national_applicability,
+        },
       ]
     end
   end

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -266,6 +266,7 @@ module CoronavirusFeatureSteps
     stub_coronavirus_landing_page_content(@coronavirus_page)
     fill_in("heading", with: "Fancy title")
     fill_in("content", with: "##Form content")
+    check("England")
     click_on("Save")
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/PSKxvsS3

Depends on: https://github.com/alphagov/collections/pull/2456

# What's changed and why?

Add a field to allow content designers to specify which UK nations a timeline entry applies too. This is related to a change on the frontend of the landing page which will allow users to filter the timeline by nation.

# Expected changes

## Form

<img width="1628" alt="Screenshot 2021-07-02 at 17 05 45" src="https://user-images.githubusercontent.com/5793815/124302095-9cd8f000-db58-11eb-93c1-7ecb11d311e5.png">

## Form with error messages

<img width="1628" alt="Screenshot 2021-07-02 at 17 06 11" src="https://user-images.githubusercontent.com/5793815/124302121-a5312b00-db58-11eb-8e71-662ecdd8667e.png">

## Reorder page

<img width="700" alt="Screenshot 2021-07-07 at 09 50 27" src="https://user-images.githubusercontent.com/5793815/124736093-95c23100-df0e-11eb-9664-75dff1aa4bd4.png">


## Summary page

<img width="1000" alt="Screenshot 2021-07-07 at 09 54 11" src="https://user-images.githubusercontent.com/5793815/124736034-87741500-df0e-11eb-8be5-3d1184ebfcba.png">

# Deployment plan
This change isn't behind a feature flag because it's expected that https://github.com/alphagov/collections/pull/2456 will be reviewed and deployed first.

- [x] Make sure https://github.com/alphagov/collections/pull/2465 has been deployed
- [ ] Co-ordinate a time for this PR to be merged with a content designer
- [ ] Merge this PR
- [ ] Ask the content designer to log into Collections Publisher to edit/delete/add entries and set national applicability for all entries
- [ ] Publish the landing page  


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
