### PR TITLE
Allow Level 1 Specialist topics to be archived

### DIFF
--- a/app/controllers/mainstream_browse_pages_controller.rb
+++ b/app/controllers/mainstream_browse_pages_controller.rb
@@ -3,7 +3,7 @@ class MainstreamBrowsePagesController < ApplicationController
   before_action :protect_archived_browse_pages!, only: %i[edit update publish]
 
   def index
-    @browse_pages = MainstreamBrowsePage.sorted_parents
+    @browse_pages = MainstreamBrowsePage.sorted_level_one
   end
 
   def show

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,7 +3,7 @@ class TopicsController < ApplicationController
   before_action :protect_archived_tags!, only: %i[edit update publish]
 
   def index
-    @topics = Topic.sorted_parents
+    @topics = Topic.sorted_level_one
   end
 
   def show

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -26,6 +26,10 @@ class MainstreamBrowsePage < Tag
     level_two? && published?
   end
 
+  def can_have_email_subscriptions?
+    false
+  end
+
 private
 
   def parents_cannot_have_topics_associated

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -22,6 +22,10 @@ class MainstreamBrowsePage < Tag
     %w[.json]
   end
 
+  def can_be_archived?
+    level_two? && published?
+  end
+
 private
 
   def parents_cannot_have_topics_associated

--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -11,7 +11,7 @@ class MainstreamBrowsePage < Tag
   end
 
   def dependent_tags
-    if child?
+    if level_two?
       parent.children - [self] + [parent]
     else
       MainstreamBrowsePage.all - [self]
@@ -20,10 +20,6 @@ class MainstreamBrowsePage < Tag
 
   def subroutes
     %w[.json]
-  end
-
-  def top_level_mainstream_browse_page?
-    !child?
   end
 
 private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -157,6 +157,10 @@ class Tag < ApplicationRecord
     raise NotImplementedError
   end
 
+  def can_have_email_subscriptions?
+    raise NotImplementedError
+  end
+
 private
 
   def parent_is_not_a_child

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,8 +27,8 @@ class Tag < ApplicationRecord
 
   before_validation :generate_content_id, on: :create
 
-  scope :only_parents, -> { where("parent_id IS NULL") }
-  scope :only_children, -> { where("parent_id IS NOT NULL") }
+  scope :only_level_two, -> { where("parent_id IS NULL") }
+  scope :only_level_one, -> { where("parent_id IS NOT NULL") }
 
   # The links last sent to the content-store.
   serialize :published_groups, JSON
@@ -65,11 +65,11 @@ class Tag < ApplicationRecord
     parent.present?
   end
 
-  alias_method :child?, :has_parent?
-  alias_method :parent?, :can_have_children?
+  alias_method :level_two?, :has_parent?
+  alias_method :level_one?, :can_have_children?
 
-  def self.sorted_parents
-    only_parents.includes(children: [:lists]).order(:title)
+  def self.sorted_level_one
+    only_level_two.includes(children: [:lists]).order(:title)
   end
 
   def sorted_children
@@ -141,10 +141,6 @@ class Tag < ApplicationRecord
 
   def dependent_tags
     [] # should be overridden in subclasses
-  end
-
-  def top_level_mainstream_browse_page?
-    false # should be overridden in subclasses
   end
 
   def lists_that_do_not_include_list_item(list_item)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -86,6 +86,10 @@ class Tag < ApplicationRecord
     sorted_children.reject { |child| child.state == "archived" }
   end
 
+  def has_active_children?
+    children.draft.any? || children.published.any?
+  end
+
   def title_including_parent
     if has_parent?
       "#{parent.title} / #{title}"
@@ -150,7 +154,7 @@ class Tag < ApplicationRecord
   end
 
   def can_be_archived?
-    level_two? && published?
+    raise NotImplementedError
   end
 
 private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -149,6 +149,10 @@ class Tag < ApplicationRecord
     end
   end
 
+  def can_be_archived?
+    level_two? && published?
+  end
+
 private
 
   def parent_is_not_a_child

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -23,6 +23,10 @@ class Topic < Tag
     end
   end
 
+  def can_be_archived?
+    published? && !has_active_children?
+  end
+
   def subscriber_list_search_attributes
     { "links" => { topics: [content_id] } }
   end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -27,6 +27,10 @@ class Topic < Tag
     published? && !has_active_children?
   end
 
