### PR TITLE
Header section controller and view

### DIFF
--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -1,5 +1,6 @@
 module Coronavirus
   class PagesController < ApplicationController
+    before_action :require_unreleased_feature_permissions!, only: %w[edit_header update_header]
     before_action :require_coronavirus_editor_permissions!
     before_action :initialise_pages, only: %w[index]
     layout "admin_layout"

--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -30,7 +30,7 @@ module Coronavirus
         draft_updater.send
       end
 
-      redirect_to coronavirus_page_path(@page.slug), notice: "Success"
+      redirect_to coronavirus_page_path(@page.slug), notice: helpers.t("coronavirus.pages.update_header.success")
     rescue Pages::DraftUpdater::DraftUpdaterError => e
       flash.now[:alert] = e.message
       render :edit_header, status: :internal_server_error

--- a/app/views/coronavirus/pages/_form.html.erb
+++ b/app/views/coronavirus/pages/_form.html.erb
@@ -1,0 +1,85 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Title",
+    bold: true,
+  },
+  name: "landing_page[header_title]",
+  value: @page.header_title,
+  id: "header_title",
+  error_message: error_items(@page.errors.messages, :header_title),
+} %>
+
+<%= render "components/markdown_editor", {
+  label: {
+    text: "Header body",
+    bold: true
+  },
+  textarea: {
+    name: "landing_page[header_body]",
+    id: "header_body",
+    rows: 20,
+    value: @page.header_body
+  },
+  error_message: error_items(@page.errors.messages, :header_body),
+  controls: [:headings, :numbered_list, :bullets]
+} %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Header action link",
+  heading_level: 4,
+  margin_bottom: 5
+} %>
+
+<%= render "govuk_publishing_components/components/hint", {
+  text: "Add content across two lines for the header action link. This allows mobile users to see the link text correctly wrap over 2 lines in a block, rather than allowing their device to choose."
+} %>
+
+<%= render "govuk_publishing_components/components/character_count", {
+  textarea: {
+    label: {
+      text: "Action link text line one",
+      bold: true
+    },
+    name: "landing_page[header_link_pre_wrap_text]",
+    value: @page.header_link_pre_wrap_text,
+    hint: "40 characters recommended. Any content that goes over the recommended character limit should be added to line 2 and checked in the preview.",
+    error_message: error_items(@page.errors.messages, :header_link_pre_wrap_text),
+    rows: 1,
+  },
+  id: "header_link_pre_wrap_text",
+  maxlength: 40
+} %>
+
+<%= render "govuk_publishing_components/components/character_count", {
+  textarea: {
+    label: {
+      text: "Action link text line 2",
+      bold: true
+    },
+    name: "landing_page[header_link_post_wrap_text]",
+    value: @page.header_link_post_wrap_text,
+    hint: "40 characters recommended.",
+    error_message: error_items(@page.errors.messages, :header_link_post_wrap_text),
+    rows: 1,
+  },
+  id: "header_link_post_wrap_text",
+  maxlength: 40
+} %>
+
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Action link URL",
+    bold: true,
+  },
+  name: "landing_page[header_link_url]",
+  value: @page.header_link_url,
+  id: "header_link_url",
+  hint: "For example, '/government/news/coronavirus-covid-19' or 'https://www.nhs.uk/coronavirus-announcement'",
+  error_message: error_items(@page.errors.messages, :header_link_url),
+} %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Save",
+  margin_bottom: true
+} %>
+<%= tag.p (link_to 'Cancel', coronavirus_page_path(@page.slug), class: "govuk-link govuk-link--no-visited-state"), class: "govuk-body" %>

--- a/app/views/coronavirus/pages/_form.html.erb
+++ b/app/views/coronavirus/pages/_form.html.erb
@@ -1,6 +1,6 @@
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Title",
+    text: t("coronavirus.pages.edit_header.form.title.label"),
     bold: true,
   },
   name: "landing_page[header_title]",
