### PR TITLE
Update broken link for content patterns guidance

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,7 +184,7 @@ en:
 
           Start a step with an action and keep it short, for example: ‘Check what age you can drive’.
 
-          [The content patterns guidance](https://gov-uk.atlassian.net/wiki/spaces/MS/pages/416317515/Step+and+task+content+patterns)
+          [The content patterns guidance](https://gov-uk.atlassian.net/wiki/spaces/CC/pages/1498251331/Content+patterns)
 
           #### Formatting
 


### PR DESCRIPTION
Link for content patterns guidance seems to be broken and this [was highlighted](https://gds.slack.com/archives/C051S690LGL/p1723554496733949) by Gavan Curley <gavan.curley@digital.cabinet-office.gov.uk>.
Have updated the link to point to the one shared.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
