### PR TITLE
Upgrade CI to use MySQL8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,7 @@ node {
     brakeman: true
   )
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
+
+  // Run against the MySQL 8 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/collections_publisher_test")
 }

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,8 +12,7 @@ development:
 test: &test
   <<: *default
   database: collections_publisher_test
-  url: <%= ENV["DATABASE_URL"].try(:sub, /(development)?$/, 'test')%>
-
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 production:
   <<: *default
 


### PR DESCRIPTION
### Description 

This changes the Jenkins CI configuration to use MySQL 8.

MySQL is [available at port `33068 `](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use) on the CI server. By explicitly setting the `TEST_DATABASE_URL`, we're telling Rails to use that MySQL server.

Previously, Rails implicitly used the default MySQL port `3306` which is a MySQL 5.5 server.

Trello ticket: https://trello.com/c/btcm7JyB/

### CD guidance 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
