### PR TITLE
Revert  "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "aasm"
 gem "generic_form_builder"
 gem "inline_svg"
 gem "kramdown"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mysql2"
 gem "sass-rails"
 gem "sentry-sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,11 +198,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     mail-notify (1.1.0)
       actionmailer (>= 5.2.4.6)
       actionpack (>= 5.2.7.1)
@@ -482,7 +479,7 @@ DEPENDENCIES
   govuk_test
   inline_svg
   kramdown
-  mail (~> 2.8.0)
+  mail (~> 2.7.1)
   mail-notify
   mysql2
   nokogiri


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
