### PR TITLE
Fix lists related bugs

### DIFF
--- a/app/helpers/error_items_helper.rb
+++ b/app/helpers/error_items_helper.rb
@@ -6,6 +6,8 @@ module ErrorItemsHelper
   end
 
   def errors_for(object, attribute)
+    return nil if object.errors.blank?
+
     object.errors.errors.filter_map do |error|
       if error.attribute == attribute
         {

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -74,7 +74,7 @@
             {
               link: {
                 text: list_item.title,
-                path: content_tagger_url + '/taggings/' + @tag.tagged_document_for_base_path(list_item.base_path).content_id,
+                path: content_tagger_url + '/taggings/' + (@tag.tagged_document_for_base_path(list_item.base_path)&.content_id || "lookup"),
               },
               metadata: metadata
             },


### PR DESCRIPTION
## Description 

While testing the new functionality, I have come across two bugs.

1. An empty array is passed as an error message on the move item page 
<img width="462" alt="image" src="https://user-images.githubusercontent.com/42515961/172638986-6d0d15a1-8394-4164-89fe-0db78836406c.png">

The error handling for the checkbox component is built slightly differently to the other components. Resultantly, an empty array is rendered as an error message for the checkbox component. This is due to there not being a presence check within the checkbox component within the text output.

This is easily mitigated on our end by ensuring that objects passed into the errors_for method return nil when errors are not present.

2. Lists where an item has been untagged on content tagger blow up 

At the moment, if someone untags a document on content tagger it causes an error to occur when you attempt to link to the document on content tagger on the list show page. This happens as the link to content tagger is located by parsing the tags tagged documents for a content id to construct the path.

This updates the link so that if a content id cannot be found it passes them to the lookup page on Content Tagger where they can locate the link and update the tagging.

## Trello card

https://trello.com/c/9VoxrVPi/413-rebuild-curate-lists-page-on-collections-publisher


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
