### PR TITLE
Remove NHS box banner

### DIFF
--- a/app/services/coronavirus/pages/content_builder.rb
+++ b/app/services/coronavirus/pages/content_builder.rb
@@ -41,7 +41,6 @@ module Coronavirus::Pages
         title
         meta_description
         announcements_label
-        nhs_banner
         sections_heading
         topic_section
         notifications

--- a/spec/fixtures/coronavirus_landing_page.yml
+++ b/spec/fixtures/coronavirus_landing_page.yml
@@ -13,14 +13,6 @@ content:
       link_nowrap_text: and preventing the spread
   announcements_label: Announcements
   announcements:
-  nhs_banner:
-    heading: "Do not leave home if you or someone you live with has either:"
-    list:
-      - a high temperature
-      - a new, continuous cough
-    call_to_action:
-      title: Check the NHS website if you have symptoms
-      href: https://www.nhs.uk/conditions/coronavirus-covid-19/
   sections_heading: Guidance and support
   sections:
   topic_section:

--- a/spec/fixtures/coronavirus_landing_page_with_announcements.yml
+++ b/spec/fixtures/coronavirus_landing_page_with_announcements.yml
@@ -22,14 +22,6 @@ content:
     - text: All non-essential shops and community spaces are closed
       href: /government/publications/further-businesses-and-premises-to-close
       published_text: Published 3 November 2020
-  nhs_banner:
-    heading: "Do not leave home if you or someone you live with has either:"
-    list:
-      - a high temperature
-      - a new, continuous cough
-    call_to_action:
-      title: Check the NHS website if you have symptoms
-      href: https://www.nhs.uk/conditions/coronavirus-covid-19/
   sections_heading: Guidance and support
   sections:
   topic_section:

--- a/spec/fixtures/simple_coronavirus_page.yml
+++ b/spec/fixtures/simple_coronavirus_page.yml
@@ -4,7 +4,6 @@ content:
   header_section: "header_section"
   announcements_label: "announcements_label"
   announcements: []
-  nhs_banner: "nhs_banner"
   sections_heading: "sections_heading"
   sections: "sections"
   topic_section: "topic_section"


### PR DESCRIPTION
## What

Remove `nhs_banner`

## Why

On [1st April - Remove NHS Box, Announcements, Timeline Entries, Statistics sections from landing page and move DA Links](https://trello.com/c/zxAAM52Y) we stopped rendering the NHS box on the landing page.

[Trello](https://trello.com/c/vn3rFVge/814-remove-nhs-box-from-yaml-file-and-as-required-for-publishing-in-collections-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
