### PR TITLE
Use content ids to present curated lists (aka groups)

### DIFF
--- a/app/presenters/groups_presenter.rb
+++ b/app/presenters/groups_presenter.rb
@@ -7,7 +7,8 @@ class GroupsPresenter
     @tag.lists.ordered.map do |list|
       {
         name: list.name,
-        contents: list.tagged_list_items.map(&:base_path),
+        contents: list.tagged_list_items.map(&:base_path), # should be removed once migration to content_ids is complete
+        content_ids: list.tagged_list_items.map(&:content_id),
       }
     end
   end

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ListItemsController, type: :controller do
               {
                 "name" => list.name,
                 "contents" => [],
+                "content_ids" => [],
               },
             ],
             "internal_name" => tag.title,
@@ -196,11 +197,17 @@ RSpec.describe ListItemsController, type: :controller do
                   "contents" => [
                     list_item2.base_path,
                   ],
+                  "content_ids" => [
+                    list_item2.content_id,
+                  ],
                 },
                 {
                   "name" => list2.name,
                   "contents" => [
                     list_item1.base_path,
+                  ],
+                  "content_ids" => [
+                    list_item1.content_id,
                   ],
                 },
               ],
@@ -274,11 +281,17 @@ RSpec.describe ListItemsController, type: :controller do
                   "contents" => [
                     list_item2.base_path,
                   ],
+                  "content_ids" => [
+                    list_item2.content_id,
+                  ],
                 },
                 {
                   "name" => list2.name,
                   "contents" => [
                     list_item1.base_path,
+                  ],
+                  "content_ids" => [
+                    list_item1.content_id,
                   ],
                 },
               ],

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -142,6 +142,12 @@ RSpec.describe ListsController do
                     "/new-list",
                     "/newer-list",
                   ],
+                  "content_ids" => [
+                    list_item1.content_id,
+                    list_item2.content_id,
+                    "789",
+                    "012",
+                  ],
                 },
               ],
               "internal_name" => tag.title,
@@ -200,6 +206,11 @@ RSpec.describe ListsController do
                     list_item1.base_path,
                     list_item2.base_path,
                     "/new-list",
+                  ],
+                  "content_ids" => [
+                    list_item1.content_id,
+                    list_item2.content_id,
+                    "789",
                   ],
                 },
               ],
@@ -300,6 +311,10 @@ RSpec.describe ListsController do
                     list_item2.base_path,
                     list_item1.base_path,
                   ],
+                  "content_ids" => [
+                    list_item2.content_id,
+                    list_item1.content_id,
+                  ],
                 },
               ],
               "internal_name" => tag.title,
@@ -352,6 +367,10 @@ RSpec.describe ListsController do
                   "contents" => [
                     list_item2.base_path,
                     list_item1.base_path,
+                  ],
+                  "content_ids" => [
+                    list_item2.content_id,
+                    list_item1.content_id,
                   ],
                 },
               ],

--- a/spec/features/cuarating_lists_spec.rb
+++ b/spec/features/cuarating_lists_spec.rb
@@ -91,14 +91,17 @@ RSpec.feature "Curating lists" do
             {
               "name" => @list1.name,
               "contents" => [],
+              "content_ids" => [],
             },
             {
               "name" => @list2.name,
               "contents" => [],
+              "content_ids" => [],
             },
             {
               "name" => "David Lister",
               "contents" => [],
+              "content_ids" => [],
             },
           ],
           "internal_name" => @child.title_including_parent,
@@ -131,10 +134,12 @@ RSpec.feature "Curating lists" do
             {
               "name" => "Updated list name",
               "contents" => [],
+              "content_ids" => [],
             },
             {
               "name" => @list2.name,
               "contents" => [],
+              "content_ids" => [],
             },
           ],
           "internal_name" => @child.title_including_parent,
@@ -170,10 +175,12 @@ RSpec.feature "Curating lists" do
             {
               "name" => @list2.name,
               "contents" => [],
+              "content_ids" => [],
             },
             {
               "name" => @list1.name,
               "contents" => [],
+              "content_ids" => [],
             },
           ],
           "internal_name" => @child.title_including_parent,
@@ -206,6 +213,7 @@ RSpec.feature "Curating lists" do
             {
               "name" => @list2.name,
               "contents" => [],
+              "content_ids" => [],
             },
           ],
           "internal_name" => @child.title_including_parent,

--- a/spec/features/curating_a_list_spec.rb
+++ b/spec/features/curating_a_list_spec.rb
@@ -129,6 +129,11 @@ RSpec.feature "Curating a list" do
                 @list_item2.base_path,
                 "/naturalisation",
               ],
