### PR TITLE
Add a task to unpublish the coronavirus hub pages

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -84,4 +84,12 @@ namespace :publishing_api do
     )
     puts "Links patched for root page..."
   end
+
+  desc "Unpublish all Coronavirus hub pages"
+  task unpublish_all_coronavirus_hub_pages: :environment do
+    %i[business education workers].map do |hub|
+      page = Coronavirus::Pages::Configuration.page(hub)
+      GdsApi.publishing_api.unpublish(page[:content_id], type: "redirect", alternative_path: "/coronavirus", discard_drafts: true)
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/ZzFMVDNS/661-remove-the-hubs

# What's changed and why?
We have been given permission to retire the coronavirus hub pages.
The links to the hub pages have already been removed and the content in the hubs as already been added to the accordions.

This task is temporary and will be removed in the story to remove all hub-related code.

## Testing in integration
<img width="819" alt="Screenshot 2021-10-13 at 11 53 19" src="https://user-images.githubusercontent.com/5793815/137119824-97c14457-62d4-4c7b-8f6c-00397c623664.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
