### PR TITLE
Fix label ('Date' -> 'Time')

### DIFF
--- a/app/views/step_by_step_pages/schedule_datetime.html.erb
+++ b/app/views/step_by_step_pages/schedule_datetime.html.erb
@@ -56,7 +56,7 @@
     id: "time",
     name: "schedule[time]",
     label: {
-      text: t("step_by_step_pages.schedule_datetime.date.label"),
+      text: t("step_by_step_pages.schedule_datetime.time.label"),
       bold: true,
     },
     input: {


### PR DESCRIPTION
This label was mistakenly copied from the Date one.

| Before | After |
|--------|-----|
| ![before](https://github.com/alphagov/collections-publisher/assets/5111927/5bfb3389-84a5-4793-a6fc-a5aa99022a8d) | ![after](https://github.com/alphagov/collections-publisher/assets/5111927/f866316d-c845-443c-8beb-5fc839b43117) |

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5825085

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
