### PR TITLE
Allow draft Level 1 Specialist topics to be removed 

### DIFF
--- a/app/models/mainstream_browse_page.rb
+++ b/app/models/mainstream_browse_page.rb
@@ -26,6 +26,10 @@ class MainstreamBrowsePage < Tag
     level_two? && published?
   end
 
+  def can_be_removed?
+    level_two? && draft?
+  end
+
   def can_have_email_subscriptions?
     false
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -154,15 +154,15 @@ class Tag < ApplicationRecord
   end
 
   def can_be_archived?
-    raise NotImplementedError
+    raise NoMethodError
   end
 
   def can_be_removed?
-    raise NotImplementedError
+    raise NoMethodError
   end
 
   def can_have_email_subscriptions?
-    raise NotImplementedError
+    raise NoMethodError
   end
 
 private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -157,6 +157,10 @@ class Tag < ApplicationRecord
     raise NotImplementedError
   end
 
+  def can_be_removed?
+    level_two? && draft?
+  end
+
   def can_have_email_subscriptions?
     raise NotImplementedError
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -158,7 +158,7 @@ class Tag < ApplicationRecord
   end
 
   def can_be_removed?
-    level_two? && draft?
+    raise NotImplementedError
   end
 
   def can_have_email_subscriptions?

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -27,6 +27,10 @@ class Topic < Tag
     published? && !has_active_children?
   end
 
+  def can_be_removed?
+    draft? && children.empty?
+  end
+
   def can_have_email_subscriptions?
     level_two?
   end

--- a/app/services/draft_tag_remover.rb
+++ b/app/services/draft_tag_remover.rb
@@ -6,8 +6,7 @@ class DraftTagRemover
   end
 
   def remove
-    raise "Can't unpublish published tags with this class" if tag.published?
-    raise "Can't unpublish parent tags" if tag.level_one?
+    raise "Can't delete this tag" unless tag.can_be_removed?
 
     Tag.transaction do
       add_gone_item

--- a/app/views/mainstream_browse_pages/show.html.erb
+++ b/app/views/mainstream_browse_pages/show.html.erb
@@ -104,7 +104,8 @@
                 propose_archive_mainstream_browse_page_path(@browse_page),
                 class: %w(govuk-link govuk-link--no-visited-state)
               %>
-            <% elsif @browse_page.level_two? %>
+            <% end %>
+            <% if @browse_page.can_be_removed? %>
               <%= link_to 'Delete page', archive_mainstream_browse_page_path(@browse_page),
                 method: 'post',
                 data: { confirm: 'Are you sure?' },

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -88,7 +88,8 @@
                 propose_archive_topic_path(@topic),
                 class: %w(govuk-link govuk-link--no-visited-state)
               %>
-            <% elsif @topic.level_two? %>
+            <% end %>
+            <% if @topic.can_be_removed? %>
               <%= link_to 'Delete', archive_topic_path(@topic),
                 method: 'post',
                 data: { confirm: 'Are you sure?' },

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -36,8 +36,8 @@ RSpec.feature "Archiving topic tags" do
     then_i_see_that_i_cannot_edit_the_page
   end
 
-  scenario "User archives draft tag" do
-    given_there_is_a_draft_topic
+  scenario "User archives draft level 2 tag" do
+    given_there_is_a_draft_level_2_topic
     and_i_visit_the_topic
     when_i_click_the_delete_button
     then_the_tag_is_deleted
@@ -53,6 +53,13 @@ RSpec.feature "Archiving topic tags" do
 
     when_i_visit_the_topic_edit_page
     then_i_see_that_i_cannot_edit_the_page
+  end
+
+  scenario "User archives draft level 1 tag" do
+    given_there_is_a_draft_level_1_topic
+    and_i_visit_the_topic
+    when_i_click_the_delete_button
+    then_the_tag_is_deleted
   end
 
   scenario "User redirects to invalid basepath" do
@@ -92,12 +99,16 @@ RSpec.feature "Archiving topic tags" do
     @topic = create(:topic, :published, slug: "bar", parent: create(:topic, slug: "foo"))
   end
 
-  def given_there_is_a_draft_topic
+  def given_there_is_a_draft_level_2_topic
     @topic = create(:topic, :draft, slug: "bar", parent: create(:topic, slug: "foo"))
   end
 
   def given_there_is_a_published_level_1_topic
     @topic = create(:topic, :published, slug: "bar")
+  end
+
+  def given_there_is_a_draft_level_1_topic
+    @topic = create(:topic, :draft, slug: "bar")
   end
 
   def and_there_is_a_topic_that_can_be_used_as_a_replacement

--- a/spec/models/mainstream_browse_page_spec.rb
+++ b/spec/models/mainstream_browse_page_spec.rb
@@ -45,4 +45,30 @@ RSpec.describe MainstreamBrowsePage do
       expect(mainstream_browse_page.can_be_archived?).to eql(false)
     end
   end
