### PR TITLE
Automatically unsubscribe users from emails when a specialist topic is archived

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,6 +1,7 @@
 require "gds_api/publishing_api"
 require "gds_api/content_store"
 require "gds_api/link_checker_api"
+require "gds_api/email_alert_api"
 
 module Services
   def self.publishing_api
@@ -22,6 +23,13 @@ module Services
     @link_checker_api ||= GdsApi::LinkCheckerApi.new(
       Plek.new.find("link-checker-api"),
       bearer_token: ENV["LINK_CHECKER_API_BEARER_TOKEN"],
+    )
+  end
+
+  def self.email_alert_api
+    @email_alert_api || GdsApi::EmailAlertApi.new(
+      Plek.new.find("email-alert-api"),
+      bearer_token: ENV["EMAIL_ALERT_API_BEARER_TOKEN"],
     )
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -22,4 +22,8 @@ class Topic < Tag
       []
     end
   end
+
+  def subscriber_list_search_attributes
+    { "links" => { topics: [content_id] } }
+  end
 end

--- a/app/services/email_alerts_unsubscriber.rb
+++ b/app/services/email_alerts_unsubscriber.rb
@@ -3,16 +3,16 @@ class EmailAlertsUnsubscriber
     new(*args).unsubscribe
   end
 
-  attr_reader :slug, :body, :govuk_request_id
+  attr_reader :item, :body, :govuk_request_id
 
-  def initialize(slug:, body: nil, govuk_request_id: nil)
-    @slug = slug
+  def initialize(item:, body: nil, govuk_request_id: nil)
+    @item = item
     @body = body
     @govuk_request_id = govuk_request_id
   end
 
   def unsubscribe
-    args = { slug: slug }
+    args = { slug: subscriber_list_slug }
 
     if body
       args.merge!({
@@ -27,5 +27,14 @@ class EmailAlertsUnsubscriber
     end
 
     Services.email_alert_api.bulk_unsubscribe(args)
+  end
+
+private
+
+  def subscriber_list_slug
+    subscriber_list = Services.email_alert_api.find_subscriber_list(
+      item.subscriber_list_search_attributes,
+    )
+    subscriber_list.dig("subscriber_list", "slug")
   end
 end

--- a/app/services/email_alerts_unsubscriber.rb
+++ b/app/services/email_alerts_unsubscriber.rb
@@ -5,7 +5,7 @@ class EmailAlertsUnsubscriber
 
   attr_reader :slug, :body, :govuk_request_id
 
-  def initialize(slug:, body: nil)
+  def initialize(slug:, body: nil, govuk_request_id: nil)
     @slug = slug
     @body = body
     @govuk_request_id = govuk_request_id
@@ -19,6 +19,11 @@ class EmailAlertsUnsubscriber
         body: body,
         sender_message_id: SecureRandom.uuid,
       })
+
+      # GOVUK-Request-Id HTTP header is set by Nginx and handled by gds-api-adapters.
+      # For out-of-band processes (asynchronous workers)
+      # it needs to be set explicitly to send emails.
+      args.merge!({ govuk_request_id: govuk_request_id }) if govuk_request_id
     end
 
     Services.email_alert_api.bulk_unsubscribe(args)

--- a/app/services/email_alerts_unsubscriber.rb
+++ b/app/services/email_alerts_unsubscriber.rb
@@ -1,0 +1,26 @@
+class EmailAlertsUnsubscriber
+  def self.call(*args)
+    new(*args).unsubscribe
+  end
+
+  attr_reader :slug, :body, :govuk_request_id
+
+  def initialize(slug:, body: nil)
+    @slug = slug
+    @body = body
+    @govuk_request_id = govuk_request_id
+  end
+
+  def unsubscribe
+    args = { slug: slug }
+
+    if body
+      args.merge!({
+        body: body,
+        sender_message_id: SecureRandom.uuid,
+      })
+    end
+
+    Services.email_alert_api.bulk_unsubscribe(args)
+  end
+end

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -15,6 +15,7 @@ class TagArchiver
       update_tag
       setup_redirects
       republish_tag
+      unsubscribe_from_email_alerts if tag.is_a?(Topic)
     end
   end
 
@@ -55,5 +56,20 @@ private
   def republish_tag
     presenter = TagPresenter.presenter_for(tag)
     ContentItemPublisher.new(presenter).send_to_publishing_api
