### PR TITLE
Migrate Mainstream browse pages to Design system

### DIFF
--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -111,3 +111,7 @@
   margin-top: 0;
   background-color: govuk-colour("light-grey");
 }
+
+.govuk-tag--small {
+  @include govuk-font(14, $weight: bold, $line-height: 1);
+}

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -72,6 +72,17 @@ class MainstreamBrowsePagesController < ApplicationController
     @browse_page = find_browse_page
   end
 
+  helper_method :issues_for
+  def issues_for(object, attribute)
+    object.errors.errors.filter_map do |error|
+      if error.attribute == attribute
+        {
+          text: error.options[:message],
+        }
+      end
+    end
+  end
+
 private
 
   def topics_for_select

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -1,5 +1,4 @@
 class MainstreamBrowsePagesController < ApplicationController
-  layout "legacy"
   before_action :require_gds_editor_permissions!
   before_action :protect_archived_browse_pages!, only: %i[edit update publish]
 

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -129,7 +129,21 @@ private
 
   def manage_child_ordering_params
     params.require(:mainstream_browse_page)
-      .permit(:child_ordering, children_attributes: %i[index id])
+      .permit(:child_ordering)
+      .merge(children_params)
+  end
+
+  def children_params
+    return unless params.dig("mainstream_browse_page", "child_ordering") == "curated"
+
+    children_attributes_hash = {}
+
+    params[:ordering].each do |input|
+      child_id, order = input
+      children_attributes_hash[order] = { "index" => order, "id" => child_id }
+    end
+
+    { children_attributes: children_attributes_hash }
   end
 
   def protect_archived_browse_pages!

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -22,6 +22,9 @@ class MainstreamBrowsePagesController < ApplicationController
     if browse_page.update(browse_page_params)
       TagBroadcaster.broadcast(browse_page)
       redirect_to browse_page
+    elsif browse_page_params.keys.include?("child_ordering")
+      @browse_page = browse_page
+      render :manage_child_ordering
     else
       @browse_page = browse_page
       @topics_for_select = topics_for_select

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -22,9 +22,6 @@ class MainstreamBrowsePagesController < ApplicationController
     if browse_page.update(browse_page_params)
       TagBroadcaster.broadcast(browse_page)
       redirect_to browse_page
-    elsif browse_page_params.keys.include?("child_ordering")
-      @browse_page = browse_page
-      render :manage_child_ordering
     else
       @browse_page = browse_page
       @topics_for_select = topics_for_select
@@ -74,6 +71,17 @@ class MainstreamBrowsePagesController < ApplicationController
     @browse_page = find_browse_page
   end
 
+  def update_child_ordering
+    @browse_page = find_browse_page
+
+    if @browse_page.update(manage_child_ordering_params)
+      TagBroadcaster.broadcast(@browse_page)
+      redirect_to @browse_page
+    else
+      render :manage_child_ordering
+    end
+  end
+
   helper_method :issues_for
   def issues_for(object, attribute)
     object.errors.errors.filter_map do |error|
@@ -116,7 +124,12 @@ private
 
   def tag_params
     params.require(:mainstream_browse_page)
-      .permit(:slug, :title, :description, :parent_id, :child_ordering, children_attributes: %i[index id])
+      .permit(:slug, :title, :description, :parent_id)
+  end
+
+  def manage_child_ordering_params
+    params.require(:mainstream_browse_page)
+      .permit(:child_ordering, children_attributes: %i[index id])
   end
 
   def protect_archived_browse_pages!

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -122,7 +122,7 @@ private
   def protect_archived_browse_pages!
     browse_page = find_browse_page
     if browse_page.archived?
-      flash[:danger] = "You cannot modify an archived mainstream browse page."
+      flash[:alert] = "You cannot modify an archived mainstream browse page."
       redirect_to browse_page
     end
   end

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -66,7 +66,7 @@ class MainstreamBrowsePagesController < ApplicationController
     if @archival.archive_or_remove
       redirect_to mainstream_browse_pages_path, success: "The mainstream browse page has been archived or removed."
     else
-      render "propose_archive"
+      render :propose_archive
     end
   end
 

--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -49,6 +49,7 @@ module HeaderHelper
   end
 
   def govuk_tag_heading(tag:, prepend: nil, append: nil)
+    context = govuk_status(tag)
     title = if prepend
               "#{prepend} #{tag.title_including_parent}"
             elsif append
@@ -58,6 +59,7 @@ module HeaderHelper
             end
 
     locals = {
+      context: context,
       title: title,
       page_title: tag.title_including_parent,
     }

--- a/app/helpers/header_helper.rb
+++ b/app/helpers/header_helper.rb
@@ -38,4 +38,32 @@ module HeaderHelper
       link_to object.to_s.humanize, object.to_sym
     end
   end
+
+  # Everything above this comment can be pulled out once we've finished porting
+  # over to the design system
+
+  # Generates a header with govuk-tags's
+
+  def govuk_heading_with_parent(tag)
+    tag.title_including_parent
+  end
+
+  def govuk_tag_heading(tag:, prepend: nil, append: nil)
+    title = if prepend
+              "#{prepend} #{tag.title_including_parent}"
+            elsif append
+              "#{tag.title_including_parent}: #{append}"
+            else
+              tag.title_including_parent
+            end
+
+    locals = {
+      title: title,
+      page_title: tag.title_including_parent,
+    }
+
+    render layout: "shared/govuk_tag_heading", locals: locals do
+      yield if block_given?
+    end
+  end
 end

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -34,7 +34,9 @@ module StatusHelper
 
   def govuk_status(tag_object)
     text, colour = return_tag_text_and_colour(tag_object)
-    tag.span text, class: "govuk-tag govuk-tag--#{colour}"
+    classes = "govuk-tag govuk-tag--#{colour} govuk-tag--small"
+
+    tag.span text, class: classes
   end
 
 private

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -28,4 +28,26 @@ module StatusHelper
   def draft_tag
     status "draft", :draft
   end
+
+  # Everything above this comment can be pulled out once we've finished porting
+  # over to the design system
+
+  def govuk_status(tag_object)
+    text, colour = return_tag_text_and_colour(tag_object)
+    tag.span text, class: "govuk-tag govuk-tag--#{colour}"
+  end
+
+private
+
+  def return_tag_text_and_colour(tag)
+    if tag.archived?
+      ["archived", :grey]
+    elsif tag.dirty?
+      ["unpublished changes", :red]
+    elsif tag.published?
+      ["published", :green]
+    elsif tag.draft?
+      ["draft", :blue]
+    end
+  end
 end

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -2,6 +2,7 @@ class MainstreamBrowsePage < Tag
   has_many :topics, through: :tag_associations, source: :to_tag
 
   validate :parents_cannot_have_topics_associated
+  validate :children_index_present, on: :update
 
   accepts_nested_attributes_for :children
 
@@ -30,6 +31,17 @@ private
   def parents_cannot_have_topics_associated
     if parent.blank? && topics.any?
       errors.add(:topics, "top-level mainstream browse pages cannot have topics assigned to them")
+    end
+  end
+
+  def children_index_present
+    return if children.blank?
+
+    sorted_children = sorted_children_that_are_not_archived
+    children_with_no_index = sorted_children.select { |child| child.index.nil? }
+
+    children_with_no_index.each do |child|
+      errors.add("children_attributes_#{sorted_children.find_index(child)}_index".to_sym, message: "Enter an index for #{child.title}")
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,9 +17,9 @@ class Tag < ApplicationRecord
   has_many :redirect_routes
 
   validates :slug, presence: { message: "Enter a slug" }
