### PR TITLE
Copy over Mainstream browse pages into Topics

### DIFF
--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -14,8 +14,8 @@ private
   end
 
   def details
-    if @tag.mainstream_browse_origin
-      return super.merge("mainstream_browse_origin" => @tag.mainstream_browse_origin)
+    if tag.mainstream_browse_origin
+      return super.merge("mainstream_browse_origin" => tag.mainstream_browse_origin)
     end
 
     super

--- a/app/services/copy_mainstream_browse_pages_to_topics.rb
+++ b/app/services/copy_mainstream_browse_pages_to_topics.rb
@@ -34,6 +34,7 @@ private
       topic.description = mainstream_browse_page.description
       topic.parent_id = mainstream_browse_page.parent_id
       topic.child_ordering = mainstream_browse_page.child_ordering
+      topic.mainstream_browse_origin = mainstream_browse_page.content_id
     end
   end
 

--- a/app/services/copy_mainstream_browse_pages_to_topics.rb
+++ b/app/services/copy_mainstream_browse_pages_to_topics.rb
@@ -1,0 +1,43 @@
+class CopyMainstreamBrowsePagesToTopics
+  def self.call(*args)
+    new(*args).copy
+  end
+
+  attr_reader :mainstream_browse_pages
+
+  def initialize(mainstream_browse_pages)
+    @mainstream_browse_pages = mainstream_browse_pages
+  end
+
+  def copy
+    new_topics = mainstream_browse_pages.map do |page|
+      new_topic = create_basic_topic(page)
+    rescue StandardError => e
+      Rails.logger.debug "Saving topic `#{page.title}` failed with error: #{e}"
+      nil
+    end
+
+    new_topics.compact.each do |topic|
+      send_to_publishing_api(topic)
+    rescue StandardError => e
+      Rails.logger.debug "`#{topic.title}` failed with error: #{e}"
+    end
+  end
+
+private
+
+  def create_basic_topic(mainstream_browse_page)
+    Topic.find_or_create_by!(
+      slug: "#{mainstream_browse_page.slug}-mainstream-copy", # Unique slug constraint
+    ) do |topic|
+      topic.title = mainstream_browse_page.title
+      topic.description = mainstream_browse_page.description
+      topic.parent_id = mainstream_browse_page.parent_id
+      topic.child_ordering = mainstream_browse_page.child_ordering
+    end
+  end
+
+  def send_to_publishing_api(topic)
+    TagPublisher.new(topic).publish
+  end
+end

--- a/app/services/copy_mainstream_browse_pages_to_topics.rb
+++ b/app/services/copy_mainstream_browse_pages_to_topics.rb
@@ -18,6 +18,7 @@ class CopyMainstreamBrowsePagesToTopics
     end
 
     new_topics.compact.each do |topic|
+      update_parent_to_new_topic(topic) if topic.has_parent?
       send_to_publishing_api(topic)
     rescue StandardError => e
       Rails.logger.debug "`#{topic.title}` failed with error: #{e}"
@@ -36,6 +37,16 @@ private
       topic.child_ordering = mainstream_browse_page.child_ordering
       topic.mainstream_browse_origin = mainstream_browse_page.content_id
     end
+  end
+
+  def update_parent_to_new_topic(topic)
+    parent_topic = Topic.find_by(title: topic.parent&.title)
+
+    topic.attributes = {
+      parent_id: parent_topic.try(:id),
+    }
+
+    topic.save!
   end
 
   def send_to_publishing_api(topic)

--- a/lib/tasks/browse_topics.rake
+++ b/lib/tasks/browse_topics.rake
@@ -4,6 +4,8 @@ require_relative "../special_route_publisher"
 namespace :browse_topics do
   desc "Copy all published Mainstream browse pages to Topics"
   task copy_mainstream_browse_pages_to_topics: :environment do
+    raise "This rake task is not intended to be run in production" if Rails.env.production?
+
     CopyMainstreamBrowsePagesToTopics.call(
       MainstreamBrowsePage.where(state: :published),
     )