+  def can_have_email_subscriptions?
+    level_two?
+  end
+
   def subscriber_list_search_attributes
     { "links" => { topics: [content_id] } }
   end

--- a/app/presenters/mainstream_browse_page_presenter.rb
+++ b/app/presenters/mainstream_browse_page_presenter.rb
@@ -11,7 +11,7 @@ private
     super.merge(
       "related_topics" => @tag.topics.order(:title).map(&:content_id),
       "active_top_level_browse_page" => active_top_level_browse_page_id,
-      "top_level_browse_pages" => @tag.class.sorted_parents.map(&:content_id),
+      "top_level_browse_pages" => @tag.class.sorted_level_one.map(&:content_id),
       "second_level_browse_pages" => second_level_browse_pages,
       "primary_publishing_organisation" => [GDS_CONTENT_ID],
     )
@@ -33,7 +33,7 @@ private
   end
 
   def second_level_browse_pages
-    if @tag.child?
+    if @tag.level_two?
       @tag.parent.sorted_children.map(&:content_id)
     else
       @tag.sorted_children.map(&:content_id)
@@ -41,7 +41,7 @@ private
   end
 
   def second_level_ordering
-    if @tag.child?
+    if @tag.level_two?
       @tag.parent.child_ordering
     else
       @tag.child_ordering

--- a/app/presenters/root_browse_page_presenter.rb
+++ b/app/presenters/root_browse_page_presenter.rb
@@ -42,7 +42,7 @@ class RootBrowsePagePresenter
 private
 
   def top_level_browse_pages
-    MainstreamBrowsePage.sorted_parents
+    MainstreamBrowsePage.sorted_level_one
   end
 
   def public_updated_at

--- a/app/presenters/root_topic_presenter.rb
+++ b/app/presenters/root_topic_presenter.rb
@@ -44,7 +44,7 @@ class RootTopicPresenter
 private
 
   def topics
-    Topic.sorted_parents
+    Topic.sorted_level_one
   end
 
   def public_updated_at

--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -7,7 +7,7 @@ class DraftTagRemover
 
   def remove
     raise "Can't unpublish published tags with this class" if tag.published?
-    raise "Can't unpublish parent tags" if tag.parent?
+    raise "Can't unpublish parent tags" if tag.level_one?
 
     Tag.transaction do
       add_gone_item

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -15,7 +15,7 @@ class TagArchiver
       update_tag
       setup_redirects
       republish_tag
-      unsubscribe_from_email_alerts if tag.is_a?(Topic)
+      unsubscribe_from_email_alerts
     end
   end
 
@@ -59,6 +59,8 @@ private
   end
 
   def unsubscribe_from_email_alerts
+    return unless tag.can_have_email_subscriptions?
+
     EmailAlertsUnsubscriber.call(
       item: tag,
       body: unsubscribe_email_body,

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -9,7 +9,7 @@ class TagArchiver
   end
 
   def archive
-    raise "Can't archive parent tags" unless tag.can_be_archived?
+    raise "Can't archive this tag" unless tag.can_be_archived?
 
     Tag.transaction do
       update_tag

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -9,7 +9,7 @@ class TagArchiver
   end
 
   def archive
-    raise "Can't archive parent tags" if tag.level_one?
+    raise "Can't archive parent tags" unless tag.can_be_archived?
 
     Tag.transaction do
       update_tag

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -9,7 +9,7 @@ class TagArchiver
   end
 
   def archive
-    raise "Can't archive parent tags" if tag.can_have_children?
+    raise "Can't archive parent tags" if tag.level_one?
 
     Tag.transaction do
       update_tag

--- a/app/views/mainstream_browse_pages/_create_update_form.html.erb
+++ b/app/views/mainstream_browse_pages/_create_update_form.html.erb
@@ -5,7 +5,7 @@
         id: "mainstream_browse_page_parent_id",
         name: "mainstream_browse_page[parent_id]",
         label: "Parent (optional)",
-        options: MainstreamBrowsePage.sorted_parents
+        options: MainstreamBrowsePage.sorted_level_one
                   .map { |topic| {text: topic.title, value: topic.id, selected: topic.id == f.object.parent_id} }
                   .prepend( { text: "", value: "" } )
       } %>
