### PR TITLE
Add mainstream_browse_type column to tags table

### DIFF
--- a/db/migrate/20220331095756_add_mainstream_browse_type_to_tags.rb
+++ b/db/migrate/20220331095756_add_mainstream_browse_type_to_tags.rb
@@ -1,0 +1,5 @@
+class AddMainstreamBrowseTypeToTags < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tags, :mainstream_browse_type, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_19_142632) do
+ActiveRecord::Schema.define(version: 2022_03_31_095756) do
 
   create_table "coronavirus_announcements", charset: "utf8", force: :cascade do |t|
     t.bigint "coronavirus_page_id", null: false
@@ -206,6 +206,7 @@ ActiveRecord::Schema.define(version: 2021_10_19_142632) do
     t.text "published_groups", size: :medium
     t.string "child_ordering", default: "alphabetical", null: false
     t.integer "index", default: 0, null: false
+    t.boolean "mainstream_browse_type", default: false
     t.index ["content_id"], name: "index_tags_on_content_id", unique: true
     t.index ["parent_id"], name: "tags_parent_id_fk"
     t.index ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true


### PR DESCRIPTION
Add mainstream_browse_type column to tags table.

This reflect changes in the content schema https://github.com/alphagov/govuk-content-schemas/pull/1087

This column will be used for:
- copying Mainstream Browse Pages into Topics [trello](https://trello.com/c/KGCUHfhi/876-copy-over-mainstream-browse-pages-into-specialist-topics)
- hiding Topics that used the be Mainstream Browse Pages [trello](https://trello.com/c/m13ffUVc/292-update-publishing-apps-that-know-of-specialist-topics-to-hide-new-synced-ones)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
