### PR TITLE
Add list show page and edit list item functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,3 +45,7 @@ group :development, :test do
   gem "timecop"
   gem "webmock", require: false
 end
+
+group :test do
+  gem "rails-controller-testing"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,11 @@ GEM
       activesupport (= 7.0.3)
       bundler (>= 1.15.0)
       railties (= 7.0.3)
+      sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -490,6 +495,7 @@ DEPENDENCIES
   plek
   pry-byebug
   rails (= 7.0.3)
+  rails-controller-testing
   rspec-rails
   rubocop-govuk
   sass-rails

--- a/app/assets/stylesheets/_curated_lists.scss
+++ b/app/assets/stylesheets/_curated_lists.scss
@@ -2,7 +2,8 @@
   margin-bottom: 10px;
 }
 
-.curated-lists .gem-c-document-list__attribute:first-child {
+.curated-lists .gem-c-document-list__attribute:first-child,
+.list-items .gem-c-document-list__attribute:first-child {
   border-right: 1px solid $govuk-border-colour;
   padding-right: 10px;
 }
@@ -13,10 +14,12 @@
   padding-right: 10px;
 }
 
-.curated-lists .gem-c-document-list__attribute:last-child {
+.curated-lists .gem-c-document-list__attribute:last-child,
+.list-items .gem-c-document-list__attribute:last-child {
   padding-left: 10px;
 }
 
-.curated-lists .gem-c-document-list__item {
+.curated-lists .gem-c-document-list__item,
+.list-items .gem-c-document-list__item {
   margin-bottom: 10px;
 }

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -8,6 +8,10 @@ class ListsController < ApplicationController
     render "start_curating_lists" unless @lists.any?
   end
 
+  def show
+    @list = @tag.lists.find(params[:id])
+  end
+
   def new
     @list = List.new
   end
@@ -111,7 +115,7 @@ class ListsController < ApplicationController
 private
 
   def get_layout
-    if redesigned_lists_permission? && action_name.in?(%w[new create edit update confirm_destroy])
+    if redesigned_lists_permission? && action_name.in?(%w[new create edit update confirm_destroy show])
       "design_system"
     else
       "legacy"

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -112,10 +112,28 @@ class ListsController < ApplicationController
     end
   end
 
+  def edit_list_items
+    @list = @tag.lists.find(params[:id])
+  end
+
+  def update_list_items
+    @list = @tag.lists.find(params[:id])
+    @available_list_items = @list.available_list_items
+
+    if save_list_items
+      ListPublisher.new(@tag).perform
+      flash[:notice] = "Items added to list successfully"
+
+      redirect_to tag_list_path(@tag, @list)
+    else
+      render :edit_list_items
+    end
+  end
+
 private
 
   def get_layout
-    if redesigned_lists_permission? && action_name.in?(%w[new create edit update confirm_destroy show])
+    if redesigned_lists_permission? && action_name.in?(%w[new create edit update confirm_destroy show edit_list_items update_list_items])
       "design_system"
     else
       "legacy"
@@ -124,6 +142,23 @@ private
 
   def list_params
     params.require(:list).permit(:name, :index)
+  end
+
+  def edit_list_items_params
+    params.dig(:list, :list_items)
+  end
+
+  def save_list_items
+    @list.errors.add(:list_items, "Select a link to add to the list") and return false if edit_list_items_params.blank?
+
+    edit_list_items_params.each do |base_path|
+      linked_item = @available_list_items.select { |item| item.base_path == base_path }.first
+      @list.list_items.create!(
+        base_path: linked_item.base_path,
+        title: linked_item.title,
+        index: @list.list_items.length + 1,
+      )
+    end
   end
 
   def active_navigation_item

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -18,6 +18,17 @@ class List < ApplicationRecord
     end
   end
 
+  def available_list_items
+    tag
+    .tagged_documents
+    .documents
+    .reject do |link|
+      list_items
+      .map(&:base_path)
+      .include?(link["base_path"])
+    end
+  end
+
 private
 
   def tagged_base_paths

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -3,6 +3,8 @@ class ListItem < ApplicationRecord
 
   validates :index, numericality: { greater_than_or_equal_to: 0 }
 
+  scope :ordered, -> { order(:index) }
+
   attr_accessor :tagged
   alias_method :tagged?, :tagged
 

--- a/app/views/lists/edit_list_items.html.erb
+++ b/app/views/lists/edit_list_items.html.erb
@@ -1,0 +1,34 @@
+<%= content_for :back_link, render("govuk_publishing_components/components/back_link", {
+  href: tag_list_path(@tag, @list)
+}) %>
+
+<%= content_for :page_title, "Add links to current list" %>
+
+<%= render 'shared/error_summary', object: @list %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @list, url: update_list_items_tag_list_path(@tag, @list), method: :patch do |f| %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        heading: "Add links to current list",
+        heading_caption: "List",
+        heading_size: "l",
+        is_page_heading: true,
+        no_hint_text: true,
+        name: "list[list_items][]",
+        id: "list_list_items",
+        error: (@list.errors[:list_items].first if errors_for(@list, :list_items).present?),
+        items: @list.available_list_items.map do |list_item|
+          {
+            label: list_item.title,
+            value: list_item.base_path,
+          }
+        end
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Add link to list"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,0 +1,79 @@
+<%= render 'shared/breadcrumbs', {
+  links: [
+    {
+      text: @tag.is_a?(MainstreamBrowsePage) ? "Mainstream browse pages" : "Topics",
+      href: @tag.is_a?(MainstreamBrowsePage) ? mainstream_browse_pages_url : topics_url
+    },
+    *([
+      text: @tag.parent[:title],
+      href: polymorphic_path(@tag.parent)
+    ] if @tag.parent.present? ),
+    {
+      text: @tag[:title],
+      href: polymorphic_path(@tag),
+    },
+    {
+      text: "List",
+    }
+  ].compact
+} %>
+
+<%= content_for :context, "List" %>
+
+<% content_for :title, @list.name %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/heading", {
+            text: "Links",
+            font_size: "m",
+            margin_bottom: 4
+          } %>
+      </div>
+
+      <div class="govuk-grid-column-one-half app-grid-column--align-right">
+        <ul class="govuk-summary-list__actions-list gem-c-summary-list__group-actions-list">
+          <li class="govuk-summary-list__actions-list-item">
+            <%= link_to 'Add links to list',
+              edit_list_items_tag_list_path(@tag, @list),
+              class: %w(govuk-link govuk-link--no-visited-state)
+            %>
+          </li>
+          <% if @list.list_items.count > 1 %>
+            <li class="govuk-summary-list__actions-list-item">
+              <%= link_to 'Reorder links',
+                "#",
+                class: %w(govuk-link govuk-link--no-visited-state)
+              %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+
+    <p class="govuk-body-s">Select page to edit tagging in Content Tagger</p>
+
+
+    <div class="list-items">
+      <% @list.list_items.ordered.each do |list_item| %>
+        <%= render "govuk_publishing_components/components/document_list", {
+          items: [
+            {
+              link: {
+                text: list_item.title,
+                path: Plek.new.website_root + list_item.base_path
+              },
+              metadata: {
+                move_list_item: tag.a("Move to a different list", href: "#", class: "govuk-link"),
+                removelist_item: tag.a("Remove", href: "#", class: "govuk-link"),
+              }
+            },
+          ]
+        } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -7,7 +7,7 @@
             text: list.name
           },
           metadata: {
-            edit_list: tag.a("Edit list", href: "#", class: "govuk-link"),
+            edit_list: tag.a("Edit list", href: tag_list_path(tag_object, list), class: "govuk-link"),
             rename_list: tag.a("Rename list", href: edit_tag_list_path(tag_object, list), class: "govuk-link"),
             delete_list: tag.a("Delete list", href: confirm_destroy_tag_list_path(tag_object, list), class: "govuk-link"),
           }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       member do
         get :confirm_destroy
         get :edit_list_items
