### PR TITLE
Add rake task to republish tags with curated lists

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,8 +27,8 @@ class Tag < ApplicationRecord
 
   before_validation :generate_content_id, on: :create
 
-  scope :only_level_two, -> { where("parent_id IS NULL") }
-  scope :only_level_one, -> { where("parent_id IS NOT NULL") }
+  scope :only_level_one, -> { where("parent_id IS NULL") }
+  scope :only_level_two, -> { where("parent_id IS NOT NULL") }
 
   # The links last sent to the content-store.
   serialize :published_groups, JSON
@@ -69,7 +69,7 @@ class Tag < ApplicationRecord
   alias_method :level_one?, :can_have_children?
 
   def self.sorted_level_one
-    only_level_two.includes(children: [:lists]).order(:title)
+    only_level_one.includes(children: [:lists]).order(:title)
   end
 
   def sorted_children

--- a/app/services/list_republisher.rb
+++ b/app/services/list_republisher.rb
@@ -1,0 +1,61 @@
+class ListRepublisher
+  def republish_tags(tags)
+    done = 0
+    tags.find_each do |tag|
+      next if tag.lists.blank?
+
+      update_groups(tag)
+      republish_tag(tag)
+
+      done += 1
+
+      if (done % 100).zero?
+        log "#{done} completed..."
+      end
+    end
+
+    log "All done"
+  end
+
+private
+
+  def update_groups(tag)
+    groups = GroupsPresenter.new(tag).groups
+    tag.update!(published_groups: groups, dirty: false)
+  end
+
+  def republish_tag(tag)
+    with_retry do
+      presenter = TagPresenter.presenter_for(tag)
+      begin
+        ContentItemPublisher.new(presenter, update_type: "republish").send_to_publishing_api
+      rescue GdsApi::TimedOutException, Timeout::Error => e
+        log "#{tag.content_id} republish tag with groups failed"
+        raise e
+      end
+    end
+  end
+
+  def with_retry
+    retries = 0
+
+    begin
+      yield
+    rescue GdsApi::TimedOutException, Timeout::Error
+      retries += 1
+      if retries <= 3
+        log "Timeout: retry #{retries}"
+        sleep 0.5
+        retry
+      end
+    end
+  end
+
+  def publishing_api
+    Services.publishing_api
+  end
+
+  def log(string)
+    Rails.logger.info(string)
+  end
+end

--- a/db/migrate/20150622073727_add_redirects_for_topics_namespace.rb
+++ b/db/migrate/20150622073727_add_redirects_for_topics_namespace.rb
@@ -1,6 +1,6 @@
 class AddRedirectsForTopicsNamespace < ActiveRecord::Migration
   def up
-    Topic.published.only_level_two.each do |topic|
+    Topic.published.only_level_one.each do |topic|
       original_topic_base_path = '/' + topic.full_slug
 
       Redirect.create!(

--- a/db/migrate/20150625151822_add_browse_redirects.rb
+++ b/db/migrate/20150625151822_add_browse_redirects.rb
@@ -4,7 +4,7 @@ class AddBrowseRedirects < ActiveRecord::Migration
       'business',
       'visas-immigration',
     ].each do |slug|
-      page = MainstreamBrowsePage.only_level_two.where(:slug => slug).first
+      page = MainstreamBrowsePage.only_level_one.where(:slug => slug).first
       raise "Failed to find top-level browse page with slug #{slug}" unless page
 
       Redirect.create!(

--- a/db/migrate/20150713124417_import_router_data_browse_redirects.rb
+++ b/db/migrate/20150713124417_import_router_data_browse_redirects.rb
@@ -20,7 +20,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
     )
 
     # /browse/citizenship/coasts-countryside,/browse/environment-countryside
-    environment_countryside = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'environment-countryside')
+    environment_countryside = MainstreamBrowsePage.only_level_one.find_by!(:slug => 'environment-countryside')
     @redirects << Redirect.create!(
       :tag => environment_countryside,
       :original_tag_base_path => "/browse/citizenship/coasts-countryside",
@@ -29,7 +29,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
     )
 
     # /browse/driving/passports-travelling-abroad,/browse/abroad