--- a/lib/tasks/browse_topics.rake
+++ b/lib/tasks/browse_topics.rake
@@ -10,4 +10,22 @@ namespace :browse_topics do
       MainstreamBrowsePage.where(state: :published),
     )
   end
+
+  desc "Copy one published Mainstream browse pages tree to Topics"
+  task :copy_mainstream_browse_pages_tree_to_topics, [:mainstream_browse_page_content_id] => :environment do |_task, args|
+    raise "This rake task is not intended to be run in production" if Rails.env.production?
+
+    mainstream_browse_page = MainstreamBrowsePage.find_by(content_id: args.mainstream_browse_page_content_id)
+
+    raise "You can only copy over published Mainstream browse pages" unless mainstream_browse_page && mainstream_browse_page.published?
+
+    top_level_mainstream_browse_page = mainstream_browse_page.parent.nil? ? mainstream_browse_page : mainstream_browse_page.parent
+
+    mainstream_browse_pages_in_the_tree = [
+      top_level_mainstream_browse_page,
+      top_level_mainstream_browse_page.children,
+    ].flatten.compact
+
+    CopyMainstreamBrowsePagesToTopics.call(mainstream_browse_pages_in_the_tree)
+  end
 end

--- a/lib/tasks/browse_topics.rake
+++ b/lib/tasks/browse_topics.rake
@@ -1,0 +1,11 @@
+require_relative "../publish_organisations_api_route"
+require_relative "../special_route_publisher"
+
+namespace :browse_topics do
+  desc "Copy all published Mainstream browse pages to Topics"
+  task copy_mainstream_browse_pages_to_topics: :environment do
+    CopyMainstreamBrowsePagesToTopics.call(
+      MainstreamBrowsePage.where(state: :published),
+    )
+  end
+end

--- a/spec/lib/tasks/browse_topics_spec.rb
+++ b/spec/lib/tasks/browse_topics_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "rake browse_topics:copy_mainstream_browse_pages_to_topics", type: :task do
+  before do
+    allow(CopyMainstreamBrowsePagesToTopics).to receive(:call)
+    Rake::Task["browse_topics:copy_mainstream_browse_pages_to_topics"].reenable
+  end
+
+  it "calls the service for published mainstream browse pages" do
+    create(:mainstream_browse_page)
+    create(:mainstream_browse_page, :archived)
+    mainstream_browse_page1 = create(:mainstream_browse_page, :published)
+    mainstream_browse_page2 = create(:mainstream_browse_page, :published)
+
+    Rake::Task["browse_topics:copy_mainstream_browse_pages_to_topics"].invoke
+
+    expect(CopyMainstreamBrowsePagesToTopics).to have_received(:call).exactly(1).time
+    expect(CopyMainstreamBrowsePagesToTopics).to have_received(:call).with(
+      [mainstream_browse_page1, mainstream_browse_page2],
+    )
+  end
+end

--- a/spec/lib/tasks/browse_topics_spec.rb
+++ b/spec/lib/tasks/browse_topics_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe "rake browse_topics:copy_mainstream_browse_pages_to_topics", type
       [mainstream_browse_page1, mainstream_browse_page2],
     )
   end
+
+  it "doesn't run in production" do
+    allow(Rails).to receive(:env) { "production".inquiry }
+
+    expect { Rake::Task["browse_topics:copy_mainstream_browse_pages_to_topics"].invoke }.to raise_error(
+      "This rake task is not intended to be run in production",
+    )
+
+    expect(CopyMainstreamBrowsePagesToTopics).not_to have_received(:call)
+  end
 end

--- a/spec/lib/tasks/browse_topics_spec.rb
+++ b/spec/lib/tasks/browse_topics_spec.rb
@@ -30,3 +30,58 @@ RSpec.describe "rake browse_topics:copy_mainstream_browse_pages_to_topics", type
     expect(CopyMainstreamBrowsePagesToTopics).not_to have_received(:call)
   end
 end
