### PR TITLE
Configure hosts for application

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
-    /collections-publisher\..*gov.uk?/,
+    /collections-publisher\..*\.gov.uk/,
   ]
 
   # Skip DNS rebinding protection for the default health check endpoint.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,4 +89,12 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.unreleased_features = ENV["UNRELEASED_FEATURES"].present?
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  config.hosts = [
+    /collections-publisher\..*gov.uk?/,
+  ]
+
+  # Skip DNS rebinding protection for the default health check endpoint.
+  config.host_authorization = { exclude: ->(request) { request.path.match?("^\/healthcheck") } }
 end


### PR DESCRIPTION
Note: the healthcheck endpoints are requested by IP, not domain, so we need to specifically exclude them from the protection.<br><br>[Trello card](https://trello.com/c/frqFN7D8)