### PR TITLE
Remove unreleased feature check

### DIFF
--- a/app/controllers/coronavirus/pages_controller.rb
+++ b/app/controllers/coronavirus/pages_controller.rb
@@ -1,6 +1,5 @@
 module Coronavirus
   class PagesController < ApplicationController
-    before_action :require_unreleased_feature_permissions!, only: %w[edit_header update_header]
     before_action :require_coronavirus_editor_permissions!
     before_action :initialise_pages, only: %w[index]
     layout "admin_layout"

--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -14,7 +14,7 @@ module Coronavirus::Pages
       @data ||= begin
         validate_content
         data = github_data
-        data["header_section"] = header_data if Rails.application.config.unreleased_features
+        data["header_section"] = header_data
         data["sections"] = sub_sections_data
         data["announcements"] = announcements_data
 

--- a/app/views/coronavirus/pages/show.html.erb
+++ b/app/views/coronavirus/pages/show.html.erb
@@ -21,9 +21,7 @@
 
 <div class="covid-manage-page govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if unreleased_feature_user? %>
-      <%= render "coronavirus/pages/show/header" %>
-    <% end %>
+    <%= render "coronavirus/pages/show/header" %>
     <%= render "coronavirus/pages/show/timeline_entries" %>
     <%= render "coronavirus/pages/show/sub_sections" %>
     <%= render "coronavirus/pages/show/announcements" %>

--- a/spec/controllers/coronavirus/pages_controller_spec.rb
+++ b/spec/controllers/coronavirus/pages_controller_spec.rb
@@ -58,17 +58,9 @@ RSpec.describe Coronavirus::PagesController do
   end
 
   describe "GET /coronavirus/:slug/edit-header" do
-    it "can only be accessed by users with Unreleased feature permissions" do
-      stub_user.permissions << "Unreleased feature"
-
+    it "renders successfully" do
       get :edit_header, params: { page_slug: page.slug }
       expect(response).to have_http_status(:success)
-    end
-
-    it "cannot be accessed by users without Unreleased feature permissions" do
-      get :edit_header, params: { page_slug: page.slug }
-
-      expect(response).to have_http_status(:forbidden)
     end
   end
 
@@ -105,7 +97,6 @@ RSpec.describe Coronavirus::PagesController do
     before do
       stub_coronavirus_landing_page_content(page)
       stub_coronavirus_publishing_api
-      stub_user.permissions << "Unreleased feature"
     end
 
     context "when header is valid" do

--- a/spec/features/coronavirus_page_spec.rb
+++ b/spec/features/coronavirus_page_spec.rb
@@ -149,7 +149,6 @@ RSpec.feature "Publish updates to Coronavirus pages" do
     end
 
     scenario "Editing the header section" do
-      given_i_can_access_unreleased_features
       given_there_is_a_coronavirus_page
       when_i_visit_a_coronavirus_page
       then_i_can_see_a_header_section

--- a/spec/services/coronavirus/pages/content_builder_spec.rb
+++ b/spec/services/coronavirus/pages/content_builder_spec.rb
@@ -142,15 +142,7 @@ RSpec.describe Coronavirus::Pages::ContentBuilder do
     end
 
     describe "#header_data" do
-      it "includes the header section from github when unreleased features are turned off" do
-        allow(Rails.configuration).to receive(:unreleased_features).and_return(false)
-        expect(subject.data["header_section"]["title"])
-          .to eq(github_content["content"]["header_section"]["title"])
-      end
-
-      it "returns the header section from the database when unreleased_features are turned on" do
-        allow(Rails.configuration).to receive(:unreleased_features).and_return(true)
-
+      it "returns the header section JSON" do
         page = create(
           :coronavirus_page,
           header_title: "Header section title",


### PR DESCRIPTION
[Trello](https://trello.com/c/9AV3j3sD/38-make-header-section-live)

- Last stage in the [deploy plan](https://trello.com/c/9AV3j3sD/38-make-header-section-live) for making the header section editable via collections publisher.
- This flag allowed us to reduce the amount of time to freeze content editing.
- Do not merge on approval. Ensure everything else on the plan has been ticked off.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