+
+RSpec.describe "rake browse_topics:copy_mainstream_browse_pages_tree_to_topics", type: :task do
+  before do
+    allow(CopyMainstreamBrowsePagesToTopics).to receive(:call)
+    Rake::Task["browse_topics:copy_mainstream_browse_pages_tree_to_topics"].reenable
+  end
+
+  it "doesn't run in production" do
+    allow(Rails).to receive(:env) { "production".inquiry }
+
+    expect { Rake::Task["browse_topics:copy_mainstream_browse_pages_tree_to_topics"].invoke }.to raise_error(
+      "This rake task is not intended to be run in production",
+    )
+
+    expect(CopyMainstreamBrowsePagesToTopics).not_to have_received(:call)
+  end
+
+  it "doesn't try to copy over not published mainstream browse pages" do
+    create(:mainstream_browse_page)
+    draft = create(:mainstream_browse_page, :draft)
+
+    expect { Rake::Task["browse_topics:copy_mainstream_browse_pages_tree_to_topics"].invoke(draft.content_id) }.to raise_error(
+      "You can only copy over published Mainstream browse pages",
+    )
+
+    expect(CopyMainstreamBrowsePagesToTopics).not_to have_received(:call)
+  end
+
+  it "calls the service with all pages in the tree, given a top level topic" do
+    create(:mainstream_browse_page)
+    create(:mainstream_browse_page, :archived)
+    top_level = create(:mainstream_browse_page, :published)
+    second_level_child = create(:mainstream_browse_page, :published, parent: top_level)
+    second_level_sibling = create(:mainstream_browse_page, :published, parent: top_level)
+
+    Rake::Task["browse_topics:copy_mainstream_browse_pages_tree_to_topics"].invoke(top_level.content_id)
+
+    expect(CopyMainstreamBrowsePagesToTopics).to have_received(:call).exactly(1).time
+    expect(CopyMainstreamBrowsePagesToTopics).to have_received(:call).with(
+      contain_exactly(top_level, second_level_child, second_level_sibling),
+    )
+  end
+
+  it "calls the service with all pages in the tree given a second level topic" do
+    top_level = create(:mainstream_browse_page, :published)
+    second_level_child = create(:mainstream_browse_page, :published, parent: top_level)
+    second_level_sibling = create(:mainstream_browse_page, :published, parent: top_level)
+
+    Rake::Task["browse_topics:copy_mainstream_browse_pages_tree_to_topics"].invoke(second_level_child.content_id)
+
+    expect(CopyMainstreamBrowsePagesToTopics).to have_received(:call).with(
+      contain_exactly(top_level, second_level_child, second_level_sibling),
+    )
+  end
+end

--- a/spec/services/copy_mainstream_browse_pages_to_topics_spec.rb
+++ b/spec/services/copy_mainstream_browse_pages_to_topics_spec.rb
@@ -90,5 +90,80 @@ RSpec.describe CopyMainstreamBrowsePagesToTopics do
         },
       )
     end
