### PR TITLE
Remove 40 character limit for action link fields

### DIFF
--- a/app/models/coronavirus/page.rb
+++ b/app/models/coronavirus/page.rb
@@ -9,8 +9,8 @@ class Coronavirus::Page < ApplicationRecord
   validates :state, inclusion: { in: STATUSES }, presence: true
 
   validates :header_title, length: { maximum: 255 }
-  validates :header_link_pre_wrap_text, length: { maximum: 40 }
-  validates :header_link_post_wrap_text, length: { maximum: 40 }
+  validates :header_link_pre_wrap_text, length: { maximum: 255 }
+  validates :header_link_post_wrap_text, length: { maximum: 255 }
   validates :header_link_url, absolute_path_or_https_url: { allow_blank: true }
 
   validate :valid_header_link_post_wrap_text

--- a/spec/models/coronavirus/page_spec.rb
+++ b/spec/models/coronavirus/page_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Coronavirus::Page do
 
     describe "header section validations" do
       it { should validate_length_of(:header_title).is_at_most(255) }
-      it { should validate_length_of(:header_link_pre_wrap_text).is_at_most(40) }
-      it { should validate_length_of(:header_link_post_wrap_text).is_at_most(40) }
+      it { should validate_length_of(:header_link_pre_wrap_text).is_at_most(255) }
+      it { should validate_length_of(:header_link_post_wrap_text).is_at_most(255) }
 
       describe "header_link_url validation" do
         it { should allow_values("/path", "https://example.com").for(:header_link_url) }


### PR DESCRIPTION
Trello: https://trello.com/c/zSJj2DNL

# What's changed?

Remove the 40 character validation on the `header_link_pre_wrap_text` and `header_link_post_wrap_text` fields made in commit: 42ea8044f9bc9f42eb0289415777b67a459ae58a

# Why?

The validation was added after the initial iteration of the hint for the fields implied that 40 characters was an enforced limit. The hint text has since been updated to state that the 40 character limit is only a suggestion, so the 40 character validation has been removed.

Rails no longer has a [size limit on text and string fields] so we still need to add some validation to protect the database from accidental abuse. 255 has been picked as the limit because 1) it matches the validation of the `header_title` field and 2) as the recommended length of the content is 40 characters, it seems unlikely that the 255 character limit will ever be reached, so therefore to the user it behaves as though there is no validation.

[size limit on text and string fields]: https://makandracards.com/makandra/481878-activerecord-string-and-text-fields-should-always-validate-their-length

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
