### PR TITLE
Don't email subscribers of retired topics if successor is a document collection

### DIFF
--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -58,8 +58,18 @@ private
     ContentItemPublisher.new(presenter).send_to_publishing_api
   end
 
+  # Temporary hack to prevent emails being sent to subscribers of a specialist topic that is being
+  # converted to a document collection. Those subscribers will be manually migrated to the new document
+  # collection subscription, which will be similar enough that a notification is not required.
+  def topic_successor_is_a_document_collection?
+    return unless tag.is_a? Topic
+
+    successor.base_path.include?("/government/collections/")
+  end
+
   def unsubscribe_from_email_alerts
     return unless tag.can_have_email_subscriptions?
+    return if topic_successor_is_a_document_collection?
 
     EmailAlertsUnsubscriber.call(
       item: tag,

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe TagArchiver do
       )
     end
 
+    it "doesn't unsubscribe from email alerts when specialist topic (level 2) is being redirected to a document collection" do
+      tag = create(:topic, :published, parent: create(:topic, slug: "mot"),
+                                       slug: "provide-mot-training",
+                                       title: "Provide MOT training")
+      successor = OpenStruct.new(base_path: "/government/collections/brexit-guidance", subroutes: [])
+
+      TagArchiver.new(tag, successor).archive
+
+      expect(Services.email_alert_api).to_not have_received(:bulk_unsubscribe)
+    end
+
     it "doesn't attempt to unsubscribe from email alerts when mainstream browse page is archived" do
       tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
 


### PR DESCRIPTION
## What

When a specialist topic is archived from the collections publisher UI, do not send an email if the page is being redirected to a document collection.

## Why

When we archive and redirect a specialist topic, we automatically unsubscribe all existing subscribers to the specialist topic, and email them a notification.

Soon we will begin the process of converting some specialist topics into document collections. The workflow for this will be:
1. From Whitehall, publish a new document collection using the content of the specialist topic.
2. From collections publisher (this application), archive and redirect the specialist topic to the new document collection page.

Because the content of these pages is so similar, we will be migrating the subscribers from the topic over to the new document collection list. We do not need to tell users about this, as from their pov there is little change to the emails they will be receiving. 

## Why is this a hack

We will be archiving and redirecting some specialist topics to _existing_ document collection pages. Ie pages that are already live on gov.uk. We will not be migrating users to these lists, because the subscriptions will not be similar enough for us to be allowed to do so within GDRP rules. In these cases, we do still need to unsubscribe users and to send them an email. We will have to do that manually by reverting https://github.com/alphagov/email-alert-api/pull/1759

Ideally we would know the topics that are being redirected to existing document collections, so that we could add an exception to this code. But we don't currently have this information, so excluding all document collections is required. 




Trello: https://trello.com/c/EiOvKQ2B/1653-ensure-converting-topics-to-collections-doesnt-trigger-an-email-to-users-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