+  end
+
+  def unsubscribe_from_email_alerts
+    EmailAlertsUnsubscriber.call(
+      slug: tag.slug,
+      body: unsubscribe_email_body,
+    )
+  end
+
+  def unsubscribe_email_body
+    <<~BODY
+      This topic has been archived. You will not get any more emails about it.
+
+      You can find more information about this topic at [#{Plek.new.website_root + successor.base_path}](#{Plek.new.website_root + successor.base_path}).
+    BODY
   end
 end

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -60,7 +60,7 @@ private
 
   def unsubscribe_from_email_alerts
     EmailAlertsUnsubscriber.call(
-      slug: tag.slug,
+      item: tag,
       body: unsubscribe_email_body,
     )
   end

--- a/app/views/topics/propose_archive.html.erb
+++ b/app/views/topics/propose_archive.html.erb
@@ -24,6 +24,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      Users who signed up to get emails for this topic will be sent an email that this topic has been archived.
+    </p>
+    
     <%= form_for @archival, url: archive_topic_path do |f| %>
       <div class="govuk-!-margin-bottom-4">
         <%= render "govuk_publishing_components/components/select", {

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature "Archiving topic tags" do
 
   scenario "User archives published tag" do
     given_there_is_a_published_topic
+    and_there_is_a_subscriber_list_for_the_topic
     and_i_visit_the_topic
     and_i_go_to_the_archive_page
 
@@ -109,5 +110,12 @@ RSpec.feature "Archiving topic tags" do
 
   def then_i_see_that_the_url_isnt_valid
     expect(page).to have_content("This URL isn't a valid target for a redirect on GOV.UK.")
+  end
+
+  def and_there_is_a_subscriber_list_for_the_topic
+    email_alert_api_has_subscriber_list_for_topic(
+      content_id: @topic.content_id,
+      list: { "title" => "Topic", "slug" => "bar" },
+    )
   end
 end

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -1,11 +1,9 @@
 require "rails_helper"
 require "gds_api/test_helpers/content_store"
-require "gds_api/test_helpers/email_alert_api"
 
 RSpec.feature "Archiving topic tags" do
   include CommonFeatureSteps
   include GdsApi::TestHelpers::ContentStore
-  include GdsApi::TestHelpers::EmailAlertApi
 
   before do
     stub_any_publishing_api_call

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -1,12 +1,15 @@
 require "rails_helper"
 require "gds_api/test_helpers/content_store"
+require "gds_api/test_helpers/email_alert_api"
 
 RSpec.feature "Archiving topic tags" do
   include CommonFeatureSteps
   include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::EmailAlertApi
 
   before do
     stub_any_publishing_api_call
+    stub_any_email_alert_api_call
     publishing_api_has_no_linked_items
 
     # Background

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -18,4 +18,15 @@ RSpec.describe Topic do
       expect(base_path).to eql("/topic/foo/bar")
     end
   end
+
+  describe "#subscriber_list_search_attributes" do
+    it "returns search attributes to search subscriber list for the topic" do
+      content_id = SecureRandom.uuid
+      topic = create(:topic, content_id: content_id)
+
+      subscriber_list_search_attributes = topic.subscriber_list_search_attributes
+
+      expect(subscriber_list_search_attributes).to eql({ "links" => { topics: [topic.content_id] } })
+    end
+  end
 end

--- a/spec/services/email_alerts_unsubscriber_spec.rb
+++ b/spec/services/email_alerts_unsubscriber_spec.rb
@@ -1,7 +1,4 @@
-require "gds_api/test_helpers/email_alert_api"
-
 RSpec.describe EmailAlertsUnsubscriber do
-  include GdsApi::TestHelpers::EmailAlertApi
 
   describe ".call" do
     it "calls the email-alert-api with the slug" do

--- a/spec/services/email_alerts_unsubscriber_spec.rb
+++ b/spec/services/email_alerts_unsubscriber_spec.rb
@@ -1,23 +1,34 @@
 RSpec.describe EmailAlertsUnsubscriber do
+  let(:topic) { create(:topic, title: "Child benefit", slug: "child-benefit") }
+
+  before do
+    email_alert_api_has_subscriber_list_for_topic(
+      content_id: topic.content_id,
+      list: {
+        "title" => "Child benefit",
+        "slug" => "tax-credits-and-child-benefit-child-benefit",
+      },
+    )
+  end
 
   describe ".call" do
     it "calls the email-alert-api with the slug" do
-      stub_email_alert_api_bulk_unsubscribe(slug: "funding-programmes")
+      stub_email_alert_api_bulk_unsubscribe(slug: "tax-credits-and-child-benefit-child-benefit")
 
-      expect { described_class.call(slug: "funding-programmes") }.to_not raise_error
+      expect { described_class.call(item: topic) }.to_not raise_error
     end
 
     it "calls the email-alert-api with the slug, email body and generated sender_message_id" do
       allow(SecureRandom).to receive(:uuid).and_return("some-uuid")
       stub_email_alert_api_bulk_unsubscribe_with_message(
-        slug: "secondments-with-government",
+        slug: "tax-credits-and-child-benefit-child-benefit",
         body: "We archived this, soz",
         sender_message_id: "some-uuid",
       )
 
       expect {
         described_class.call(
-          slug: "secondments-with-government",
+          item: topic,
           body: "We archived this, soz",
         )
       }.to_not raise_error
@@ -26,7 +37,7 @@ RSpec.describe EmailAlertsUnsubscriber do
     it "calls the email-alert-api with govuk_request_id when passed in" do
       allow(SecureRandom).to receive(:uuid).and_return("some-uuid")
       stub_email_alert_api_bulk_unsubscribe_with_message(
-        slug: "secondments-with-government",
+        slug: "tax-credits-and-child-benefit-child-benefit",
         govuk_request_id: "govuk-request-id-123",
         body: "We archived this, soz",
         sender_message_id: "some-uuid",
@@ -34,7 +45,7 @@ RSpec.describe EmailAlertsUnsubscriber do
 
       expect {
         described_class.call(
-          slug: "secondments-with-government",
+          item: topic,
           body: "We archived this, soz",
           govuk_request_id: "govuk-request-id-123",
         )
@@ -42,9 +53,11 @@ RSpec.describe EmailAlertsUnsubscriber do
     end
 
     it "raises an error when there is an error from the email_alert_api" do
-      stub_email_alert_api_bulk_unsubscribe_bad_request(slug: "not a valid slug")
+      stub_email_alert_api_does_not_have_subscriber_list({ "links" => { topics: %w[ABC] } })
 
-      expect { described_class.call(slug: "not a valid slug") }.to raise_error(GdsApi::InvalidUrl)
+      expect {
+        described_class.call(item: OpenStruct.new(subscriber_list_search_attributes: { "links" => { topics: %w[ABC] } }, content_id: "ABC"))
+      }.to raise_error(GdsApi::HTTPNotFound)
     end
   end
 end

--- a/spec/services/email_alerts_unsubscriber_spec.rb
+++ b/spec/services/email_alerts_unsubscriber_spec.rb
@@ -1,0 +1,35 @@
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.describe EmailAlertsUnsubscriber do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  describe ".call" do
+    it "calls the email-alert-api with the slug" do
+      stub_email_alert_api_bulk_unsubscribe(slug: "funding-programmes")
+
+      expect { described_class.call(slug: "funding-programmes") }.to_not raise_error
+    end
+
+    it "calls the email-alert-api with the slug, email body and generated sender_message_id" do
+      allow(SecureRandom).to receive(:uuid).and_return("some-uuid")
+      stub_email_alert_api_bulk_unsubscribe_with_message(
+        slug: "secondments-with-government",
+        body: "We archived this, soz",
+        sender_message_id: "some-uuid",
+      )
+
+      expect {
+        described_class.call(
+          slug: "secondments-with-government",
+          body: "We archived this, soz",
+        )
+      }.to_not raise_error
+    end
+
+    it "raises an error when there is an error from the email_alert_api" do
+      stub_email_alert_api_bulk_unsubscribe_bad_request(slug: "not a valid slug")
+
+      expect { described_class.call(slug: "not a valid slug") }.to raise_error(GdsApi::InvalidUrl)
+    end
+  end
+end

--- a/spec/services/email_alerts_unsubscriber_spec.rb
+++ b/spec/services/email_alerts_unsubscriber_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe EmailAlertsUnsubscriber do
       }.to_not raise_error
     end
 
+    it "calls the email-alert-api with govuk_request_id when passed in" do
+      allow(SecureRandom).to receive(:uuid).and_return("some-uuid")
+      stub_email_alert_api_bulk_unsubscribe_with_message(
+        slug: "secondments-with-government",
+        govuk_request_id: "govuk-request-id-123",
+        body: "We archived this, soz",
+        sender_message_id: "some-uuid",
+      )
+
+      expect {
+        described_class.call(
+          slug: "secondments-with-government",
+          body: "We archived this, soz",
+          govuk_request_id: "govuk-request-id-123",
+        )
+      }.to_not raise_error
+    end
+
     it "raises an error when there is an error from the email_alert_api" do
       stub_email_alert_api_bulk_unsubscribe_bad_request(slug: "not a valid slug")
 

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe TagArchiver do
 
       allow(Services).to receive(:email_alert_api).and_return(email_alert_api)
       allow(email_alert_api).to receive(:bulk_unsubscribe)
+      allow(email_alert_api).to receive(:find_subscriber_list).and_return(
+        { "subscriber_list" => { "slug" => "subscriber-list-slug" } },
+      )
     end
 
     it "won't archive parent tags" do
@@ -95,7 +98,7 @@ RSpec.describe TagArchiver do
       expect(Services.publishing_api).to have_received(:put_content)
     end
 
-    it "unsubscribes from email alerts for the specialist topic" do
+    it "unsubscribes from email alerts for the specialist topic (level 2)" do
       tag = create(:topic, :published, parent: create(:topic, slug: "mot"),
                                        slug: "provide-mot-training",
                                        title: "Provide MOT training")
@@ -110,7 +113,7 @@ RSpec.describe TagArchiver do
 
       expect(Services.email_alert_api).to have_received(:bulk_unsubscribe).with(
         hash_including(
-          slug: "provide-mot-training",
+          slug: "subscriber-list-slug",
           body: expected_email_body,
         ),
       )

--- a/spec/support/email_alert_api_helpers.rb
+++ b/spec/support/email_alert_api_helpers.rb
@@ -1,0 +1,16 @@
+require "services"
+require "gds_api/test_helpers/email_alert_api"
+
+module EmailAlertApiHelpers
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  # TODO: Move this to gds-api-adapters
+  def email_alert_api_has_subscriber_list_for_topic(content_id:, list: {})
+    url = "#{EMAIL_ALERT_API_ENDPOINT}/subscriber-lists?links%5Btopics%5D%5B0%5D=#{content_id}"
+    stub_request(:get, url).to_return(status: 200, body: { "subscriber_list" => list }.to_json)
+  end
+end
+
+RSpec.configure do |config|
+  config.include EmailAlertApiHelpers
+end


### PR DESCRIPTION
# Context

When a Specialist topic is archived we need to unsubscribe users from email alerts for this topic and email them to inform them that this topic was archived and there won't be any updates.

This is currently done in a rake task in Email Alert API and requires:
- content designer to create a list of archived topics and redirects 
- developer to update and run the rake task

# Changes proposed in this pull request

- Add Email Alert API as a service via gds-api-adapters
- Add generic EmailAlertsUnsubscriber service
- Unsubscribe users from emails when a specialist topic is archived
- Trigger sending emails to unsubscribed users with the body as per [doc](https://docs.google.com/document/d/1ixKUkQQV8OD856B4Bfy_ZxpQFrqM0GaLDumesPspWbo/edit)
- Add notice on archive specialist topic page about unsubscribing users
<kbd><img width="489" alt="Screenshot 2022-06-08 at 09 49 41" src="https://user-images.githubusercontent.com/38078064/172874082-ea826add-35f2-4acf-854f-fa8f90354213.png"></kbd>

Trello card: https://trello.com/c/CQlLYnrF/1038-automate-unsubscribing-from-archived-specialist-topics-l

## Notes / comments

I considered using Sidekiq worker for this but decided against it (see card for details).
Tested in integration: <kbd><img width="706" alt="Screenshot 2022-06-29 at 13 25 56" src="https://user-images.githubusercontent.com/38078064/176435870-8f463912-0de8-42a1-8a32-4507fcdfcb78.png"></kbd>

# Depends on / To do

- https://github.com/alphagov/govuk-secrets/pull/1298
- https://github.com/alphagov/govuk-puppet/pull/11703
- https://github.com/alphagov/gds-api-adapters/pull/1146
- https://github.com/alphagov/gds-api-adapters/pull/1151
- https://github.com/alphagov/collections-publisher/pull/1630
  - [x] rebase this PR with main for the test to pass
- [x] find the correct subscriber list slug

[^1]: https://github.com/alphagov/email-alert-api/blob/main/app/controllers/subscriber_lists_controller.rb#L56-L75
[^2]: https://github.com/alphagov/gds-api-adapters/blob/58bd9a8/lib/gds_api/email_alert_api.rb#L251-L269
---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