+  validates :slug, uniqueness: { scope: %w[parent_id], case_sensitive: false }, format: { with: /\A[a-z0-9-]*\z/, message: "Enter a valid slug" }
   validates :title, presence: { message: "Enter a title" }
   validates :content_id, presence: true
-  validates :slug, uniqueness: { scope: %w[parent_id], case_sensitive: false }, format: { with: /\A[a-z0-9-]*\z/, message: "Enter a valid slug" }
   validates :child_ordering, inclusion: { in: ORDERING_TYPES }
   validate :parent_is_not_a_child
   validate :cannot_change_slug

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,8 +16,10 @@ class Tag < ApplicationRecord
   has_many :list_items, through: :lists
   has_many :redirect_routes
 
-  validates :slug, :title, :content_id, presence: true
-  validates :slug, uniqueness: { scope: %w[parent_id], case_sensitive: false }, format: { with: /\A[a-z0-9-]*\z/ }
+  validates :slug, presence: { message: "Enter a slug" }
+  validates :title, presence: { message: "Enter a title" }
+  validates :content_id, presence: true
+  validates :slug, uniqueness: { scope: %w[parent_id], case_sensitive: false }, format: { with: /\A[a-z0-9-]*\z/, message: "Enter a valid slug" }
   validates :child_ordering, inclusion: { in: ORDERING_TYPES }
   validate :parent_is_not_a_child
   validate :cannot_change_slug
@@ -72,8 +74,10 @@ class Tag < ApplicationRecord
   def sorted_children
     if child_ordering == "alphabetical"
       children.sort_by { |child| child.title.downcase }
-    else
+    elsif children.map(&:index).all?(&:present?)
       children.sort_by(&:index)
+    else
+      children
     end
   end
 

--- a/app/views/mainstream_browse_pages/_breadcrumbs.html.erb
+++ b/app/views/mainstream_browse_pages/_breadcrumbs.html.erb
@@ -1,0 +1,12 @@
+<% content_for :breadcrumbs do %>
+  <% if links.any? %>
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      breadcrumbs: links.map do |link|
+        {
+          :title => link[:text],
+          :url => ( url_for(link[:href]) if link[:href].present? )
+        }
+      end
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/mainstream_browse_pages/_children-list.html.erb
+++ b/app/views/mainstream_browse_pages/_children-list.html.erb
@@ -1,0 +1,8 @@
+<ul class="govuk-list govuk-list--bullet">
+  <% browse_page.sorted_children.each do |child_tag| %>
+    <li>
+      <%= link_to(child_tag.title, polymorphic_path(child_tag), class: "govuk-link govuk-!-font-size-16") %>
+      <%= govuk_status(child_tag) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/mainstream_browse_pages/_create_update_form.html.erb
+++ b/app/views/mainstream_browse_pages/_create_update_form.html.erb
@@ -1,0 +1,60 @@
+<%= form_for @browse_page do |f| %>
+  <% unless update %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/select", {
+        id: "mainstream_browse_page_parent_id",
+        name: "mainstream_browse_page[parent_id]",
+        label: "Parent (optional)",
+        options: MainstreamBrowsePage.sorted_parents
+                  .map { |topic| {text: topic.title, value: topic.id, selected: topic.id == f.object.parent_id} }
+                  .prepend( { text: "", value: "" } )
+      } %>
+    </div>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: update ? "Slug (read only)" : "Slug"
+    },
+    hint: ("For example: lower-case-hyphen-separated" if update),
+    id: "mainstream_browse_page_slug",
+    name: "mainstream_browse_page[slug]",
+    readonly: update,
+    value: @browse_page[:slug],
+    error_items: issues_for(@browse_page, :slug)
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Title"
+    },
+    id: "mainstream_browse_page_title",
+    name: "mainstream_browse_page[title]",
+    value: @browse_page.title,
+    error_items: issues_for(@browse_page, :title)
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Description"
+    },
+    id: "mainstream_browse_page_description",
+    name: "mainstream_browse_page[description]",
+    value: @browse_page.description,
+    error_items: issues_for(@browse_page, :description)
+  } %>
+
+  <% if @browse_page.child? && update %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "mainstream_browse_page[topics][]",
+      heading: "Topics",
+      small: true,
+      items: @topics_for_select.map { |topic| { label: topic[:title], value: topic[:id], checked: @browse_page.topics.map(&:id).include?(topic[:id])  } }
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: update ? "Save" : "Create",
+    margin_bottom: true
+  } %>
+<% end %>

--- a/app/views/mainstream_browse_pages/_error_summary.html.erb
+++ b/app/views/mainstream_browse_pages/_error_summary.html.erb
@@ -4,8 +4,8 @@
     title: "There is a problem",
     items: object.errors.errors.map do |error|
         {
-          href:"##{@browse_page.type.underscore}_#{error.attribute.to_s}",
-          text: error.options[:message],
+          href:"##{object.class.to_s.underscore}_#{error.attribute.to_s}",
+          text: error.options[:message] || error.type,
         }
       end
   } %>

--- a/app/views/mainstream_browse_pages/_error_summary.html.erb
+++ b/app/views/mainstream_browse_pages/_error_summary.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.present? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    id: "error-summary",
+    title: "There is a problem",
+    items: object.errors.errors.map do |error|
+        {
+          href:"##{@browse_page.type.underscore}_#{error.attribute.to_s}",
+          text: error.options[:message],
+        }
+      end
+  } %>
+<% end %>

--- a/app/views/mainstream_browse_pages/_list-browse-pages.html.erb
+++ b/app/views/mainstream_browse_pages/_list-browse-pages.html.erb
@@ -1,0 +1,33 @@
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Documents list", { sortable: true, caption_classes: "govuk-visually-hidden" }) do |table| %>
+
+  <%= table.head do %>
+    <%= table.header "Title" %>
+    <%= table.header "Status" %>
+    <%= table.header "Children" %>
+    <%= table.header "Actions" if gds_editor? %>
+  <% end %>
+
+  <%= table.body do %>
+    <% @browse_pages.each do | browse_page | %>
+      <%= table.row do %>
+        <%= table.cell render "govuk_publishing_components/components/document_list", {
+          remove_top_border: true,
+          items: [
+            {
+              link: {
+                text: browse_page.title,
+                path: browse_page
+              },
+              metadata: {
+                preview_link: link_to(browse_page.base_path, Plek.new.website_root + browse_page.base_path, target: "_blank", class: "govuk-link")
+              }
+            }
+          ]
+        } %>
+        <%= table.cell govuk_status(browse_page) %>
+        <%= table.cell render "children-list", { browse_page: browse_page } %>
+        <%= table.cell link_to('Edit', edit_polymorphic_path(browse_page), class: "govuk-link") if gds_editor? %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/mainstream_browse_pages/_list-browse-pages.html.erb
+++ b/app/views/mainstream_browse_pages/_list-browse-pages.html.erb
@@ -4,7 +4,6 @@
     <%= table.header "Title" %>
     <%= table.header "Status" %>
     <%= table.header "Children" %>
-    <%= table.header "Actions" if gds_editor? %>
   <% end %>
 
   <%= table.body do %>
@@ -26,7 +25,6 @@
         } %>
         <%= table.cell govuk_status(browse_page) %>
         <%= table.cell render "children-list", { browse_page: browse_page } %>