+              "content_ids" => [
+                @list_item1.content_id,
+                @list_item2.content_id,
+                "29941ec1-4a41-4bfd-86a9-5c866bbd4c7c",
+              ],
             },
           ],
           "internal_name" => @child.title_including_parent,
@@ -170,6 +175,10 @@ RSpec.feature "Curating a list" do
                 @list_item2.base_path,
                 @list_item1.base_path,
               ],
+              "content_ids" => [
+                @list_item2.content_id,
+                @list_item1.content_id,
+              ],
             },
           ],
           "internal_name" => @child.title_including_parent,
@@ -202,6 +211,9 @@ RSpec.feature "Curating a list" do
               "name" => @list.name,
               "contents" => [
                 @list_item2.base_path,
+              ],
+              "content_ids" => [
+                @list_item2.content_id,
               ],
             },
           ],
@@ -259,12 +271,19 @@ RSpec.feature "Curating a list" do
               "contents" => [
                 @list_item1.base_path,
               ],
+              "content_ids" => [
+                @list_item1.content_id,
+              ],
             },
             {
               "name" => @list2.name,
               "contents" => [
                 @list_item1.base_path,
                 @list_item2.base_path,
+              ],
+              "content_ids" => [
+                @list_item1.content_id,
+                @list_item2.content_id,
               ],
             },
           ],

--- a/spec/presenters/groups_presenter_spec.rb
+++ b/spec/presenters/groups_presenter_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe GroupsPresenter do
 
       it "provides the curated lists ordered by their index" do
         allow(oil_rigs).to receive(:tagged_list_items).and_return([
-          OpenStruct.new(base_path: "/oil-rig-safety-requirements"),
-          OpenStruct.new(base_path: "/oil-rig-staffing"),
+          OpenStruct.new(base_path: "/oil-rig-safety-requirements", content_id: "5d2cd813-7631-11e4-a3cb-00505601111a"),
+          OpenStruct.new(base_path: "/oil-rig-staffing", content_id: "5d2cd813-7631-11e4-a3cb-00505601111b"),
         ])
 
         allow(piping).to receive(:tagged_list_items).and_return([
-          OpenStruct.new(base_path: "/undersea-piping-restrictions"),
+          OpenStruct.new(base_path: "/undersea-piping-restrictions", content_id: "5d2cd813-7631-11e4-a3cb-00505601111c"),
         ])
 
         allow(tag).to receive(:lists).and_return(double(ordered: [piping, oil_rigs]))
@@ -36,12 +36,19 @@ RSpec.describe GroupsPresenter do
               contents: [
                 "/undersea-piping-restrictions",
               ],
+              content_ids: %w[
+                5d2cd813-7631-11e4-a3cb-00505601111c
+              ],
             },
             {
               name: "Oil rigs",
               contents: [
                 "/oil-rig-safety-requirements",
                 "/oil-rig-staffing",
+              ],
+              content_ids: %w[
+                5d2cd813-7631-11e4-a3cb-00505601111a
+                5d2cd813-7631-11e4-a3cb-00505601111b
               ],
             },
           ],

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe TagPresenter do
 
       # We need to "publish" these lists.
       allow_any_instance_of(List).to receive(:tagged_list_items).and_return(
-        [OpenStruct.new(base_path: "/oil-rig-safety-requirements")],
+        [OpenStruct.new(base_path: "/oil-rig-safety-requirements", content_id: "5d2cd813-7631-11e4-a3cb-00505601111a")],
       )
       tag.update!(published_groups: GroupsPresenter.new(tag).groups, dirty: false)
 

--- a/spec/services/list_publisher_spec.rb
+++ b/spec/services/list_publisher_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ListPublisher do
 
       ListPublisher.new(topic).perform
 
-      expect(topic.published_groups).to eql([{ "name" => "A Listname", "contents" => [] }])
+      expect(topic.published_groups).to eql([{ "name" => "A Listname", "contents" => [], "content_ids" => [] }])
     end
 
     it "sends the updated information to the content-store" do


### PR DESCRIPTION
## Context

When a content item is tagged to curated Mainstream browse or Specialist topic (parent class Tag) and this content item’s slug changes the link disappears from the topic page. This is because the curated lists/groups are based on base paths. 

The “contents” slugs don’t get updated as a part of dependency resolution in Publishing API.

## What
Use content_ids to present curated lists (aka groups) instead of base_paths, as they are less volatile.

### Notes 
The “contents” key will be removed after the migration.

## Depends on
- https://github.com/alphagov/publishing-api/pull/2201

## Post-deployment tasks

- [ ] Republish all Mainstream browse pages
- [ ] Republish all Specialist topics

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
