### PR TITLE
Revert "Don't email subscribers of retired topics if successor is a document collection"

### DIFF
--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -58,18 +58,8 @@ private
     ContentItemPublisher.new(presenter).send_to_publishing_api
   end
 
-  # Temporary hack to prevent emails being sent to subscribers of a specialist topic that is being
-  # converted to a document collection. Those subscribers will be manually migrated to the new document
-  # collection subscription, which will be similar enough that a notification is not required.
-  def topic_successor_is_a_document_collection?
-    return unless tag.is_a? Topic
-
-    successor.base_path.include?("/government/collections/")
-  end
-
   def unsubscribe_from_email_alerts
     return unless tag.can_have_email_subscriptions?
-    return if topic_successor_is_a_document_collection?
 
     EmailAlertsUnsubscriber.call(
       item: tag,

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -134,17 +134,6 @@ RSpec.describe TagArchiver do
       )
     end
 
-    it "doesn't unsubscribe from email alerts when specialist topic (level 2) is being redirected to a document collection" do
-      tag = create(:topic, :published, parent: create(:topic, slug: "mot"),
-                                       slug: "provide-mot-training",
-                                       title: "Provide MOT training")
-      successor = OpenStruct.new(base_path: "/government/collections/brexit-guidance", subroutes: [])
-
-      TagArchiver.new(tag, successor).archive
-
-      expect(Services.email_alert_api).to_not have_received(:bulk_unsubscribe)
-    end
-
     it "doesn't attempt to unsubscribe from email alerts when mainstream browse page is archived" do
       tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
 


### PR DESCRIPTION
Reverts alphagov/collections-publisher#1838

See trello card: https://trello.com/c/Z90FAnOG/1829-automate-bulk-unsubscribe-of-email-subscribers-when-a-specialist-topic-is-archived-and-redirected-to-a-document-collection

This code was a temporary hack which can now be reverted as we have capacity to implement the full solution.
