### PR TITLE
Update tag archiver

### DIFF
--- a/app/services/email_alerts_updater.rb
+++ b/app/services/email_alerts_updater.rb
@@ -13,7 +13,7 @@ class EmailAlertsUpdater
   end
 
   def handle
-    if successor.is_a?(ContentItem) && subscribers_can_be_migrated_to_successor_list?
+    if subscribers_can_be_migrated_to_successor_list?
       bulk_migrate
     else
       bulk_unsubscribe

--- a/app/services/tag_archiver.rb
+++ b/app/services/tag_archiver.rb
@@ -1,11 +1,12 @@
 # TagArchiver removes a tag from the site. It sets up a redirect for the page
 # to its successor.
 class TagArchiver
-  attr_reader :tag, :successor
+  attr_reader :tag, :successor, :email_alert_updater
 
-  def initialize(tag, successor)
+  def initialize(tag, successor, email_alert_updater = EmailAlertsUpdater)
     @tag = tag
     @successor = successor
+    @email_alert_updater = email_alert_updater
   end
 
   def archive
@@ -61,6 +62,6 @@ private
   def update_email_alerts
     return unless tag.can_have_email_subscriptions?
 
-    EmailAlertsUpdater.call(item: tag, successor:)
+    email_alert_updater.call(item: tag, successor:)
   end
 end

--- a/spec/services/tag_archiver_spec.rb
+++ b/spec/services/tag_archiver_spec.rb
@@ -3,6 +3,20 @@ require "rails_helper"
 RSpec.describe TagArchiver do
   describe "#archive" do
     let(:email_alert_api) { instance_double(GdsApi::EmailAlertApi) }
+    let(:email_alert_updater) { class_double(EmailAlertsUpdater) }
+    let(:content_item_data) do
+      {
+        "base_path" => "/successor_base_path",
+        "title" => "Successor title",
+        "content_id" => "a-content-id",
+        "description" => "foo",
+        "document_type" => "document_collection",
+        "details" => {},
+        "links" => {},
+      }
+    end
+    let(:content_item_successor) { ContentItem.new(content_item_data) }
+    let(:mainstream_browse_page_successor) { create(:mainstream_browse_page) }
 
     before do
       stub_any_publishing_api_call
@@ -16,159 +30,139 @@ RSpec.describe TagArchiver do
       )
     end
 
