### PR TITLE
Add tracking back in for collections publisher

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,0 +1,12 @@
+(function (GOVUK) {
+  'use strict'
+
+  GOVUK.Analytics.load()
+  GOVUK.analyticsVars = { primaryLinkedDomains: [document.domain] }
+  GOVUK.analytics = new GOVUK.Analytics({
+    universalId: 'UA-26179049-6', // GOVUK Apps GA ID
+    cookieDomain: document.domain
+  })
+
+  GOVUK.analytics.trackPageview()
+})(window.GOVUK)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,7 +3,9 @@
 
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
+//= require govuk_publishing_components/analytics
 //= require components/autocomplete
+//= require analytics
 
 //= require rails-ujs
 


### PR DESCRIPTION
## What
Add Google analytics tracking back into the application layout.

## Why
During the migration we lost the automatic analytics tracking, this needs to be added back in.

## Additional Information
Add this to the layout so that everything is tracked automatically.

https://trello.com/c/DQuvQmhd/372-add-tracking-back-in-for-collections-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
