### PR TITLE
Styling fixes for GOVUK Design System curate links implementation

### DIFF
--- a/app/assets/stylesheets/_curated_lists.scss
+++ b/app/assets/stylesheets/_curated_lists.scss
@@ -1,4 +1,5 @@
-.curated-lists .gem-c-document-list__item-title {
+.curated-lists .gem-c-document-list__item-title,
+.list-items .gem-c-document-list__item-title {
   margin-bottom: 10px;
 }
 

--- a/app/views/list_items/confirm_destroy.html.erb
+++ b/app/views/list_items/confirm_destroy.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @list_item, url: tag_list_list_item_path(@tag, @list, @list_item), method: :delete do |f| %>
-      <p class="govuk-body-s">Are you sure you want to delete "<%= @list_item.title %>"?</p>
+      <p class="govuk-body">Are you sure you want to delete "<%= @list_item.title %>"?</p>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Remove link",

--- a/app/views/list_items/move.html.erb
+++ b/app/views/list_items/move.html.erb
@@ -16,6 +16,7 @@
         heading_size: "l",
         heading_caption: "List",
         heading_level: 1,
+        error_message: errors_for(@list_item, :new_list_id),
         items: @tag.lists_that_do_not_include_list_item(@list_item).map do |list|
         {
           value: list.id,

--- a/app/views/lists/confirm_destroy.html.erb
+++ b/app/views/lists/confirm_destroy.html.erb
@@ -9,8 +9,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @list, url: tag_list_path(@tag, @list), method: :delete do |f| %>
-      <p class="govuk-body-s">Are you sure you want to delete <%= @list.name %>?</p>
-      <p class="govuk-body-s">Links will still be tagged to the <%= "mainstream browse" if @tag.is_a? MainstreamBrowsePage %> sub-topic after the list is deleted.</p>
+      <p class="govuk-body">Are you sure you want to delete "<%= @list.name %>"?</p>
+      <p class="govuk-body">Links will still be tagged to the <%= "mainstream browse" if @tag.is_a? MainstreamBrowsePage %> sub-topic after the list is deleted.</p>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -82,5 +82,8 @@
         } %>
       <% end %>
     </div>
+    <div class="govuk-!-margin-bottom-7 govuk-!-margin-top-9">
+      <%= link_to "Return to previous page", polymorphic_path(@tag), class: "govuk-link govuk-body" %>
+    </div>
   </div>
 </div>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -39,14 +39,14 @@
           <li class="govuk-summary-list__actions-list-item">
             <%= link_to 'Add links to list',
               edit_list_items_tag_list_path(@tag, @list),
-              class: %w(govuk-link govuk-link--no-visited-state)
+              class: %w(govuk-link govuk-link--no-visited-state govuk-body)
             %>
           </li>
           <% if @list.list_items.count > 1 %>
             <li class="govuk-summary-list__actions-list-item">
               <%= link_to 'Reorder links',
                 manage_list_item_ordering_tag_list_path(@tag, @list),
-                class: %w(govuk-link govuk-link--no-visited-state)
+                class: %w(govuk-link govuk-link--no-visited-state govuk-body)
               %>
             </li>
           <% end %>
@@ -54,18 +54,19 @@
       </div>
     </div>
 
-    <p class="govuk-body-s">Select page to edit tagging in Content Tagger</p>
-
+    <% if @list.list_items.present? %>
+      <p class="govuk-body">Select page to edit tagging in Content Tagger</p>
+    <% end %>
 
     <div class="list-items">
       <% @list.list_items.ordered.each do |list_item| %>
         <% if @tag.lists_that_do_not_include_list_item(list_item).present? %>
           <% metadata = {
-                move_list_item: tag.a("Move to a different list", href: move_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link"),
-                remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link"),
+                move_list_item: tag.a("Move to a different list", href: move_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link govuk-body"),
+                remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link govuk-body"),
               } %>
         <% else %>
-          <% metadata = { remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link") } %>
+          <% metadata = { remove_list_item: tag.a("Remove", href: confirm_destroy_tag_list_list_item_path(@tag, @list, list_item), class: "govuk-link govuk-body") } %>
         <% end %>
 
         <%= render "govuk_publishing_components/components/document_list", {

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -74,7 +74,7 @@
             {
               link: {
                 text: list_item.title,
-                path: Plek.new.website_root + list_item.base_path
+                path: content_tagger_url + '/taggings/' + @tag.tagged_document_for_base_path(list_item.base_path).content_id,
               },
               metadata: metadata
             },

--- a/app/views/shared/_list-links-preview.html.erb
+++ b/app/views/shared/_list-links-preview.html.erb
@@ -11,14 +11,14 @@
       <li class="govuk-summary-list__actions-list-item">
         <%= link_to 'Add list',
           new_tag_list_path(tag),
-          class: %w(govuk-link govuk-link--no-visited-state)
+          class: %w(govuk-link govuk-link--no-visited-state govuk-body)
         %>
       </li>
       <% if tag.lists.count > 1 %>
         <li class="govuk-summary-list__actions-list-item">
           <%= link_to 'Reorder list',
             tag_manage_list_ordering_path(tag),
-            class: %w(govuk-link govuk-link--no-visited-state)
+            class: %w(govuk-link govuk-link--no-visited-state govuk-body)
           %>
         </li>
       <% end %>

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -24,5 +24,6 @@
 </p>
 
 <%= render "govuk_publishing_components/components/list", {
+  extra_spacing: true,
   items: tag_object.uncurated_tagged_documents.map { |item| link_to item.title, content_tagger_url + '/taggings/lookup' + item.content_id, class: 'govuk-link' }
 } %>

--- a/app/views/shared/tags/_curated_links_preview.html.erb
+++ b/app/views/shared/tags/_curated_links_preview.html.erb
@@ -7,9 +7,9 @@
             text: list.name
           },
           metadata: {
-            edit_list: tag.a("Edit list", href: tag_list_path(tag_object, list), class: "govuk-link"),
-            rename_list: tag.a("Rename list", href: edit_tag_list_path(tag_object, list), class: "govuk-link"),
-            delete_list: tag.a("Delete list", href: confirm_destroy_tag_list_path(tag_object, list), class: "govuk-link"),
+            edit_list: tag.a("Edit list", href: tag_list_path(tag_object, list), class: "govuk-link govuk-body"),
+            rename_list: tag.a("Rename list", href: edit_tag_list_path(tag_object, list), class: "govuk-link govuk-body"),
+            delete_list: tag.a("Delete list", href: confirm_destroy_tag_list_path(tag_object, list), class: "govuk-link govuk-body"),
           }
         },
       ]
@@ -19,7 +19,7 @@
 
 <h3 class="govuk-heading-m govuk-!-margin-top-8">Unused links</h3>
 
-<p class="govuk-body-s">
+<p class="govuk-body">
   Unused links have not been included in any of the curated lists. These links will not be shown to users. Select the page title to edit page tagging in Content Tagger.
 </p>
 

--- a/app/views/shared/tags/_uncurated_links_preview.html.erb
+++ b/app/views/shared/tags/_uncurated_links_preview.html.erb
@@ -1,6 +1,8 @@
-<p class="govuk-body-s">Links for this tag have not been curated into lists. Click on the title for editing on Content Tagger.</p>
+<p class="govuk-body">There are currently no curated lists for this <%= tag.class.model_name.human.downcase %>. This <%= tag.class.model_name.human.downcase %> will appear as an A to Z list.</p>
+
+<p class="govuk-body">Select the page title to edit tagging in Content Tagger.</p>
 
 <%= render "govuk_publishing_components/components/list", {
-  visible_counters: true,
+  extra_spacing: true,
   items: tag.tagged_documents.map { |link|  link_to link.title, content_tagger_url + '/taggings/' + link.content_id, class: 'govuk-link' }
 } %>

--- a/spec/features/curating_a_list_spec.rb
+++ b/spec/features/curating_a_list_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Curating a list" do
 
   def and_the_link_items_should_link_to_the_live_page
     expect(all(".gem-c-document-list__item-title")[0].text).to eq @list.list_items.first.title
-    expect(all(".gem-c-document-list__item-title")[0][:href]).to eq Plek.new.website_root + @list.list_items.ordered.first.base_path
+    expect(all(".gem-c-document-list__item-title")[0][:href]).to eq "#{Plek.new.external_url_for('content-tagger')}/taggings/29941ec1-4a41-4bfd-86a9-5c866bbd4c7a"
   end
 
   def when_i_click_add_links_to_list

--- a/spec/features/navigating_topics_spec.rb
+++ b/spec/features/navigating_topics_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature "Navigating topics" do
   end
 
   def then_i_should_see_that_the_items_have_not_been_curated
-    expect(page).to have_content "Links for this tag have not been curated into lists"
+    expect(page).to have_content "There are currently no curated lists for this topic. This topic will appear as an A to Z list."
   end
 
   def and_i_see_the_linked_items_of_this_page


### PR DESCRIPTION
## Description

Recently we've ported the Curate Links section of Collections Publisher over to use the GOVUK Design System. 
Nikin and me he a quick follow up session to run through the new implementation of curate lists and fix any issues with the implementation or styling.

## Changes

### Font size on para's and links

Previously these were using font size 16, we've bumped them to 19

**Tag show page**

|Before|After|
|------------|------------| 
|<img width="753" alt="image" src="https://user-images.githubusercontent.com/42515961/171164968-4b0689de-a620-437d-ac5b-e5dc2ab1fb5b.png">|<img width="698" alt="image" src="https://user-images.githubusercontent.com/42515961/171164918-d26c4f7a-b189-4566-a55d-f30096c80872.png">|

**List show page**

|Before|After|
|------------|------------| 
|<img width="706" alt="image" src="https://user-images.githubusercontent.com/42515961/171165074-416ebeb0-f335-4b93-b011-92f30838b673.png">|<img width="746" alt="image" src="https://user-images.githubusercontent.com/42515961/171165127-00930699-4154-4a7e-acb0-dc129f8d49a8.png">|


**List destroy page**

|Before|After|
|------------|------------| 
|<img width="587" alt="image" src="https://user-images.githubusercontent.com/42515961/171165493-92fd4946-9551-480f-8dc6-6cea2a58281c.png">|<img width="674" alt="image" src="https://user-images.githubusercontent.com/42515961/171165556-928f64ca-d728-4dd3-a803-589b1250c297.png">|

**List item destroy page**

|Before|After|
|------------|------------| 
|<img width="459" alt="image" src="https://user-images.githubusercontent.com/42515961/171165431-8ff75f86-41ae-476b-9526-f4a2b41a5109.png">|<img width="617" alt="image" src="https://user-images.githubusercontent.com/42515961/171165368-bbd2c204-ca53-4efc-bc30-b174f4de5a4d.png">|


### Add spacing between document title and links on list show page

|Before|After|
|------------|------------| 
|<img width="598" alt="image" src="https://user-images.githubusercontent.com/42515961/171165962-83e3b4aa-148e-427a-a6d0-fd890a1573c4.png">|<img width="664" alt="image" src="https://user-images.githubusercontent.com/42515961/171165929-eca70974-cc8a-43e8-b7af-5d03b43b33b9.png">|

### Add return to previous page link to list show page

|Before|After|
|------------|------------| 
|<img width="781" alt="image" src="https://user-images.githubusercontent.com/42515961/171166034-48bcf583-3db2-4655-a470-c5461c66f680.png">|<img width="794" alt="image" src="https://user-images.githubusercontent.com/42515961/171166073-7e4eff48-aa48-48ca-ada1-2c0d60d42f1a.png">|

### Add spacing to uncurated links list

|Before|After|
|------------|------------| 
|<img width="670" alt="image" src="https://user-images.githubusercontent.com/42515961/171166206-a2c3ff28-9b10-4bef-9578-1dda76a55976.png">|<img width="642" alt="image" src="https://user-images.githubusercontent.com/42515961/171166175-ee0e5a6d-8504-49aa-b44c-a25f38df78ed.png">|

### Link error for move radio fieldset

|Before|After|
|------------|------------| 
|<img width="911" alt="image" src="https://user-images.githubusercontent.com/42515961/171166518-d57d62b8-f8a4-4faa-9276-9b6da78e100e.png">|<img width="959" alt="image" src="https://user-images.githubusercontent.com/42515961/171166481-896ac8ce-cd01-4e07-84b9-ba5072df23e4.png">|

### Uncurated lists styling

|Before|After|
|------------|------------| 
|<img width="628" alt="image" src="https://user-images.githubusercontent.com/42515961/172577925-b10cdc38-1b4a-4fd6-8d7f-b2b66906ceea.png">|<img width="673" alt="image" src="https://user-images.githubusercontent.com/42515961/172577771-608d4d5b-de18-4c31-a588-32677f8932b4.png">|

### Non-visual changes

- Links on the list show page now link 


## Trello card

https://trello.com/c/9VoxrVPi/413-rebuild-curate-lists-page-on-collections-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
