### PR TITLE
Update content of flash messages for lists and list items

### DIFF
--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -38,7 +38,7 @@ class ListItemsController < ApplicationController
 
     if redesigned_lists_permission?
       ListPublisher.new(@tag).perform
-      flash[:notice] = "Content removed from list"
+      flash[:notice] = "#{list_item.title} removed from list"
 
       redirect_to tag_list_path(@tag, @list)
     else
@@ -98,7 +98,7 @@ class ListItemsController < ApplicationController
     new_index = new_list.list_items.map(&:index).max.to_i + 1
     @list_item.update!(list: new_list, index: new_index)
     ListPublisher.new(@tag).perform
-    flash[:notice] = "Item moved to new list successfully"
+    flash[:notice] = "#{@list_item.title} moved to #{new_list.name} successfully"
 
     redirect_to tag_list_path(@tag, @list)
   end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -28,7 +28,7 @@ class ListsController < ApplicationController
     if redesigned_lists_permission?
       if @list.save
         ListPublisher.new(@tag).perform
-        flash[:notice] = "List created"
+        flash[:notice] = "#{@list.name} list created"
 
         redirect_to polymorphic_path(@tag)
       else
@@ -56,7 +56,7 @@ class ListsController < ApplicationController
     if redesigned_lists_permission?
       if list.destroyed?
         ListPublisher.new(@tag).perform
-        flash[:notice] = "List deleted"
+        flash[:notice] = "#{list.name} list deleted"
       else
         flash[:alert] = "Could not delete the list"
       end
@@ -80,7 +80,7 @@ class ListsController < ApplicationController
     if redesigned_lists_permission?
       if @list.update(list_params)
         ListPublisher.new(@tag).perform
-        flash[:notice] = "List updated"
+        flash[:notice] = "#{@list.name} list updated"
 
         redirect_to polymorphic_path(@tag)
       else
@@ -122,7 +122,7 @@ class ListsController < ApplicationController
 
     if save_list_items
       ListPublisher.new(@tag).perform
-      flash[:notice] = "Items added to list successfully"
+      flash[:notice] = "#{helpers.pluralize(edit_list_items_params.count, 'link')} successfully added to the list"
 
       redirect_to tag_list_path(@tag, @list)
     else
@@ -138,7 +138,7 @@ class ListsController < ApplicationController
     @list = @tag.lists.find(params[:id])
     save_ordering
     ListPublisher.new(@tag).perform