-        <%= table.cell link_to('Edit', edit_polymorphic_path(browse_page), class: "govuk-link") if gds_editor? %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/mainstream_browse_pages/_list-children-pages.html.erb
+++ b/app/views/mainstream_browse_pages/_list-children-pages.html.erb
@@ -1,0 +1,37 @@
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Children", { caption_classes: "govuk-heading-m" }) do |table| %>
+
+  <%= table.head do %>
+    <%= table.header "Title" %>
+    <%= table.header "Status" %>
+    <%= table.header "Actions" if gds_editor? %>
+  <% end %>
+
+  <%= table.body do %>
+    <% @browse_page.sorted_children.each do | browse_page | %>
+      <%= table.row do %>
+        <%= table.cell render "govuk_publishing_components/components/document_list", {
+          remove_top_border: true,
+          items: [
+            {
+              link: {
+                text: browse_page.title,
+                path: browse_page
+              },
+              metadata: {
+                preview_link: link_to(browse_page.base_path, Plek.new.website_root + browse_page.base_path, target: "_blank", class: "govuk-link")
+              },
+              edit:  {
+                href: edit_mainstream_browse_page_path(@browse_page),
+                link_text: "Edit page"
+              }
+            }
+          ]
+        } %>
+
+        <%= table.cell govuk_status(browse_page) %>
+        <%= table.cell link_to('Edit', edit_polymorphic_path(browse_page), class: "govuk-link") if gds_editor? %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+<% end %>

--- a/app/views/mainstream_browse_pages/_list-links-preview.html.erb
+++ b/app/views/mainstream_browse_pages/_list-links-preview.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+        text: "Links",
+        font_size: "m",
+        margin_bottom: 4
+      } %>
+  </div>
+  <div class="govuk-grid-column-one-third app-grid-column--align-right">
+    <% if !tag.tagged_documents.empty? %>
+      <div class="govuk-body">
+        <%= link_to 'Edit tag list',
+          tag_lists_path(tag),
+          class: %w(govuk-link govuk-link--no-visited-state)
+        %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% if tag.tagged_documents.empty? %>
+  <p class="govuk-body">There are no documents tagged to this item.</p>
+<% elsif tag.display_curated_links? %>
+  <%= render 'shared/tags/curated_links_preview', tag_object: tag %>
+<% else %>
+  <%= render 'shared/tags/uncurated_links_preview', tag: tag %>
+<% end %>

--- a/app/views/mainstream_browse_pages/_list-specialist-sector-pages.html.erb
+++ b/app/views/mainstream_browse_pages/_list-specialist-sector-pages.html.erb
@@ -1,0 +1,33 @@
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self, "Specialist sector pages", { caption_classes: "govuk-heading-m" }) do |table| %>
+
+  <%= table.head do %>
+    <%= table.header "Title" %>
+    <%= table.header "Status" %>
+    <%= table.header "Actions" if gds_editor? %>
+  <% end %>
+
+  <%= table.body do %>
+    <% @browse_page.topics.each do | browse_page | %>
+      <%= table.row do %>
+        <%= table.cell render "govuk_publishing_components/components/document_list", {
+          remove_top_border: true,
+          items: [
+            {
+              link: {
+                text: browse_page.title,
+                path: browse_page
+              },
+              metadata: {
+                preview_link: link_to(browse_page.base_path, Plek.new.website_root + browse_page.base_path, target: "_blank", class: "govuk-link")
+              }
+            }
+          ]
+        } %>
+
+        <%= table.cell govuk_status(browse_page) %>
+        <%= table.cell link_to('Edit', edit_polymorphic_path(browse_page), class: "govuk-link") if gds_editor? %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+<% end %>

--- a/app/views/mainstream_browse_pages/_redirects.html.erb
+++ b/app/views/mainstream_browse_pages/_redirects.html.erb
@@ -1,16 +1,29 @@
-<h3>Redirects</h3>
-
-<table class='table'>
-  <tr>
-    <th>Added</th>
-    <th>From</th>
-    <th>To</th>
-  </tr>
-  <% redirect_routes.order('created_at DESC').each do |redirect_route| %>
-    <tr>
-      <td><%= redirect_route.created_at.to_formatted_s(:long) %></td>
-      <td><%= link_to redirect_route.from_base_path, website_url(redirect_route.from_base_path), target: '_blank' %></td>
-      <td><%= link_to redirect_route.to_base_path, website_url(redirect_route.to_base_path), target: '_blank' %></td>
-    </tr>
-  <% end %>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+  caption: "Redirects",
+  caption_classes: "govuk-heading-m",
+  first_cell_is_header: true,
+  head: [
+    {
+      text: "Added",
+    },
+    {
+      text: "From",
+    },
+    {
+      text: "To",
+    }
+  ],
+  rows: redirect_routes.order('created_at DESC').map { |redirect_route|
+      [
+        {
+          text: redirect_route.created_at.to_formatted_s(:long)
+        },
+        {
+          text: tag.a(redirect_route.from_base_path, href: website_url(redirect_route.from_base_path), class: "govuk-link", target: '_blank')
+        },
+        {
+          text: tag.a(redirect_route.to_base_path, href: website_url(redirect_route.to_base_path), class: "govuk-link", target: '_blank')
+        }
+      ]
+    }
+} %>

--- a/app/views/mainstream_browse_pages/archived_browse_page.html.erb
+++ b/app/views/mainstream_browse_pages/archived_browse_page.html.erb
@@ -1,7 +1,27 @@
-<%= tag_header @browse_page %>
+<%= render 'breadcrumbs', {
+  links: [
+    {
+      text: 'Mainstream browse pages',
+      href: mainstream_browse_pages_url
+    },
+    *([
+      text: @browse_page.parent[:title],
+      href: mainstream_browse_page_url(@browse_page.parent)
+    ] if @browse_page.parent.present? ),
+    {
+      text: @browse_page[:title],
+    }
+  ]
+} %>
 
-<p class="no-content">
-  This mainstream browse page has been archived.
-</p>
+<% content_for :title, govuk_tag_heading(tag: @browse_page) %>
 
-<%= render 'redirects', redirect_routes: @browse_page.redirect_routes %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <p class="govuk-body">
+      This mainstream browse page has been archived.
+    </p>
+
+    <%= render 'redirects', redirect_routes: @browse_page.redirect_routes %>
+  </div>
+</div>

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -24,51 +24,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @browse_page do |f| %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Slug (read only)"
-        },
-        id: "mainstream_browse_page_slug",
-        name: "mainstream_browse_page[slug]",
-        readonly: true,
-        value: @browse_page[:slug],
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title"
-        },
-        id: "mainstream_browse_page_title",
-        name: "mainstream_browse_page[title]",
-        value: @browse_page[:title],
-        error_items: issues_for(@browse_page, :title),
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Description"
-        },
-        id: "mainstream_browse_page_description",
-        name: "mainstream_browse_page[description]",
-        value: @browse_page[:description],
-        error_items: issues_for(@browse_page, :description),
-      } %>
-
-      <% if @browse_page.child? %>
-        <%= render "govuk_publishing_components/components/checkboxes", {
-          name: "mainstream_browse_page[topics][]",
-          heading: "Topics",
-          small: true,
-          items: @topics_for_select.map { |topic| { label: topic[:title], value: topic[:id], checked: @browse_page.topics.map(&:id).include?(topic[:id])  } }
-        } %>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        margin_bottom: true
-      } %>
-    <% end %>
-
+    <%= render 'create_update_form', update: true %>
   </div>
 </div>

--- a/app/views/mainstream_browse_pages/edit.html.erb
+++ b/app/views/mainstream_browse_pages/edit.html.erb
@@ -1,18 +1,74 @@
-<%= tag_header @browse_page, 'Edit' %>
+<%= render 'breadcrumbs', {
+  links: [
+    {
+      text: 'Mainstream browse pages',
+      href: mainstream_browse_pages_url
+    },
+    *([
+      text: @browse_page.parent[:title],
+      href: mainstream_browse_page_url(@browse_page.parent)
+    ] if @browse_page.parent.present? ),
+    {
+      text: @browse_page[:title],
+      href: mainstream_browse_page_url(@browse_page)
+    },
+    {
+      text: 'Edit',
+    }
+  ]
+} %>
 
