### PR TITLE
Fix timeline page layout

### DIFF
--- a/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
+++ b/app/assets/stylesheets/views/_coronavirus_manage_pages.scss
@@ -1,18 +1,3 @@
-.covid-manage-page__summary-list,
-.covid-manage-page__summary-list--divider {
-  .govuk-summary-list__key {
-    width: 50%;
-  }
-
-  .govuk-summary-list__value {
-    width: 10;
-  }
-
-  .govuk-summary-list__actions {
-    width: 40%;
-  }
-}
-
 .covid-manage-page__summary-list--divider:not(:first-child) {
   margin-top: govuk-spacing(8);
   margin-bottom: govuk-spacing(6);


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fix the layout of the summary list component on `/coronavirus/landing` by removing the custom styles that were being applied to the component in this context. These styles were setting widths that caused this component to break.

The layout still isn't perfect, but it's considerably more readable. We'll try to improve the component itself to fix the layout of the `Change/Delete` links in future.

## Why
We shouldn't have styles in applications that override component styles - this breaks component isolation and makes it harder to iterate components.

## Visual changes

Before | After
------ | -------
![Screenshot 2022-03-09 at 09 59 55](https://user-images.githubusercontent.com/861310/157420213-0b6dbfc7-e4dd-40c3-9999-e6a3470f96d5.png) | ![Screenshot 2022-03-09 at 10 00 05](https://user-images.githubusercontent.com/861310/157420251-8820e385-1522-4ef7-8a94-a56ee089dbd3.png)

