### PR TITLE
Upgrade govuk publishing components gov.uk frontend v5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.4)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../images
 //= link application.css
 //= link application.js
+//= link es6-components.js
 //= link domain-config.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,8 +2,15 @@
 // system aspects of Collections Publisher
 
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
-//= require govuk_publishing_components/analytics
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/contextual-guidance
+//= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/metadata
+//= require govuk_publishing_components/components/reorderable-list
+//= require govuk_publishing_components/components/table
+//= require govuk_publishing_components/components/tabs
 //= require components/autocomplete
 //= require analytics
 

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,16 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/accordion
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/skip-link

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,42 @@
 // This file is used as the root SCSS file for the govuk_publishing_components/design
 // system aspects of Collections Publisher
 
-@import "govuk_publishing_components/all_components";
+@import 'govuk_publishing_components/govuk_frontend_support';
+@import 'govuk_publishing_components/component_support';
+@import 'govuk_publishing_components/components/accordion';
+@import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/breadcrumbs';
+@import 'govuk_publishing_components/components/button';
+@import 'govuk_publishing_components/components/character-count';
+@import 'govuk_publishing_components/components/checkboxes';
+@import 'govuk_publishing_components/components/contextual-guidance';
+@import 'govuk_publishing_components/components/date-input';
+@import 'govuk_publishing_components/components/details';
+@import 'govuk_publishing_components/components/document-list';
+@import 'govuk_publishing_components/components/error-alert';
+@import 'govuk_publishing_components/components/error-message';
+@import 'govuk_publishing_components/components/error-summary';
+@import 'govuk_publishing_components/components/fieldset';
+@import 'govuk_publishing_components/components/govspeak';
+@import 'govuk_publishing_components/components/heading';
+@import 'govuk_publishing_components/components/hint';
+@import 'govuk_publishing_components/components/input';
+@import 'govuk_publishing_components/components/inset-text';
+@import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/layout-footer';
+@import 'govuk_publishing_components/components/layout-for-admin';
+@import 'govuk_publishing_components/components/layout-header';
+@import 'govuk_publishing_components/components/metadata';
+@import 'govuk_publishing_components/components/radio';
+@import 'govuk_publishing_components/components/reorderable-list';
+@import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/select';
+@import 'govuk_publishing_components/components/skip-link';
+@import 'govuk_publishing_components/components/success-alert';
+@import 'govuk_publishing_components/components/summary-list';
+@import 'govuk_publishing_components/components/table';
+@import 'govuk_publishing_components/components/tabs';
+@import 'govuk_publishing_components/components/textarea';
 @import "./components/all";
 @import "./objects/broken-link-status";
 @import "./objects/grid";

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -36,7 +36,7 @@ module StatusHelper
     text, colour = return_tag_text_and_colour(tag_object)
     classes = "govuk-tag govuk-tag--#{colour} govuk-tag--small"
 
-    tag.span text, class: classes
+    tag.span text.capitalize, class: classes
   end
 
 private

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,7 +1,8 @@
 <% content_for :head do %>
-  <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>" />
+  <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
   <%= javascript_include_tag "domain-config" %>
   <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
+  <%= javascript_include_tag "es6-components", type: "module" %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_admin",

--- a/app/views/mainstream_browse_pages/_create_update_form.html.erb
+++ b/app/views/mainstream_browse_pages/_create_update_form.html.erb
@@ -43,7 +43,7 @@
     value: @browse_page.description,
     error_items: errors_for(@browse_page, :description),
   } %>
-  
+
   <%= render "govuk_publishing_components/components/button", {
     text: update ? "Save" : "Create",
     margin_bottom: true,

--- a/app/views/shared/_children-list.html.erb
+++ b/app/views/shared/_children-list.html.erb
@@ -1,6 +1,6 @@
 <ul class="govuk-list govuk-list--bullet">
   <% page.sorted_children.each do |child_tag| %>
-    <li class="govuk-!-font-size-14">
+    <li class="govuk-body-s">
       <%= link_to(child_tag.title, polymorphic_path(child_tag), class: "govuk-link") %>
       <%= govuk_status(child_tag) %>
     </li>

--- a/spec/features/managing_browse_pages_spec.rb
+++ b/spec/features/managing_browse_pages_spec.rb
@@ -111,13 +111,13 @@ RSpec.feature "Managing browse pages" do
 
   def then_i_see_that_the_page_is_in_draft
     within ".govuk-summary-list--no-border" do
-      expect(page).to have_content("draft")
+      expect(page).to have_content("Draft")
     end
   end
 
   def then_i_see_that_the_page_is_published
     within ".govuk-summary-list--no-border" do
-      expect(page).to have_content("published")
+      expect(page).to have_content("Published")
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/HYqXLv8w/347-upgrade-govukpublishingcomponents-gem-dependency-v5-of-govuk-frontend-collections-publisher)

This work updates Collections Publisher to V5 of the Design System. The only visual changes this makes are shown below. All other issues identified when testing (see [here](https://trello.com/c/3KcURoRn)) are now resolved.

Visual changes: 
- Tags now appear with the first letter capitalised rather than all lower case
- The font size of the list of subtopics is increased from 14px to 16px. The Design System is moving away from 14px text. 

|Updated|Current|
|-|-|
|![Screenshot 2024-07-22 at 15 45 45](https://github.com/user-attachments/assets/9acb0e19-a27f-439b-a05e-285020ecb97a)|![Screenshot 2024-07-22 at 15 45 59](https://github.com/user-attachments/assets/5f82f093-1500-415d-8718-ce9d9b4fe8db)|