### PR TITLE
Show subtopics on archived specialist topic pages 

### DIFF
--- a/app/views/shared/_list-children-pages.html.erb
+++ b/app/views/shared/_list-children-pages.html.erb
@@ -10,7 +10,7 @@
     <%= table.head do %>
       <%= table.header "Title" %>
       <%= table.header "Status" %>
-      <%= table.header "Actions" if gds_editor? %>
+      <%= table.header "Actions" if gds_editor? && page.has_active_children? %>
     <% end %>
 
     <%= table.body do %>
@@ -36,7 +36,7 @@
           } %>
 
           <%= table.cell govuk_status(child_page) %>
-          <%= table.cell link_to('Edit', edit_polymorphic_path(child_page), class: "govuk-link") if gds_editor? %>
+          <%= table.cell link_to('Edit', edit_polymorphic_path(child_page), class: "govuk-link") if gds_editor? && page.has_active_children?%>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/topics/archived_topic.html.erb
+++ b/app/views/topics/archived_topic.html.erb
@@ -23,5 +23,11 @@
     </p>
 
     <%= render 'shared/redirects', redirect_routes: @topic.redirect_routes %>
+
+    <% if @topic.children.any? %>
+      <section class="govuk-!-margin-bottom-3">
+        <%= render "shared/list-children-pages", page: @topic %>
+      </section>
+    <% end %>
   </div>
 </div>

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature "Archiving topic tags" do
     when_i_visit_the_topic_edit_page
     then_i_see_that_i_cannot_edit_the_page
     and_i_see_archived_subtopics
+    and_i_cannot_see_the_action_to_edit_subtopics
   end
 
   scenario "User redirects to invalid basepath" do
@@ -123,6 +124,11 @@ RSpec.feature "Archiving topic tags" do
 
   def and_i_see_archived_subtopics
     expect(page).to have_content "Subtopics"
+  end
+
+  def and_i_cannot_see_the_action_to_edit_subtopics
+    expect(page).not_to have_css(".govuk-table__header", text: "Actions")
+    expect(page).not_to have_link("Edit")
   end
 
   def when_i_submit_an_invalid_base_path_as_redirect

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -53,6 +53,7 @@ RSpec.feature "Archiving topic tags" do
 
     when_i_visit_the_topic_edit_page
     then_i_see_that_i_cannot_edit_the_page
+    and_i_see_archived_subtopics
   end
 
   scenario "User redirects to invalid basepath" do
@@ -97,7 +98,7 @@ RSpec.feature "Archiving topic tags" do
   end
 
   def given_there_is_a_published_level_1_topic
-    @topic = create(:topic, :published, slug: "bar")
+    @topic = create(:topic, :published, slug: "bar", children: [create(:topic, :archived)])
   end
 
   def and_there_is_a_topic_that_can_be_used_as_a_replacement
@@ -118,6 +119,10 @@ RSpec.feature "Archiving topic tags" do
 
   def then_i_see_that_i_cannot_edit_the_page
     expect(page).to have_content "You cannot modify an archived specialist topic."
+  end
+
+  def and_i_see_archived_subtopics
+    expect(page).to have_content "Subtopics"
   end
 
   def when_i_submit_an_invalid_base_path_as_redirect


### PR DESCRIPTION
## Context
It is possible to archive level 1 specialist topics https://github.com/alphagov/collections-publisher/pull/1650.  We should also show the subtopics (children) and link to them in the archived topic view.
However it’s not possible to edit archived subtopics so we shouldn’t be showing this as an option. The users should still be able to view the archived subtopic and test the redirects.

## Changes proposed

* Add subtopics table to the archived topic page

<kbd><img width="610" alt="Screenshot 2022-08-09 at 06 54 41" src="https://user-images.githubusercontent.com/38078064/183576538-3b392d34-8fd3-4459-9437-c9b6ebe0feff.png"></kbd>

## Review comments
* Because it's not possible to archive a topic with active children (published or draft) in the UI, this subtopic table will only include archived subtopics.
* There is something not quite right with the heading in the views. Resolving this seems out of scope for this PR, so I just followed suit. For example see the headers on the show pages: 

```
<h3 class="govuk-heading-m gem-c-summary-list__group-title">Content</h3>

<h2 class="gem-c-heading gem-c-heading--font-size-27 govuk-!-margin-bottom-3">Subtopics</h2>
```

[Trello](https://trello.com/c/Zl4XSEhQ/1211-show-subtopics-on-archived-specialist-topic-pages-s)
---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
