### PR TITLE
Add move to different list functionality

### DIFF
--- a/app/assets/stylesheets/_curated_lists.scss
+++ b/app/assets/stylesheets/_curated_lists.scss
@@ -3,7 +3,7 @@
 }
 
 .curated-lists .gem-c-document-list__attribute:first-child,
-.list-items .gem-c-document-list__attribute:first-child {
+.list-items .gem-c-document-list__attribute:first-child:not(:last-child) {
   border-right: 1px solid $govuk-border-colour;
   padding-right: 10px;
 }
@@ -15,7 +15,7 @@
 }
 
 .curated-lists .gem-c-document-list__attribute:last-child,
-.list-items .gem-c-document-list__attribute:last-child {
+.list-items .gem-c-document-list__attribute:last-child:not(:first-child) {
   padding-left: 10px;
 }
 

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -85,10 +85,28 @@ class ListItemsController < ApplicationController
     @list_item = @list.list_items.find(params[:id])
   end
 
+  def move
+    @list_item = @list.list_items.find(params[:id])
+  end
+
+  def update_move
+    @list_item = @list.list_items.find(params[:id])
+    @list_item.errors.add(:new_list_id, "Choose a list") if move_list_item_params.blank?
+    render :move and return if @list_item.errors.present?
+
+    new_list = @tag.lists.find(move_list_item_params)
+    new_index = new_list.list_items.map(&:index).max.to_i + 1
+    @list_item.update!(list: new_list, index: new_index)
+    ListPublisher.new(@tag).perform
+    flash[:notice] = "Item moved to new list successfully"
+
+    redirect_to tag_list_path(@tag, @list)
+  end
+
 private
 
   def get_layout
-    if redesigned_lists_permission? && action_name.in?(%w[confirm_destroy])
+    if redesigned_lists_permission? && action_name.in?(%w[confirm_destroy move update_move])
       "design_system"
     else
       "legacy"
@@ -101,5 +119,9 @@ private
 
   def list_item_params
     params.require(:list_item).permit(:title, :base_path, :index)
+  end
+
+  def move_list_item_params
+    params.dig(:list_item, :new_list_id)
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -147,6 +147,12 @@ class Tag < ApplicationRecord
     false # should be overridden in subclasses
   end
 
+  def lists_that_do_not_include_list_item(list_item)
+    lists.reject do |list|
+      list.list_items.any? { |item| item.base_path == list_item.base_path }
+    end
+  end
+
 private
 
   def parent_is_not_a_child

--- a/app/views/list_items/move.html.erb
+++ b/app/views/list_items/move.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :back_link, render("govuk_publishing_components/components/back_link", {
+  href: tag_list_path(@tag, @list)
+}) %>
+
+<%= content_for :page_title, "Move link to a different list" %>
+
+<%= render 'shared/error_summary', object: @list_item %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @list, url: update_move_tag_list_list_item_path(@tag, @list, @list_item), method: :patch do |f| %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "list_item[new_list_id]",
+        id: "list_item_new_list_id",
+        heading: "Move link to a different list",
+        heading_size: "l",
+        heading_caption: "List",
+        heading_level: 1,
+        items: @tag.lists_that_do_not_include_list_item(@list_item).map do |list|
+        {
+          value: list.id,
+          text: list.name,
+        }
+        end
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Next"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -59,6 +59,15 @@
 
     <div class="list-items">
       <% @list.list_items.ordered.each do |list_item| %>
+        <% if @tag.lists_that_do_not_include_list_item(list_item).present? %>
+          <% metadata = {
+                move_list_item: tag.a("Move to a different list", href: "#", class: "govuk-link"),
+                remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link"),
+              } %>
+        <% else %>
+          <% metadata = { remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link") } %>
+        <% end %>
+
         <%= render "govuk_publishing_components/components/document_list", {
           items: [
             {
@@ -66,10 +75,7 @@
                 text: list_item.title,
                 path: Plek.new.website_root + list_item.base_path
               },
-              metadata: {
-                move_list_item: tag.a("Move to a different list", href: "#", class: "govuk-link"),
-                remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link"),
-              }
+              metadata: metadata
             },
           ]
         } %>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -61,7 +61,7 @@
       <% @list.list_items.ordered.each do |list_item| %>
         <% if @tag.lists_that_do_not_include_list_item(list_item).present? %>
           <% metadata = {
-                move_list_item: tag.a("Move to a different list", href: "#", class: "govuk-link"),
+                move_list_item: tag.a("Move to a different list", href: move_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link"),
                 remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link"),
               } %>
         <% else %>

--- a/app/views/shared/_list-links-preview.html.erb
+++ b/app/views/shared/_list-links-preview.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/heading", {
-        text: "Links",
+        text: "Lists",
         font_size: "m",
         margin_bottom: 4
       } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,8 @@ Rails.application.routes.draw do
       resources :list_items, only: %i[create update destroy] do
         member do
           get :confirm_destroy
+          get :move
+          patch :update_move
         end
       end
     end

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -360,4 +360,191 @@ RSpec.describe ListItemsController, type: :controller do
       end
     end
   end
+
+  describe "GET move" do
+    let(:list) { create(:list, tag: tag) }
+    let!(:list_item) { create(:list_item, list: list) }
+
+    context "Tag is a MainstreamBrowsePage" do
+      let(:tag) { create(:mainstream_browse_page) }
+
+      it "assign the correct instance variables and renders the move template" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        get :move, params: { tag_id: tag.content_id, list_id: list.id, id: list_item.id }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list.id
+        expect(assigns(:list_item).id).to eq list_item.id
+        expect(response.status).to eq(200)
+        expect(response).to render_template :move
+      end
+
+      it "does not allow users without GDS Editor permissions access" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        get :move, params: { tag_id: tag.content_id, list_id: list.id, id: list_item.id }
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "Tag is a topic and user does not have `GDS Editor permissions`" do
+      let(:tag) { create(:topic) }
+
+      it "assign the correct instance vaiables and renders the move template" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        get :move, params: { tag_id: tag.content_id, list_id: list.id, id: list_item.id }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list.id
+        expect(assigns(:list_item).id).to eq list_item.id
+        expect(response.status).to eq(200)
+        expect(response).to render_template :move
+      end
+    end
+  end
+
+  describe "PATCH update_move" do
+    let(:list1) { create(:list, tag: tag) }
+    let(:list2) { create(:list, tag: tag) }
+    let!(:list_item1) { create(:list_item, list: list1, index: 1) }
+    let!(:list_item2) { create(:list_item, list: list1, index: 2) }
+    let(:tagged_documents) do
+      [
+        TaggedDocuments::Document.new(list_item1.title, list_item1.base_path, "123"),
+        TaggedDocuments::Document.new(list_item2.title, list_item2.base_path, "456"),
+        TaggedDocuments::Document.new("New list", "/new-list", "789"),
+      ]
+    end
+
+    before do
+      stub_any_publishing_api_call
+      allow_any_instance_of(TaggedDocuments).to receive(:documents).and_return(tagged_documents)
+    end
+
+    context "Tag is a MainstreamBrowsePage" do
+      let(:tag) { create(:mainstream_browse_page, :published) }
+
+      it "updates the list item to belong to list_id passed in and makes the correct calls to the Publishing API" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        patch :update_move, params: {
+          tag_id: tag.content_id,
+          list_id: list1.id,
+          id: list_item1.id,
+          list_item: { new_list_id: list2.id },
+        }
+
+        expect(list1.reload.list_items.count).to eq 1
+        expect(list2.reload.list_items.count).to eq 1
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(tag_list_path(tag, list1))
+        expect(flash.notice).to eq "Item moved to new list successfully"
+        assert_publishing_api_put_content(
+          tag.content_id,
+          request_json_includes(
+            "details" => {
+              "groups" => [
+                {
+                  "name" => list1.name,
+                  "contents" => [
+                    list_item2.base_path,
+                  ],
+                },
+                {
+                  "name" => list2.name,
+                  "contents" => [
+                    list_item1.base_path,
+                  ],
+                },
+              ],
+              "internal_name" => tag.title,
+              "second_level_ordering" => "alphabetical",
+              "ordered_second_level_browse_pages" => [],
+            },
+          ),
+        )
+        assert_publishing_api_publish(tag.content_id)
+        assert_publishing_api_patch_links(tag.content_id)
+      end
+
+      it "does not allow users without GDS Editor permissions access" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        patch :update_move, params: {
+          tag_id: tag.content_id,
+          list_id: list1.id,
+          id: list_item1.id,
+          list_item: { new_list_id: list2.id },
+        }
+
+        expect(response.status).to eq(403)
+      end
+
+      it "adds and error and renders the move view if a new_list_id is not passed in" do
+        stub_user.update!(permissions: ["signin", "GDS Editor", "Redesigned lists"])
+
+        patch :update_move, params: {
+          tag_id: tag.content_id,
+          list_id: list1.id,
+          id: list_item1.id,
+        }
+
+        expect(assigns(:tag).id).to eq tag.id
+        expect(assigns(:list).id).to eq list1.id
+        expect(assigns(:list_item).id).to eq list_item1.id
+        expect(assigns(:list_item).errors.first.message).to eq "Choose a list"
+        expect(response.status).to eq(200)
+        expect(response).to render_template :move
+      end
+    end
+
+    context "Tag is a topic and user does not have `GDS Editor permissions`" do
+      let(:tag) { create(:topic, :published) }
+
+      it "updates the list item to belong to list_id passed in and makes the correct calls to the Publishing API" do
+        stub_user.update!(permissions: ["signin", "Redesigned lists"])
+
+        patch :update_move, params: {
+          tag_id: tag.content_id,
+          list_id: list1.id,
+          id: list_item2.id,
+          list_item: { new_list_id: list2.id },
+        }
+
+        expect(list1.reload.list_items.count).to eq 1
+        expect(list2.reload.list_items.count).to eq 1
+        expect(list2.list_items.first.index).to eq 1
+        expect(response.status).to eq(302)
+        expect(response).to redirect_to(tag_list_path(tag, list1))
+        expect(flash.notice).to eq "Item moved to new list successfully"
+        assert_publishing_api_put_content(
+          tag.content_id,
+          request_json_includes(
+            "details" => {
+              "groups" => [
+                {
+                  "name" => list1.name,
+                  "contents" => [
+                    list_item1.base_path,
+                  ],
+                },
+                {
+                  "name" => list2.name,
+                  "contents" => [
+                    list_item2.base_path,
+                  ],
+                },
+              ],
+              "internal_name" => tag.title,
+            },
+          ),
+        )
+        assert_publishing_api_publish(tag.content_id)
+        assert_publishing_api_patch_links(tag.content_id)
+      end
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -268,4 +268,19 @@ RSpec.describe Tag do
       ])
     end
   end
