### PR TITLE
Migration to remove tags of type topic 4/4

### DIFF
--- a/db/migrate/20240320072303_remove_tags_of_type_topic.rb
+++ b/db/migrate/20240320072303_remove_tags_of_type_topic.rb
@@ -1,0 +1,5 @@
+class RemoveTagsOfTypeTopic < ActiveRecord::Migration[7.1]
+  def change
+    Tag.where(type: "Topic").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_080818) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_20_072303) do
   create_table "coronavirus_pages", charset: "utf8mb3", force: :cascade do |t|
     t.string "sections_title"
     t.string "base_path"


### PR DESCRIPTION
This is the final PR to remove topics from this app. At this point all code and reference to topics has been removed and this last PR runs a migration to remove **Tags** of type **Topic** from the database.

Ticket: https://trello.com/c/RLc9saF6/2461-remove-specialist-topic-code-from-collections-publisher-m-l

Subsequent PR's
- https://github.com/alphagov/collections-publisher/pull/2099
- https://github.com/alphagov/collections-publisher/pull/2102
- https://github.com/alphagov/collections-publisher/pull/2111