### PR TITLE
Replace archived govuk-content-schema-test-helpers gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "faker"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "govuk_test"
   gem "nokogiri"
   gem "parser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,8 +145,6 @@ GEM
     generic_form_builder (0.13.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_admin_template (6.9.2)
       bootstrap-sass (~> 3.4)
       jquery-rails (~> 4.3)
@@ -171,6 +169,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -475,10 +475,10 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   generic_form_builder
-  govuk-content-schema-test-helpers
   govuk_admin_template
   govuk_app_config
   govuk_publishing_components
+  govuk_schemas
   govuk_sidekiq
   govuk_test
   inline_svg

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe PublishingAPINotifier do
         PublishingAPINotifier.notify(tag)
 
         expect(stubbed_content_store).to have_draft_content_item_slug("/topic/foo")
-        expect(stubbed_content_store.last_updated_item).to be_valid_against_schema("topic")
+        expect(stubbed_content_store.last_updated_item).to be_valid_against_publisher_schema("topic")
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe PublishingAPINotifier do
         PublishingAPINotifier.notify(tag)
 
         expect(stubbed_content_store).to have_content_item_slug("/topic/foo")
-        expect(stubbed_content_store.last_updated_item).to be_valid_against_schema("topic")
+        expect(stubbed_content_store.last_updated_item).to be_valid_against_publisher_schema("topic")
       end
 
       it "sends topic redirects to the publishing-api" do
@@ -119,7 +119,7 @@ RSpec.describe PublishingAPINotifier do
 
         PublishingAPINotifier.notify(tag)
         content_item = stubbed_content_store.item_by_content_id(tag.content_id)
-        expect(content_item).to be_valid_against_schema("topic")
+        expect(content_item).to be_valid_against_publisher_schema("topic")
         expect(content_item[:redirects]).to eq([{ path: "/foo", destination: "/topic/foo", type: "exact" }])
       end
     end

--- a/spec/presenters/archived_tag_presenter_spec.rb
+++ b/spec/presenters/archived_tag_presenter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ArchivedTagPresenter do
     it "is valid against the schemas" do
       presenter = ArchivedTagPresenter.new(child)
 
-      expect(presenter.render_for_publishing_api).to be_valid_against_schema("redirect")
+      expect(presenter.render_for_publishing_api).to be_valid_against_publisher_schema("redirect")
     end
   end
 

--- a/spec/presenters/coronavirus/page_presenter_spec.rb
+++ b/spec/presenters/coronavirus/page_presenter_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe Coronavirus::PagePresenter do
   include CoronavirusFeatureSteps
-  include GovukContentSchemaTestHelpers
 
   let(:page) { create :coronavirus_page }
   let(:base_path) { page.base_path }
@@ -34,7 +33,7 @@ RSpec.describe Coronavirus::PagePresenter do
 
   describe "#payload" do
     it "presents the payload correctly" do
-      expect(subject.payload).to be_valid_against_schema("coronavirus_landing_page")
+      expect(subject.payload).to be_valid_against_publisher_schema("coronavirus_landing_page")
       expect(subject.payload).to eq payload
     end
   end

--- a/spec/presenters/mainstream_browse_page_presenter_spec.rb
+++ b/spec/presenters/mainstream_browse_page_presenter_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
     end
 
     it "is valid against the schema" do
-      expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+      expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
     end
 
     describe "linking to related topics" do
@@ -92,7 +92,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
     end
@@ -184,7 +184,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
 
@@ -200,7 +200,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
 
@@ -229,7 +229,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
 
@@ -246,7 +246,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
     end
@@ -289,7 +289,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
 
@@ -306,7 +306,7 @@ RSpec.describe MainstreamBrowsePagePresenter do
         end
 
         it "is valid against the schema" do
-          expect(presented_data).to be_valid_against_schema("mainstream_browse_page")
+          expect(presented_data).to be_valid_against_publisher_schema("mainstream_browse_page")
         end
       end
     end

--- a/spec/presenters/redirect_item_presenter_spec.rb
+++ b/spec/presenters/redirect_item_presenter_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RedirectItemPresenter do
 
       rendered = RedirectItemPresenter.new(item).render_for_publishing_api
 
-      expect(rendered).to be_valid_against_schema("redirect")
+      expect(rendered).to be_valid_against_publisher_schema("redirect")
     end
   end
 end

--- a/spec/presenters/root_browse_page_presenter_spec.rb
+++ b/spec/presenters/root_browse_page_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RootBrowsePagePresenter do
       create(:mainstream_browse_page, title: "Top-Level Page 2")
 
       rendered = RootBrowsePagePresenter.new("state" => "draft").render_for_publishing_api
-      expect(rendered).to be_valid_against_schema("mainstream_browse_page")
+      expect(rendered).to be_valid_against_publisher_schema("mainstream_browse_page")
     end
 
     it ":public_updated_at equals the time of last browse page update" do

--- a/spec/presenters/root_topic_presenter_spec.rb
+++ b/spec/presenters/root_topic_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RootTopicPresenter do
 
       rendered = RootTopicPresenter.new("state" => "published").render_for_publishing_api
 
-      expect(rendered).to be_valid_against_schema("topic")
+      expect(rendered).to be_valid_against_publisher_schema("topic")
     end
 
     it ":public_updated_at equals the time of last browse page update" do

--- a/spec/presenters/step_nav_presenter_spec.rb
+++ b/spec/presenters/step_nav_presenter_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe StepNavPresenter do
-  include GovukContentSchemaTestHelpers
-
   describe "#render_for_publishing_api" do
     before do
       allow(Services.publishing_api).to receive(:lookup_content_id)
@@ -18,7 +16,7 @@ RSpec.describe StepNavPresenter do
 
     it "presents a step by step page in the correct format" do
       presented = subject.render_for_publishing_api
-      expect(presented).to be_valid_against_schema("step_by_step_nav")
+      expect(presented).to be_valid_against_publisher_schema("step_by_step_nav")
 
       expect(presented[:update_type]).to eq("minor")
       expect(presented[:base_path]).to eq("/how-to-be-the-amazing-1")
@@ -47,7 +45,7 @@ RSpec.describe StepNavPresenter do
         <p>This is another great step</p>
       BODY
 
-      expect(presented).to be_valid_against_schema("step_by_step_nav")
+      expect(presented).to be_valid_against_publisher_schema("step_by_step_nav")
       expect(presented[:details][:body]).to eq(expected)
     end
 
@@ -76,7 +74,7 @@ RSpec.describe StepNavPresenter do
       intent = PublishIntent.new(update_type: "major", change_note: "All your update belong to us")
       presented = subject.render_for_publishing_api(intent)
 
-      expect(presented).to be_valid_against_schema("step_by_step_nav")
+      expect(presented).to be_valid_against_publisher_schema("step_by_step_nav")
       expect(presented[:update_type]).to eq("major")
       expect(presented[:change_note]).to eq("All your update belong to us")
     end

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TagPresenter do
     it "is valid against the schema without lists" do
       presented_data = TopicPresenter.new(tag).render_for_publishing_api
 
-      expect(presented_data).to be_valid_against_schema("topic")
+      expect(presented_data).to be_valid_against_publisher_schema("topic")
     end
 
     it "is valid against the schema with lists" do
@@ -58,7 +58,7 @@ RSpec.describe TagPresenter do
 
       presented_data = TopicPresenter.new(tag).render_for_publishing_api
 
-      expect(presented_data).to be_valid_against_schema("topic")
+      expect(presented_data).to be_valid_against_publisher_schema("topic")
     end
 
     it "uses the published groups if it's set" do

--- a/spec/presenters/topic_presenter_spec.rb
+++ b/spec/presenters/topic_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TopicPresenter do
       end
 
       it "is valid against the schema" do
-        expect(presented_data).to be_valid_against_schema("topic")
+        expect(presented_data).to be_valid_against_publisher_schema("topic")
       end
 
       it "returns the base_path for the topic" do
@@ -99,7 +99,7 @@ RSpec.describe TopicPresenter do
       end
 
       it "is valid against the schema" do
-        expect(presented_data).to be_valid_against_schema("topic")
+        expect(presented_data).to be_valid_against_publisher_schema("topic")
       end
 
       it "sets public_updated_at based on the topic update time" do

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,10 +1,3 @@
-require "govuk-content-schema-test-helpers"
+require "govuk_schemas/rspec_matchers"
 
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
-
-require "govuk-content-schema-test-helpers/rspec_matchers"
-
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Trello: https://trello.com/c/b9PRFqgU

# What's changed?
Replaces the govuk-content-schema-test-helpers gem with the govuk_schemas gem to validate content item schemas.

# Why?
[govuk-content-schema-test-helpers] has been archived and there is a concern that it no longer receives any security updates. The advice in the govuk-content-schema-test-helpers repo is to replace it with the govuk_schemas gem.

[govuk-content-schema-test-helpers]: https://github.com/alphagov/govuk-content-schema-test-helpers