### PR TITLE
Revert "build(deps): bump govuk_publishing_components from 29.14.0 to…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (29.15.0)
+    govuk_publishing_components (29.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -178,7 +178,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
-    i18n (1.11.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     inline_svg (1.8.0)
       activesupport (>= 3.0)


### PR DESCRIPTION
… 29.15.0"

Reverting due to backwards compatibility bug in 29.15.0. See: https://github.com/alphagov/govuk_publishing_components/issues/2861

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
