### PR TITLE
Create migration to add sub heading to coronavirus subsection

### DIFF
--- a/db/migrate/20211001131132_add_sub_heading_to_coronavirus_sub_section.rb
+++ b/db/migrate/20211001131132_add_sub_heading_to_coronavirus_sub_section.rb
@@ -1,0 +1,5 @@
+class AddSubHeadingToCoronavirusSubSection < ActiveRecord::Migration[6.1]
+  def change
+    add_column :coronavirus_sub_sections, :sub_heading, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_02_095110) do
+ActiveRecord::Schema.define(version: 2021_10_01_131132) do
 
   create_table "coronavirus_announcements", charset: "utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id", null: false
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_07_02_095110) do
     t.string "action_link_url"
     t.string "action_link_content"
     t.string "action_link_summary"
+    t.string "sub_heading"
     t.index ["coronavirus_page_id"], name: "index_coronavirus_sub_sections_on_coronavirus_page_id"
   end
 


### PR DESCRIPTION
This is in order that we can retire the hubs and add the content therein to
the accordions on the landing page.

Trello - https://trello.com/c/0W3i2dN8/645-add-subheading-field-to-subsections-in-coronavirus-publishing-tool

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
