### PR TITLE
Email bulk migration exceptions

### DIFF
--- a/app/forms/topic_archival_form.rb
+++ b/app/forms/topic_archival_form.rb
@@ -14,6 +14,9 @@ class TopicArchivalForm
     end
 
     true
+  rescue EmailAlertApi::SubscriberListUpdater::SuccessorDestinationError => e
+    errors.add :base, e.message
+    false
   rescue GdsApi::HTTPClientError
     errors.add :base, "The tag could not be deleted because of an error."
     false

--- a/config/exceptional_bulk_migrations.yml
+++ b/config/exceptional_bulk_migrations.yml
@@ -1,0 +1,5 @@
+development:
+test:
+  /topic/current/path: /government/successor/path
+production:
+  /topic/personal-tax/foreign-entertainer-rules: /government/collections/foreign-entertainers-forms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,3 +232,13 @@ en:
       sidebar_settings: Choose to hide the sidebar on certain pages.
       secondary_links: Choose additional pages to show the step by step sidebar.
       tags: Tag the step by step to the GOV.UK taxonomy and mainstream browse pages.
+  subscriber_list_updater:
+    errors:
+      wrong_destination_path: >-
+        Wrong destination path,
+        is: "%{is}",
+        should be: "%{should_be}"
+      wrong_destination_type: >-
+        Wrong destination type,
+        is: "%{is}",
+        should be: "%{should_be}"


### PR DESCRIPTION
Includes the setting for the foreign entertainer tax rules bulk migration exception

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Update collections publisher with a special case to make sure email notifications are handled correctly.

## Why

HMRC want to archive this specialist topic page [https://www.gov.uk/topic/personal-tax/foreign-entertainer-rules](https://www.gov.uk/topic/personal-tax/foreign-entertainer-rules "smartCard-inline")
and redirect it to an existing document collection (which is also tagged to the specialist topic) [https://www.gov.uk/government/collections/foreign-entertainers-forms](https://www.gov.uk/government/collections/foreign-entertainers-forms "smartCard-inline")

HMRC will update the content on the collection page so it has the same content as on the specialist topic page.

They’d like to move existing email subscribers on the specialist topic pages to the collection page.

[Trello card](https://trello.com/c/GDf3Rx7t/2254-email-migration-exception-foreign-entertainer-tax-rules-m)