-    flash["notice"] = "List items reordered successfully"
+    flash["notice"] = "List links reordered successfully"
 
     redirect_to tag_list_path(@tag, @list)
   end

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe ListItemsController, type: :controller do
         expect { ListItem.find(list_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
         expect(response.status).to eq(302)
         expect(response).to redirect_to(tag_list_path(tag, list))
-        expect(flash.notice).to eq "Content removed from list"
+        expect(flash.notice).to eq "#{list_item.title} removed from list"
         assert_publishing_api_put_content(
           tag.content_id,
           request_json_includes(
@@ -441,7 +441,7 @@ RSpec.describe ListItemsController, type: :controller do
         expect(list2.reload.list_items.count).to eq 1
         expect(response.status).to eq(302)
         expect(response).to redirect_to(tag_list_path(tag, list1))
-        expect(flash.notice).to eq "Item moved to new list successfully"
+        expect(flash.notice).to eq "#{list_item1.title} moved to #{list2.name} successfully"
         assert_publishing_api_put_content(
           tag.content_id,
           request_json_includes(
@@ -510,7 +510,7 @@ RSpec.describe ListItemsController, type: :controller do
         patch :update_move, params: {
           tag_id: tag.content_id,
           list_id: list1.id,
-          id: list_item2.id,
+          id: list_item1.id,
           list_item: { new_list_id: list2.id },
         }
 
@@ -519,7 +519,7 @@ RSpec.describe ListItemsController, type: :controller do
         expect(list2.list_items.first.index).to eq 1
         expect(response.status).to eq(302)
         expect(response).to redirect_to(tag_list_path(tag, list1))
-        expect(flash.notice).to eq "Item moved to new list successfully"
+        expect(flash.notice).to eq "#{list_item1.title} moved to #{list2.name} successfully"
         assert_publishing_api_put_content(
           tag.content_id,
           request_json_includes(
@@ -528,13 +528,13 @@ RSpec.describe ListItemsController, type: :controller do
                 {
                   "name" => list1.name,
                   "contents" => [
-                    list_item1.base_path,
+                    list_item2.base_path,
                   ],
                 },
                 {
                   "name" => list2.name,
                   "contents" => [
-                    list_item2.base_path,
+                    list_item1.base_path,
                   ],
                 },
               ],


### PR DESCRIPTION
## Description 

This adds additional content based on feedback from Design that the flash messages should be slightly more verbose and use consistent language.

The document with the requested changes can be found here https://docs.google.com/document/d/1FWW9oY6vD6WTJH5QJh2xqV2rc1onU9ajC63Bo2xUYno/edit

## Screenshots

### New list 

|Before|After|
|-----------|-----------|
|<img width="942" alt="image" src="https://user-images.githubusercontent.com/42515961/172374412-c2424198-b88b-4006-9899-af13ccd74d8e.png">|<img width="917" alt="image" src="https://user-images.githubusercontent.com/42515961/172372563-5e826cfd-ff64-40bb-90fa-f73b09ee88b7.png">|

### Edit list

|Before|After|
|-----------|-----------|
|<img width="981" alt="image" src="https://user-images.githubusercontent.com/42515961/172374487-5db31d08-0426-4052-a626-12b01f56474e.png">|<img width="937" alt="image" src="https://user-images.githubusercontent.com/42515961/172372635-ddfe7feb-3969-4075-959f-19f19a7c585a.png">|

### Delete list 

|Before|After|
|-----------|-----------|
|<img width="911" alt="image" src="https://user-images.githubusercontent.com/42515961/172374330-38a9b96a-7cff-4fb8-af13-b4d4c51e3122.png">|<img width="912" alt="image" src="https://user-images.githubusercontent.com/42515961/172372828-73469208-55bd-4ddd-af2f-82500fe67add.png">|

### Adding links

|Before|After|
|-----------|-----------|
|<img width="889" alt="image" src="https://user-images.githubusercontent.com/42515961/172374274-9cc53cdf-bd93-4e42-b27d-d1bf68cbcaa5.png">|<img width="887" alt="image" src="https://user-images.githubusercontent.com/42515961/172372970-5c8afddd-b5a2-4e8a-b35c-c8d75702426f.png">|

**and singular**

<img width="936" alt="image" src="https://user-images.githubusercontent.com/42515961/172373113-bb5eef3c-4705-4b8b-a1c1-1c1374d66f57.png">
 
### Removing link

|Before|After|
|-----------|-----------|
|<img width="930" alt="image" src="https://user-images.githubusercontent.com/42515961/172374178-3eff641b-c6ba-4606-8f9c-c8fe36e3ad82.png">|<img width="918" alt="image" src="https://user-images.githubusercontent.com/42515961/172373155-b127b68c-4816-4b4d-96df-7c47aa184207.png">|

### Reordering links

|Before|After|
|-----------|-----------|
|<img width="904" alt="image" src="https://user-images.githubusercontent.com/42515961/172373677-3289aa34-7dd2-46bb-8ec8-946995fce23f.png">|<img width="949" alt="image" src="https://user-images.githubusercontent.com/42515961/172373224-0e7bee9d-cb6b-469d-b2bb-90f565336bf9.png">|

### Moving link to different list

|Before|After|
|-----------|-----------|
|<img width="942" alt="image" src="https://user-images.githubusercontent.com/42515961/172373524-8f5b0352-0585-48f5-8882-d948b23120d2.png">|<img width="954" alt="image" src="https://user-images.githubusercontent.com/42515961/172373289-05bf9538-3346-4f68-8ec1-765b6880d4aa.png">|

## Trello card 

https://trello.com/c/9VoxrVPi/413-rebuild-curate-lists-page-on-collections-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