+
+    it "tags the documents tagged to MainstreamBrowsePage to the new Topic" do
+      stub_publishing_api_has_linked_items(
+        [
+          { base_path: "/carers-allowance", title: "Carer's Allowance", content_id: "f508898d-1ba0-46f7-b150-828166886d97" },
+        ],
+        {
+          content_id: mainstream_browse_page.content_id,
+          link_type: "mainstream_browse_pages",
+          fields: %i[title base_path content_id],
+        },
+      )
+      stub_publishing_api_has_links(
+        {
+          "content_id" => "f508898d-1ba0-46f7-b150-828166886d97",
+          "links" => {
+            "mainstream_browse_pages" => %W[#{mainstream_browse_page.content_id} affe9184-22a0-4e27-9254-2e43f6b2c870],
+            "organisations" => %w[b548a09f-8b35-4104-89f4-f1a40bf3136d],
+            "parent" => %w[d35b8c98-7419-42f6-b7af-443e4f25edfc],
+            "taxons" => %w[eb6965c7-3056-45d0-ae50-2f0a5e2e0854],
+          },
+        },
+      )
+
+      described_class.call([mainstream_browse_page])
+      topic = Topic.find_by(title: "Carers")
+
+      assert_publishing_api_patch_links(
+        "f508898d-1ba0-46f7-b150-828166886d97",
+        links: {
+          mainstream_browse_pages: %W[#{mainstream_browse_page.content_id} affe9184-22a0-4e27-9254-2e43f6b2c870],
+          organisations: %w[b548a09f-8b35-4104-89f4-f1a40bf3136d],
+          parent: %w[d35b8c98-7419-42f6-b7af-443e4f25edfc],
+          taxons: %w[eb6965c7-3056-45d0-ae50-2f0a5e2e0854],
+          topics: [topic.content_id],
+        },
+        bulk_publishing: true,
+      )
+    end
+
+    it "does not override existing links to topics" do
+      stub_publishing_api_has_linked_items(
+        [
+          { base_path: "/carers-allowance", title: "Carer's Allowance", content_id: "f508898d-1ba0-46f7-b150-828166886d97" },
+        ],
+        {
+          content_id: mainstream_browse_page.content_id,
+          link_type: "mainstream_browse_pages",
+          fields: %i[title base_path content_id],
+        },
+      )
+      stub_publishing_api_has_links(
+        {
+          "content_id" => "f508898d-1ba0-46f7-b150-828166886d97",
+          "links" => {
+            "mainstream_browse_pages" => %W[#{mainstream_browse_page.content_id} affe9184-22a0-4e27-9254-2e43f6b2c870],
+            "parent" => %w[d35b8c98-7419-42f6-b7af-443e4f25edfc],
+            "topics" => %w[1a2a11e7-ccec-4d6c-a7e1-10b699f51b9a],
+          },
+        },
+      )
+
+      described_class.call([mainstream_browse_page])
+      topic = Topic.find_by(title: "Carers")
+
+      assert_publishing_api_patch_links(
+        "f508898d-1ba0-46f7-b150-828166886d97",
+        links: {
+          mainstream_browse_pages: %W[#{mainstream_browse_page.content_id} affe9184-22a0-4e27-9254-2e43f6b2c870],
+          parent: %w[d35b8c98-7419-42f6-b7af-443e4f25edfc],
+          topics: %W[1a2a11e7-ccec-4d6c-a7e1-10b699f51b9a #{topic.content_id}],
+        },
+        bulk_publishing: true,
+      )
+    end
   end
 end

--- a/spec/services/copy_mainstream_browse_pages_to_topics_spec.rb
+++ b/spec/services/copy_mainstream_browse_pages_to_topics_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe CopyMainstreamBrowsePagesToTopics do
+  include GdsApi::TestHelpers::PublishingApi
+
+  let!(:parent) do
+    create(:mainstream_browse_page, :published,
+           title: "Disabled people",
+           slug: "disabilities",
+           parent_id: nil,
+           children: [])
+  end
+
+  let(:mainstream_browse_page) do
+    create(:mainstream_browse_page, :published,
+           title: "Carers",
+           slug: "carers",
+           parent_id: parent.id)
+  end
+
+  before do
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+  end
+
+  describe ".call" do
+    it "saves a copy of Mainstream Browse Page as a Topic" do
+      publishing_api_has_no_linked_items
+
+      described_class.call([mainstream_browse_page])
+      topic = Topic.find_by(title: "Carers")
+
+      expect(topic.type).to eq("Topic")
+      expect(topic.slug).to eq("carers-mainstream-copy")
+
+      assert_publishing_api_put_content(
+        topic.content_id,
+        request_json_includes({
+          "title" => "Carers",
+          "base_path": "/topic/carers-mainstream-copy",
+          "document_type" => "topic",
+          "schema_name": "topic",
+        }),
+      )
+    end
+  end
+end

--- a/spec/services/copy_mainstream_browse_pages_to_topics_spec.rb
+++ b/spec/services/copy_mainstream_browse_pages_to_topics_spec.rb
@@ -43,5 +43,23 @@ RSpec.describe CopyMainstreamBrowsePagesToTopics do
         }),
       )
     end
+
+    it "flags that the Topic used to be a Mainstream Browse Page" do
+      publishing_api_has_no_linked_items
+
+      described_class.call([mainstream_browse_page])
+      topic = Topic.find_by(title: "Carers")
+
+      assert_publishing_api_put_content(
+        topic.content_id,
+        request_json_includes(
+          "details": {
+            "groups": [],
+            "internal_name": "Carers",
+            "mainstream_browse_origin": mainstream_browse_page.content_id,
+          },
+        ),
+      )
+    end
   end
 end


### PR DESCRIPTION
## Context
Link to Trello card: https://trello.com/c/KGCUHfhi/876-copy-over-mainstream-browse-pages-into-specialist-topics

# Changes proposed in this pull request

Add a rake task to copy over Mainstream Browse Pages (MBP) into Topics.
The task is intended to run once.

Tested locally with a copy of production data. Completed in ~ 40 minutes

# Assumptions / Scope

- At this point we don't copy over MBP's attributes which would require Topic content schema changes such as equivalent of `top_level_browse_pages`. We decided that those changes can be later once we identify what we need

- Only published MBP will be cloned
The product team decided that we will not copy over archived ones. I decided not to copy draft MBP as there is not much value in keeping those in sync. I think a MBP should be copied into a Topic when the MBP is published.

- We assume that there are no duplicates, we naively copy all MBPs.

# How it works

- First, **create basic new Topics**
    - the new Topic is at this point associated to the MBP parent because the corresponding Topic parent may not exist yet
    - the slug is appended with `-mainstream-copy` as there is a unique slug constaing. This will like need to be removed once we finish the work and the original MBP is unpublished/deleted
    - :construction: **this will change** - new Topics have a flag that it used to be a MBP 

- **Tag documents that are tagged to the MBP to the new Topic**
    This is the slowest operation. As far as I know there is no way to simply add a new link to topic or tag all documents to the Topic in one call. Therefore for each document (there is ~3.5k documents tagged to MBPs) it:
    - calls  the Publishing API to get document's current links
    - adds the link to the new Topic
    - sends the new links to the Publishing API
    
- **Copy curated lists and list items**
    when there are no lists `"groups": []`

After those operations:

- **Update parent and child associations between the new Topic**
    When the Tag/Topic is published, it ustilises the `DependentTagPublishWorker` in the `PublishingAPINotifier` to ensure the "reverse linking"

- **Send everything to Publishing API**
    If the MBP has curated lists, this can be making a lot of calls to Publishing API (`put_content` and `publish` with empty groups and with populated groups). Curated lists/groups are published separately to the Topics itself. The Topic needs to be published before the ListPublisher is called as it fetches the tagged_documents utilising `Services.publishing_api.get_linked_items`
If we don't publish the Topic first we'll get 404 No item with content_id of the new Topic.

# Guidance to review
    
Commit by commit.

> I'm aware that this is not the prettiest of codes and could do with refactoring to confirm to best object oriented design practices. The private methods should be refactored to Services, which can be used to clone MPB into a Topic when a MBP is published. It'll be quicker (less tests to change) to do it after the initial functionality is reviewed.

To test locally:
1. Replicate production data for publishing-api, content-store and collections-publisher
2. Call the rake task or service in rails console in docker

# Things to check and review questions  
- Are there any other tags/keys in "links" in we need to carry over? E.g. “related_content”
- Is there a way of reducing the number of calls Publishing API? Would it be worth the effort.

**Notes:**
- I suspect we will also need to reference the cloned topic on the original MBP. This will clarify while we are working on syncing the document tagging ("_When a document is tagged to MBP, also tag it to the clone Topic_")
- If we decide to first start syncing any *new* MBPs, and then use this to backfill the data we will need to add a line to skip if the cloned Topic exists
- TODO: Refactor
  - make private methods separate services
  - add a namespace so it's easier to delete

# Depends on
- Hiding the Browse topic from publishing apps: Whitehall, Publisher, Collections Publisher, Content tagger being completed 
- Hide the new Browse topics from the frontend apps being completed 


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
