### PR TITLE
Fix broken test for govuk publishing components 35.16.0 update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     google-protobuf (3.24.3-aarch64-linux)
     google-protobuf (3.24.3-arm64-darwin)
     google-protobuf (3.24.3-x86_64-linux)
-    googleapis-common-protos-types (1.8.0)
+    googleapis-common-protos-types (1.9.0)
       google-protobuf (~> 3.18)
     govuk_app_config (9.2.0)
       logstasher (~> 2.1)
@@ -173,10 +173,10 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_personalisation (0.14.0)
+    govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.12.0)
+    govuk_publishing_components (35.16.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -251,7 +251,7 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.4.0)
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
@@ -281,7 +281,7 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
-    opentelemetry-api (1.2.2)
+    opentelemetry-api (1.2.3)
     opentelemetry-common (0.20.0)
       opentelemetry-api (~> 1.0)
     opentelemetry-exporter-otlp (0.26.1)
@@ -548,7 +548,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.6)
-    rouge (4.1.2)
+    rouge (4.1.3)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -641,7 +641,7 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
-    sprockets (4.2.0)
+    sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.4.2)

--- a/spec/features/curating_a_list_spec.rb
+++ b/spec/features/curating_a_list_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Curating a list" do
 
   def and_the_link_items_should_link_to_the_live_page
     expect(all(".gem-c-document-list__item-title")[0].text).to eq @list.list_items.first.title
-    expect(all(".gem-c-document-list__item-title")[0][:href]).to eq "#{Plek.external_url_for('content-tagger')}/taggings/29941ec1-4a41-4bfd-86a9-5c866bbd4c7a"
+    expect(all(".gem-c-document-list__item-title")[0].find_link[:href]).to eq "#{Plek.external_url_for('content-tagger')}/taggings/29941ec1-4a41-4bfd-86a9-5c866bbd4c7a"
   end
 
   def when_i_click_add_links_to_list


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
