### PR TITLE
Update Rails to 7.1.0

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,8 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Compress JavaScript.
-  config.assets.js_compressor = :uglifier
-
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
This PR will update rails to version 7.1.0.

There was a previous attempt at this that failed in the docker image build, due to an incompatibility in syntax with uglifier. This PR includes the update to uglifier syntax to handle the incompatibility.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
