### PR TITLE
Remove Rails override

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -6,5 +6,3 @@ overrides:
   - dependency: govuk_publishing_components
     allowed_semver_bumps:
       - patch
-  - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
-    auto_merge: false


### PR DESCRIPTION
The config already has `update_external_dependencies: false`, so Rails updates are already blocked.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