-<%= form_for @browse_page do |f| %>
-  <%= f.text_field :slug, :disabled => true %>
-  <%= f.text_field :title %>
-  <%= f.text_field :description %>
+<% content_for :title, govuk_tag_heading(tag: @browse_page, prepend: 'Edit') %>
 
-  <% if @browse_page.child? %>
-    <%= f.select :topics,
-        options_from_collection_for_select(@topics_for_select, :id, :title_including_parent, @browse_page.topics.map(&:id)),
-        {},
-        { multiple: true,
-          class: "select2",
-          data: { placeholder: "Choose additional topics..." } } %>
-  <% end %>
+<%= render 'error_summary', object: @browse_page %>
 
-  <%= f.submit 'Save', class: 'btn-submit' %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @browse_page do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Slug (read only)"
+        },
+        id: "mainstream_browse_page_slug",
+        name: "mainstream_browse_page[slug]",
+        readonly: true,
+        value: @browse_page[:slug],
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Title"
+        },
+        id: "mainstream_browse_page_title",
+        name: "mainstream_browse_page[title]",
+        value: @browse_page[:title],
+        error_items: issues_for(@browse_page, :title),
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Description"
+        },
+        id: "mainstream_browse_page_description",
+        name: "mainstream_browse_page[description]",
+        value: @browse_page[:description],
+        error_items: issues_for(@browse_page, :description),
+      } %>
+
+      <% if @browse_page.child? %>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: "mainstream_browse_page[topics][]",
+          heading: "Topics",
+          small: true,
+          items: @topics_for_select.map { |topic| { label: topic[:title], value: topic[:id], checked: @browse_page.topics.map(&:id).include?(topic[:id])  } }
+        } %>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: true
+      } %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/mainstream_browse_pages/index.html.erb
+++ b/app/views/mainstream_browse_pages/index.html.erb
@@ -1,10 +1,13 @@
-<%= header "Mainstream browse pages", breadcrumbs: ["Mainstream browse pages"] do %>
-  <%= link_to new_mainstream_browse_page_path, class: 'new' do %>
-    <%= icon :add %> Add a mainstream browse page
-  <% end %>
-<% end %>
+<% content_for :title, "Mainstream browse pages" %>
+<% content_for :title_side, render("govuk_publishing_components/components/button", {
+  text: "Add a mainstream browse page",
+  href: new_mainstream_browse_page_path,
+  margin_bottom: true
+}) %>
 
-<%= render 'shared/tags/table',
-      resources: @browse_pages,
-      empty_message: "No mainstream browse pages exist yet.
-        #{link_to('Add one', new_mainstream_browse_page_path)}".html_safe %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body govuk-!-margin-bottom-3"><%= pluralize(@browse_pages.count, "mainstream browse pages") %></p>
+    <%= render "list-browse-pages" %>
+  </div>
+</div>

--- a/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
+++ b/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
@@ -20,7 +20,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @browse_page do |f| %>
+    <%= form_for @browse_page, url: update_child_ordering_mainstream_browse_page_path, method: :patch do |f| %>
 
       <div class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/select", {
@@ -49,7 +49,7 @@
           <input type="hidden" value="<%= child.id %>" name="mainstream_browse_page[children_attributes][<%= index %>][id]" id="mainstream_browse_page_children_attributes_<%= index %>_id">
         <% end %>
       <% end %>
-      
+
       <%= render "govuk_publishing_components/components/button", {
         text: "Save",
         margin_bottom: true

--- a/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
+++ b/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
@@ -1,9 +1,59 @@
-<%= tag_header @browse_page, 'Manage child ordering' %>
+<%= render 'breadcrumbs', {
+  links: [
+    {
+      text: 'Mainstream browse pages',
+      href: mainstream_browse_pages_url
+    },
+    {
+      text: @browse_page[:title],
+      href: mainstream_browse_page_url(@browse_page)
+    },
+    {
+      text: 'Manage child ordering',
+    }
+  ]
+} %>
 
-<%= form_for @browse_page do |f| %>
-  <%= f.select :child_ordering, Tag::ORDERING_TYPES %>
-  <%= f.fields_for :children, @browse_page.sorted_children_that_are_not_archived do |c| %>
-    <%= c.text_field :index, label: "#{c.object.title} (#{c.object.slug})" %>
-  <% end %>
-  <%= f.submit 'Save', class: 'btn-submit' %>
-<% end %>
+<% content_for :title, govuk_tag_heading(tag: @browse_page, append: "Manage child ordering") %>
+
+<%= render 'error_summary', object: @browse_page %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @browse_page do |f| %>
+
+      <div class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/select", {
+          id: "mainstream_browse_page_child_ordering",
+          name: "mainstream_browse_page[child_ordering]",
+          label: "Child ordering",
+          options: Tag::ORDERING_TYPES.map { |type| { text: type.capitalize, value: type, selected: @browse_page.child_ordering == type } }
+        } %>
+      </div>
+
+      <%= render "govuk_publishing_components/components/fieldset", {
+        legend_text: "Ordering of child pages",
+        heading_size: "s"
+      } do %>
+        <% @browse_page.sorted_children_that_are_not_archived.each_with_index do | child, index | %>
+          <%# @TODO: Needs backend controller redesigned so it does not require a input and hidden field to update the ordering %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: child.title
+            },
+            id: "mainstream_browse_page_children_attributes_#{index}_index",
+            name: "mainstream_browse_page[children_attributes][#{index}][index]",
+            value: child.index,
+            error_items: issues_for(@browse_page, "children_attributes_#{index}_index".to_sym)
+          } %>
+          <input type="hidden" value="<%= child.id %>" name="mainstream_browse_page[children_attributes][<%= index %>][id]" id="mainstream_browse_page_children_attributes_<%= index %>_id">
+        <% end %>
+      <% end %>
+      
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: true
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
+++ b/app/views/mainstream_browse_pages/manage_child_ordering.html.erb
@@ -21,7 +21,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @browse_page, url: update_child_ordering_mainstream_browse_page_path, method: :patch do |f| %>
-
       <div class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/select", {
           id: "mainstream_browse_page_child_ordering",
@@ -31,24 +30,14 @@
         } %>
       </div>
 
-      <%= render "govuk_publishing_components/components/fieldset", {
-        legend_text: "Ordering of child pages",
-        heading_size: "s"
-      } do %>
-        <% @browse_page.sorted_children_that_are_not_archived.each_with_index do | child, index | %>
-          <%# @TODO: Needs backend controller redesigned so it does not require a input and hidden field to update the ordering %>
-          <%= render "govuk_publishing_components/components/input", {
-            label: {
-              text: child.title
-            },
-            id: "mainstream_browse_page_children_attributes_#{index}_index",
-            name: "mainstream_browse_page[children_attributes][#{index}][index]",
-            value: child.index,
-            error_items: issues_for(@browse_page, "children_attributes_#{index}_index".to_sym)
-          } %>
-          <input type="hidden" value="<%= child.id %>" name="mainstream_browse_page[children_attributes][<%= index %>][id]" id="mainstream_browse_page_children_attributes_<%= index %>_id">
-        <% end %>
-      <% end %>
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        items: @browse_page.sorted_children_that_are_not_archived.map do |child|
+          {
+            id: child.id,
+            title: child.title,
+          }
+        end
+      } %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Save",

