### PR TITLE
Remove mainstream_browse_type column from tags table

### DIFF
--- a/db/migrate/20221109124352_remove_mainstream_browse_type_from_tags.rb
+++ b/db/migrate/20221109124352_remove_mainstream_browse_type_from_tags.rb
@@ -1,0 +1,5 @@
+class RemoveMainstreamBrowseTypeFromTags < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :tags, :mainstream_browse_type, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_13_150444) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_09_124352) do
   create_table "coronavirus_pages", charset: "utf8mb3", force: :cascade do |t|
     t.string "sections_title"
     t.string "base_path"
@@ -182,7 +182,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_13_150444) do
     t.text "published_groups", size: :medium
     t.string "child_ordering", default: "alphabetical", null: false
     t.integer "index", default: 0, null: false
-    t.boolean "mainstream_browse_type", default: false
     t.index ["content_id"], name: "index_tags_on_content_id", unique: true
     t.index ["parent_id"], name: "tags_parent_id_fk"
     t.index ["slug", "parent_id"], name: "index_tags_on_slug_and_parent_id", unique: true


### PR DESCRIPTION
Reverts https://github.com/alphagov/collections-publisher/pull/1561 

We are no longer going to merge Mainstream browse pages into Specialist topics so it's not needed

[Trello](https://trello.com/c/4CjEsirD/117-remove-code-related-to-topic-merging)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
