### PR TITLE
Present header section in db to publishing-api

### DIFF
--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -14,7 +14,7 @@ module Coronavirus::Pages
       @data ||= begin
         validate_content
         data = github_data
-        data["header_section"] = header_data
+        data["header_section"] = header_data if Rails.application.config.unreleased_features
         data["sections"] = sub_sections_data
         data["announcements"] = announcements_data
 

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -14,6 +14,7 @@ module Coronavirus::Pages
       @data ||= begin
         validate_content
         data = github_data
+        data["header_section"] = header_data
         data["sections"] = sub_sections_data
         data["announcements"] = announcements_data
 
@@ -39,7 +40,6 @@ module Coronavirus::Pages
       %w[
         title
         meta_description
-        header_section
         announcements_label
         announcements
         nhs_banner
@@ -58,6 +58,18 @@ module Coronavirus::Pages
 
     def github_data
       @github_data ||= github_raw_data["content"]
+    end
+
+    def header_data
+      {
+        "title" => page.header_title,
+        "intro" => page.header_body,
+        "link" => {
+          "href" => page.header_link_url,
+          "link_text" => page.header_link_pre_wrap_text,
+          "link_nowrap_text" => page.header_link_post_wrap_text,
+        },
+      }
     end
 
     def sub_sections_data

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -142,7 +142,15 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     end
 
     describe "#header_data" do
-      it "returns the header" do
+      it "includes the header section from github when unreleased features are turned off" do
+        allow(Rails.configuration).to receive(:unreleased_features).and_return(false)
+        expect(subject.data["header_section"]["title"])
+          .to eq(github_content["content"]["header_section"]["title"])
+      end
+
+      it "returns the header section from the database when unreleased_features are turned on" do
+        allow(Rails.configuration).to receive(:unreleased_features).and_return(true)
+
         page = create(
           :coronavirus_page,
           header_title: "Header section title",

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -60,7 +60,20 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
       ]
     end
 
+    let(:header_json) do
+      {
+        "title" => page.header_title,
+        "intro" => page.header_body,
+        "link" => {
+          "href" => page.header_link_url,
+          "link_text" => page.header_link_pre_wrap_text,
+          "link_nowrap_text" => page.header_link_post_wrap_text,
+        },
+      }
+    end
+
     before do
+      data["header_section"] = header_json
       data["sections"] = [sub_section_json]
       data["announcements"] = [announcement_json]
       data["timeline"]["list"] = [timeline_json]
@@ -126,6 +139,31 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
           "national_applicability" => timeline_entry_0.national_applicability,
         },
       ]
+    end
+
+    describe "#header_data" do
+      it "returns the header" do
+        page = create(
+          :coronavirus_page,
+          header_title: "Header section title",
+          header_body: "Header section body",
+          header_link_url: "/foo-bar",
+          header_link_pre_wrap_text: "Text before the wrap",
+          header_link_post_wrap_text: "and text after",
+        )
+
+        expected_header_section = {
+          "title" => page.header_title,
+          "intro" => page.header_body,
+          "link" => {
+            "href" => page.header_link_url,
+            "link_text" => page.header_link_pre_wrap_text,
+            "link_nowrap_text" => page.header_link_post_wrap_text,
+          },
+        }
+
+        expect(described_class.new(page).header_data).to eq(expected_header_section)
+      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/YZaACJRR

# What's changed and why?
The header section is being made editable via collections-publisher rather than via the YAML file in Github. To avoid making changes in the rendering application, the format that the header section data is presented to  publishing-api has not changed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
