### PR TITLE
Make ruby tests a reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,3 @@ jobs:
   test-ruby:
     name: Test Ruby
     uses: ./.github/workflows/rspec.yml
-


### PR DESCRIPTION
This application depends on the Content Schemas. Making the tests reusable allows Publishing API to run the tests when the Content Schemas are updated.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
