### PR TITLE
Revert "Migration to remove tags of type topic 4/4"

### DIFF
--- a/db/migrate/20240320072303_remove_tags_of_type_topic.rb
+++ b/db/migrate/20240320072303_remove_tags_of_type_topic.rb
@@ -1,5 +1,0 @@
-class RemoveTagsOfTypeTopic < ActiveRecord::Migration[7.1]
-  def change
-    Tag.where(type: "Topic").destroy_all
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_20_072303) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_18_080818) do
   create_table "coronavirus_pages", charset: "utf8mb3", force: :cascade do |t|
     t.string "sections_title"
     t.string "base_path"


### PR DESCRIPTION
Reverts alphagov/collections-publisher#2118


We have an issue with:


```
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_production`.`redirect_routes`, CONSTRAINT `fk_rails_a469af518f` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`))
/app/db/migrate/20240320072303_remove_tags_of_type_topic.rb:4:in `change'
Caused by:
ActiveRecord::InvalidForeignKey: Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_production`.`redirect_routes`, CONSTRAINT `fk_rails_a469af518f` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`)) (ActiveRecord::InvalidForeignKey)
/app/db/migrate/20240320072303_remove_tags_of_type_topic.rb:4:in `change'
Caused by:
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_production`.`redirect_routes`, CONSTRAINT `fk_rails_a469af518f` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`)) (Mysql2::Error)
/app/db/migrate/20240320072303_remove_tags_of_type_topic.rb:4:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```