+
+  describe "#lists_that_do_not_include_list_item" do
+    let(:tag) { create(:tag, slug: "a-tag") }
+    let(:subtag) { create(:tag, parent: tag, slug: "a-subtag") }
+
+    it "returns all lists that include a specific list item" do
+      list1 = create(:list, tag: subtag)
+      list_item = create(:list_item, list: list1, base_path: "/content-page-1")
+      list2 = create(:list, tag: subtag)
+      create(:list_item, list: list2, base_path: "/content-page-1")
+      list3 = create(:list, tag: subtag)
+
+      expect(subtag.lists_that_do_not_include_list_item(list_item)).to match_array([list3])
+    end
+  end
 end


### PR DESCRIPTION
## Description 

### Previous PRs

https://github.com/alphagov/collections-publisher/pull/1595 - built the functionality for adding, editing, reordering and deleting lists
https://github.com/alphagov/collections-publisher/pull/1601 - added the list show page and ability to add new list items to a list.
https://github.com/alphagov/collections-publisher/pull/1609 - reorder list item functionality
https://github.com/alphagov/collections-publisher/pull/1610 - Deleting a list item 

The focus of this PR is adding the ability for a user to move a list item to another list.

## Changes 

### Adds a move link page

<img width="849" alt="image" src="https://user-images.githubusercontent.com/42515961/170475179-4b7b1438-6dec-432f-b8c1-e88ec338c2f3.png">

## Guidance for review

Per commit will definitely be easiest. Probs worth giving the designs/last pr a glance if you're not familiar with the card.

Guidance on the publishing components used in the frontend can be found here https://components.publishing.service.gov.uk/component-guide/

## Trello card 

https://trello.com/c/9VoxrVPi/413-rebuild-curate-lists-page-on-collections-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
