### PR TITLE
Adding ability to add ASSETS_PREFIX ENV value.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
 FROM $builder_image AS builder
 
+ENV ASSETS_PREFIX=/assets/collections-publisher
+
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
@@ -18,7 +20,8 @@ RUN bundle exec rails assets:precompile && \
 
 FROM $base_image
 
-ENV GOVUK_APP_NAME=collections-publisher
+ENV GOVUK_APP_NAME=collections-publisher \
+    ASSETS_PREFIX=/assets/collections-publisher
 
 WORKDIR /app
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,8 @@ module CollectionsPublisher
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
+    config.assets.prefix = ENV.fetch("ASSETS_PREFIX", "/assets")
+
     # Sets local to "true" in all forms that use form_with. This is only needed
     # until the application is upgraded to Rails 6.1.
     config.action_view.form_with_generates_remote_forms = false


### PR DESCRIPTION
This will allow for adding precompiled assets into `/public/assets/collections-publisher` folder when defining the ENV `ASSETS_PREFIX=collections-publisher`

if ENV value is not present it will default to /public/assets/ folder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
