### PR TITLE
Add GA4 analytics

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link application.css
 //= link application.js
+//= link domain-config.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,3 +19,6 @@
 //= require @webcomponents/custom-elements/custom-elements.min.js
 
 //= require components/markdown-editor.js
+
+window.GOVUK.approveAllCookieTypes()
+window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })

--- a/app/assets/javascripts/domain-config.js
+++ b/app/assets/javascripts/domain-config.js
@@ -1,0 +1,24 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.vars = window.GOVUK.vars || {}
+window.GOVUK.vars.extraDomains = [
+  {
+    name: 'production',
+    domains: [
+      'collections-publisher.publishing.service.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    gaProperty: 'UA-26179049-6'
+  },
+  {
+    name: 'integration',
+    domains: [
+      'collections-publisher.integration.publishing.service.gov.uk'
+    ],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    auth: '8jHx-VNEguw67iX9TBC6_g',
+    preview: 'env-50',
+    gaProperty: 'UA-26179049-6'
+  }
+]

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,6 +1,13 @@
+<% content_for :head do %>
+  <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>" />
+  <%= javascript_include_tag "domain-config" %>
+  <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/layout_for_admin",
   product_name: "Collections Publisher",
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
+  head: yield(:head),
   browser_title: yield(:page_title).presence || yield(:title) do %>
 
   <%= render "govuk_publishing_components/components/skip_link" %>


### PR DESCRIPTION
## What

Use the `load-analytics' script of govuk_publishing_components to add GA4 analytics to collections-publisher. Includes extra configuration to set the correct domains for GA4 to initialise and code to automatically accept all cookies to make tracking work.

## Why

UA is being deprecated, we need to switch our apps to use GA4 instead.

[Relevant Trello Card](https://trello.com/c/U1GlVZRF/196-implement-page-view-tracking-in-ga4-for-mpe-owned-publishing-apps)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
