### PR TITLE
Add mainstream_browse_origin to TopicPresenter

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -3,6 +3,8 @@ class Topic < Tag
 
   alias_method :subtopic?, :has_parent?
 
+  attr_accessor :mainstream_browse_origin
+
   def base_path
     "/topic/#{full_slug}"
   end

--- a/app/presenters/topic_presenter.rb
+++ b/app/presenters/topic_presenter.rb
@@ -12,4 +12,12 @@ private
       "primary_publishing_organisation" => [GDS_CONTENT_ID],
     )
   end
+
+  def details
+    if @tag.mainstream_browse_origin
+      return super.merge("mainstream_browse_origin" => @tag.mainstream_browse_origin)
+    end
+
+    super
+  end
 end

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -62,16 +62,22 @@ RSpec.describe TopicPresenter do
           expect(rendered_links[:links]).to have_key("primary_publishing_organisation")
           expect(rendered_links[:links]["primary_publishing_organisation"]).to eq([organisation])
         end
+
+        it "does not include a mainstream browse origin if there isn't one" do
+          expect(presented_data[:details]).not_to have_key("mainstream_browse_origin")
+        end
       end
     end
 
     context "for a subtopic" do
       let(:parent) { create(:topic, slug: "oil-and-gas") }
       let(:topic) do
-        create(:topic, parent: parent,
-                       slug: "offshore",
-                       title: "Offshore",
-                       description: "Oil rigs, pipelines etc.")
+        topic = create(:topic, parent: parent,
+                               slug: "offshore",
+                               title: "Offshore",
+                               description: "Oil rigs, pipelines etc.")
+        topic.mainstream_browse_origin = "test6df9-1178-41b1-abb1-1830fef79347"
+        topic
       end
       let(:presenter) { TopicPresenter.new(topic) }
       let(:presented_data) { presenter.render_for_publishing_api }
@@ -114,6 +120,11 @@ RSpec.describe TopicPresenter do
       it "includes a link to its parent" do
         expect(rendered_links[:links]).to have_key("parent")
         expect(rendered_links[:links]["parent"]).to eq([parent.content_id])
+      end
+
+      it "includes a mainstream browse origin if the Topic derived from copying a Mainstream Browse Page" do
+        expect(presented_data[:details]).to have_key("mainstream_browse_origin")
+        expect(presented_data[:details]["mainstream_browse_origin"]).to eq("test6df9-1178-41b1-abb1-1830fef79347")
       end
     end
   end


### PR DESCRIPTION
Following the content schema change in: https://github.com/alphagov/govuk-content-schemas/pull/1089

We want to reference the content_id of Mainstream browse page the topic
originated from as a part of unified topic system work.

Until the work is completed we will need to keep the Mainstream browse page and
the cloned Topic is sync. Since other attributes of the Mainstream browse page
such as title or slug can change, this adds a unique reference we can use to
identify the cloned Topic.
We decided not to store it in the Collections publisher database.

Adding this as a separate PR as it's needed by a few other pieced of work:
- This attribute will be populated when a new Topic is created and send to the
Publishing API.
- The presence of this attribute will be used to hide those Topic in the views.

https://trello.com/c/KGCUHfhi/876-copy-over-mainstream-browse-pages-into-specialist-topics

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