-    it "won't archive parent (level 1) mainstream_browse_page tags" do
-      tag = create(:mainstream_browse_page, :published)
-
-      expect { TagArchiver.new(tag, build(:mainstream_browse_page)).archive }.to raise_error(RuntimeError)
-    end
-
-    it "won't archive parent (level 1) topic tags with published or draft children (level 2) tags" do
-      tag = create(:topic, :published, children: [create(:topic, :published)])
-
-      expect { TagArchiver.new(tag, build(:topic)).archive }.to raise_error(RuntimeError)
-    end
-
-    it "archives the level 2 tag" do
-      tag = create(:topic, :published, parent: create(:topic))
-
-      TagArchiver.new(tag, build(:topic)).archive
-      tag.reload
-
-      expect(tag.archived?).to be(true)
-    end
-
-    it "archives the level 1 tag with archived children" do
-      tag = create(:topic, :published, children: [create(:topic, :archived)])
-
-      TagArchiver.new(tag, build(:topic)).archive
-      tag.reload
-
-      expect(tag.archived?).to be(true)
-    end
-
-    it "creates a redirect to its successor" do
-      tag = create(:topic, :published, parent: create(:topic))
-      successor = create(:topic)
-
-      TagArchiver.new(tag, successor).archive
-      redirect = tag.redirect_routes.first
-
-      expect(redirect.from_base_path).to eql tag.base_path
-      expect(redirect.to_base_path).to eql successor.base_path
-    end
-
-    it "creates a redirect to its non-topic successor" do
-      tag = create(:topic, :published, parent: create(:topic))
-      successor = OpenStruct.new(base_path: "www.gov.uk/successor", subroutes: [])
-
-      TagArchiver.new(tag, successor).archive
-      redirect = tag.redirect_routes.first
-
-      expect(redirect.from_base_path).to eql tag.base_path
-      expect(redirect.to_base_path).to eql successor.base_path
-    end
-
-    it "creates redirects for the suffixes" do
-      tag = create(:topic, :published, slug: "bar", parent: create(:topic, slug: "foo"))
-      successor = create(:topic)
-
-      TagArchiver.new(tag, successor).archive
-
-      expect(tag.redirect_routes.map(&:from_base_path)).to eql([
-        "/topic/foo/bar",
-        "/topic/foo/bar/latest",
-      ])
-    end
-
-    it "redirects to the base path when the successor is a parent topic" do
-      tag = create(:topic, :published, parent: create(:topic))
-      successor = create(:topic, slug: "foo")
-
-      TagArchiver.new(tag, successor).archive
-
-      expect(tag.redirect_routes.map(&:to_base_path)).to eql([
-        "/topic/foo",
-        "/topic/foo",
-      ])
-    end
-
-    it "redirects to the suffixes when the successor is a child topic" do
-      tag = create(:topic, :published, parent: create(:topic))
-      successor = create(:topic, slug: "bar", parent: create(:topic, slug: "foo"))
-
-      TagArchiver.new(tag, successor).archive
-
-      expect(tag.redirect_routes.map(&:to_base_path)).to eql([
-        "/topic/foo/bar",
-        "/topic/foo/bar/latest",
-      ])
-    end
-
-    it "republishes the content item" do
-      tag = create(:topic, :published, parent: create(:topic))
-
-      TagArchiver.new(tag, build(:topic)).archive
-
-      expect(Services.publishing_api).to have_received(:put_content)
-    end
-
-    it "unsubscribes from email alerts for the specialist topic (level 2)" do
-      tag = create(:topic, :published, parent: create(:topic, slug: "mot"),
-                                       slug: "provide-mot-training",
-                                       title: "Provide MOT training")
-      successor = OpenStruct.new(base_path: "/guidance/become-an-mot-training-provider", subroutes: [])
-      expected_email_body = <<~BODY
-        This topic has been archived. You will not get any more emails about it.
-
-        You can find more information about this topic at [#{Plek.website_root}/guidance/become-an-mot-training-provider](#{Plek.website_root}/guidance/become-an-mot-training-provider).
-      BODY
-
-      TagArchiver.new(tag, successor).archive
-
-      expect(Services.email_alert_api).to have_received(:bulk_unsubscribe).with(
-        hash_including(
-          slug: "subscriber-list-slug",
-          body: expected_email_body,
-        ),
-      )
-    end
-
-    it "doesn't attempt to unsubscribe from email alerts when mainstream browse page is archived" do
-      tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
-
-      TagArchiver.new(tag, build(:mainstream_browse_page)).archive
-
-      expect(Services.email_alert_api).to_not have_received(:bulk_unsubscribe)
-    end
-
-    it "doesn't attempt to unsubscribe from email alerts when level one topic is archived" do
-      tag = create(:topic, :published, children: [create(:topic, :archived)])
-
-      TagArchiver.new(tag, build(:mainstream_browse_page)).archive
-
-      expect(Services.email_alert_api).to_not have_received(:bulk_unsubscribe)
-    end
-
     it "doesn't have side effects when the call to publishing API fails" do
       tag = create(:topic, :published, parent: create(:topic))
 
       expect(Services.publishing_api).to receive(:put_content).and_raise("publishing API call failed")
-      expect { TagArchiver.new(tag, build(:topic)).archive }.to raise_error("publishing API call failed")
+      expect { TagArchiver.new(tag, content_item_successor).archive }.to raise_error("publishing API call failed")
       tag.reload
 
       expect(tag.archived?).to be(false)
       expect(tag.redirect_routes.size).to be(0)
     end
 
-    it "doesn't have side effects when the call to email alert API fails" do
-      tag = create(:topic, :published, parent: create(:topic))
+    context "when archiving mainstream browse pages" do
+      it "won't archive parent (level 1) mainstream_browse_page tags" do
+        tag = create(:mainstream_browse_page, :published)
 
-      expect(email_alert_api).to receive(:bulk_unsubscribe).and_raise("email alert API call failed")
-      expect { TagArchiver.new(tag, build(:topic)).archive }.to raise_error("email alert API call failed")
-      tag.reload
+        expect { TagArchiver.new(tag, build(:mainstream_browse_page)).archive }.to raise_error(RuntimeError)
+      end
 
-      expect(tag.archived?).to be(false)
-      expect(tag.redirect_routes.size).to be(0)
+      it "archives the level 2 mainstream_browse_page tags" do
+        tag = create(:mainstream_browse_page, :published, parent: create(:topic))
+
+        TagArchiver.new(tag, mainstream_browse_page_successor).archive
+        tag.reload
+
+        expect(tag.archived?).to be(true)
+      end
+
+      it "creates a redirect to its successor" do
+        tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
+
+        TagArchiver.new(tag, mainstream_browse_page_successor).archive
+        redirect = tag.redirect_routes.first
+
+        expect(redirect.from_base_path).to eql tag.base_path
+        expect(redirect.to_base_path).to eql mainstream_browse_page_successor.base_path
+      end
+
+      it "creates redirects for the suffixes" do
+        tag = create(:mainstream_browse_page, :published, slug: "bar", parent: create(:mainstream_browse_page, slug: "foo"))
+
+        TagArchiver.new(tag, mainstream_browse_page_successor).archive
+
+        expect(tag.redirect_routes.map(&:from_base_path)).to eql([
+          "/browse/foo/bar",
+          "/browse/foo/bar.json",
+        ])
+      end
+
+      it "republishes the content item" do
+        tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
+
+        TagArchiver.new(tag, mainstream_browse_page_successor).archive
+
+        expect(Services.publishing_api).to have_received(:put_content)
+      end
+
+      it "does not call the email alert updater" do
+        tag = create(:mainstream_browse_page, :published, parent: create(:mainstream_browse_page))
+        any_successor = create(:mainstream_browse_page)
+
+        expect(email_alert_updater).to receive(:call).with(item: tag, successor: any_successor).never
+        TagArchiver.new(tag, any_successor).archive
+      end
+    end
+
+    context "when archiving specialist topics" do
+      it "won't archive parent (level 1) topic tags with published or draft children (level 2) tags" do
+        tag = create(:topic, :published, children: [create(:topic, :published)])
+
+        expect { TagArchiver.new(tag, content_item_successor).archive }.to raise_error(RuntimeError)
+      end
+
+      it "archives the level 2 tag" do
+        tag = create(:topic, :published, parent: create(:topic))
+
+        TagArchiver.new(tag, content_item_successor).archive
+        tag.reload
+
+        expect(tag.archived?).to be(true)
+      end
+
+      it "archives the level 1 tag with archived children" do
+        tag = create(:topic, :published, children: [create(:topic, :archived)])
+
+        TagArchiver.new(tag, content_item_successor).archive
+        tag.reload
+
+        expect(tag.archived?).to be(true)
+      end
+
+      it "creates a redirect to its successor" do
+        tag = create(:topic, :published, parent: create(:topic))
+
+        TagArchiver.new(tag, content_item_successor).archive
+        redirect = tag.redirect_routes.first
+
+        expect(redirect.from_base_path).to eql tag.base_path
+        expect(redirect.to_base_path).to eql content_item_successor.base_path
+      end
+
+      it "creates redirects for the suffixes" do
+        tag = create(:topic, :published, slug: "bar", parent: create(:topic, slug: "foo"))
+
+        TagArchiver.new(tag, content_item_successor).archive
+
+        expect(tag.redirect_routes.map(&:from_base_path)).to eql([
+          "/topic/foo/bar",
+          "/topic/foo/bar/latest",
+        ])
+      end
+
+      it "republishes the content item" do
+        tag = create(:topic, :published, parent: create(:topic))
+
+        TagArchiver.new(tag, content_item_successor).archive
+
+        expect(Services.publishing_api).to have_received(:put_content)
+      end
+
+      it "calls the email alert updater when archiving level 2 specialist topics" do
+        tag = create(:topic, :published, parent: create(:topic))
+        expect(email_alert_updater).to receive(:call).with(item: tag, successor: content_item_successor)
+
+        TagArchiver.new(tag, content_item_successor, email_alert_updater).archive
+      end
+
+      it "does not call the email alert updater when archiving level 1 specialist topics" do
+        tag = create(:topic, :published, children: [create(:topic, :archived)])
+        any_successor = create(:mainstream_browse_page)
+
+        expect(email_alert_updater).to receive(:call).with(item: tag, successor: any_successor).never
+        TagArchiver.new(tag, any_successor).archive
+      end
     end
   end
 end


### PR DESCRIPTION
In https://github.com/alphagov/collections-publisher/pull/1848 we updated the UI in this application so that it's no longer possible to redirect specialist topics to specialist topics, only to redirect to content_items. This is because we are soon retiring the entire specialist topic tree.

The tag archiver specs were not updated to reflect this change, and still tested the topic -> topic redirect behaviour.

This PR:
- Updates the specs
- Removes the unnecessary type check in the email alert updater class
- Injects the email_alerts_updater class to simplify the tests

Trello: https://trello.com/c/siCRG1zk/1978-extend-the-collections-publisher-tag-archiver-service-to-handle-document-collections-which-have-a-taxonomytopicemailoverride-fie

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