+
+  describe "#can_be_removed?" do
+    it "returns true for draft level two mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :draft, parent: create(:mainstream_browse_page))
+
+      expect(mainstream_browse_page.can_be_removed?).to eql(true)
+    end
+
+    it "returns false for published level two mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
+
+      expect(mainstream_browse_page.can_be_removed?).to eql(false)
+    end
+
+    it "returns false for archived level two mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :archived, parent: create(:mainstream_browse_page))
+
+      expect(mainstream_browse_page.can_be_removed?).to eql(false)
+    end
+
+    it "returns false for level one mainstream browse page" do
+      mainstream_browse_page = create(:mainstream_browse_page, :draft, parent: nil, children: [create(:mainstream_browse_page, :draft)])
+
+      expect(mainstream_browse_page.can_be_removed?).to eql(false)
+    end
+  end
 end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -63,6 +63,32 @@ RSpec.describe Topic do
     end
   end
 
+  describe "#can_be_removed?" do
+    it "returns true for draft level two specialist topic" do
+      topic = create(:topic, :draft, parent: create(:topic))
+
+      expect(topic.can_be_removed?).to eql(true)
+    end
+
+    it "returns false for published level two specialist topic" do
+      topic = create(:topic, :published, parent: create(:topic))
+
+      expect(topic.can_be_removed?).to eql(false)
+    end
+
+    it "returns false for archived level two specialist topic" do
+      topic = create(:topic, :archived, parent: create(:topic))
+
+      expect(topic.can_be_removed?).to eql(false)
+    end
+
+    it "returns false for level one specialist topic" do
+      topic = create(:topic, :draft, parent: nil, children: [create(:topic, :draft)])
+
+      expect(topic.can_be_removed?).to eql(false)
+    end
+  end
+
   describe "#can_have_email_subscriptions?" do
     it "returns true for level two topic" do
       topic = create(:topic, parent: create(:topic))

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Topic do
       expect(topic.can_be_removed?).to eql(true)
     end
 
+    it "returns true for draft level one specialist topic without children" do
+      topic = create(:topic, :draft, parent: nil, children: [])
+
+      expect(topic.can_be_removed?).to eql(true)
+    end
+
     it "returns false for published level two specialist topic" do
       topic = create(:topic, :published, parent: create(:topic))
 
@@ -82,7 +88,7 @@ RSpec.describe Topic do
       expect(topic.can_be_removed?).to eql(false)
     end
 
-    it "returns false for level one specialist topic" do
+    it "returns false for level one specialist topic with children" do
       topic = create(:topic, :draft, parent: nil, children: [create(:topic, :draft)])
 
       expect(topic.can_be_removed?).to eql(false)

--- a/spec/services/draft_tag_remover_spec.rb
+++ b/spec/services/draft_tag_remover_spec.rb
@@ -13,14 +13,28 @@ RSpec.describe DraftTagRemover do
       expect { DraftTagRemover.new(topic).remove }.to raise_error(RuntimeError)
     end
 
-    it "guards against removing parent (level 1) tags" do
-      topic = create(:topic, :draft)
+    it "guards against removing parent (level 1) Mainstream browse page" do
+      topic = create(:mainstream_browse_page, :draft)
 
       expect { DraftTagRemover.new(topic).remove }.to raise_error(RuntimeError)
     end
 
-    it "removes the tag from the database" do
+    it "guards against removing parent (level 1) Topic which has children" do
+      topic = create(:topic, :draft, children: [create(:topic, :draft)])
+
+      expect { DraftTagRemover.new(topic).remove }.to raise_error(RuntimeError)
+    end
+
+    it "removes level 2 tag from the database" do
       topic = create(:topic, :draft, parent: create(:topic))
+
+      DraftTagRemover.new(topic).remove
+
+      expect { topic.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "removes level 1 topic from the database as long as it has no children" do
+      topic = create(:topic, :draft, children: [])
 
       DraftTagRemover.new(topic).remove
 


### PR DESCRIPTION
## Context 

Find and view - Navigation and presentation team will be archiving a lot of specialist topics as part of our epic to retire the specialist topic tree. We did work to allow Level 1 Specialist topics to be archived.

For completeness and consistency, we should also allow draft level 1 Specialist topics to be removed in the UI.
There is currently a draft level 1 topic in production titled "To delete". 

<kbd><img width="761" alt="Screenshot 2022-08-09 at 11 24 03" src="https://user-images.githubusercontent.com/38078064/183626600-cb5ed061-a24d-46d8-90cf-d809f8513156.png"></kbd>

[Trello](https://trello.com/c/trPPWKvB/1185-allow-draft-level-1-specialist-topics-to-be-removed-m)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
