### PR TITLE
Update to specialist topic archive UI

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -75,7 +75,7 @@ private
   def topic_archival_form_params
     params
       .fetch(:topic_archival_form, {})
-      .permit(:tag, :successor, :successor_path)
+      .permit(:tag, :successor_path)
   end
 
   def find_topic

--- a/app/forms/topic_archival_form.rb
+++ b/app/forms/topic_archival_form.rb
@@ -22,11 +22,12 @@ class TopicArchivalForm
 private
 
   def successor_object
-    Struct.new("RedirectToPath", :base_path, :subroutes)
-    Struct::RedirectToPath.new(successor_path, [])
+    RedirectToPath.new(successor_path, [])
   end
 
   def published_topics
     Topic.includes(:parent).published.sort_by(&:title_including_parent)
   end
+
+  RedirectToPath = Struct.new(:base_path, :subroutes)
 end

--- a/app/forms/topic_archival_form.rb
+++ b/app/forms/topic_archival_form.rb
@@ -1,17 +1,13 @@
 class TopicArchivalForm
   include ActiveModel::Model
-  attr_accessor :tag, :successor, :successor_path
+  attr_accessor :tag, :successor_path
 
-  validates :successor_path, presence: true, valid_govuk_path: true, if: :redirecting_to_path?
-
-  def topics
-    published_topics - [tag]
-  end
+  validates :successor_path, presence: true, valid_govuk_path: true
 
   def archive_or_remove
-    return false unless valid?
-
     if tag.published?
+      return false unless valid?
+
       TagArchiver.new(tag, successor_object).archive
     else
       DraftTagRemover.new(tag).remove
@@ -26,19 +22,11 @@ class TopicArchivalForm
 private
 
   def successor_object
-    if redirecting_to_path?
-      Struct.new("RedirectToPath", :base_path, :subroutes)
-      Struct::RedirectToPath.new(successor_path, [])
-    else
-      Topic.find_by(id: successor)
-    end
+    Struct.new("RedirectToPath", :base_path, :subroutes)
+    Struct::RedirectToPath.new(successor_path, [])
   end
 
   def published_topics
     Topic.includes(:parent).published.sort_by(&:title_including_parent)
-  end
-
-  def redirecting_to_path?
-    !successor_path.nil?
   end
 end

--- a/app/views/topics/propose_archive.html.erb
+++ b/app/views/topics/propose_archive.html.erb
@@ -27,33 +27,10 @@
     <p class="govuk-body">
       Users who signed up to get emails for this topic will be sent an email that this topic has been archived.
     </p>
-    
-    <%= form_for @archival, url: archive_topic_path do |f| %>
-      <div class="govuk-!-margin-bottom-4">
-        <%= render "govuk_publishing_components/components/select", {
-          id: "topic_archival_form_successor",
-          name: "topic_archival_form[successor]",
-          label: "Choose a specialist topic to redirect to:",
-          options: @archival.topics.map do |topic|
-            {
-              text: topic.title_including_parent,
-              value: topic.id
-            }
-          end
-        } %>
-      </div>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Archive and redirect to a specialist topic",
-        margin_bottom: true,
-        destructive: true,
-      } %>
-    <% end %>
-
     <%= form_for @archival, url: archive_topic_path do |f| %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: "Or type in a URL to redirect to a page:"
+          text: "Type in a URL to redirect to a page:"
         },
         hint: 'Please specify it as a relative path (for example "/government/publications/what-hmrc-does-to-prevent-tax-evasion")',
         id: "topic_archival_form_successor_path",

--- a/spec/features/archiving_topic_tags_spec.rb
+++ b/spec/features/archiving_topic_tags_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Archiving topic tags" do
 
     # Background
     given_i_am_a_gds_editor
-    and_there_is_a_topic_that_can_be_used_as_a_replacement
   end
 
   scenario "User visits an archived tag" do
@@ -29,7 +28,7 @@ RSpec.feature "Archiving topic tags" do
     and_i_visit_the_topic
     and_i_go_to_the_archive_page
 
-    when_i_redirect_the_topic_to_a_successor_topic
+    when_i_redirect_the_topic_to_a_successor_page
     then_the_tag_is_archived
 
     when_i_visit_the_topic_edit_page
@@ -48,7 +47,7 @@ RSpec.feature "Archiving topic tags" do
     and_i_visit_the_topic
     and_i_go_to_the_archive_page
 
-    when_i_redirect_the_topic_to_a_successor_topic
+    when_i_redirect_the_topic_to_a_successor_page
     then_the_tag_is_archived
 
     when_i_visit_the_topic_edit_page
@@ -76,9 +75,10 @@ RSpec.feature "Archiving topic tags" do
     expect { @topic.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  def when_i_redirect_the_topic_to_a_successor_topic
-    select "The Successor Topic", from: "topic_archival_form_successor"
-    click_button "Archive and redirect to a specialist topic"
+  def when_i_redirect_the_topic_to_a_successor_page
+    stub_content_store_has_item("/a-successor-page")
+    fill_in "topic_archival_form[successor_path]", with: "/a-successor-page"
+    click_button "Archive and redirect to a page"
   end
 
   def when_i_visit_the_topic_edit_page
@@ -111,10 +111,6 @@ RSpec.feature "Archiving topic tags" do
 
   def given_there_is_a_draft_level_1_topic
     @topic = create(:topic, :draft, slug: "bar")
-  end
-
-  def and_there_is_a_topic_that_can_be_used_as_a_replacement
-    create(:topic, :published, title: "The Successor Topic")
   end
 
   def when_i_click_the_delete_button

--- a/spec/forms/topic_archival_form_spec.rb
+++ b/spec/forms/topic_archival_form_spec.rb
@@ -4,19 +4,6 @@ require "gds_api/test_helpers/content_store"
 RSpec.describe TopicArchivalForm do
   include GdsApi::TestHelpers::ContentStore
 
-  describe "#topics" do
-    it "returns published topics that can be successors" do
-      create(:topic, :draft)
-      create(:topic, :archived)
-      published = create(:topic, :published)
-      topic_self = create(:topic, :published)
-
-      topics = TopicArchivalForm.new(tag: topic_self).topics
-
-      expect(topics).to eql([published])
-    end
-  end
-
   describe "#successor_path" do
     it "is not valid if the URL returns a 404 status code" do
       stub_content_store_does_not_have_item("/not-here")


### PR DESCRIPTION
We are soon retiring the entire specialist topic tree. We will be archiving and redirecting to non-topic pages only from now on.

## Before

<img width="773" alt="Screenshot 2023-03-17 at 14 17 57" src="https://user-images.githubusercontent.com/17908089/225930758-0f0a42f9-e862-410d-8840-d34bc7b4e14b.png">

---------
## After
<img width="705" alt="Screenshot 2023-03-17 at 14 17 45" src="https://user-images.githubusercontent.com/17908089/225930828-87a28fe9-ed75-4d53-9c3e-ca48ecb89870.png">

------

https://trello.com/c/bQBWoeXI/1708-remove-specialist-topic-redirect-field-from-collections-publisher
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