@@ -44,7 +44,7 @@
     error_items: errors_for(@browse_page, :description)
   } %>
 
-  <% if @browse_page.child? && update %>
+  <% if @browse_page.level_two? && update %>
     <%= render "govuk_publishing_components/components/checkboxes", {
       name: "mainstream_browse_page[topics][]",
       heading: "Topics",

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -98,22 +98,20 @@
               %>
             </div>
           <% end %>
-          <% if @browse_page.level_two? %>
-            <div class="govuk-!-margin-bottom-1">
-              <% if @browse_page.published? %>
-                <%= link_to 'Archive mainstream browse page',
-                  propose_archive_mainstream_browse_page_path(@browse_page),
-                  class: %w(govuk-link govuk-link--no-visited-state)
-                %>
-              <% else %>
-                <%= link_to 'Delete page', archive_mainstream_browse_page_path(@browse_page),
-                  method: 'post',
-                  data: { confirm: 'Are you sure?' },
-                  class: %w(govuk-link app-link--destructive)
-                %>
-              <% end %>
-            </div>
-          <% end %>
+          <div class="govuk-!-margin-bottom-1">
+            <% if @browse_page.can_be_archived? %>
+              <%= link_to 'Archive mainstream browse page',
+                propose_archive_mainstream_browse_page_path(@browse_page),
+                class: %w(govuk-link govuk-link--no-visited-state)
+              %>
+            <% elsif @browse_page.level_two? %>
+              <%= link_to 'Delete page', archive_mainstream_browse_page_path(@browse_page),
+                method: 'post',
+                data: { confirm: 'Are you sure?' },
+                class: %w(govuk-link app-link--destructive)
+              %>
+            <% end %>
+          </div>
         </div>
       </div>
     </aside>

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -42,7 +42,7 @@
           *([
             field: "Subtopic ordering",
             value: @browse_page.child_ordering.capitalize
-          ] if @browse_page.top_level_mainstream_browse_page? )
+          ] if @browse_page.level_one? )
         ],
         edit: {
           href: edit_mainstream_browse_page_path(@browse_page),
@@ -63,7 +63,7 @@
       </section>
     <% end %>
 
-    <% if @browse_page.child? %>
+    <% if @browse_page.level_two? %>
       <section class="govuk-!-margin-bottom-3">
         <%= render 'shared/list-links-preview', tag: @browse_page %>
       </section>
@@ -98,7 +98,7 @@
               %>
             </div>
           <% end %>
-          <% if @browse_page.child? %>
+          <% if @browse_page.level_two? %>
             <div class="govuk-!-margin-bottom-1">
               <% if @browse_page.published? %>
                 <%= link_to 'Archive mainstream browse page',

--- a/app/views/topics/_create_update_form.html.erb
+++ b/app/views/topics/_create_update_form.html.erb
@@ -5,7 +5,7 @@
         id: "topic_parent_id",
         name: "topic[parent_id]",
         label: "Parent (optional)",
-        options: Topic.sorted_parents
+        options: Topic.sorted_level_one
                   .map { |topic| {text: topic.title, value: topic.id, selected: topic.id == f.object.parent_id} }
                   .prepend( { text: "", value: "" } )
       } %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -82,22 +82,20 @@
               <% end %>
             </div>
           <% end %>
-          <% if @topic.level_two? %>
-            <div class="govuk-!-margin-bottom-1">
-              <% if @topic.published? %>
-                <%= link_to 'Archive specialist topic page',
-                  propose_archive_topic_path(@topic),
-                  class: %w(govuk-link govuk-link--no-visited-state)
-                %>
-              <% else %>
-                <%= link_to 'Delete', archive_topic_path(@topic),
-                  method: 'post',
-                  data: { confirm: 'Are you sure?' },
-                  class: %w(govuk-link app-link--destructive)
-                %>
-              <% end %>
-            </div>
-          <% end %>
+          <div class="govuk-!-margin-bottom-1">
+            <% if @topic.can_be_archived? %>
+              <%= link_to 'Archive specialist topic page',
+                propose_archive_topic_path(@topic),
+                class: %w(govuk-link govuk-link--no-visited-state)
+              %>
+            <% elsif @topic.level_two? %>
+              <%= link_to 'Delete', archive_topic_path(@topic),
+                method: 'post',
+                data: { confirm: 'Are you sure?' },
+                class: %w(govuk-link app-link--destructive)
+              %>
+            <% end %>
+          </div>
         </div>
       </div>
     </aside>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -53,7 +53,7 @@
       </section>
     <% end %>
 
