### PR TITLE
Remove hub pages from database

### DIFF
--- a/lib/tasks/coronavirus.rake
+++ b/lib/tasks/coronavirus.rake
@@ -23,13 +23,6 @@ namespace :coronavirus do
     puts "sections_title: #{page.sections_title}"
   end
 
-  desc "Sync timeline entries with entries in the yaml file"
-  task sync_timeline_entries: :environment do
-    Coronavirus::Pages::TimelineEntryBuilder.new.create_timeline_entries
-
-    puts "Timeline Entries synced for coronavirus landing page..."
-  end
-
   desc "Remove hub pages"
   task remove_hub_pages: :environment do
     %w[business education workers].each do |hub|


### PR DESCRIPTION
Trello: https://trello.com/c/ZzFMVDNS

# What's changed and why?

We have been given permission to retire the coronavirus hub pages.
The links to the hub pages have already been removed and the content in the hubs as already been added to the accordions and the hub pages have been unpublished, so the database entries can be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