@@ -11,7 +11,7 @@
 
 <%= render "components/markdown_editor", {
   label: {
-    text: "Header body",
+    text: t("coronavirus.pages.edit_header.form.body.label"),
     bold: true
   },
   textarea: {
@@ -25,24 +25,24 @@
 } %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: "Header action link",
+  text: t("coronavirus.pages.edit_header.form.header_link.title"),
   heading_level: 4,
   margin_bottom: 5
 } %>
 
 <%= render "govuk_publishing_components/components/hint", {
-  text: "Add content across two lines for the header action link. This allows mobile users to see the link text correctly wrap over 2 lines in a block, rather than allowing their device to choose."
+  text: t("coronavirus.pages.edit_header.form.header_link.hint")
 } %>
 
 <%= render "govuk_publishing_components/components/character_count", {
   textarea: {
     label: {
-      text: "Action link text line one",
+      text: t("coronavirus.pages.edit_header.form.header_link.header_link_pre_wrap_text.label"),
       bold: true
     },
     name: "landing_page[header_link_pre_wrap_text]",
     value: @page.header_link_pre_wrap_text,
-    hint: "40 characters recommended. Any content that goes over the recommended character limit should be added to line 2 and checked in the preview.",
+    hint: t("coronavirus.pages.edit_header.form.header_link.header_link_pre_wrap_text.hint"),
     error_message: error_items(@page.errors.messages, :header_link_pre_wrap_text),
     rows: 1,
   },
@@ -53,12 +53,12 @@
 <%= render "govuk_publishing_components/components/character_count", {
   textarea: {
     label: {
-      text: "Action link text line 2",
+      text: t("coronavirus.pages.edit_header.form.header_link.header_link_post_wrap_text.label"),
       bold: true
     },
     name: "landing_page[header_link_post_wrap_text]",
     value: @page.header_link_post_wrap_text,
-    hint: "40 characters recommended.",
+    hint: t("coronavirus.pages.edit_header.form.header_link.header_link_post_wrap_text.hint"),
     error_message: error_items(@page.errors.messages, :header_link_post_wrap_text),
     rows: 1,
   },
@@ -68,13 +68,13 @@
 
 <%= render "govuk_publishing_components/components/input", {
   label: {
-    text: "Action link URL",
+    text: t("coronavirus.pages.edit_header.form.header_link.header_link_url.label"),
     bold: true,
   },
   name: "landing_page[header_link_url]",
   value: @page.header_link_url,
   id: "header_link_url",
-  hint: "For example, '/government/news/coronavirus-covid-19' or 'https://www.nhs.uk/coronavirus-announcement'",
+  hint: t("coronavirus.pages.edit_header.form.header_link.header_link_url.hint"),
   error_message: error_items(@page.errors.messages, :header_link_url),
 } %>
 

--- a/app/views/coronavirus/pages/edit_header.html.erb
+++ b/app/views/coronavirus/pages/edit_header.html.erb
@@ -1,6 +1,6 @@
 <%= render 'coronavirus/shared/breadcrumbs', text: "Edit" %>
-<% content_for :title, "Edit Landing Page Header" %>
-<% content_for :context, "Landing Page Header" %>
+<% content_for :title, t("coronavirus.shared.title") %>
+<% content_for :context, t("coronavirus.pages.edit_header.title") %>
 <% if @page.errors.any? %>
   <%= render "shared/sub_sections/form_errors", resource: @page %>
 <% end %>

--- a/app/views/coronavirus/pages/edit_header.html.erb
+++ b/app/views/coronavirus/pages/edit_header.html.erb
@@ -1,0 +1,14 @@
+<%= render 'coronavirus/shared/breadcrumbs', text: "Edit" %>
+<% content_for :title, "Edit Landing Page Header" %>
+<% content_for :context, "Landing Page Header" %>
+<% if @page.errors.any? %>
+  <%= render "shared/sub_sections/form_errors", resource: @page %>
+<% end %>
+
+<div class="covid-edit-page govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with method: :patch, url: coronavirus_page_edit_header_path do %>
+      <%= render "form" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/coronavirus/pages/show.html.erb
+++ b/app/views/coronavirus/pages/show.html.erb
@@ -21,7 +21,9 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "coronavirus/pages/show/header" %>
+    <% if unreleased_feature_user? %>
+      <%= render "coronavirus/pages/show/header" %>
+    <% end %>
     <%= render "coronavirus/pages/show/timeline_entries" %>
     <%= render "coronavirus/pages/show/sub_sections" %>
     <%= render "coronavirus/pages/show/announcements" %>

--- a/app/views/coronavirus/pages/show.html.erb
+++ b/app/views/coronavirus/pages/show.html.erb
@@ -21,6 +21,7 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "coronavirus/pages/show/header" %>
     <%= render "coronavirus/pages/show/timeline_entries" %>
     <%= render "coronavirus/pages/show/sub_sections" %>
     <%= render "coronavirus/pages/show/announcements" %>

--- a/app/views/coronavirus/pages/show/_header.html.erb
+++ b/app/views/coronavirus/pages/show/_header.html.erb
@@ -1,0 +1,9 @@
+<div class="covid-manage-page__summary-list--divider">
+  <%= render "govuk_publishing_components/components/summary_list", {
+    title: "Header",
+    edit: {
+      link_text: "Change",
+      href: coronavirus_page_edit_header_path(@page.slug)
+    }
+  } %>
+</div>

--- a/app/views/coronavirus/pages/show/_header.html.erb
+++ b/app/views/coronavirus/pages/show/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="covid-manage-page__summary-list--divider">
   <%= render "govuk_publishing_components/components/summary_list", {
-    title: "Header",
+    title: t("coronavirus.pages.show.header_section.title"),
     edit: {
       link_text: "Change",
       href: coronavirus_page_edit_header_path(@page.slug)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,25 @@ en:
         landing_page_edit:
           accordions: Edit landing page accordions, announcements and timeline
           something_else: Edit something else on the landing page
+      edit_header:
+        title: Edit Landing Page Header
+        form:
+          title:
+            label: Title
+          body:
+            label: Header body
+          header_link:
+            title: Header action link
+            hint: Add content across two lines for the header action link. This allows mobile users to see the link text correctly wrap over 2 lines in a block, rather than allowing their device to choose.
+            header_link_pre_wrap_text:
+              label: Action link text line one
+              hint: 40 characters recommended. Any content that goes over the recommended character limit should be added to line 2 and checked in the preview.
+            header_link_post_wrap_text:
+              label: Action link text line 2
+              hint: 40 characters recommended.
+            header_link_url:
+              label: Action link URL
+              hint: "For example, '/government/news/coronavirus-covid-19' or 'https://www.nhs.uk/coronavirus-announcement'"
       show:
         context: Coronavirus landing page
         actions:
@@ -70,6 +89,8 @@ en:
           preview: Preview
           publish: Publish
         link_text: Coronavirus pages
+        header_section:
+          title: Header
         timeline_entries:
           title: Timeline entries
           confirm: Are you sure?
@@ -84,6 +105,8 @@ en:
           confirm: Are you sure?
           reorder: Reorder
           add: Add announcement
+      update_header:
+        success: Success
       publish:
         success: Page published!
         failed: You have already published this page.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
       get "discard", on: :member
       post "publish", to: "pages#publish", on: :member
 
+      get "edit-header", to: "pages#edit_header"
+      patch "edit-header", to: "pages#update_header"
+
       get "github_changes", to: "github_changes#index", on: :member
       post "github_changes/update", to: "github_changes#update", on: :member
       post "github_changes/publish", to: "github_changes#publish", on: :member

--- a/spec/controllers/coronavirus/pages_controller_spec.rb
+++ b/spec/controllers/coronavirus/pages_controller_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Coronavirus::PagesController do
+  include CoronavirusFeatureSteps
   render_views
 
   let(:stub_user) { create :user, :coronovirus_editor, name: "Name Surname" }
@@ -53,6 +54,78 @@ RSpec.describe Coronavirus::PagesController do
     it "instructs publishing api to discard the draft content item" do
       subject
       assert_publishing_api_discard_draft(page.content_id)
+    end
+  end
+
+  describe "GET /coronavirus/:slug/edit-header" do
+    it "renders page successfully" do
+      get :edit_header, params: { page_slug: page.slug }
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "PATCH /coronavirus/:slug/edit-header" do
+    let!(:page) do
+      create :coronavirus_page,
+             header_title: "title",
+             header_body: "body",
+             header_link_url: "https://www.hello.com",
+             header_link_pre_wrap_text: "Pre wrap text",
+             header_link_post_wrap_text: "Post wrap text"
+    end
+
+    let(:landing_page_params) do
+      {
+        header_title: "title updated",
+        header_body: "body",
+        header_link_url: "https://www.hello.com",
+        header_link_pre_wrap_text: "Pre wrap text",
+        header_link_post_wrap_text: "Post wrap text",
+      }
+    end
+
+    let(:landing_page_with_invalid_param) do
+      {
+        header_title: "title updated",
+        header_body: "body updated",
+        header_link_url: "com",
+        header_link_pre_wrap_text: "Pre wrap text",
+        header_link_post_wrap_text: "Post wrap text",
+      }
+    end
+
+    before do
+      stub_coronavirus_landing_page_content(page)
+      stub_coronavirus_publishing_api
+    end
+
+    context "when header is valid" do
+      it "updates header data" do
+        expect { patch :update_header, params: { page_slug: page.slug, landing_page: landing_page_params } }.to change { page.reload.header_title }.to("title updated")
+      end
+
+      it "redirects to coronavirus page" do
+        patch :update_header, params: { page_slug: page.slug, landing_page: landing_page_params }
+        expect(response).to redirect_to(coronavirus_page_path(page.slug))
+      end
+    end
+
+    context "when header is invalid" do
+      it "does not update header data" do
+        patch :update_header, params: { page_slug: page.slug, landing_page: landing_page_with_invalid_param }
+        expect(page.header_body).to eq("body")
+      end
+
+      it "returns an unprocessable entity response" do
+        patch :update_header, params: { page_slug: page.slug, landing_page: landing_page_with_invalid_param }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "renders error" do
+        patch :update_header, params: { page_slug: page.slug, landing_page: landing_page_with_invalid_param }
+
+        expect(response.body).to include(CGI.escapeHTML("Header link url needs to be a https:// URL or a path prefixed with /"))
+      end
     end
   end
 end

--- a/spec/controllers/coronavirus/pages_controller_spec.rb
+++ b/spec/controllers/coronavirus/pages_controller_spec.rb
@@ -58,9 +58,17 @@ RSpec.describe Coronavirus::PagesController do
   end
 
   describe "GET /coronavirus/:slug/edit-header" do
-    it "renders page successfully" do
+    it "can only be accessed by users with Unreleased feature permissions" do
+      stub_user.permissions << "Unreleased feature"
+
       get :edit_header, params: { page_slug: page.slug }
       expect(response).to have_http_status(:success)
+    end
+
+    it "cannot be accessed by users without Unreleased feature permissions" do
+      get :edit_header, params: { page_slug: page.slug }
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
@@ -97,6 +105,7 @@ RSpec.describe Coronavirus::PagesController do
     before do
       stub_coronavirus_landing_page_content(page)
       stub_coronavirus_publishing_api
+      stub_user.permissions << "Unreleased feature"
     end
 
     context "when header is valid" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -60,6 +60,93 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       i_see_error_message_no_changes_to_discard
       and_i_see_state_is_published
     end
+
+    scenario "Viewing announcements" do
+      given_there_is_coronavirus_page_with_announcements
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_an_announcements_section
+      and_i_can_see_existing_announcements
+    end
+
+    scenario "Adding announcements" do
+      given_there_is_coronavirus_page_with_announcements
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_an_announcements_section
+      and_i_add_a_new_announcement
+      then_i_see_the_create_announcement_form
+      when_i_fill_in_the_announcement_form_with_valid_data
+      then_i_can_see_a_new_announcement_has_been_created
+    end
+
+    scenario "Editing announcements" do
+      given_there_is_coronavirus_page_with_announcements
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_an_announcements_section
+      when_i_can_click_change_for_an_announcement
+      then_i_see_the_edit_announcement_form
+      when_i_can_edit_the_announcement_form_with_valid_data
+      then_i_can_see_that_the_announcement_has_been_updated
+    end
+
+    scenario "Deleting announcements", js: true do
+      given_there_is_coronavirus_page_with_announcements
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_an_announcements_section
+      when_i_delete_an_announcement
+      then_i_can_see_an_announcement_has_been_deleted
+    end
+
+    scenario "Reordering announcements", js: true do
+      given_there_is_coronavirus_page_with_announcements
+      when_i_visit_the_reorder_announcements_page
+      then_i_see_the_announcements_in_order
+      when_i_move_announcement_one_down
+      then_i_see_announcement_updated_message
+      and_i_see_the_announcements_have_changed_order
+    end
+
+    scenario "Adding timeline entries" do
+      given_there_is_a_coronavirus_page
+      when_i_visit_a_coronavirus_page
+      and_i_add_a_new_timeline_entry
+      then_i_see_the_timeline_entry_form
+      when_i_fill_in_the_timeline_entry_form_with_valid_data
+      then_i_see_a_new_timeline_entry_has_been_created
+    end
+
+    scenario "Editing timeline entries" do
+      given_there_is_a_coronavirus_page_with_timeline_entries
+      when_i_visit_a_coronavirus_page
+      and_i_change_a_timeline_entry
+      then_i_see_the_timeline_entry_form
+      and_i_see_the_existing_timeline_entry_data
+      when_i_fill_in_the_timeline_entry_form_with_valid_data
+      then_i_see_the_timeline_entry_has_been_updated
+    end
+
+    scenario "Reordering timeline entries", js: true do
+      given_there_is_a_coronavirus_page_with_timeline_entries
+      when_i_visit_the_reorder_timeline_entries_page
+      then_i_see_the_timeline_entries_in_order
+      when_i_move_timeline_entry_one_down
+      then_i_see_timeline_entries_updated_message
+      and_i_see_the_timeline_entries_have_changed_order
+    end
+
+    scenario "Viewing timeline entries" do
+      given_there_is_a_coronavirus_page_with_timeline_entries
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_a_timeline_entries_section
+      and_i_can_see_existing_timeline_entries
+    end
+
+    scenario "Deleting timeline entries", js: true do
+      given_there_is_a_coronavirus_page_with_timeline_entries
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_a_timeline_entries_section
+      when_i_delete_a_timeline_entry
+      then_i_can_see_the_timeline_entry_has_been_deleted
+    end
   end
 
   describe "Changes made in github" do
@@ -70,126 +157,37 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       stub_any_publishing_api_put_intent
     end
 
-    context "Landing page" do
-      scenario "User selects landing page" do
-        when_i_visit_the_coronavirus_index_page
-        and_i_select_landing_page
-        i_see_an_update_draft_button
-        and_a_preview_button
-        and_a_publish_button
-      end
+    scenario "User selects landing page" do
+      when_i_visit_the_coronavirus_index_page
+      and_i_select_landing_page
+      i_see_an_update_draft_button
+      and_a_preview_button
+      and_a_publish_button
+    end
 
-      scenario "Updating draft landing page" do
-        when_i_visit_the_coronavirus_index_page
-        and_i_select_landing_page
-        and_i_push_a_new_draft_version
-        then_the_content_is_sent_to_publishing_api
-        and_i_see_a_draft_updated_message
-      end
+    scenario "Updating draft landing page" do
+      when_i_visit_the_coronavirus_index_page
+      and_i_select_landing_page
+      and_i_push_a_new_draft_version
+      then_the_content_is_sent_to_publishing_api
+      and_i_see_a_draft_updated_message
+    end
 
-      scenario "Updating landing draft with invalid content" do
-        when_i_visit_the_coronavirus_index_page
-        and_i_select_landing_page
-        and_i_push_a_new_draft_version_with_invalid_content
-        and_i_see_an_alert
-      end
+    scenario "Updating landing draft with invalid content" do
+      when_i_visit_the_coronavirus_index_page
+      and_i_select_landing_page
+      and_i_push_a_new_draft_version_with_invalid_content
+      and_i_see_an_alert
+    end
 
-      scenario "Publishing landing page" do
-        when_i_visit_the_coronavirus_index_page
-        and_i_select_landing_page
-        and_i_choose_a_major_update
-        and_i_publish_the_page
-        and_i_remain_on_the_coronavirus_github_changes_page
-        then_the_page_publishes
-        and_i_see_github_changes_published_message
-      end
-
-      scenario "Viewing announcements" do
-        given_there_is_coronavirus_page_with_announcements
-        when_i_visit_a_coronavirus_page
-        then_i_can_see_an_announcements_section
-        and_i_can_see_existing_announcements
-      end
-
-      scenario "Adding announcements" do
-        given_there_is_coronavirus_page_with_announcements
-        when_i_visit_a_coronavirus_page
-        then_i_can_see_an_announcements_section
-        and_i_add_a_new_announcement
-        then_i_see_the_create_announcement_form
-        when_i_fill_in_the_announcement_form_with_valid_data
-        then_i_can_see_a_new_announcement_has_been_created
-      end
-
-      scenario "Editing announcements" do
-        given_there_is_coronavirus_page_with_announcements
-        when_i_visit_a_coronavirus_page
-        then_i_can_see_an_announcements_section
-        when_i_can_click_change_for_an_announcement
-        then_i_see_the_edit_announcement_form
-        when_i_can_edit_the_announcement_form_with_valid_data
-        then_i_can_see_that_the_announcement_has_been_updated
-      end
-
-      scenario "Deleting announcements", js: true do
-        given_there_is_coronavirus_page_with_announcements
-        when_i_visit_a_coronavirus_page
-        then_i_can_see_an_announcements_section
-        when_i_delete_an_announcement
-        then_i_can_see_an_announcement_has_been_deleted
-      end
-
-      scenario "Reordering announcements", js: true do
-        given_there_is_coronavirus_page_with_announcements
-        when_i_visit_the_reorder_announcements_page
-        then_i_see_the_announcements_in_order
-        when_i_move_announcement_one_down
-        then_i_see_announcement_updated_message
-        and_i_see_the_announcements_have_changed_order
-      end
-
-      scenario "Adding timeline entries" do
-        given_there_is_a_coronavirus_page
-        when_i_visit_a_coronavirus_page
-        and_i_add_a_new_timeline_entry
-        then_i_see_the_timeline_entry_form
-        when_i_fill_in_the_timeline_entry_form_with_valid_data
-        then_i_see_a_new_timeline_entry_has_been_created
-      end
-
-      scenario "Editing timeline entries" do
-        given_there_is_a_coronavirus_page_with_timeline_entries
-        when_i_visit_a_coronavirus_page
-        and_i_change_a_timeline_entry
-        then_i_see_the_timeline_entry_form
-        and_i_see_the_existing_timeline_entry_data
-        when_i_fill_in_the_timeline_entry_form_with_valid_data
-        then_i_see_the_timeline_entry_has_been_updated
-      end
-
-      scenario "Reordering timeline entries", js: true do
-        given_there_is_a_coronavirus_page_with_timeline_entries
-        when_i_visit_the_reorder_timeline_entries_page
-        then_i_see_the_timeline_entries_in_order
-        when_i_move_timeline_entry_one_down
-        then_i_see_timeline_entries_updated_message
-        and_i_see_the_timeline_entries_have_changed_order
-      end
-
-      scenario "Viewing timeline entries" do
-        given_there_is_a_coronavirus_page_with_timeline_entries
-        when_i_visit_a_coronavirus_page
-        then_i_can_see_a_timeline_entries_section
-        and_i_can_see_existing_timeline_entries
-      end
-
-      scenario "Deleting timeline entries", js: true do
-        given_there_is_a_coronavirus_page_with_timeline_entries
-        when_i_visit_a_coronavirus_page
-        then_i_can_see_a_timeline_entries_section
-        when_i_delete_a_timeline_entry
-        then_i_can_see_the_timeline_entry_has_been_deleted
-      end
+    scenario "Publishing landing page" do
+      when_i_visit_the_coronavirus_index_page
+      and_i_select_landing_page
+      and_i_choose_a_major_update
+      and_i_publish_the_page
+      and_i_remain_on_the_coronavirus_github_changes_page
+      then_the_page_publishes
+      and_i_see_github_changes_published_message
     end
   end
 end

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -149,6 +149,7 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Editing the header section" do
+      given_i_can_access_unreleased_features
       given_there_is_a_coronavirus_page
       when_i_visit_a_coronavirus_page
       then_i_can_see_a_header_section

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -147,6 +147,16 @@ RSpec.feature "Publish updates to Coronavirus pages" do
       when_i_delete_a_timeline_entry
       then_i_can_see_the_timeline_entry_has_been_deleted
     end
+
+    scenario "Editing the header section" do
+      given_there_is_a_coronavirus_page
+      when_i_visit_a_coronavirus_page
+      then_i_can_see_a_header_section
+      when_i_edit_the_header_section
+      then_i_can_see_the_edit_header_form
+      when_i_fill_in_the_edit_header_form_with_valid_data
+      then_i_see_header_updated_message
+    end
   end
 
   describe "Changes made in github" do

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -302,6 +302,35 @@ module CoronavirusFeatureSteps
     expect(page).not_to have_text(@timeline_entry_one.heading)
   end
 
+  # Editing the header section
+
+  def then_i_can_see_a_header_section
+    expect(page).to have_content("Header")
+  end
+
+  def when_i_edit_the_header_section
+    page.find("a[href=\"/coronavirus/landing/edit-header\"]", text: "Change").click
+  end
+
+  def then_i_can_see_the_edit_header_form
+    expect(page).to have_text("Header body")
+    expect(page).to have_text("Header action link")
+  end
+
+  def when_i_fill_in_the_edit_header_form_with_valid_data
+    stub_coronavirus_landing_page_content(@coronavirus_page)
+    fill_in("header_title", with: "Fancy title")
+    fill_in("header_body", with: "##Form content")
+    fill_in("header_link_pre_wrap_text", with: "Pre wrap text")
+    fill_in("header_link_post_wrap_text", with: "Post wrap text")
+    fill_in("header_link_url", with: "/link")
+    click_on("Save")
+  end
+
+  def then_i_see_header_updated_message
+    expect(page).to have_text("Success")
+  end
+
   def set_up_basic_sub_sections
     @coronavirus_page = FactoryBot.create(:coronavirus_page, state: "published")
     FactoryBot.create(:coronavirus_sub_section,

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -305,7 +305,7 @@ module CoronavirusFeatureSteps
   # Editing the header section
 
   def then_i_can_see_a_header_section
-    expect(page).to have_content("Header")
+    expect(page).to have_content(I18n.t("coronavirus.pages.show.header_section.title"))
   end
 
   def when_i_edit_the_header_section
@@ -313,8 +313,8 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_can_see_the_edit_header_form
-    expect(page).to have_text("Header body")
-    expect(page).to have_text("Header action link")
+    expect(page).to have_text(I18n.t("coronavirus.pages.edit_header.form.body.label"))
+    expect(page).to have_text(I18n.t("coronavirus.pages.edit_header.form.header_link.title"))
   end
 
   def when_i_fill_in_the_edit_header_form_with_valid_data
@@ -328,7 +328,7 @@ module CoronavirusFeatureSteps
   end
 
   def then_i_see_header_updated_message
-    expect(page).to have_text("Success")
+    expect(page).to have_text(I18n.t("coronavirus.pages.update_header.success"))
   end
 
   def set_up_basic_sub_sections


### PR DESCRIPTION
Trello: https://trello.com/c/hbvDJVBx

# What's changed?
Adds a section that allows publishers to edit the header content on the coronavirus landing page.

# Why?
The header section content was stored in a YAML file on GitHub. This meant that only content designers who are comfortable using GitHub or a developer could update this section. Moving this content into Collections Publisher with the rest of the landing page content opens up editing to content designers across GOV.UK.

# Expected changes

## New edit page
![screenshot-collections-publisher dev gov uk-2021 11 01-12_57_57](https://user-images.githubusercontent.com/5793815/139675303-2421bd05-df80-4b65-ac4e-282f68aa8e2f.png)


## Validation errors
<img width="1006" alt="Screenshot 2021-10-29 at 15 45 43" src="https://user-images.githubusercontent.com/5793815/139457045-d140d299-3e23-4e3e-a419-bac8486c2e17.png">
<img width="1006" alt="Screenshot 2021-10-29 at 15 45 30" src="https://user-images.githubusercontent.com/5793815/139457050-c72cc940-9aec-45a5-a5b0-03166931a1cb.png">

## Summary page changes
<img width="685" alt="Screenshot 2021-10-29 at 15 40 32" src="https://user-images.githubusercontent.com/5793815/139457041-53b1a57f-d914-42a6-955d-bc1650297d1b.png">
<img width="1006" alt="Screenshot 2021-10-29 at 15 45 13" src="https://user-images.githubusercontent.com/5793815/139457054-756051ef-e154-45b8-aca3-db8639b134dc.png">

# Note to reviewer
The content on the new "Edit header" page has not been finalised and should be considered placeholder content.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
