### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,15 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+node_modules
+script
+spec
+test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN bundle install
 COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
 COPY . .
+RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log
 
 
@@ -22,6 +23,7 @@ WORKDIR $APP_HOME
 COPY --from=builder /usr/bin/node* /usr/bin/
 COPY --from=builder /usr/lib/node_modules/ /usr/lib/node_modules/
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,28 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-ENV ASSETS_PREFIX=/assets/collections-publisher
-
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
-
-RUN bundle exec rails assets:precompile && \
-    yarn install --frozen-lockfile && \
-    rm -fr /app/log
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+COPY . .
+RUN rails assets:precompile && rm -fr log
 
 
 FROM $base_image
 
-ENV GOVUK_APP_NAME=collections-publisher \
-    ASSETS_PREFIX=/assets/collections-publisher
+ENV GOVUK_APP_NAME=collections-publisher
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder /usr/bin/node* /usr/bin/
+COPY --from=builder /usr/lib/node_modules/ /usr/lib/node_modules/
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.0.4"
 
 gem "aasm"
+gem "bootsnap", require: false
 gem "generic_form_builder"
 gem "inline_svg"
 gem "kramdown"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     brakeman (5.2.3)
     builder (3.2.4)
     byebug (11.1.3)
@@ -215,6 +217,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    msgpack (1.6.0)
     multi_xml (0.6.0)
     mysql2 (0.5.4)
     net-imap (0.3.4)
@@ -464,6 +467,7 @@ DEPENDENCIES
   aasm
   better_errors
   binding_of_caller
+  bootsnap
   byebug
   database_cleaner
   factory_bot_rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,9 @@ module CollectionsPublisher
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
-    config.assets.prefix = ENV.fetch("ASSETS_PREFIX", "/assets")
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/collections-publisher"
 
     # Sets local to "true" in all forms that use form_with. This is only needed
     # until the application is upgraded to Rails 6.1.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Include the app name in `assets.prefix` so that assets can coexist nicely with other apps' assets on S3.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Add .dockerignore.

Tested: app boots successfully with `docker run`.