### PR TITLE
Fix flash messages

### DIFF
--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -13,9 +13,9 @@ class ListItemsController < ApplicationController
     respond_to do |format|
       format.html do
         if saved
-          flash[:success] = "Content added"
+          flash[:notice] = "Content added"
         else
-          flash[:danger] = "Could not add that list item to your list"
+          flash[:alert] = "Could not add that list item to your list"
         end
 
         redirect_to tag_lists_path(@tag)
@@ -41,9 +41,9 @@ class ListItemsController < ApplicationController
     respond_to do |format|
       format.html do
         if destroyed
-          flash[:success] = "Content removed from list"
+          flash[:notice] = "Content removed from list"
         else
-          flash[:danger] = "Could not remove the list item from this list"
+          flash[:alert] = "Could not remove the list item from this list"
         end
 
         redirect_to tag_lists_path(@tag)

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -18,9 +18,9 @@ class ListsController < ApplicationController
 
     if list.save
       @tag.mark_as_dirty!
-      flash[:success] = "List created"
+      flash[:notice] = "List created"
     else
-      flash[:danger] = "Could not create your list"
+      flash[:alert] = "Could not create your list"
     end
 
     redirect_to tag_lists_path(@tag)
@@ -32,9 +32,9 @@ class ListsController < ApplicationController
 
     if list.destroyed?
       @tag.mark_as_dirty!
-      flash[:success] = "List deleted"
+      flash[:notice] = "List deleted"
     else
-      flash[:danger] = "Could not delete the list"
+      flash[:alert] = "Could not delete the list"
     end
 
     redirect_to tag_lists_path(@tag)
@@ -49,9 +49,9 @@ class ListsController < ApplicationController
     respond_to do |format|
       format.html do
         if saved
-          flash[:success] = "List updated"
+          flash[:notice] = "List updated"
         else
-          flash[:danger] = "Could not save your list"
+          flash[:alert] = "Could not save your list"
         end
 
         redirect_to tag_lists_path(@tag)

--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -61,7 +61,7 @@ class MainstreamBrowsePagesController < ApplicationController
     @archival.tag = find_browse_page
 
     if @archival.archive_or_remove
-      redirect_to mainstream_browse_pages_path, success: "The mainstream browse page has been archived or removed."
+      redirect_to mainstream_browse_pages_path, notice: "The mainstream browse page has been archived or removed."
     else
       render :propose_archive
     end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -20,7 +20,7 @@ class TopicsController < ApplicationController
 
     if topic.update(topic_params)
       TagBroadcaster.broadcast(topic)
-      redirect_to topic, success: "Specialist sector updated"
+      redirect_to topic, notice: "Specialist sector updated"
     else
       @topic = topic
       render "edit"
@@ -60,7 +60,7 @@ class TopicsController < ApplicationController
     @archival.tag = find_topic
 
     if @archival.archive_or_remove
-      redirect_to topics_path, success: "The topic has been archived or removed."
+      redirect_to topics_path, notice: "The topic has been archived or removed."
     else
       render "propose_archive"
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,7 +17,8 @@ class Tag < ApplicationRecord
   has_many :redirect_routes
 
   validates :slug, presence: { message: "Enter a slug" }
-  validates :slug, uniqueness: { scope: %w[parent_id], case_sensitive: false }, format: { with: /\A[a-z0-9-]*\z/, message: "Enter a valid slug" }
+  validates :slug, uniqueness: { scope: %w[parent_id], case_sensitive: false, message: "Slug has been taken" }
+  validates :slug, format: { with: /\A[a-z0-9-]*\z/, message: "Enter a valid slug" }
   validates :title, presence: { message: "Enter a title" }
   validates :content_id, presence: true
   validates :child_ordering, inclusion: { in: ORDERING_TYPES }

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ListItemsController, type: :controller do
         end
 
         it "indicates a success state to the user" do
-          expect(flash.key?(:success)).to be(true)
+          expect(flash.key?(:notice)).to be(true)
         end
       end
 
@@ -50,7 +50,7 @@ RSpec.describe ListItemsController, type: :controller do
         end
 
         it "indicates a fail state to the user" do
-          expect(flash.key?(:danger)).to be(true)
+          expect(flash.key?(:alert)).to be(true)
         end
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe ListItemsController, type: :controller do
         end
 
         it "indicates a success state to the user" do
-          expect(flash.key?(:success)).to be(true)
+          expect(flash.key?(:notice)).to be(true)
         end
 
         it "redirects to tag lists path" do
@@ -189,7 +189,7 @@ RSpec.describe ListItemsController, type: :controller do
 
         it "indicates a fail state to the user" do
           destroy_list_item
-          expect(flash.key?(:danger)).to be(true)
+          expect(flash.key?(:alert)).to be(true)
         end
       end
     end

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -42,6 +42,13 @@ RSpec.feature "Managing browse pages" do
     then_i_see_a_validation_error
   end
 
+  scenario "Unique slug validation unique slug fails" do
+    given_there_is_published_browse_page
+    when_i_visit_the_new_browse_page_form
+    and_i_fill_in_the_form_with_already_existing_slug
+    then_i_see_uniqueness_validation_error
+  end
+
   def given_there_is_published_browse_page
     @page = create(:mainstream_browse_page, :published, slug: "citizenship", title: "Citizenship")
   end
@@ -89,6 +96,8 @@ RSpec.feature "Managing browse pages" do
     click_on "Create"
     @content_id = extract_content_id_from(current_path)
   end
+
+  alias_method :and_i_fill_in_the_form_with_already_existing_slug, :and_i_fill_in_the_form
 
   def and_i_fill_in_the_form_with_invalid_data
     fill_in "Title", with: ""
@@ -159,5 +168,15 @@ RSpec.feature "Managing browse pages" do
     expect(page).to have_content("Enter a title")
     expect(page).to have_content("Enter a slug")
     expect(find("#mainstream_browse_page_description").value).to eql "A changed description"
+  end
+
+  def then_i_see_uniqueness_validation_error
+    within(".govuk-error-summary__list") do
+      expect(page).to have_content("Slug has been taken")
+    end
+
+    within(".govuk-error-message") do
+      expect(page).to have_content("Slug has been taken")
+    end
   end
 end


### PR DESCRIPTION
The new layout using GOV.UK Design System renders flash notices only if the
keys are "alert" or "notice". Any messages stored under other keys such as
"success" or "danger" were not displayed.

https://trello.com/b/iACGoJN3/govuk-explore-doing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