--- a/app/views/mainstream_browse_pages/new.html.erb
+++ b/app/views/mainstream_browse_pages/new.html.erb
@@ -16,55 +16,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <%= form_for @browse_page do |f| %>
-      <div class="govuk-!-margin-bottom-4">
-        <%= render "govuk_publishing_components/components/select", {
-          id: "mainstream_browse_page_parent_id",
-          name: "mainstream_browse_page[parent_id]",
-          label: "Parent (optional)",
-          options: MainstreamBrowsePage.sorted_parents
-                    .map { |topic| {text: topic.title, value: topic.id, selected: topic.id == f.object.parent_id} }
-                    .prepend( { text: "", value: "" } )
-        } %>
-      </div>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Slug"
-        },
-        hint: "For example: lower-case-hyphen-separated",
-        id: "mainstream_browse_page_slug",
-        name: "mainstream_browse_page[slug]",
-        value: @browse_page.slug,
-        error_items: issues_for(@browse_page, :slug)
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title"
-        },
-        id: "mainstream_browse_page_title",
-        name: "mainstream_browse_page[title]",
-        value: @browse_page.title,
-        error_items: issues_for(@browse_page, :title)
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Description"
-        },
-        id: "mainstream_browse_page_description",
-        name: "mainstream_browse_page[description]",
-        value: @browse_page.description,
-        error_items: issues_for(@browse_page, :description)
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Create",
-        margin_bottom: true
-      } %>
-    <% end %>
-
+    <%= render 'create_update_form', update: false %>
   </div>
 </div>

--- a/app/views/mainstream_browse_pages/new.html.erb
+++ b/app/views/mainstream_browse_pages/new.html.erb
@@ -1,16 +1,70 @@
-<%= header "New mainstream browse page",
-  breadcrumbs: [:mainstream_browse_pages, @browse_page.parent, "New"] %>
+<%= render 'breadcrumbs', {
+  links: [
+    {
+      text: 'Mainstream browse pages',
+      href: mainstream_browse_pages_url
+    },
+    {
+      text: 'New',
+    }
+  ]
+} %>
 
-<%= form_for @browse_page do |f| %>
-  <%= f.select :parent_id,
-      MainstreamBrowsePage.sorted_parents.map { |topic| [topic.title, topic.id] },
-      { include_blank: true },
-      { class: 'select2',
-        data: { placeholder: "Choose a parent page (optional)" } } %>
+<% content_for :title, "New mainstream browse page" %>
 
-  <%= f.text_field :slug %>
-  <%= f.text_field :title %>
-  <%= f.text_field :description %>
+<%= render 'error_summary', object: @browse_page %>
 
-  <%= f.submit 'Create', class: 'btn-submit' %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_for @browse_page do |f| %>
+      <div class="govuk-!-margin-bottom-4">
+        <%= render "govuk_publishing_components/components/select", {
+          id: "mainstream_browse_page_parent_id",
+          name: "mainstream_browse_page[parent_id]",
+          label: "Parent (optional)",
+          options: MainstreamBrowsePage.sorted_parents
+                    .map { |topic| {text: topic.title, value: topic.id, selected: topic.id == f.object.parent_id} }
+                    .prepend( { text: "", value: "" } )
+        } %>
+      </div>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Slug"
+        },
+        hint: "For example: lower-case-hyphen-separated",
+        id: "mainstream_browse_page_slug",
+        name: "mainstream_browse_page[slug]",
+        value: @browse_page.slug,
+        error_items: issues_for(@browse_page, :slug)
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Title"
+        },
+        id: "mainstream_browse_page_title",
+        name: "mainstream_browse_page[title]",
+        value: @browse_page.title,
+        error_items: issues_for(@browse_page, :title)
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Description"
+        },
+        id: "mainstream_browse_page_description",
+        name: "mainstream_browse_page[description]",
+        value: @browse_page.description,
+        error_items: issues_for(@browse_page, :description)
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create",
+        margin_bottom: true
+      } %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/mainstream_browse_pages/propose_archive.html.erb
+++ b/app/views/mainstream_browse_pages/propose_archive.html.erb
@@ -1,24 +1,66 @@
-<%= tag_header @archival.tag, 'Archive mainstream browse page' %>
+<%= render 'breadcrumbs', {
+  links: [
+    {
+      text: 'Mainstream browse pages',
+      href: mainstream_browse_pages_url
+    },
+    *([
+      text: @archival.tag.parent[:title],
+      href: mainstream_browse_page_url(@archival.tag.parent)
+    ] if @archival.tag.parent.present? ),
+    {
+      text: @archival.tag[:title],
+      href: mainstream_browse_page_url(@archival.tag)
+    },
+    {
+      text: 'Archive',
+    }
+  ]
+} %>
 
-<% if @archival.errors[:base].any? %>
-  <div class="alert alert-danger">
-    <%= @archival.errors[:base].to_sentence %>
+<%= govuk_tag_heading(tag: @archival.tag, append: 'Archive mainstream browse page') %>
+
+<%= render 'error_summary', object: @archival %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @archival, url: archive_mainstream_browse_page_path do |f| %>
+      <div class="govuk-!-margin-bottom-4">
+        <%= render "govuk_publishing_components/components/select", {
+          id: "mainstream_browse_page_archival_form_successor",
+          name: "mainstream_browse_page_archival_form[successor]",
+          label: "Choose a mainstream browse page to redirect to:",
+          options: @archival.browse_pages.map do |browse_page|
+            {
+              text: browse_page.title_including_parent,
+              value: browse_page.id
+            }
+          end
+        } %>
+      </div>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Archive and redirect to a mainstream browse page",
+        margin_bottom: true,
+        destructive: true,
+      } %>
+    <% end %>
+    <%= form_for @archival, url: archive_mainstream_browse_page_path do |f| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Or type in a URL to redirect to a page:"
+        },
+        hint: 'Please specify it as a relative path (for example "/government/publications/what-hmrc-does-to-prevent-tax-evasion")',
+        id: "mainstream_browse_page_archival_form_successor_path",
+        name: "mainstream_browse_page_archival_form[successor_path]",
+        error_items: issues_for(@archival, :successor_path)
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Archive and redirect to a page",
+        margin_bottom: true,
+        destructive: true,
+      } %>
+    <% end %>
   </div>
-<% end %>
-
-<%= form_for @archival, url: archive_mainstream_browse_page_path(@archival.tag) do |f| %>
-  <%= f.select :successor,
-    options_from_collection_for_select(@archival.browse_pages, :id, :title_including_parent),
-    { label: 'Choose a mainstream browse page to redirect to:' },
-    { class: 'select2' } %>
-
-  <%= f.submit 'Archive and redirect to a mainstream browse page', class: 'btn-submit btn-danger' %>
-<% end %>
-
-<%= form_for @archival, url: archive_mainstream_browse_page_path(@archival.tag) do |f| %>
-  <%= f.text_field :successor_path,
-    { label: 'Or type in a URL to redirect to a page:',
-      placeholder: 'Please specify it as a relative path (for example "/government/publications/what-hmrc-does-to-prevent-tax-evasion")' } %>
-
-  <%= f.submit 'Archive and redirect to a page', class: 'btn-submit btn-danger' %>
-<% end %>
+</div>

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -1,45 +1,126 @@
-<%= tag_header @browse_page do %>
-  <%= link_to "Edit page",
-    edit_mainstream_browse_page_path(@browse_page) %>
+<%= render 'breadcrumbs', {
+  links: [
+    {
+      text: 'Mainstream browse pages',
+      href: mainstream_browse_pages_url
+    },
+    *([
+      text: @browse_page.parent[:title],
+      href: mainstream_browse_page_url(@browse_page.parent)
+    ] if @browse_page.parent.present? ),
+    {
+      text: @browse_page[:title]
+    }
+  ]
+} %>
 
-  <% if @browse_page.can_have_children? %>
-    <%= link_to "Manage child ordering",
-      manage_child_ordering_mainstream_browse_page_path(@browse_page) %>
-  <% end %>
+<% content_for :title, govuk_heading_with_parent(@browse_page) %>
 
