### PR TITLE
Fix url validation regex for unpublishing step by steps

### DIFF
--- a/app/models/step_by_step_page.rb
+++ b/app/models/step_by_step_page.rb
@@ -94,8 +94,8 @@ class StepByStepPage < ApplicationRecord
   end
 
   def self.validate_redirect(redirect_url)
-    regex = /\A\/([a-z0-9]+-)*[a-z0-9]+\z/
-    redirect_url =~ regex
+    regex = /\A\/[\/.a-zA-Z0-9-]*\z/
+    regex.match?(redirect_url)
   end
 
   def status


### PR DESCRIPTION
This update the regex for unpublishing step by step to be more permissive. Previously url paths with multiple parts i.e. extra "/"s would be considered invalid. This also tidies up the code to return true or false, rather than the match number or nil.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
