### PR TITLE
Update edit link text

### DIFF
--- a/app/views/coronavirus/pages/show/_announcements.html.erb
+++ b/app/views/coronavirus/pages/show/_announcements.html.erb
@@ -3,7 +3,7 @@
    {
      id: announcement.id,
      field: announcement.title,
-     edit: { href: edit_coronavirus_page_announcement_path(@page.slug, announcement) },
+     edit: { href: edit_coronavirus_page_announcement_path(@page.slug, announcement), link_text: t("coronavirus.pages.show.announcements.edit") },
      delete: {
        href: coronavirus_page_announcement_path(@page.slug, announcement),
        data_attributes: {

--- a/app/views/coronavirus/pages/show/_sub_sections.html.erb
+++ b/app/views/coronavirus/pages/show/_sub_sections.html.erb
@@ -3,7 +3,7 @@
    {
      id: sub_section.id,
      field: sub_section.title,
-     edit: { href: edit_coronavirus_page_sub_section_path(@page.slug, sub_section) },
+     edit: { href: edit_coronavirus_page_sub_section_path(@page.slug, sub_section), link_text: t("coronavirus.pages.show.sub_sections.edit") },
      delete: {
        href: coronavirus_page_sub_section_path(@page.slug, sub_section),
        data_attributes: {

--- a/app/views/coronavirus/pages/show/_timeline_entries.html.erb
+++ b/app/views/coronavirus/pages/show/_timeline_entries.html.erb
@@ -4,7 +4,7 @@
      id: timeline_entry.id,
      field: timeline_entry.heading,
      value: timeline_entry.national_applicability_text,
-     edit: { href: edit_coronavirus_page_timeline_entry_path(@page.slug, timeline_entry) },
+     edit: { href: edit_coronavirus_page_timeline_entry_path(@page.slug, timeline_entry), link_text: t("coronavirus.pages.show.timeline_entries.edit") },
      delete: {
        href: coronavirus_page_timeline_entry_path(@page.slug, timeline_entry),
        data_attributes: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,15 +96,18 @@ en:
           confirm: Are you sure?
           reorder: Reorder
           add: Add timeline entry
+          edit: Edit
         sub_sections:
           confirm: Are you sure?
           reorder: Reorder
           add: Add accordion
+          edit: Edit
         announcements:
           title: Announcements
           confirm: Are you sure?
           reorder: Reorder
           add: Add announcement
+          edit: Edit
       update_header:
         success: Success
       publish:

--- a/spec/support/coronavirus_feature_steps.rb
+++ b/spec/support/coronavirus_feature_steps.rb
@@ -194,7 +194,7 @@ module CoronavirusFeatureSteps
   end
 
   def when_i_can_click_change_for_an_announcement
-    page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}/edit\"]", text: "Change").click
+    page.find("a[href=\"/coronavirus/landing/announcements/#{@announcement_one.id}/edit\"]", text: I18n.t("coronavirus.pages.show.announcements.edit")).click
   end
 
   def then_i_see_the_edit_announcement_form
@@ -239,7 +239,7 @@ module CoronavirusFeatureSteps
   # Editing timeline entries
 
   def and_i_change_a_timeline_entry
-    page.find("a[href=\"/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}/edit\"]", text: "Change").click
+    page.find("a[href=\"/coronavirus/landing/timeline_entries/#{@timeline_entry_one.id}/edit\"]", text: I18n.t("coronavirus.pages.show.timeline_entries.edit")).click
   end
 
   def when_i_visit_the_edit_timeline_entry_page


### PR DESCRIPTION
Change edit link label text from "Change" to "Edit".

The word "Change" causes the action column to wrap around due to the component not being responsive. Previously we had css overrides but this was removed by PR #1539.

While we wait for the components to update the layouts, this change will help keep a nice consistent layout.

### Before
<img width="704" alt="Screenshot 2022-03-10 at 11 44 41 am" src="https://user-images.githubusercontent.com/4599889/157655341-113b0235-978e-41da-9b55-931a15b811fd.png">

### After
<img width="698" alt="Screenshot 2022-03-10 at 11 35 56 am" src="https://user-images.githubusercontent.com/4599889/157655369-727b98b0-e1f6-4aec-969a-00b0c5d40e62.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