-  <% if @browse_page.may_publish? %>
-    <%= link_to "Publish mainstream browse page",
-               publish_mainstream_browse_page_path(@browse_page),
-               method: :post %>
-  <% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section class="govuk-!-margin-bottom-3">
+      <%= render "govuk_publishing_components/components/summary_list", {
+        borderless: true,
+        title: "Content",
+        items: [
+          {
+            field: "URL",
+            value: link_to(@browse_page.base_path, Plek.new.website_root + @browse_page.base_path, target: "_blank", class: "govuk-link")
+          },
+          *([
+            field: "Parent",
+            value: link_to(@browse_page.parent[:title], mainstream_browse_page_url(@browse_page.parent), class: "govuk-link")
+          ] if @browse_page.parent.present? ),
+          {
+            field: "Description",
+            value: @browse_page[:description].present? ? @browse_page[:description] : "Empty"
+          },
+          {
+            field: "Status",
+            value: govuk_status(@browse_page)
+          },
+          *([
+            field: "Child ordering",
+            value: @browse_page.child_ordering.capitalize
+          ] if @browse_page.top_level_mainstream_browse_page? )
+        ],
+        edit: {
+          href: edit_mainstream_browse_page_path(@browse_page),
+          link_text: "Edit page"
+        }
+      } %>
+    </section>
 
-  <% if @browse_page.child? %>
-    <% if @browse_page.published? %>
-      <%= link_to 'Archive mainstream browse page', propose_archive_mainstream_browse_page_path(@browse_page) %>
-    <% else %>
-      <%= link_to 'Remove mainstream browse page', archive_mainstream_browse_page_path(@browse_page),
-        method: 'post',
-        data: { confirm: 'Are you sure?' } %>
+    <% if @browse_page.can_have_children? %>
+      <section class="govuk-!-margin-bottom-3">
+        <%= render "list-children-pages" %>
+      </section>
     <% end %>
-  <% end %>
-<% end %>
 
-<%= render 'shared/tags/metadata', resource: @browse_page %>
-<%= render 'shared/tags/children', resource: @browse_page %>
+    <% if @browse_page.topics.any? %>
+      <section class="govuk-!-margin-bottom-3">
+        <%= render "list-specialist-sector-pages" %>
+      </section>
+    <% end %>
 
-<% if @browse_page.topics.any? %>
-  <section class="children">
-    <header class="heading-with-actions">
-      <h2>Specialist sector pages</h2>
-    </header>
+    <% if @browse_page.child? %>
+      <section class="govuk-!-margin-bottom-3">
+        <%= render 'list-links-preview', tag: @browse_page %>
+      </section>
+    <% end %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <aside class="app-side__wrapper">
+      <div class="app-side">
+        <div class="app-side__actions">
+          <% if @browse_page.may_publish? %>
+            <div class="govuk-!-margin-bottom-1">
+              <%= link_to "Publish",
+                publish_mainstream_browse_page_path(@browse_page),
+                method: :post,
+                class: %w(govuk-button),
+                data: { module: "govuk-button" } %>
+            </div>
+          <% end %>
+          <% if @browse_page.can_have_children? %>
+            <div class="govuk-!-margin-bottom-1">
+              <% if gds_editor? %>
+                <%= link_to "Add child page",
+                  new_polymorphic_path(@browse_page, parent_id: @browse_page.id),
+                  class: %w(govuk-link govuk-link--no-visited-state) %>
+              <% end %>
+            </div>
+            <div class="govuk-!-margin-bottom-1">
+              <%= link_to "Manage child ordering",
+                manage_child_ordering_mainstream_browse_page_path(@browse_page),
+                class: %w(govuk-link govuk-link--no-visited-state)
+              %>
+            </div>
+          <% end %>
+          <% if @browse_page.child? %>
+            <div class="govuk-!-margin-bottom-1">
+              <% if @browse_page.published? %>
+                <%= link_to 'Archive mainstream browse page',
+                  propose_archive_mainstream_browse_page_path(@browse_page),
+                  class: %w(govuk-link govuk-link--no-visited-state)
+                %>
+              <% else %>
+                <%= link_to 'Delete page', archive_mainstream_browse_page_path(@browse_page),
+                  method: 'post',
+                  data: { confirm: 'Are you sure?' },
+                  class: %w(govuk-link app-link--destructive)
+                %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
 
-    <%= render 'shared/tags/table',
-          resources: @browse_page.topics,
-          include_children_column: false,
-          empty_message: "No topics exist yet." %>
-  </section>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<% if @browse_page.child? %>
-  <%= render 'shared/tags/lists_of_links_preview', tag: @browse_page %>
-<% end %>
+  </div>
+</div>

--- a/app/views/shared/_govuk_tag_heading.html.erb
+++ b/app/views/shared/_govuk_tag_heading.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, page_title %>
 
-<% content_for :title, raw(title) %>
+<% content_for :context, context %>
+<% content_for :title, title %>
 
 <% if block_given? %>
   <nav class="actions">

--- a/app/views/shared/_govuk_tag_heading.html.erb
+++ b/app/views/shared/_govuk_tag_heading.html.erb
@@ -1,0 +1,9 @@
+<%= content_for :page_title, page_title %>
+
+<% content_for :title, raw(title) %>
+
+<% if block_given? %>
+  <nav class="actions">
+    <%= yield %>
+  </nav>
+<% end %>

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -1,41 +1,27 @@
-<%= link_to 'Edit list', tag_lists_path(tag),
-      class: 'btn btn-md btn-default pull-right',
-      id: 'edit-list' %>
+<p class="govuk-body">Links for this tag have been curated into lists. Click on the title for editing on Content Tagger.</p>
 
-<h2>Links</h2>
-
-<p>
-  Links for this tag have been curated into lists. Click on the title for editing on Content Tagger.
-</p>
-
-<% tag.lists.each do |list| %>
-  <h4><%= list.name %></h4>
+<% tag_object.lists.each do |list| %>
+  <h3 class="govuk-heading-s"><%= list.name %></h3>
   <% if list.list_items.empty? %>
-    <em>No items in list</em>
+    <em class="govuk-body">No items in list</em>
   <% end %>
-  <ul>
-  <% list.list_items_with_tagging_status.each do |list_item| %>
-    <li>
-      <% if list_item.tagged? %>
-        <a href=<%= content_tagger_url + '/taggings/' + list_item.content_id %>>
-          <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
-        </a>
-      <% else %>
-        <p class='label label-warning'>Tag was removed</p>
-        <%= raw list_item.display_title || "<em>Unknown title (#{list_item.base_path})</em>" %>
-      <% end %>
-    </li>
-  <% end %>
-  </ul>
+
+  <%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: list.list_items_with_tagging_status.map do |list_item|
+      if list_item.tagged?
+        link_to(list_item.display_title || tag.em("Unknown title (#{list_item.base_path}", class: 'govuk-body-s'),
+         content_tagger_url + '/taggings/' + list_item.content_id, class: 'govuk-link')
+      else
+        list_item.display_title || tag.em("Unknown title (#{list_item.base_path})", class: 'govuk-body-s')
+      end
+    end
+  } %>
 <% end %>
 
-<h4>Uncurated items <em>(not shown to user)</em></h4>
-<ul>
-<% tag.uncurated_tagged_documents.each do |item| %>
-  <li class="tagged-document">
-    <a href=<%= content_tagger_url + '/taggings/lookup' + item.content_id %>>
-      <%= item.title %>
-    </a>
-  </li>
-<% end %>
-</ul>
+<h3 class="govuk-heading-s">Uncurated items <em class="govuk-body">(not shown to user)</em></h3>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: tag_object.uncurated_tagged_documents.map { |item| link_to item.title, content_tagger_url + '/taggings/lookup' + item.content_id, class: 'govuk-link' }
+} %>