+        patch :update_list_items
       end
 
       resources :list_items, only: %i[create update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,9 +78,10 @@ Rails.application.routes.draw do
     get :manage_list_ordering
     patch :update_list_ordering
 
-    resources :lists, only: %i[index new edit create update destroy] do
+    resources :lists, only: %i[index new edit create update destroy show] do
       member do
         get :confirm_destroy
+        get :edit_list_items
       end
 
       resources :list_items, only: %i[create update destroy]

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe ListsController do
+  include PublishingApiHelpers
+
   describe "GET show" do
     let(:list) { create(:list, tag: tag) }
 
@@ -39,6 +41,163 @@ RSpec.describe ListsController do
         expect(assigns(:list).id).to eq list.id
         expect(response.status).to eq(200)
         expect(response).to render_template :show
+      end
+    end
+  end
+
+  describe "GET edit_list_items" do
+    let(:list) { create(:list, tag: tag) }
+
+    context "Tag is a MainstreamBrowsePage" do
+      let(:tag) { create(:mainstream_browse_page) }
+
+      it "assign the correct instance variables and renders the edit_list_items template" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        get :edit_list_items, params: { tag_id: tag.content_id, id: list.id }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list.id
+        expect(response.status).to eq(200)
+        expect(response).to render_template :edit_list_items
+      end
+
+      it "does not allow users without GDS Editor permissions access" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        get :edit_list_items, params: { tag_id: tag.content_id, id: list.id }
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "Tag is a topic and user does not have `GDS Editor permissions`" do
+      let(:tag) { create(:topic) }
+
+      it "assign the correct instance vaiables and renders the edit_list_items template" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        get :edit_list_items, params: { tag_id: tag.content_id, id: list.id }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list.id
+        expect(response.status).to eq(200)
+        expect(response).to render_template :edit_list_items
+      end
+    end
+  end
+
+  describe "PATCH update_list_items" do
+    let(:list) { create(:list, tag: tag) }
+    let!(:list_item1) { create(:list_item, list: list, index: 1) }
+    let!(:list_item2) { create(:list_item, list: list, index: 2) }
+    let(:tagged_documents) do
+      [
+        TaggedDocuments::Document.new(list_item1.title, list_item1.base_path, "123"),
+        TaggedDocuments::Document.new(list_item2.title, list_item2.base_path, "456"),
+        TaggedDocuments::Document.new("New list", "/new-list", "789"),
+      ]
+    end
+
+    before do
+      stub_any_publishing_api_call
+      allow_any_instance_of(TaggedDocuments).to receive(:documents).and_return(tagged_documents)
+    end
+
+    context "Tag is a MainstreamBrowsePage" do
+      let(:tag) { create(:mainstream_browse_page, :published) }
+
+      it "creates a new list item and makes the correct calls to the Publishing API" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        patch :update_list_items, params: { tag_id: tag.content_id, id: list.id, list: { list_items: ["/new-list"] } }
+
+        new_list_item = list.reload.list_items.last
+
+        expect(list.list_items.count).to eq 3
+        expect(new_list_item.title).to eq "New list"
+        expect(new_list_item.base_path).to eq "/new-list"
+        expect(new_list_item.index).to eq 3
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(tag_list_path(tag, list))
+        assert_publishing_api_put_content(
+          tag.content_id,
+          request_json_includes(
+            "details" => {
+              "groups" => [
+                {
+                  "name" => list.name,
+                  "contents" => [
+                    list_item1.base_path,
+                    list_item2.base_path,
+                    "/new-list",
+                  ],
+                },
+              ],
+              "internal_name" => tag.title,
+              "second_level_ordering" => "alphabetical",
+              "ordered_second_level_browse_pages" => [],
+            },
+          ),
+        )
+        assert_publishing_api_publish(tag.content_id)
+        assert_publishing_api_patch_links(tag.content_id)
+      end
+
+      it "does not allow users without GDS Editor permissions access" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        patch :update_list_items, params: { tag_id: tag.content_id, id: list.id, list: { list_items: ["/new-list"] } }
+
+        expect(response.status).to eq(403)
+      end
+
+      it "adds an error to the list and rerenders then page when no list items are passed into the params" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        patch :update_list_items, params: { tag_id: tag.content_id, id: list.id, list: { list_items: [] } }
+
+        expect(assigns(:list).errors.first.message).to eq "Select a link to add to the list"
+        expect(response).to render_template :edit_list_items
+      end
+    end
+
+    context "Tag is a topic and user does not have `GDS Editor permissions`" do
+      let(:tag) { create(:topic, :published) }
+
+      it "creates a new list item and makes the correct calls to the Publishing API" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        patch :update_list_items, params: { tag_id: tag.content_id, id: list.id, list: { list_items: ["/new-list"] } }
+
+        new_list_item = list.reload.list_items.last
+
+        expect(list.list_items.count).to eq 3
+        expect(new_list_item.title).to eq "New list"
+        expect(new_list_item.base_path).to eq "/new-list"
+        expect(new_list_item.index).to eq 3
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(tag_list_path(tag, list))
+        assert_publishing_api_put_content(
+          tag.content_id,
+          request_json_includes(
+            "details" => {
+              "groups" => [
+                {
+                  "name" => list.name,
+                  "contents" => [
+                    list_item1.base_path,
+                    list_item2.base_path,
+                    "/new-list",
+                  ],
+                },
+              ],
+              "internal_name" => tag.title,
+            },
+          ),
+        )
+        assert_publishing_api_publish(tag.content_id)
+        assert_publishing_api_patch_links(tag.content_id)
       end
     end
   end

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe ListsController do
+  describe "GET show" do
+    let(:list) { create(:list, tag: tag) }
+
+    context "Tag is a MainstreamBrowsePage" do
+      let(:tag) { create(:mainstream_browse_page) }
+
+      it "assign the correct instance variables and renders the show template" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        get :show, params: { tag_id: tag.content_id, id: list.id }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list.id
+        expect(response.status).to eq(200)
+        expect(response).to render_template :show
+      end
+
+      it "does not allow users without GDS Editor permissions access" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        get :show, params: { tag_id: tag.content_id, id: list.id }
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "Tag is a topic and user does not have `GDS Editor permissions`" do
+      let(:tag) { create(:topic) }
+
+      it "assign the correct instance vaiables and renders the show template" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        get :show, params: { tag_id: tag.content_id, id: list.id }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list.id
+        expect(response.status).to eq(200)
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -183,7 +183,9 @@ FactoryBot.define do
   end
 
   factory :list_item do
-    title { "A list item title" }
+    sequence(:title) { |n| "List item #{n}" }
+    sequence(:base_path) { |n| "/base-path-#{n}" }
+    sequence(:index)
   end
 
   factory :tag do

--- a/spec/features/curating_a_list_spec.rb
+++ b/spec/features/curating_a_list_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.feature "Curating a list" do
+  include CommonFeatureSteps
+  include PublishingApiHelpers
+
+  before do
+    stub_any_publishing_api_call
+    given_i_am_a_gds_editor
+    and_i_have_the_redesigned_lists_permission
+    and_there_are_is_a_child_object_with_list_items
+  end
+
+  scenario "Adding a link to a list" do
+    when_i_visit_the_child_show_page
+    and_i_click_the_edit_list_link
+    then_i_see_the_list_show_page
+    and_the_link_items_should_link_to_the_live_page
+
+    when_i_click_add_links_to_list
+    and_i_submit_the_form_without_choosing_a_link
+    then_i_am_told_to_select_a_link
+
+    when_i_choose_a_link_to_add
+    then_i_see_the_link_has_been_added
+    and_the_correct_calls_are_made_to_the_publishing_api_for_editing_list_items
+  end
+
+  def and_there_are_is_a_child_object_with_list_items
+    @parent = create(:topic, :published)
+    @child = create(:topic, :published, parent: @parent)
+    @list = create(:list, tag: @child)
+    @list_item1 = create(:list_item, list: @list, index: 0)
+    @list_item2 = create(:list_item, list: @list, index: 1)
+    publishing_api_has_linked_items(
+      @child.content_id,
+      items: [
+        { base_path: @list_item1.base_path, title: @list_item1.title, content_id: "29941ec1-4a41-4bfd-86a9-5c866bbd4c7a" },
+        { base_path: @list_item2.base_path, title: @list_item2.title, content_id: "29941ec1-4a41-4bfd-86a9-5c866bbd4c7b" },
+        { base_path: "/naturalisation", title: "Naturalisation", content_id: "29941ec1-4a41-4bfd-86a9-5c866bbd4c7c" },
+        { base_path: "/marriage", title: "Marriage", content_id: "29941ec1-4a41-4bfd-86a9-5c866bbd4c7d" },
+      ],
+    )
+  end
+
+  def when_i_visit_the_child_show_page
+    visit topic_path(@child)
+  end
+
+  def and_i_click_the_edit_list_link
+    click_link "Edit list"
+  end
+
+  def then_i_see_the_list_show_page
+    expect(page).to have_current_path(tag_list_path(@child, @list))
+  end
+
+  def and_the_link_items_should_link_to_the_live_page
+    expect(all(".gem-c-document-list__item-title")[0].text).to eq @list.list_items.first.title
+    expect(all(".gem-c-document-list__item-title")[0][:href]).to eq Plek.new.website_root + @list.list_items.ordered.first.base_path
+  end
+
+  def when_i_click_add_links_to_list
+    click_link "Add links to list"
+  end
+
+  def and_i_submit_the_form_without_choosing_a_link
+    click_button "Add link to list"
+  end
+
+  def then_i_am_told_to_select_a_link
+    within "#error-summary" do
+      expect(page).to have_content "Select a link to add to the list"
+    end
+  end
+
+  def when_i_choose_a_link_to_add
+    check "Naturalisation"
+    click_button "Add link to list"
+  end
+
+  def then_i_see_the_link_has_been_added
+    expect(all(".gem-c-document-list__item-title")[2].text).to eq "Naturalisation"
+  end
+
+  def and_the_correct_calls_are_made_to_the_publishing_api_for_editing_list_items
+    assert_publishing_api_put_content(
+      @child.content_id,
+      request_json_includes(
+        "details" => {
+          "groups" => [
+            {
+              "name" => @list.name,
+              "contents" => [
+                @list_item1.base_path,
+                @list_item2.base_path,
+                "/naturalisation",
+              ],
+            },
+          ],
+          "internal_name" => @child.title_including_parent,
+        },
+      ),
+    )
+    assert_publishing_api_publish(@child.content_id)
+    assert_publishing_api_patch_links(@child.content_id)
+  end
+end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -48,4 +48,23 @@ RSpec.describe List do
       expect(list_item.tagged?).to eql(false)
     end
   end
+
+  describe "#available_list_items" do
+    it "returns tagged list items from the publishing api that are in the list" do
+      list = create(:list)
+      create(:list_item, list: list, base_path: "/item-in-list")
+      publishing_api_has_linked_items(
+        list.tag.content_id,
+        items: [
+          { base_path: "/item-in-list", title: "Item in list", content_id: "123" },
+          { base_path: "/item-not-in-list", title: "Item not in list", content_id: "456" },
+        ],
+      )
+
+      expect(list.available_list_items.count).to eq 1
+      expect(list.available_list_items.first.base_path).to eq "/item-not-in-list"
+      expect(list.available_list_items.first.title).to eq "Item not in list"
+      expect(list.available_list_items.first.content_id).to eq "456"
+    end
+  end
 end


### PR DESCRIPTION
## Description 

This PR follows on from #1595 which built the functionality for adding, editing, reordering and deleting lists.

The focus of this PR is adding the ability for a user to add additional list items (links) to a list. The ability to reorder list items, move one to a different list and delete a list item will be added in follow up PRs

## Changes 

### Adds a list show page 

A new page that shows all the list items and available actions to add new items, reorder items, move an item to a different list and remove an item from a list. 

For now only the `Add links to list` link is wired in

<img width="892" alt="image" src="https://user-images.githubusercontent.com/42515961/169255087-f6a7f090-1f7b-450c-b880-4073b0bc13b1.png">


### Add list items page

Adds checkboxes for all the tagged documents which are associated with the mainstream browse page or topic that are not currently in the list

<img width="913" alt="image" src="https://user-images.githubusercontent.com/42515961/169262546-7da67903-1b80-4071-b54b-1eb6c6a17dd2.png">

## Guidance for review

Per commit will definitely be easiest. Probs worth giving the designs/last pr a glance if you're not familiar with the card.

Guidance on the publishing components used in the frontend can be found here https://components.publishing.service.gov.uk/component-guide/

## Trello card 

https://trello.com/c/9VoxrVPi/413-rebuild-curate-lists-page-on-collections-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
