### PR TITLE
Remove contents from GroupsPresenter

### DIFF
--- a/app/presenters/groups_presenter.rb
+++ b/app/presenters/groups_presenter.rb
@@ -7,7 +7,6 @@ class GroupsPresenter
     @tag.lists.ordered.map do |list|
       {
         name: list.name,
-        contents: list.tagged_list_items.map(&:base_path), # should be removed once migration to content_ids is complete
         content_ids: list.tagged_list_items.map(&:content_id),
       }
     end

--- a/spec/controllers/list_items_controller_spec.rb
+++ b/spec/controllers/list_items_controller_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe ListItemsController, type: :controller do
             "groups" => [
               {
                 "name" => list.name,
-                "contents" => [],
                 "content_ids" => [],
               },
             ],
@@ -194,18 +193,12 @@ RSpec.describe ListItemsController, type: :controller do
               "groups" => [
                 {
                   "name" => list1.name,
-                  "contents" => [
-                    list_item2.base_path,
-                  ],
                   "content_ids" => [
                     list_item2.content_id,
                   ],
                 },
                 {
                   "name" => list2.name,
-                  "contents" => [
-                    list_item1.base_path,
-                  ],
                   "content_ids" => [
                     list_item1.content_id,
                   ],
@@ -278,18 +271,12 @@ RSpec.describe ListItemsController, type: :controller do
               "groups" => [
                 {
                   "name" => list1.name,
-                  "contents" => [
-                    list_item2.base_path,
-                  ],
                   "content_ids" => [
                     list_item2.content_id,
                   ],
                 },
                 {
                   "name" => list2.name,
-                  "contents" => [
-                    list_item1.base_path,
-                  ],
                   "content_ids" => [
                     list_item1.content_id,
                   ],

--- a/spec/controllers/lists_controller_spec.rb
+++ b/spec/controllers/lists_controller_spec.rb
@@ -136,12 +136,6 @@ RSpec.describe ListsController do
               "groups" => [
                 {
                   "name" => list.name,
-                  "contents" => [
-                    list_item1.base_path,
-                    list_item2.base_path,
-                    "/new-list",
-                    "/newer-list",
-                  ],
                   "content_ids" => [
                     list_item1.content_id,
                     list_item2.content_id,
@@ -202,11 +196,6 @@ RSpec.describe ListsController do
               "groups" => [
                 {
                   "name" => list.name,
-                  "contents" => [
-                    list_item1.base_path,
-                    list_item2.base_path,
-                    "/new-list",
-                  ],
                   "content_ids" => [
                     list_item1.content_id,
                     list_item2.content_id,
@@ -307,10 +296,6 @@ RSpec.describe ListsController do
               "groups" => [
                 {
                   "name" => list.name,
-                  "contents" => [
-                    list_item2.base_path,
-                    list_item1.base_path,
-                  ],
                   "content_ids" => [
                     list_item2.content_id,
                     list_item1.content_id,
@@ -364,10 +349,6 @@ RSpec.describe ListsController do
               "groups" => [
                 {
                   "name" => list.name,
-                  "contents" => [
-                    list_item2.base_path,
-                    list_item1.base_path,
-                  ],
                   "content_ids" => [
                     list_item2.content_id,
                     list_item1.content_id,

--- a/spec/features/cuarating_lists_spec.rb
+++ b/spec/features/cuarating_lists_spec.rb
@@ -90,17 +90,14 @@ RSpec.feature "Curating lists" do
           "groups" => [
             {
               "name" => @list1.name,
-              "contents" => [],
               "content_ids" => [],
             },
             {
               "name" => @list2.name,
-              "contents" => [],
               "content_ids" => [],
             },
             {
               "name" => "David Lister",
-              "contents" => [],
               "content_ids" => [],
             },
           ],
@@ -133,12 +130,10 @@ RSpec.feature "Curating lists" do
           "groups" => [
             {
               "name" => "Updated list name",
-              "contents" => [],
               "content_ids" => [],
             },
             {
               "name" => @list2.name,
-              "contents" => [],
               "content_ids" => [],
             },
           ],
@@ -174,12 +169,10 @@ RSpec.feature "Curating lists" do
           "groups" => [
             {
               "name" => @list2.name,
-              "contents" => [],
               "content_ids" => [],
             },
             {
               "name" => @list1.name,
-              "contents" => [],
               "content_ids" => [],
             },
           ],
@@ -212,7 +205,6 @@ RSpec.feature "Curating lists" do
           "groups" => [
             {
               "name" => @list2.name,
-              "contents" => [],
               "content_ids" => [],
             },
           ],

--- a/spec/features/curating_a_list_spec.rb
+++ b/spec/features/curating_a_list_spec.rb
@@ -124,11 +124,6 @@ RSpec.feature "Curating a list" do
           "groups" => [
             {
               "name" => @list.name,
-              "contents" => [
-                @list_item1.base_path,
-                @list_item2.base_path,
-                "/naturalisation",
-              ],
               "content_ids" => [
                 @list_item1.content_id,
                 @list_item2.content_id,
@@ -171,10 +166,6 @@ RSpec.feature "Curating a list" do
           "groups" => [
             {
               "name" => @list.name,
-              "contents" => [
-                @list_item2.base_path,
-                @list_item1.base_path,
-              ],
               "content_ids" => [
                 @list_item2.content_id,
                 @list_item1.content_id,
@@ -209,9 +200,6 @@ RSpec.feature "Curating a list" do
           "groups" => [
             {
               "name" => @list.name,
-              "contents" => [
-                @list_item2.base_path,
-              ],
               "content_ids" => [
                 @list_item2.content_id,
               ],
@@ -268,19 +256,12 @@ RSpec.feature "Curating a list" do
           "groups" => [
             {
               "name" => @list.name,
-              "contents" => [
-                @list_item1.base_path,
-              ],
               "content_ids" => [
                 @list_item1.content_id,
               ],
             },
             {
               "name" => @list2.name,
-              "contents" => [
-                @list_item1.base_path,
-                @list_item2.base_path,
-              ],
               "content_ids" => [
                 @list_item1.content_id,
                 @list_item2.content_id,

--- a/spec/presenters/groups_presenter_spec.rb
+++ b/spec/presenters/groups_presenter_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe GroupsPresenter do
 
       it "provides the curated lists ordered by their index" do
         allow(oil_rigs).to receive(:tagged_list_items).and_return([
-          OpenStruct.new(base_path: "/oil-rig-safety-requirements", content_id: "5d2cd813-7631-11e4-a3cb-00505601111a"),
-          OpenStruct.new(base_path: "/oil-rig-staffing", content_id: "5d2cd813-7631-11e4-a3cb-00505601111b"),
+          OpenStruct.new(content_id: "5d2cd813-7631-11e4-a3cb-00505601111a"),
+          OpenStruct.new(content_id: "5d2cd813-7631-11e4-a3cb-00505601111b"),
         ])
 
         allow(piping).to receive(:tagged_list_items).and_return([
-          OpenStruct.new(base_path: "/undersea-piping-restrictions", content_id: "5d2cd813-7631-11e4-a3cb-00505601111c"),
+          OpenStruct.new(content_id: "5d2cd813-7631-11e4-a3cb-00505601111c"),
         ])
 
         allow(tag).to receive(:lists).and_return(double(ordered: [piping, oil_rigs]))
@@ -33,19 +33,12 @@ RSpec.describe GroupsPresenter do
           [
             {
               name: "Piping",
-              contents: [
-                "/undersea-piping-restrictions",
-              ],
               content_ids: %w[
                 5d2cd813-7631-11e4-a3cb-00505601111c
               ],
             },
             {
               name: "Oil rigs",
-              contents: [
-                "/oil-rig-safety-requirements",
-                "/oil-rig-staffing",
-              ],
               content_ids: %w[
                 5d2cd813-7631-11e4-a3cb-00505601111a
                 5d2cd813-7631-11e4-a3cb-00505601111b

--- a/spec/presenters/tag_presenter_spec.rb
+++ b/spec/presenters/tag_presenter_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe TagPresenter do
 
       # We need to "publish" these lists.
       allow_any_instance_of(List).to receive(:tagged_list_items).and_return(
-        [OpenStruct.new(base_path: "/oil-rig-safety-requirements", content_id: "5d2cd813-7631-11e4-a3cb-00505601111a")],
+        [OpenStruct.new(content_id: "5d2cd813-7631-11e4-a3cb-00505601111a")],
       )
       tag.update!(published_groups: GroupsPresenter.new(tag).groups, dirty: false)
 

--- a/spec/services/list_publisher_spec.rb
+++ b/spec/services/list_publisher_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ListPublisher do
 
       ListPublisher.new(topic).perform
 
-      expect(topic.published_groups).to eql([{ "name" => "A Listname", "contents" => [], "content_ids" => [] }])
+      expect(topic.published_groups).to eql([{ "name" => "A Listname", "content_ids" => [] }])
     end
 
     it "sends the updated information to the content-store" do

--- a/spec/services/list_republisher_spec.rb
+++ b/spec/services/list_republisher_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ListRepublisher do
 
       mainstream_browse_page.reload
       expect(mainstream_browse_page.published_groups).to eq([{
-        "content_ids" => [list_item.content_id], "contents" => [list_item.base_path], "name" => list.name
+        "content_ids" => [list_item.content_id], "name" => list.name
       }])
       assert_publishing_api_put_content(
         mainstream_browse_page.content_id,
@@ -50,7 +50,6 @@ RSpec.describe ListRepublisher do
             "groups": [
               {
                 "name": list.name,
-                "contents": [list_item.base_path],
                 "content_ids": [list_item.content_id],
               },
             ],


### PR DESCRIPTION
 It's been replaced by content_ids in https://github.com/alphagov/collections-publisher/pull/1749

Depends on:
- https://github.com/alphagov/publishing-api/pull/2233

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