--- a/app/views/shared/tags/_lists_of_links_preview.html.erb
+++ b/app/views/shared/tags/_lists_of_links_preview.html.erb
@@ -1,7 +1,19 @@
 <% if tag.tagged_documents.empty? %>
   <p>There are no documents tagged to this item.</p>
 <% elsif tag.display_curated_links? %>
-  <%= render 'shared/tags/curated_links_preview', tag: tag %>
+  <%= link_to 'Edit list', tag_lists_path(tag),
+        class: 'btn btn-md btn-default pull-right',
+        id: 'edit-list' %>
+
+  <h2>Links</h2>
+
+  <%= render 'shared/tags/curated_links_preview', tag_object: tag %>
 <% else %>
+  <%= link_to 'Start curating links', tag_lists_path(tag),
+        class: 'btn btn-md btn-default pull-right',
+        id: 'edit-list' %>
+
+  <h2>Links</h2>
+
   <%= render 'shared/tags/uncurated_links_preview', tag: tag %>
 <% end %>

--- a/app/views/shared/tags/_uncurated_links_preview.html.erb
+++ b/app/views/shared/tags/_uncurated_links_preview.html.erb
@@ -1,19 +1,6 @@
-<%= link_to 'Start curating links', tag_lists_path(tag),
-      class: 'btn btn-md btn-default pull-right',
-      id: 'edit-list' %>
+<p class="govuk-body-s">Links for this tag have not been curated into lists. Click on the title for editing on Content Tagger.</p>
 
-<h2>Links</h2>
-
-<p>
-  Links for this tag have not been curated into lists. Click on the title for editing on Content Tagger.
-</p>
-
-<ul>
-<% tag.tagged_documents.each do |link| %>
-  <li class="tagged-document">
-    <a href=<%= content_tagger_url + '/taggings/' + link.content_id %>>
-      <%= link.title %>
-    </a>
-  </li>
-<% end %>
-</ul>
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: tag.tagged_documents.map { |link|  link_to link.title, content_tagger_url + '/taggings/' + link.content_id, class: 'govuk-link' }
+} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
       get :propose_archive
       post :archive
       get :"manage-child-ordering"
+      patch :update_child_ordering
     end
   end
 

--- a/spec/features/archiving_mainstream_browse_page_tags_spec.rb
+++ b/spec/features/archiving_mainstream_browse_page_tags_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Archiving mainstream browse page tags" do
   end
 
   def when_i_click_the_remove_button
-    click_link "Remove mainstream browse page"
+    click_link "Delete page"
   end
 
   def and_i_go_to_the_archive_page

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Managing browse pages" do
   end
 
   def when_i_click_on_the_publish_button
-    click_on "Publish mainstream browse page"
+    click_on "Publish"
   end
 
   def when_i_navigate_to_the_edit_page
@@ -101,13 +101,13 @@ RSpec.feature "Managing browse pages" do
   end
 
   def then_i_see_that_the_page_is_in_draft
-    within ".attributes" do
+    within ".govuk-summary-list--no-border" do
       expect(page).to have_content("draft")
     end
   end
 
   def then_i_see_that_the_page_is_published
-    within ".attributes" do
+    within ".govuk-summary-list--no-border" do
       expect(page).to have_content("published")
     end
   end

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -156,7 +156,8 @@ RSpec.feature "Managing browse pages" do
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Enter a title")
+    expect(page).to have_content("Enter a slug")
     expect(find("#mainstream_browse_page_description").value).to eql "A changed description"
   end
 end

--- a/spec/features/managing_topic_pages_spec.rb
+++ b/spec/features/managing_topic_pages_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Managing topics" do
   end
 
   def then_i_see_a_validation_error
-    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Enter a title")
     expect(find("#topic_description").value).to eql "A changed description"
   end
 end

--- a/spec/features/navigating_browse_pages_spec.rb
+++ b/spec/features/navigating_browse_pages_spec.rb
@@ -20,15 +20,15 @@ RSpec.feature "Managing browse pages" do
   end
 
   def given_there_are_browse_pages
