### PR TITLE
Add task to sync coronavirus header with YAML

### DIFF
--- a/app/services/coronavirus/pages/header_section_builder.rb
+++ b/app/services/coronavirus/pages/header_section_builder.rb
@@ -1,0 +1,28 @@
+module Coronavirus::Pages
+  class HeaderSectionBuilder
+    def create_header
+      return if header_from_yaml.blank?
+
+      Coronavirus::Page.transaction do
+        coronavirus_page.update!(
+          header_title: header_from_yaml["title"],
+          header_body: header_from_yaml["intro"],
+          header_link_url: header_from_yaml["link"]["href"],
+          header_link_pre_wrap_text: header_from_yaml["link"]["link_text"],
+          header_link_post_wrap_text: header_from_yaml["link"]["link_nowrap_text"],
+        )
+      end
+    end
+
+  private
+
+    def header_from_yaml
+      @github_data ||= YamlFetcher.new(coronavirus_page.raw_content_url).body_as_hash
+      @github_data.dig("content", "header_section")
+    end
+
+    def coronavirus_page
+      @coronavirus_page ||= Coronavirus::Page.find_by(slug: "landing")
+    end
+  end
+end

--- a/lib/tasks/coronavirus.rake
+++ b/lib/tasks/coronavirus.rake
@@ -1,0 +1,8 @@
+namespace :coronavirus do
+  desc "Sync header section with header section in the yaml file"
+  task sync_header_section: :environment do
+    Coronavirus::Pages::HeaderSectionBuilder.new.create_header
+
+    puts "Header section synced for coronavirus landing page."
+  end
+end

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -2,15 +2,15 @@ content:
   title: "Coronavirus (COVID-19): what you need to do"
   meta_description: "Find out about the government response to coronavirus (COVID-19) and what you need to do."
   header_section:
-    pretext-1: Stay alert
-    pretext-2: Anyone can spread the virus.
-    list:
+    title: Stay alert
+    intro: |
       - Only go outside for food, health reasons or work (where this absolutely cannot be done from home)
       - Stay 2 metres (6ft) away from other people
       - Wash your hands as soon as you get home
     link:
       href: /government/publications/full-guidance-on-staying-at-home-and-away-from-others
-      text: Full guidance on staying at home and away from others
+      link_text: Full guidance on staying at home
+      link_nowrap_text: and preventing the spread
   announcements_label: Announcements
   announcements:
   nhs_banner:

--- a/spec/services/coronavirus/pages/header_section_builder_spec.rb
+++ b/spec/services/coronavirus/pages/header_section_builder_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Coronavirus::Pages::HeaderSectionBuilder do
+  let(:fixture_path) { Rails.root.join "spec/fixtures/coronavirus_landing_page.yml" }
+  let(:github_content) { YAML.safe_load(File.read(fixture_path)) }
+  let(:coronavirus_page) { create(:coronavirus_page) }
+
+  before do
+    stub_request(:get, Regexp.new(coronavirus_page.raw_content_url))
+      .to_return(status: 200, body: github_content.to_json)
+  end
+
+  it "creates new header entries" do
+    described_class.new.create_header
+    coronavirus_page.reload
+
+    github_header_section = github_content.dig("content", "header_section")
+
+    expect(coronavirus_page.header_title).to eq(github_header_section["title"])
+    expect(coronavirus_page.header_body).to eq(github_header_section["intro"])
+    expect(coronavirus_page.header_link_url).to eq(github_header_section["link"]["href"])
+    expect(coronavirus_page.header_link_pre_wrap_text).to eq(github_header_section["link"]["link_text"])
+    expect(coronavirus_page.header_link_post_wrap_text).to eq(github_header_section["link"]["link_nowrap_text"])
+  end
+
+  it "does not update existing header entries if the YAML file is empty" do
+    coronavirus_page = create(
+      :coronavirus_page,
+      header_title: "Existing title",
+      header_body: "Existing body",
+      header_link_url: "/path",
+      header_link_pre_wrap_text: "Existing link text",
+      header_link_post_wrap_text: "Existing link wrap text",
+    )
+
+    github_content.dig("content", "header_section").clear
+
+    described_class.new.create_header
+    coronavirus_page.reload
+
+    expect(coronavirus_page.header_title).to eq("Existing title")
+    expect(coronavirus_page.header_body).to eq("Existing body")
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Atk2LuuG

# What's changed and why?
Adds a rake task to sync the header section on the coronavirus landing
page with the entries in the YAML file.

Creating a rake task avoids the risk of copy and paste errors that could
occur if the section was updated manually.

This is a throwaway task that should only be run once and will be
removed after the header section has been deployed.

Usage:

```
bundle exec rake coronavirus:sync_header_section
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
