### PR TITLE
Trigger deploy only after CI has run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,10 @@ on:
         - staging
         - production
         default: 'integration'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   build-and-publish-image:


### PR DESCRIPTION
This updates the trigger for automatic deployments to integration. Now
deployment will wait for CI to successfully run on the commit on the main
branch (i.e. a merge).
