### PR TITLE
Destroy Tags of type Topic with dependent destroy

### DIFF
--- a/db/migrate/20240403151146_destroy_tags_of_type_topic.rb
+++ b/db/migrate/20240403151146_destroy_tags_of_type_topic.rb
@@ -1,0 +1,10 @@
+class DestroyTagsOfTypeTopic < ActiveRecord::Migration[7.1]
+  class Tag < ApplicationRecord
+    self.inheritance_column = :_type_disabled
+    has_many :redirect_routes, dependent: :destroy
+  end
+
+  def change
+    Tag.where(type: "Topic").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_080818) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_03_151146) do
   create_table "coronavirus_pages", charset: "utf8mb3", force: :cascade do |t|
     t.string "sections_title"
     t.string "base_path"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This PR fixes the issue below: 

```
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_production`.`redirect_routes`, CONSTRAINT `fk_rails_a469af518f` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`))
/app/db/migrate/20240320072303_remove_tags_of_type_topic.rb:4:in `change'
Caused by:
ActiveRecord::InvalidForeignKey: Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_production`.`redirect_routes`, CONSTRAINT `fk_rails_a469af518f` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`)) (ActiveRecord::InvalidForeignKey)
/app/db/migrate/20240320072303_remove_tags_of_type_topic.rb:4:in `change'
Caused by:
Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`collections_publisher_production`.`redirect_routes`, CONSTRAINT `fk_rails_a469af518f` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`)) (Mysql2::Error)
/app/db/migrate/20240320072303_remove_tags_of_type_topic.rb:4:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

Related revert PR: https://github.com/alphagov/collections-publisher/pull/2132