### PR TITLE
Add instructions to avoid linking to Done pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -322,6 +322,8 @@ en:
 
           - could help you complete a task but is not the main piece of content included in the step by step.
           - is optional and not useful enough to be included in the step by step
+          
+        Do not add links to Done pages, as these are automatically included for links to supported formats.
     summary_page:
       sidebar_settings: Choose to hide the sidebar on certain pages.
       secondary_links: Choose additional pages to show the step by step sidebar.


### PR DESCRIPTION
Doing so will cause an error, because these formats automatically have their Done page links included since https://github.com/alphagov/collections-publisher/blob/f4321e88f6c358b5dd57f3b7a04f25992a108433/app/presenters/step_nav_presenter.rb#L105



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
