### PR TITLE
Remove metadata component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,6 @@
 //= require govuk_publishing_components/components/checkboxes
 //= require govuk_publishing_components/components/contextual-guidance
 //= require govuk_publishing_components/components/govspeak
-//= require govuk_publishing_components/components/metadata
 //= require govuk_publishing_components/components/reorderable-list
 //= require govuk_publishing_components/components/table
 //= require govuk_publishing_components/components/tabs

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,7 +26,6 @@
 @import 'govuk_publishing_components/components/layout-footer';
 @import 'govuk_publishing_components/components/layout-for-admin';
 @import 'govuk_publishing_components/components/layout-header';
-@import 'govuk_publishing_components/components/metadata';
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/reorderable-list';
 @import 'govuk_publishing_components/components/search';

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -53,3 +53,20 @@
     float: right;
   }
 }
+
+.metadata {
+  margin: 0;
+  @include govuk-font(19);
+
+  dt {
+    font-weight: bold;
+  }
+
+  dd {
+    margin: 0 0 govuk-spacing(3);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/utilities/_overrides.scss
+++ b/app/assets/stylesheets/utilities/_overrides.scss
@@ -34,36 +34,6 @@
   }
 }
 
-.gem-c-metadata {
-  @include govuk-font(19);
-  margin-bottom: 0;
-
-  dl {
-    margin: 0;
-  }
-
-  .gem-c-metadata__term {
-    width: auto;
-    max-width: inherit;
-    padding-right: 0;
-    float: none;
-    @include govuk-font($size: 19, $weight: bold);
-  }
-
-  .gem-c-metadata__definition {
-    width: auto;
-    margin: 0;
-    margin-bottom: govuk-spacing(3);
-    float: none;
-
-    &:last-child {
-      margin: 0;
-    }
-
-    @include govuk-clearfix;
-  }
-}
-
 .govuk-table {
   .gem-c-document-list__item {
     margin: 0;

--- a/app/views/coronavirus/pages/show.html.erb
+++ b/app/views/coronavirus/pages/show.html.erb
@@ -27,9 +27,12 @@
   <div class="govuk-grid-column-one-third">
     <%= render "coronavirus/pages/show/actions" %>
     <div class="app-side">
-      <%= render "govuk_publishing_components/components/metadata", {
-        other: metadata,
-      } %>
+      <dl class="metadata">
+        <% metadata.each do |item| %>
+          <dt><%= item[0] %>:</dt>
+          <dd><%= item[1] %></dd>
+        <% end %>
+      </dl>
     </div>
   </div>
 </div>

--- a/app/views/step_by_step_pages/show.html.erb
+++ b/app/views/step_by_step_pages/show.html.erb
@@ -85,9 +85,12 @@
     <%= render "step_by_step_pages/show/actions" %>
 
     <div class="app-side">
-      <%= render "govuk_publishing_components/components/metadata", {
-        other: @step_by_step_page_presenter.summary_metadata,
-      } %>
+      <dl class="metadata">
+        <% @step_by_step_page_presenter.summary_metadata.each do |item| %>
+          <dt><%= item[0] %>:</dt>
+          <dd><%= item[1] %></dd>
+        <% end %>
+      </dl>
     </div>
   </div>
 </div>

--- a/spec/features/create_step_by_step_spec.rb
+++ b/spec/features/create_step_by_step_spec.rb
@@ -90,7 +90,7 @@ RSpec.feature "Create new step by step page" do
   end
 
   def and_i_see_i_saved_it_last
-    within(".gem-c-metadata") do
+    within(".metadata") do
       expect(page).to have_content("Status: Draft")
       expect(page).to have_content("by Test author")
     end

--- a/spec/features/managing_step_by_step_pages_spec.rb
+++ b/spec/features/managing_step_by_step_pages_spec.rb
@@ -551,7 +551,7 @@ RSpec.feature "Managing step by step pages" do
   end
 
   def and_i_can_see_a_metadata_section
-    within(".gem-c-metadata") do
+    within(".metadata") do
       expect(page).to have_content("Status: Draft")
       expect(page).to have_content("Last saved")
       expect(page).to have_content("Created")

--- a/spec/features/reviewing_step_by_steps_spec.rb
+++ b/spec/features/reviewing_step_by_steps_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Reviewing step by step pages" do
   end
 
   def and_the_step_by_step_status_should_be(status)
-    expect(page).to have_css(".gem-c-metadata", text: "Status: #{status}")
+    expect(page).to have_css(".metadata", text: "Status: #{status}")
   end
 
   def and_i_submit_the_form


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Remove instances of the [metadata component](https://components.publishing.service.gov.uk/component-guide/metadata) from the application and replace with custom styling.

## Why
The appearance of the metadata component here was being overridden by custom styles within the application. This is against our principle of component isolation as it makes it harder to make changes to components without instances like this breaking. The required styles also differ significantly from the appearance of the component.

## Visual changes
Shouldn't be any visual difference. This applies to the content of the grey box on the bottom right of the below screenshot, on the step by step and coronavirus pages.

<img width="1090" height="742" alt="Screenshot 2026-07-06 at 11 18 43" src="https://github.com/user-attachments/assets/061626ac-2c93-476e-91e9-6bda8b74cfcf" />
