### PR TITLE
Bump version of gds api adapters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.1)
     ffi (1.15.5)
-    gds-api-adapters (88.0.0)
+    gds-api-adapters (88.1.0)
       addressable
       link_header
       null_logger


### PR DESCRIPTION
This will allow us to access support for email alert api's `bulk_migrate` endpoint, which will be used as part of automatically migrating email subscriptions when retiring specialist topics.

[Trello](https://trello.com/c/8FdQqZPb/1715-update-collections-publishers-tag-archiver-service-to-handle-existing-email-subscriptions-when-specialist-topics-are-archived-l)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
