### PR TITLE
Bring specialist topics into browse curation

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -19,13 +19,32 @@ class List < ApplicationRecord
   end
 
   def available_list_items
-    tag
-    .tagged_documents
-    .documents
-    .reject do |link|
-      list_items
-      .map(&:base_path)
-      .include?(link["base_path"])
+    list_items_tagged_to_this_tag =
+      tag
+      .tagged_documents
+      .documents
+      .reject do |link|
+        list_items
+        .map(&:base_path)
+        .include?(link["base_path"])
+      end
+    # browse/benefits
+    if tag.parent.content_id == "f141fa95-0d79-4aed-8429-ed223a8f106a"
+      subtopics = Tag.find_by(content_id: "4505d908-89f2-4322-956b-29ac243c608b").children
+      list_items_tagged_to_mapped_equivalent =
+        # topic/benefits-credits
+        subtopics.map do |child|
+          child.tagged_documents
+               .documents
+               .reject do |link|
+            list_items
+           .map(&:base_path)
+           .include?(link["base_path"])
+          end
+        end
+      (list_items_tagged_to_this_tag + list_items_tagged_to_mapped_equivalent).flatten
+    else
+      list_items_tagged_to_this_tag
     end
   end
 

--- a/app/models/tagged_documents.rb
+++ b/app/models/tagged_documents.rb
@@ -9,7 +9,7 @@ class TaggedDocuments
 
   def documents
     @documents ||= search_result.map do |result|
-      Document.new(result["title"], result["base_path"], result["content_id"])
+      Document.new(result["title"], result["base_path"], result["content_id"], tag.type)
     end
   end
 
@@ -31,5 +31,5 @@ private
     end
   end
 
-  Document = Struct.new(:title, :base_path, :content_id)
+  Document = Struct.new(:title, :base_path, :content_id, :tag_type)
 end

--- a/app/views/lists/edit_list_items.html.erb
+++ b/app/views/lists/edit_list_items.html.erb
@@ -20,7 +20,7 @@
         error: (@list.errors[:list_items].first if errors_for(@list, :list_items).present?),
         items: @list.available_list_items.map do |list_item|
           {
-            label: list_item.title,
+            label: (list_item.tag_type == "MainstreamBrowsePage" ? list_item.title : "Specialist Topic: #{list_item.title}"),
             value: list_item.base_path,
           }
         end


### PR DESCRIPTION
Very quick spike to investigate bringing content tagged to a specialist topic into a related browse page. I've hard coded a mapping between browse/benefits, and topic/benefits-credits.

To note:
Adding a piece of content to a section of a mainstream browse (or specialist topic) page in collections publisher does not tag the document, and so it doesn't have any impact on breadcrumbs or email alerts. 

Breadcrumb curation is complicated:

<img width="1321" alt="Screenshot 2022-07-12 at 11 11 09" src="https://user-images.githubusercontent.com/17908089/178467147-8bf376a6-d755-4200-8e23-b0faa6262a40.png">

To get a mainstream browse breadcrumb, the breadcrumb selector in publishing components requires that two fields are set to the mainstream browse topic: `parent` AND `mainstream_browse_page` (See [here](https://github.com/alphagov/govuk_publishing_components/blob/404a5ecf39d506ec733fce3eb93dbdc33fc7d961/lib/govuk_publishing_components/presenters/breadcrumb_selector.rb#L50), [here](https://github.com/alphagov/govuk_publishing_components/blob/404a5ecf39d506ec733fce3eb93dbdc33fc7d961/lib/govuk_publishing_components/presenters/contextual_navigation.rb#L40-L42) and [here](https://github.com/alphagov/govuk_publishing_components/blob/404a5ecf39d506ec733fce3eb93dbdc33fc7d961/lib/govuk_publishing_components/presenters/content_breadcrumbs_based_on_ancestors.rb#L30)):

✅  Publisher sets both fields
❌ Content tagger sets only mainstream browse

So if we want to allow specialist content added to a mainstream browse page to get the browse breadcrumb either:

- Update publishing components so that for content tagged to mainstream browse, ignore the parent field if it's nil or contains a topic.
- Update content tagger so that it has the same mainstream browse curation UI as Publisher ie it has a drop down for mainstream browse, and another drop down for mainstream browse breadcrumb (which sets the `parent` field)

## Next steps

If we want to support specialist content being added to mainstream browse without merging the trees:

1. Update collections publisher as per this spike. A mapping would be required. We would need some design input.
2. Update breadcrumb curation as described above


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
