### PR TITLE
Remove parser from being a direct dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ group :development, :test do
   gem "govuk_schemas"
   gem "govuk_test"
   gem "nokogiri"
-  gem "parser"
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rubocop-govuk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,6 @@ DEPENDENCIES
   mail-notify
   mysql2
   nokogiri
-  parser
   plek
   pry-byebug
   rails (= 7.0.4)


### PR DESCRIPTION
This app doesn't directly use this gem and it has just a dependency of rubocop-govuk.

Removing this from a direct dependency resolves a wtf and means we won't have direct dependabot for this dependency unless there is a security issue.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