-    create(:mainstream_browse_page, :published, title: "Money and Tax")
-    citizenship = create(:mainstream_browse_page, :published, title: "Citizenship")
-    create(:mainstream_browse_page, parent: citizenship, title: "Voting")
-    british_citizenship = create(:mainstream_browse_page, parent: citizenship, title: "British citizenship")
+    @money_and_tax = create(:mainstream_browse_page, :published, title: "Money and Tax")
+    @citizenship = create(:mainstream_browse_page, :published, title: "Citizenship")
+    @voting = create(:mainstream_browse_page, parent: @citizenship, title: "Voting")
+    @british_citizenship = create(:mainstream_browse_page, parent: @citizenship, title: "British citizenship")
 
     @linked_item_content_id1 = "6896f0f3-9b79-4ec3-9f16-892f7f35e921"
     @linked_item_content_id2 = "f608313e-524a-478a-ae73-03cfdc920bdd"
     publishing_api_has_linked_items(
-      british_citizenship.content_id,
+      @british_citizenship.content_id,
       items: [
         { base_path: "/naturalisation", title: "Naturalisation", content_id: @linked_item_content_id1 },
         { base_path: "/marriage", title: "Marriage", content_id: @linked_item_content_id2 },
@@ -37,11 +37,12 @@ RSpec.feature "Managing browse pages" do
   end
 
   def then_i_see_the_top_level_pages
-    titles = page.all(".tags-list tbody td:first-child").map(&:text)
-    expect(titles).to eq([
-      "Citizenship",
-      "Money and Tax",
-    ])
+    title_cells = page.all(".govuk-table__row td:first-child")
+
+    expect(title_cells[0]).to have_link(@citizenship.title)
+    expect(title_cells[0]).to have_link(@citizenship.base_path)
+    expect(title_cells[1]).to have_link(@money_and_tax.title)
+    expect(title_cells[1]).to have_link(@money_and_tax.base_path)
   end
 
   def when_i_click_on_a_browse_page

--- a/spec/features/navigating_browse_pages_spec.rb
+++ b/spec/features/navigating_browse_pages_spec.rb
@@ -50,11 +50,12 @@ RSpec.feature "Managing browse pages" do
   end
 
   def then_i_see_the_child_pages
-    child_titles = page.all(".children .tags-list tbody td:first-child").map(&:text)
-    expect(child_titles).to eq([
-      "British citizenship",
-      "Voting",
-    ])
+    child_titles = page.all(".govuk-table__row td[1]")
+
+    expect(child_titles[0]).to have_link(@british_citizenship.title)
+    expect(child_titles[0]).to have_link(@british_citizenship.base_path)
+    expect(child_titles[1]).to have_link(@voting.title)
+    expect(child_titles[1]).to have_link(@voting.base_path)
   end
 
   def when_i_click_on_a_child_page
@@ -62,11 +63,9 @@ RSpec.feature "Managing browse pages" do
   end
 
   def then_i_see_the_documents_tagged_to_it
-    tagged_document_titles = page.all(".tagged-document").map(&:text)
-    expect(tagged_document_titles).to eq(%w[
-      Naturalisation
-      Marriage
-    ])
+    tagged_document_titles = page.all(".govuk-list li")
+    expect(tagged_document_titles[0].text).to eq("Naturalisation")
+    expect(tagged_document_titles[1].text).to eq("Marriage")
     expect(page).to have_link(nil, href: "#{Plek.new.external_url_for('content-tagger')}/taggings/#{@linked_item_content_id1}")
     expect(page).to have_link(nil, href: "#{Plek.new.external_url_for('content-tagger')}/taggings/#{@linked_item_content_id2}")
   end

--- a/spec/features/order_browse_pages_spec.rb
+++ b/spec/features/order_browse_pages_spec.rb
@@ -26,10 +26,11 @@ RSpec.feature "Order browse pages" do
     then_i_see_the_alphabetical_order
   end
 
-  scenario "User triggers validation errors by leaving blank inputs" do
+  scenario "User triggers validation errors when curating child order" do
     given_there_are_browse_pages
     when_i_visit_the_browse_pages_index
     when_i_navigate_to_the_child_ordering_page
+    and_i_select_curated_ordering
     and_i_fill_in_the_form_with_a_blank_input
     then_i_see_a_validation_error
   end

--- a/spec/features/order_browse_pages_spec.rb
+++ b/spec/features/order_browse_pages_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Order browse pages" do
   end
 
   def then_i_see_my_curated_ordering
-    titles = page.all(".tags-list tbody td:first-child").map(&:text)
+    titles = page.all(".gem-c-document-list__item-title").map(&:text)
     expect(titles).to eq([
       "Pepperoni",
       "Four seasons",
@@ -69,7 +69,7 @@ RSpec.feature "Order browse pages" do
   end
 
   def then_i_see_the_alphabetical_order
-    titles = page.all(".tags-list tbody td:first-child").map(&:text)
+    titles = page.all(".gem-c-document-list__item-title").map(&:text)
     expect(titles).to eq([
       "Four seasons",
       "Pepperoni",

--- a/spec/features/order_browse_pages_spec.rb
+++ b/spec/features/order_browse_pages_spec.rb
@@ -22,9 +22,16 @@ RSpec.feature "Order browse pages" do
     given_there_are_browse_pages
     when_i_visit_the_browse_pages_index
     when_i_navigate_to_the_child_ordering_page
-    and_i_select_alphabetical_ordering
-    and_i_submit_the_form
+    and_i_select_alphabetical_ordering_and_submit
     then_i_see_the_alphabetical_order
+  end
+
+  scenario "User triggers validation errors by leaving blank inputs" do
+    given_there_are_browse_pages
+    when_i_visit_the_browse_pages_index
+    when_i_navigate_to_the_child_ordering_page
+    and_i_fill_in_the_form_with_a_blank_input
+    then_i_see_a_validation_error
   end
 
   def given_there_are_browse_pages
@@ -39,12 +46,12 @@ RSpec.feature "Order browse pages" do
   end
 
   def and_i_select_curated_ordering
-    select "curated", from: "Child ordering"
+    select "Curated", from: "Child ordering"
   end
 
   def and_i_submit_an_ordering
-    fill_in @four_seasons.slug.to_s, with: "1"
-    fill_in @pepperoni.slug.to_s, with: "0"
+    fill_in @four_seasons.title.to_s, with: "1"
+    fill_in @pepperoni.title.to_s, with: "0"
     click_on "Save"
   end
 
@@ -56,8 +63,9 @@ RSpec.feature "Order browse pages" do
     ])
   end
 
-  def and_i_select_alphabetical_ordering
-    select "alphabetical", from: "Child ordering"
+  def and_i_select_alphabetical_ordering_and_submit
+    select "Alphabetical", from: "Child ordering"
+    click_on "Save"
   end
 
   def then_i_see_the_alphabetical_order
@@ -66,5 +74,14 @@ RSpec.feature "Order browse pages" do
       "Four seasons",
       "Pepperoni",
     ])
+  end
+
+  def and_i_fill_in_the_form_with_a_blank_input
+    fill_in @four_seasons.title.to_s, with: ""
+    click_on "Save"
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_content "Enter an index for #{@four_seasons.title}"
   end
 end

--- a/spec/features/tagging_browse_with_topics_spec.rb
+++ b/spec/features/tagging_browse_with_topics_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Tagging browse pages with topics" do
 
   def and_i_add_a_new_tag_and_submit
     within "form" do
-      select "Alpha", from: "mainstream_browse_page_topics"
+      check "Alpha"
       click_on "Save"
     end
 
@@ -62,7 +62,6 @@ RSpec.feature "Tagging browse pages with topics" do
   end
 
   def then_i_my_browse_page_is_selected
-    expect(page).to have_select("mainstream_browse_page_topics",
-                                selected: %w[Alpha])
+    expect(find_field("Alpha")).to be_checked
   end
 end


### PR DESCRIPTION
## What
Convert the mainstream browser pages views in Collections publisher to the Design system.

## Why
This will address any accessibility concerns and make the whole app consistent with one design pattern.

## Additional Information

We should move things like for like (or as close as possible). Once we have like for like migration, we can iterate on the user journey if needed.

## Screenshots

### Index 

|Before|After|
|------------|------------|
|<img width="798" alt="image" src="https://user-images.githubusercontent.com/42515961/159896604-4c2f8057-ddf1-4f9d-b0ff-6c9665bf1dad.png">|<img width="689" alt="image" src="https://user-images.githubusercontent.com/42515961/159892584-3ad4cc5c-53be-4cbe-ae66-b6f230b824e3.png">|

### New

|Before|After|
|------------|------------|
|<img width="652" alt="image" src="https://user-images.githubusercontent.com/42515961/159896720-8dcec3ac-f3e9-4c44-9584-ba55e07c7725.png">|<img width="702" alt="image" src="https://user-images.githubusercontent.com/42515961/159892755-47d0824a-2e7a-4923-9f1d-0a238917c9e8.png">|

### Edit

|Before|After|
|------------|------------|
|<img width="616" alt="image" src="https://user-images.githubusercontent.com/42515961/159897526-5ddd08e1-1ec8-42a2-ab2c-95406d771375.png">|<img width="618" alt="image" src="https://user-images.githubusercontent.com/42515961/159898239-20c4bb09-6968-4265-93a7-77e4fcf55f53.png">|

### Show (parent)

|Before|After|
|------------|------------|
|<img width="786" alt="image" src="https://user-images.githubusercontent.com/42515961/159896943-fefd9ed1-4e32-4a8d-8bff-3c489d6c1b0b.png">|<img width="609" alt="image" src="https://user-images.githubusercontent.com/42515961/159898364-0dd0eb97-5a33-498a-8113-712bdb38d48c.png">|

### Show (child)

|Before|After|
|------------|------------|
|<img width="783" alt="image" src="https://user-images.githubusercontent.com/42515961/159897060-3087f42a-e3f8-4750-b0d4-ad7f7cda80e2.png">|<img width="696" alt="image" src="https://user-images.githubusercontent.com/42515961/159895697-6c340e9b-030a-4160-ac29-37ab10f41f80.png">|

### Manage ordering  

|Before|After|
|------------|------------|
|<img width="737" alt="image" src="https://user-images.githubusercontent.com/42515961/159897155-afe0d4ac-9fe8-4ebf-bc4d-44ae31a1c99f.png">|<img width="636" alt="image" src="https://user-images.githubusercontent.com/42515961/159895784-bbec567e-4e58-4b63-97e7-f714739e328f.png">|

### Error handling 

|Before|After|
|------------|------------|
|<img width="461" alt="image" src="https://user-images.githubusercontent.com/42515961/159899668-69918841-fd12-4b07-bed4-adf57fa94aa0.png">|<img width="677" alt="image" src="https://user-images.githubusercontent.com/42515961/159900951-4c9b4b0d-4417-437a-96a1-eee84625ce6c.png">|


## Guidance for review

Probably easiest to run it locally and then compare it to the app on integration.

https://trello.com/c/iRM9tUxa/307-convert-remaining-views-in-collections-publisher-to-design-system

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