-    <% if @topic.child? %>
+    <% if @topic.level_two? %>
       <section class="govuk-!-margin-bottom-3">
         <%= render 'shared/list-links-preview', tag: @topic %>
       </section>
@@ -82,7 +82,7 @@
               <% end %>
             </div>
           <% end %>
-          <% if @topic.child? %>
+          <% if @topic.level_two? %>
             <div class="govuk-!-margin-bottom-1">
               <% if @topic.published? %>
                 <%= link_to 'Archive specialist topic page',

--- a/db/migrate/20150622073727_add_redirects_for_topics_namespace.rb
+++ b/db/migrate/20150622073727_add_redirects_for_topics_namespace.rb
@@ -1,6 +1,6 @@
 class AddRedirectsForTopicsNamespace < ActiveRecord::Migration
   def up
-    Topic.published.only_parents.each do |topic|
+    Topic.published.only_level_two.each do |topic|
       original_topic_base_path = '/' + topic.full_slug
 
       Redirect.create!(
@@ -11,7 +11,7 @@ class AddRedirectsForTopicsNamespace < ActiveRecord::Migration
       )
     end
 
-    Topic.published.only_children.each do |topic|
+    Topic.published.only_level_one.each do |topic|
       original_topic_base_path = '/' + topic.full_slug
 
       Redirect.create!(

--- a/db/migrate/20150625151822_add_browse_redirects.rb
+++ b/db/migrate/20150625151822_add_browse_redirects.rb
@@ -4,7 +4,7 @@ class AddBrowseRedirects < ActiveRecord::Migration
       'business',
       'visas-immigration',
     ].each do |slug|
-      page = MainstreamBrowsePage.only_parents.where(:slug => slug).first
+      page = MainstreamBrowsePage.only_level_two.where(:slug => slug).first
       raise "Failed to find top-level browse page with slug #{slug}" unless page
 
       Redirect.create!(

--- a/db/migrate/20150713124417_import_router_data_browse_redirects.rb
+++ b/db/migrate/20150713124417_import_router_data_browse_redirects.rb
@@ -20,7 +20,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
     )
 
     # /browse/citizenship/coasts-countryside,/browse/environment-countryside
-    environment_countryside = MainstreamBrowsePage.only_parents.find_by!(:slug => 'environment-countryside')
+    environment_countryside = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'environment-countryside')
     @redirects << Redirect.create!(
       :tag => environment_countryside,
       :original_tag_base_path => "/browse/citizenship/coasts-countryside",
@@ -29,7 +29,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
     )
 
     # /browse/driving/passports-travelling-abroad,/browse/abroad
-    abroad = MainstreamBrowsePage.only_parents.find_by!(:slug => 'abroad')
+    abroad = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'abroad')
     @redirects << Redirect.create!(
       :tag => abroad,
       :original_tag_base_path => "/browse/driving/passports-travelling-abroad",
@@ -46,7 +46,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
     )
 
     # /browse/housing,/browse/housing-local-services
-    housing_local_services = MainstreamBrowsePage.only_parents.find_by!(:slug => 'housing-local-services')
+    housing_local_services = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'housing-local-services')
     @redirects << Redirect.create!(
       :tag => housing_local_services,
       :original_tag_base_path => "/browse/housing",
@@ -74,7 +74,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
       )
     end
 
