### PR TITLE
Add table for the nhs_section of covid landing pg

### DIFF
--- a/app/models/nhs_section.rb
+++ b/app/models/nhs_section.rb
@@ -1,0 +1,3 @@
+class NhsSection < ApplicationRecord
+  validates :heading, length: { maximum: 255 }
+end

--- a/db/migrate/20220208143527_create_nhs_sections.rb
+++ b/db/migrate/20220208143527_create_nhs_sections.rb
@@ -1,0 +1,10 @@
+class CreateNhsSections < ActiveRecord::Migration[6.1]
+  def change
+    create_table :nhs_sections do |t|
+      t.string :heading
+      t.text :sections
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -247,4 +247,9 @@ FactoryBot.define do
     national_applicability { %w[england] }
     page factory: :coronavirus_page
   end
+
+  factory :nhs_section do
+    heading { "Testing and vaccinations" }
+    sections { "Find out how to get tested, what your test result means and how to report your result." }
+  end
 end

--- a/spec/models/nhs_section_spec.rb
+++ b/spec/models/nhs_section_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe NhsSection, type: :model do
+  describe "validations" do
+    it { should validate_length_of(:heading).is_at_most(255) }
+  end
+end


### PR DESCRIPTION
We want to make the NHS section publishable from Collections Publisher,
adding this table will lay down the ground work in making that possible.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/9lhF8mlD/595-publishable-nhs-section-in-collections-publisher-database-migration)
