### PR TITLE
Revert "Bump govuk_publishing_components from 60.0.2 to 61.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,16 +172,16 @@ GEM
     generic_form_builder (0.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    google-protobuf (4.32.1)
+    google-protobuf (4.32.0)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.32.1-aarch64-linux-gnu)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.32.1-arm64-darwin)
+    google-protobuf (4.32.0-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.32.1-x86_64-linux-gnu)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
     googleapis-common-protos-types (1.21.0)
@@ -201,7 +201,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (61.1.0)
+    govuk_publishing_components (60.0.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -285,7 +285,7 @@ GEM
       bigdecimal
     net-http (0.6.0)
       uri
-    net-imap (0.5.11)
+    net-imap (0.5.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -323,7 +323,7 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
-    opentelemetry-api (1.7.0)
+    opentelemetry-api (1.6.0)
     opentelemetry-common (0.22.0)
       opentelemetry-api (~> 1.0)
     opentelemetry-exporter-otlp (0.30.0)
@@ -333,11 +333,11 @@ GEM
       opentelemetry-common (~> 0.20)
       opentelemetry-sdk (~> 1.2)
       opentelemetry-semantic_conventions
-    opentelemetry-helpers-mysql (0.3.0)
-      opentelemetry-api (~> 1.7)
+    opentelemetry-helpers-mysql (0.2.0)
+      opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.21)
-    opentelemetry-helpers-sql (0.2.0)
-      opentelemetry-api (~> 1.7)
+    opentelemetry-helpers-sql (0.1.1)
+      opentelemetry-api (~> 1.0)
     opentelemetry-helpers-sql-obfuscation (0.3.0)
       opentelemetry-common (~> 0.21)
     opentelemetry-instrumentation-action_mailer (0.4.0)
@@ -488,7 +488,7 @@ GEM
     opentelemetry-instrumentation-racecar (0.4.0)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.23.0)
-    opentelemetry-instrumentation-rack (0.27.1)
+    opentelemetry-instrumentation-rack (0.27.0)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.23.0)
     opentelemetry-instrumentation-rails (0.37.0)
@@ -536,12 +536,12 @@ GEM
       opentelemetry-semantic_conventions (>= 1.8.0)
     opentelemetry-registry (0.4.0)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.9.0)
+    opentelemetry-sdk (1.8.1)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.36.0)
+    opentelemetry-semantic_conventions (1.11.0)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -633,8 +633,8 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.4.4)
-    rouge (4.6.1)
+    rexml (3.4.2)
+    rouge (4.6.0)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)


### PR DESCRIPTION
This reverts commit 2cc4ad0937017ff440310c71291c837b05d246a9.

It was causing layout issues in the site header.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
