### PR TITLE
[DO NOT MERGE] Add local jQuery

### DIFF
--- a/app/assets/javascripts/admin_layout.js
+++ b/app/assets/javascripts/admin_layout.js
@@ -1,3 +1,4 @@
+//= require jquery/dist/jquery
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 

--- a/app/assets/javascripts/admin_layout.js
+++ b/app/assets/javascripts/admin_layout.js
@@ -1,6 +1,7 @@
 //= require jquery/dist/jquery
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
+//= require components/autocomplete
 
 //= require jquery-ui.sortable.min
 //= require jquery_ujs

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
+//= require jquery/dist/jquery
 //= require components/autocomplete.js
 //= require jquery-ui.sortable.min
 //= require jquery.clicktoggle

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -3,11 +3,11 @@ window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
 (function (Modules) {
-  function Autocomplete () { }
+  function Autocomplete ($module) {
+    this.$module = $module
+  }
 
-  Autocomplete.prototype.start = function ($module) {
-    this.$module = $module[0]
-
+  Autocomplete.prototype.init = function () {
     var $input = this.$module.querySelector('input')
 
     if ($input) {

--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,2 +1,3 @@
+@import "./autocomplete";
 @import "./markdown-editor";
 @import "./timeline-entry";

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "accessible-autocomplete": "^2.0.4",
     "core-js-bundle": "^3.0.0-alpha.1",
     "es5-polyfill": "^0.0.6",
-    "markdown-toolbar-element": "^0.2.0"
+    "markdown-toolbar-element": "^0.2.0",
+    "jquery": "1.12.4"
   },
   "devDependencies": {
     "jasmine-browser-runner": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1702,6 +1702,11 @@ jasmine-core@^4.0.1:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.0.1.tgz#ea4b0495d82155023bd56c25181d9f9b623f61b8"
   integrity sha512-w+JDABxQCkxbGGxg+a2hUVZyqUS2JKngvIyLGu/xiw2ZwgsoSB0iiecLQsQORSeaKQ6iGrCyWG86RfNDuoA7Lg==
 
+jquery@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds jQuery into this application, using the package.json to include the version currently in the components gem.

**This PR should be merged immediately prior to the removal of jQuery from the rest of GOV.UK, as the change will result in an increased asset size for this application**. Having two copies of jQuery running together appears to not cause any problems, but we want to avoid a situation where collections-publisher has no jQuery supplied.

Also fixes a problem where the autocomplete component wasn't appearing correctly in the component guide for this application.

## Why
We're removing jQuery from the components gem. This application has a lot of jQuery and isn't public facing, so to prevent  blocking it's easiest right now to give collections-publisher its own jQuery.

## Visual changes
None

Trello card: https://trello.com/c/mAfQNVRG/745-investigate-which-apps-we-could-remove-jquery-from?filter=member:andysellick2