### PR TITLE
Remove validation for unnecessary GitHub content

### DIFF
--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -41,10 +41,8 @@ module Coronavirus::Pages
         title
         meta_description
         announcements_label
-        announcements
         nhs_banner
         sections_heading
-        sections
         topic_section
         notifications
       ]


### PR DESCRIPTION
# What's changed and why?

The `announcements` and `sections` keys don't contain any content in GitHub so they were removed from the YAML in:
https://github.com/alphagov/govuk-coronavirus-content/pull/630

The validation here needs to be updated to match.

Fixes error:

![image (1)](https://user-images.githubusercontent.com/5793815/141168871-6322c7ba-bee0-4ddd-b267-0e2d48b747c3.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
