### PR TITLE
Remove Beta Banner from collections publisher

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -36,11 +36,6 @@
     ].delete_if{ |item| item[:user_has_permission_to_see] == false },
   }%>
   <div class="govuk-width-container">
-    <%= render "govuk_publishing_components/components/phase_banner", {
-      app_name: "Collections Publisher",
-      phase: "beta"
-    } %>
-
     <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>
 

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -5,7 +5,7 @@
 
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {
-    product_name: "",
+    product_name: "Collections Publisher",
     environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
     navigation_items: [
       {


### PR DESCRIPTION
## What
Remove beta banner in Collections Publisher

## Why
This is incorrect as the product is not beta and is not being rebuilt - this may be considered misleading to the user.

https://trello.com/c/aFpyXJdm/415-remove-beta-banner-in-collections-publisher

## Before

<img width="1022" alt="Screenshot 2022-05-05 at 2 14 34 am" src="https://user-images.githubusercontent.com/4599889/166850900-3d3d309a-8074-4235-9172-b881e13f59d3.png">

## After

<img width="1048" alt="Screenshot 2022-05-05 at 9 37 08 am" src="https://user-images.githubusercontent.com/4599889/166889007-d6724b5b-768d-4ae7-921e-242241451bd7.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
