### PR TITLE
Lint: use list syntax for Dockerfile CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ USER app
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
-CMD bundle exec puma
+CMD ["bundle", "exec", "puma"]


### PR DESCRIPTION
Generated with `gsed -i 's/^CMD bundle exec puma$/CMD [bundle, exec, puma]/'`