-    abroad = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'abroad')
+    abroad = MainstreamBrowsePage.only_level_one.find_by!(:slug => 'abroad')
     @redirects << Redirect.create!(
       :tag => abroad,
       :original_tag_base_path => "/browse/driving/passports-travelling-abroad",
@@ -46,7 +46,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
     )
 
     # /browse/housing,/browse/housing-local-services
-    housing_local_services = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'housing-local-services')
+    housing_local_services = MainstreamBrowsePage.only_level_one.find_by!(:slug => 'housing-local-services')
     @redirects << Redirect.create!(
       :tag => housing_local_services,
       :original_tag_base_path => "/browse/housing",
@@ -74,7 +74,7 @@ class ImportRouterDataBrowseRedirects < ActiveRecord::Migration
       )
     end
 
-    visas_immigration = MainstreamBrowsePage.only_level_two.find_by!(:slug => 'visas-immigration')
+    visas_immigration = MainstreamBrowsePage.only_level_one.find_by!(:slug => 'visas-immigration')
     {
       "after-youve-applied" => "manage-your-application",
       "employers-sponsorship" => "sponsor-workers-students",

--- a/db/migrate/20150714140302_import_router_data_topic_redirects.rb
+++ b/db/migrate/20150714140302_import_router_data_topic_redirects.rb
@@ -11,7 +11,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
 
   def create_redirects
     # /childrens-services,/topic/schools-colleges-childrens-services
-    schools_colleges_childrens_services = Topic.only_level_two.find_by!(:slug => 'schools-colleges-childrens-services')
+    schools_colleges_childrens_services = Topic.only_level_one.find_by!(:slug => 'schools-colleges-childrens-services')
     @redirects << Redirect.create!(
       :tag => schools_colleges_childrens_services,
       :original_tag_base_path => "/childrens-services",
@@ -41,7 +41,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
 
     # /commercial-fishing-fisheries/monitoring-enforcement,/topic/commercial-fishing-fisheries/regulations-monitoring-enforcement
     # /commercial-fishing-fisheries/regulations-restrictions,/topic/commercial-fishing-fisheries/regulations-monitoring-enforcement
-    commercial_fishing_fisheries = Topic.only_level_two.find_by!(:slug => 'commercial-fishing-fisheries')
+    commercial_fishing_fisheries = Topic.only_level_one.find_by!(:slug => 'commercial-fishing-fisheries')
     {
       "monitoring-enforcement" => "regulations-monitoring-enforcement",
       "regulations-restrictions" => "regulations-monitoring-enforcement",
@@ -55,7 +55,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
       )
     end
 
-    competition = Topic.only_level_two.find_by!(:slug => 'competition')
+    competition = Topic.only_level_one.find_by!(:slug => 'competition')
     [
       "business-law-compliance",
       "competition-law-compliance",
@@ -86,7 +86,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
     end
 
     # /health-protection/migrant-health,/topic/health-protection
-    health_protection = Topic.only_level_two.find_by!(:slug => 'health-protection')
+    health_protection = Topic.only_level_one.find_by!(:slug => 'health-protection')
     @redirects << Redirect.create!(
       :tag => health_protection,
       :original_tag_base_path => "/health-protection/migrant-health",
@@ -118,7 +118,7 @@ class ImportRouterDataTopicRedirects < ActiveRecord::Migration
     end
 
     # /schools-colleges,/topic/schools-colleges-childrens-services
-    schools_colleges_childrens_services = Topic.only_level_two.find_by!(:slug => 'schools-colleges-childrens-services')
+    schools_colleges_childrens_services = Topic.only_level_one.find_by!(:slug => 'schools-colleges-childrens-services')
     @redirects << Redirect.create!(
       :tag => schools_colleges_childrens_services,
       :original_tag_base_path => "/schools-colleges",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -13,6 +13,11 @@ namespace :publishing_api do
     TagRepublisher.new.republish_tags(Tag.published)
   end
 
+  desc "Update groups and send published curated level two tags to the publishing-api"
+  task send_published_tags_with_lists: :environment do
+    ListRepublisher.new.republish_tags(Tag.only_level_two.published)
+  end
+
   desc "Publish the /api/organisations prefix route"
   task publish_organisations_api_route: :environment do
     PublishOrganisationsApiRoute.new.publish

--- a/spec/lib/tasks/publishing_api_spec.rb
+++ b/spec/lib/tasks/publishing_api_spec.rb
@@ -21,3 +21,25 @@ RSpec.describe "rake publishing_api:publish_special_route", type: :task do
     assert_publishing_api_publish("bb986a97-3b8c-4b1a-89bf-2a9f46be9747")
   end
 end
+
+RSpec.describe "rake publishing_api:send_published_tags_with_lists", type: :task do
+  let(:list_republisher) { instance_double(ListRepublisher) }
+
+  let(:level_one_tag) { create(:tag, :published, parent: nil) }
+  let(:draft_level_two_tag) { create(:tag, parent: level_one_tag) }
+  let(:published_level_two_tag) { create(:tag, :published, parent: level_one_tag) }
+
+  before do
+    Rake::Task["publishing_api:send_published_tags_with_lists"].reenable
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+    allow(ListRepublisher).to receive(:new).and_return(list_republisher)
+    allow(list_republisher).to receive(:republish_tags)
+  end
+
+  it "republishes only published level two tags " do
+    Rake::Task["publishing_api:send_published_tags_with_lists"].invoke
+
+    expect(list_republisher).to have_received(:republish_tags).with([published_level_two_tag])
+  end
+end

--- a/spec/services/list_republisher_spec.rb
+++ b/spec/services/list_republisher_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe ListRepublisher do
+  describe "#republish_tags" do
+    let(:mainstream_browse_page) { create(:mainstream_browse_page, :published, child_ordering: "curated") }
+    let(:list_item) { create(:list_item) }
+    let!(:list) { create(:list, tag: mainstream_browse_page, list_items: [list_item]) }
+
+    before do
+      stub_any_publishing_api_put_content
+      stub_any_publishing_api_publish
+      stub_any_publishing_api_patch_links
+
+      allow(Services.publishing_api).to receive(:get_linked_items).with(
+        mainstream_browse_page.content_id,
+        hash_including(link_type: :mainstream_browse_pages),
+      ).and_call_original
+
+      stub_publishing_api_has_linked_items(
+        [
+          { base_path: list_item.base_path, title: list_item.title, content_id: "f508898d-1ba0-46f7-b150-828166886d97" },
+        ],
+        {
+          content_id: mainstream_browse_page.content_id,
+          link_type: "mainstream_browse_pages",
+          fields: %i[title base_path content_id],
+        },
+      )
+      allow(Services.publishing_api).to receive(:get_linked_items).with(
+        mainstream_browse_page.content_id,
+        hash_including(link_type: :topics),
+      ).and_return(
+        [{ "title" => list_item.title,
+           "base_path" => list_item.base_path,
+           "content_id" => list_item.content_id }],
+      )
+    end
+
+    it "republishes given tags with lists/groups" do
+      described_class.new.republish_tags(Tag.all)
+
+      mainstream_browse_page.reload
+      expect(mainstream_browse_page.published_groups).to eq([{
+        "content_ids" => [list_item.content_id], "contents" => [list_item.base_path], "name" => list.name
+      }])
+      assert_publishing_api_put_content(
+        mainstream_browse_page.content_id,
+        request_json_includes(
+          "details": {
+            "groups": [
+              {
+                "name": list.name,
+                "contents": [list_item.base_path],
+                "content_ids": [list_item.content_id],
+              },
+            ],
+            "internal_name": mainstream_browse_page.title,
+            "second_level_ordering": mainstream_browse_page.child_ordering,
+            "ordered_second_level_browse_pages": [],
+          },
+        ),
+      )
+    end
+
+    it "skips tags without lists/groups" do
+      a_to_z_mainstream_browse = create(:mainstream_browse_page, :published, lists: [])
+
+      described_class.new.republish_tags(Tag.all)
+
+      expect(TagPresenter).not_to receive(:presenter_for).with(a_to_z_mainstream_browse)
+    end
+  end
+end


### PR DESCRIPTION
The existing `send_published_tags` task does not represent "groups" which are used to render curated lists. 
https://github.com/alphagov/collections-publisher/blob/main/app/presenters/tag_presenter.rb#L79-L84

We need to republish tags with curated lists / groups to migrate from using "contents" to "content_ids".

Code inspired by [ListPublisher](https://github.com/alphagov/collections-publisher/blob/main/app/services/list_publisher.rb) and TagRepublisher.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
