### PR TITLE
Set environment variables before running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,13 +3,14 @@
 library("govuk")
 
 node {
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
+
+  // Run against the MySQL 8 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/collections_publisher_test")
+  
   govuk.buildProject(
     rubyLintDirs: "",
     publishingE2ETests: true,
     brakeman: true
   )
-  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-collections-publisher")
-
-  // Run against the MySQL 8 Docker instance on GOV.UK CI
-  govuk.setEnvar("TEST_DATABASE_URL", "mysql2://root:root@127.0.0.1:33068/collections_publisher_test")
 }


### PR DESCRIPTION
The environment variables set-up here were not having any impact because the govuk.buildProject method was called before them.

This means that we were running the full e2e test suite - not just collections publisher tests, and not using MySQL 8 in tests 🤦

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