-    visas_immigration = MainstreamBrowsePage.only_parents.find_by!(:slug => 'visas-immigration')
+    visas_immigration = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'visas-immigration')
     {
       "after-youve-applied" => "manage-your-application",
       "employers-sponsorship" => "sponsor-workers-students",

--- a/db/migrate/20150714140302_import_router_data_topic_redirects.rb
+++ b/db/migrate/20150714140302_import_router_data_topic_redirects.rb
@@ -11,7 +11,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
 
   def create_redirects
     # /childrens-services,/topic/schools-colleges-childrens-services
-    schools_colleges_childrens_services = Topic.only_parents.find_by!(:slug => 'schools-colleges-childrens-services')
+    schools_colleges_childrens_services = Topic.only_level_two.find_by!(:slug => 'schools-colleges-childrens-services')
     @redirects << Redirect.create!(
       :tag => schools_colleges_childrens_services,
       :original_tag_base_path => "/childrens-services",
@@ -41,7 +41,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
 
     # /commercial-fishing-fisheries/monitoring-enforcement,/topic/commercial-fishing-fisheries/regulations-monitoring-enforcement
     # /commercial-fishing-fisheries/regulations-restrictions,/topic/commercial-fishing-fisheries/regulations-monitoring-enforcement
-    commercial_fishing_fisheries = Topic.only_parents.find_by!(:slug => 'commercial-fishing-fisheries')
+    commercial_fishing_fisheries = Topic.only_level_two.find_by!(:slug => 'commercial-fishing-fisheries')
     {
       "monitoring-enforcement" => "regulations-monitoring-enforcement",
       "regulations-restrictions" => "regulations-monitoring-enforcement",
@@ -55,7 +55,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
       )
     end
 
-    competition = Topic.only_parents.find_by!(:slug => 'competition')
+    competition = Topic.only_level_two.find_by!(:slug => 'competition')
     [
       "business-law-compliance",
       "competition-law-compliance",
@@ -86,7 +86,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
     end
 
     # /health-protection/migrant-health,/topic/health-protection
-    health_protection = Topic.only_parents.find_by!(:slug => 'health-protection')
+    health_protection = Topic.only_level_two.find_by!(:slug => 'health-protection')
     @redirects << Redirect.create!(
       :tag => health_protection,
       :original_tag_base_path => "/health-protection/migrant-health",
@@ -118,7 +118,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
     end
 
     # /schools-colleges,/topic/schools-colleges-childrens-services
-    schools_colleges_childrens_services = Topic.only_parents.find_by!(:slug => 'schools-colleges-childrens-services')
+    schools_colleges_childrens_services = Topic.only_level_two.find_by!(:slug => 'schools-colleges-childrens-services')
     @redirects << Redirect.create!(
       :tag => schools_colleges_childrens_services,
       :original_tag_base_path => "/schools-colleges",

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature "Archiving topic tags" do
     then_i_see_that_archived_topics_cannot_be_modified
   end
 
-  scenario "User archives published tag" do
-    given_there_is_a_published_topic
+  scenario "User archives published level 2 tag" do
+    given_there_is_a_published_level_2_topic
     and_there_is_a_subscriber_list_for_the_topic
     and_i_visit_the_topic
     and_i_go_to_the_archive_page
@@ -43,8 +43,20 @@ RSpec.feature "Archiving topic tags" do
     then_the_tag_is_deleted
   end
 
+  scenario "User archives published level 1 tag" do
+    given_there_is_a_published_level_1_topic
+    and_i_visit_the_topic
+    and_i_go_to_the_archive_page
+
+    when_i_redirect_the_topic_to_a_successor_topic
+    then_the_tag_is_archived
+
+    when_i_visit_the_topic_edit_page
+    then_i_see_that_i_cannot_edit_the_page
+  end
+
   scenario "User redirects to invalid basepath" do
-    given_there_is_a_published_topic
+    given_there_is_a_published_level_2_topic
     and_i_visit_the_topic
     and_i_go_to_the_archive_page
     when_i_submit_an_invalid_base_path_as_redirect
@@ -76,12 +88,16 @@ RSpec.feature "Archiving topic tags" do
     @topic = create(:topic, :archived)
   end
 
-  def given_there_is_a_published_topic
+  def given_there_is_a_published_level_2_topic
     @topic = create(:topic, :published, slug: "bar", parent: create(:topic, slug: "foo"))
   end
 
   def given_there_is_a_draft_topic
     @topic = create(:topic, :draft, slug: "bar", parent: create(:topic, slug: "foo"))
+  end
+
+  def given_there_is_a_published_level_1_topic
+    @topic = create(:topic, :published, slug: "bar")
   end
 
   def and_there_is_a_topic_that_can_be_used_as_a_replacement

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -19,4 +19,30 @@ RSpec.describe MainstreamBrowsePage do
       expect(tag.base_path).to eq("/browse/#{tag.slug}")
     end
   end
+
+  describe "#can_be_archived?" do
+    it "returns true for published level two mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
+
+      expect(mainstream_browse_page.can_be_archived?).to eql(true)
+    end
+
+    it "returns false for draft level two mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :draft, parent: create(:mainstream_browse_page))
+
+      expect(mainstream_browse_page.can_be_archived?).to eql(false)
+    end
+
+    it "returns false for archived level two mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :archived, parent: create(:mainstream_browse_page))
+
+      expect(mainstream_browse_page.can_be_archived?).to eql(false)
+    end
+
+    it "returns false for level one mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :published, parent: nil, children: [create(:mainstream_browse_page, :draft)])
+
+      expect(mainstream_browse_page.can_be_archived?).to eql(false)
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -155,6 +155,32 @@ RSpec.describe Tag do
     end
   end
 
+  describe "#has_active_children?" do
+    it "returns true when tag has any published children" do
+      tag = create(:tag, children: [create(:tag, :published)])
+
+      expect(tag.has_active_children?).to eql true
+    end
+
+    it "returns true when tag has any draft children" do
+      tag = create(:tag, children: [create(:tag, :draft)])
+
+      expect(tag.has_active_children?).to eql true
+    end
+
+    it "returns false when tag has only archived children" do
+      tag = create(:tag, children: [create(:tag, :archived)])
+
+      expect(tag.has_active_children?).to eql false
+    end
+
+    it "returns false when tag has no children" do
+      tag = create(:tag, children: [])
+
+      expect(tag.has_active_children?).to eql false
+    end
+  end
+
   describe "generating a content ID" do
     it "generates a UUID on creation" do
       expect(SecureRandom).to receive(:uuid).and_return("a random UUID")

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe Topic do
     end
   end
 
+  describe "#can_have_email_subscriptions?" do
+    it "returns true for level two topic" do
+      topic = create(:topic, parent: create(:topic))
+
+      expect(topic.can_have_email_subscriptions?).to eql(true)
+    end
+
+    it "returns false for level one topic" do
+      topic = create(:topic, parent: nil)
+
+      expect(topic.can_have_email_subscriptions?).to eql(false)
+    end
+  end
+
   describe "#subscriber_list_search_attributes" do
     it "returns search attributes to search subscriber list for the topic" do
       content_id = SecureRandom.uuid

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -19,6 +19,32 @@ RSpec.describe Topic do
     end
   end
 
+  describe "#can_be_archived?" do
+    it "returns true for published level two topic" do
+      topic = create(:topic, :published, parent: create(:topic))
+
+      expect(topic.can_be_archived?).to eql(true)
+    end
+
+    it "returns false for draft level two topic" do
+      topic = create(:topic, :draft, parent: create(:topic))
+
+      expect(topic.can_be_archived?).to eql(false)
+    end
+
+    it "returns false for archived level two topic" do
+      topic = create(:topic, :archived, parent: create(:topic))
+
+      expect(topic.can_be_archived?).to eql(false)
+    end
+
+    it "returns false for level one topic" do
+      topic = create(:topic, :published, parent: nil)
+
+      expect(topic.can_be_archived?).to eql(false)
+    end
+  end
+
   describe "#subscriber_list_search_attributes" do
     it "returns search attributes to search subscriber list for the topic" do
       content_id = SecureRandom.uuid

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -38,8 +38,26 @@ RSpec.describe Topic do
       expect(topic.can_be_archived?).to eql(false)
     end
 
-    it "returns false for level one topic" do
-      topic = create(:topic, :published, parent: nil)
+    it "returns true for published level one topic without children (subtopics)" do
+      topic = create(:topic, :published, parent: nil, children: [])
+
+      expect(topic.can_be_archived?).to eql(true)
+    end
+
+    it "returns true for published level one topic when all children (subtopics) are archived" do
+      topic = create(:topic, :published, parent: nil, children: [create(:topic, :archived)])
+
+      expect(topic.can_be_archived?).to eql(true)
+    end
+
+    it "returns false for published level one topic when it has draft children (subtopics)" do
+      topic = create(:topic, :published, parent: nil, children: [create(:topic, :draft)])
+
+      expect(topic.can_be_archived?).to eql(false)
+    end
+
+    it "returns false for published level one topic when it has published children (subtopics)" do
+      topic = create(:topic, :published, parent: nil, children: [create(:topic, :published)])
 
       expect(topic.can_be_archived?).to eql(false)
     end

--- a/spec/services/draft_tag_remover_spec.rb
+++ b/spec/services/draft_tag_remover_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DraftTagRemover do
       expect { DraftTagRemover.new(topic).remove }.to raise_error(RuntimeError)
     end
 
-    it "guards against removing parent tags" do
+    it "guards against removing parent (level 1) tags" do
       topic = create(:topic, :draft)
 
       expect { DraftTagRemover.new(topic).remove }.to raise_error(RuntimeError)

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -134,8 +134,16 @@ RSpec.describe TagArchiver do
       )
     end
 
-    it "doesn't attempt to unsbscribe from email alerts when mainstream browse page is archived" do
+    it "doesn't attempt to unsubscribe from email alerts when mainstream browse page is archived" do
       tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
+
+      TagArchiver.new(tag, build(:mainstream_browse_page)).archive
+
+      expect(Services.email_alert_api).to_not have_received(:bulk_unsubscribe)
+    end
+
+    it "doesn't attempt to unsubscribe from email alerts when level one topic is archived" do
+      tag = create(:topic, :published, children: [create(:topic, :archived)])
 
       TagArchiver.new(tag, build(:mainstream_browse_page)).archive
 

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe TagArchiver do
       )
     end
 
-    it "won't archive parent tags" do
+    it "won't archive parent (level 1) tags" do
       tag = create(:topic, :published)
 
       expect { TagArchiver.new(tag, build(:topic)).archive }.to raise_error(RuntimeError)
     end
 
-    it "archives the tag" do
+    it "archives the level 2 tag" do
       tag = create(:topic, :published, parent: create(:topic))
 
       TagArchiver.new(tag, build(:topic)).archive


### PR DESCRIPTION
## Context

We will be archiving a lot of specialist topics as part of our epic to retire the specialist topic tree. It is currently only possible to archive level two specialist topics in Collections Publisher UI. We need the UI to support archiving level one specialist topics, as it would make the workflow for retiring the specialist topic tree easier.

## Changes proposed in this PR
- Rename methods (see the first commit for details). Related cards:
  - [Write glossary of information architecture related terminology](https://trello.com/c/UgR7LtOm/767-write-glossary-of-information-architecture-related-terminology-for-team-alignment)
  - [Update copy in publishing apps](https://trello.com/c/V4XDiKNe/888-%F0%9F%8F%94epic-update-copy-in-publishing-apps-based-on-jenns-doc)
- Allow Level 1 Specialist topics to be archived
  - 'Archive...' link not showing when there are published subtopics <kbd><img width="787" alt="Screenshot 2022-07-31 at 13 20 46" src="https://user-images.githubusercontent.com/38078064/182026413-f20476dc-ed88-44d6-9a09-5b7b46ebb405.png"></kbd>

  - 'Archive...' link on a page with archived subtopics <kbd><img width="789" alt="Screenshot 2022-07-31 at 13 21 54" src="https://user-images.githubusercontent.com/38078064/182026622-4c21de6e-d606-4b58-9e8e-9881e1af61b5.png"></kbd>

  - Existing Archive view, now also used for level 1 topics
  <kbd><img width="540" alt="Screenshot 2022-07-31 at 13 22 14" src="https://user-images.githubusercontent.com/38078064/182026655-1e26a3bb-4544-48dc-8d46-f592493a7cb8.png"></kbd>

  - Archived Level 1 topic 
  <kbd><img width="592" alt="Screenshot 2022-07-31 at 13 22 35" src="https://user-images.githubusercontent.com/38078064/182026668-09b5e9c8-8e8c-4e3c-9052-026254a764eb.png"></kbd>

### Notes
Because we need this functionality quickly there will be follow up PRs to:
- allow draft level 1 Specialist topics to be removed
- show details of archived subtopics on the archived show page
- ~enable the same functionality for Mainstream browse pages, which inherits from the Tag model~ NOT NEEDED

[Trello](https://trello.com/c/gAyZKjHC/1183-allow-level-one-topics-to-be-archived-via-the-collections-publisher-ui-m)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
