### PR TITLE
Add Rubygem platforms for GOV.UK environments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,12 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
     null_logger (0.0.1)
@@ -453,7 +459,10 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   aasm


### PR DESCRIPTION
Trello: https://trello.com/c/o8ki524G/800-fix-issue-that-stops-mailfetcher-running-on-ruby-312

This adds Linux, Arm Linux and Arm MacOS platforms for bundler and allows precompiled gems to be installed. This allows faster installation on these platforms and resolves an issue on production where Rubygems can get confused as to which gem to use [1]

[1]: https://github.com/alphagov/publisher/pull/1699/commits/cee149a469376ec9f3ef1577e207de285101783b

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
